### PR TITLE
opentelemetry-collector-builder: 0.101.0 -> 0.112.0

### DIFF
--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     homepage = "https://github.com/open-telemetry/opentelemetry-collector.git";
     changelog = "https://github.com/open-telemetry/opentelemetry-collector/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ DavSanchez ];
+    maintainers = with lib.maintainers; [ davsanchez ];
     mainProgram = "ocb";
   };
 }

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -5,13 +5,13 @@
 }:
 buildGoModule rec {
   pname = "ocb";
-  version = "0.101.0";
+  version = "0.112.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-collector";
     rev = "cmd/builder/v${version}";
-    hash = "sha256-Ucp00OjyPtHA6so/NOzTLtPSuhXwz6A2708w2WIZb/E=";
+    sha256 = "sha256-Ucp00OjyPtHA6so/NOzTLtPSuhXwz6A2708w2WIZb/E=";
   };
 
   sourceRoot = "${src.name}/cmd/builder";
@@ -27,7 +27,7 @@ buildGoModule rec {
   # The TestGenerateAndCompile tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
   checkFlags = [ "-skip TestGenerateAndCompile" ];
 
-  # Rename the to ocb (it's generated as "builder")
+  # Rename to ocb (it's generated as "builder")
   postInstall = ''
     mv $out/bin/builder $out/bin/ocb
   '';
@@ -37,7 +37,7 @@ buildGoModule rec {
     homepage = "https://github.com/open-telemetry/opentelemetry-collector.git";
     changelog = "https://github.com/open-telemetry/opentelemetry-collector/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ davsanchez ];
+    maintainers = with lib.maintainers; [ DavSanchez ];
     mainProgram = "ocb";
   };
 }

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   };
 
   sourceRoot = "${src.name}/cmd/builder";
-  vendorHash = "sha256-MTwD9xkrq3EudppLSoONgcPCBWlbSmaODLH9NtYgVOk=";
+  vendorHash = "sha256-vZsGSLdzKa4sA/N3RG6Kwn8tMoIIhPJ6uAkM4pheitU=";
 
   CGO_ENABLED = 0;
   ldflags = [

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -24,8 +24,10 @@ buildGoModule rec {
     "-X go.opentelemetry.io/collector/cmd/builder/internal.version=${version}"
   ];
 
-  # The TestGenerateAndCompile tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
-  checkFlags = [ "-skip TestGenerateAndCompile" ];
+  # Some tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
+  checkFlags = [
+    "-skip TestGenerateAndCompile|TestReplaceStatementsAreComplete|TestVersioning"
+  ];
 
   # Rename to ocb (it's generated as "builder")
   postInstall = ''

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "open-telemetry";
     repo = "opentelemetry-collector";
     rev = "cmd/builder/v${version}";
-    sha256 = "sha256-Ucp00OjyPtHA6so/NOzTLtPSuhXwz6A2708w2WIZb/E=";
+    hash = "sha256-0eL9J+PrURiNkL6CzUIlcvjyZor8iS9vKX8j0srLlZ8=";
   };
 
   sourceRoot = "${src.name}/cmd/builder";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
