### PR TITLE
Support dynamically linked binaries on OpenBSD.

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -134,6 +134,7 @@ let
     else if targetPlatform.isLoongArch64              then "${sharedLibraryLoader}/lib/ld-linux-loongarch*.so.1"
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
     else if targetPlatform.isFreeBSD                  then "${sharedLibraryLoader}/libexec/ld-elf.so.1"
+    else if targetPlatform.isOpenBSD                  then "${sharedLibraryLoader}/libexec/ld.so"
     else if hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
     else "";
 

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
@@ -1,11 +1,13 @@
 {
   lib,
+  stdenvNoLibc,
   symlinkJoin,
   libcMinimal,
   librthread,
   libm,
   librpcsvc,
   libutil,
+  rtld,
   version,
 }:
 
@@ -27,13 +29,16 @@ symlinkJoin rec {
         (lib.getLib p)
         (lib.getMan p)
       ])
-      [
-        libcMinimal
-        libm
-        librthread
-        librpcsvc
-        libutil
-      ];
+      (
+        [
+          libcMinimal
+          libm
+          librthread
+          librpcsvc
+          libutil
+        ]
+        ++ (lib.optional (!stdenvNoLibc.hostPlatform.isStatic) rtld)
+      );
 
   postBuild = ''
     rm -r "$out/nix-support"

--- a/pkgs/os-specific/bsd/openbsd/pkgs/openbsdSetupHook/setup-hook.sh
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/openbsdSetupHook/setup-hook.sh
@@ -1,6 +1,11 @@
 addOpenBSDMakeFlags() {
   prependToVar makeFlags "INCSDIR=${!outputDev}/include"
   prependToVar makeFlags "MANDIR=${!outputMan}/share/man"
+  # Variables are used to declare dependencies, but we handle them with cc-wrapper
+  prependToVar makeFlags "CRTBEGIN="
+  prependToVar makeFlags "CRTEND="
+  prependToVar makeFlags "LIBCRT0="
+  prependToVar makeFlags "LIBC="
 }
 
 fixOpenBSDInstallDirs() {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rtld/ldso-fix-makefile.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rtld/ldso-fix-makefile.patch
@@ -1,0 +1,57 @@
+diff --git a/libexec/ld.so/Makefile b/libexec/ld.so/Makefile
+index 7f8f6ef2961..469c34bb6de 100644
+--- a/libexec/ld.so/Makefile
++++ b/libexec/ld.so/Makefile
+@@ -1,6 +1,5 @@
+ #	$OpenBSD: Makefile,v 1.88 2024/04/05 13:51:47 deraadt Exp $
+ 
+-SUBDIR=ldconfig ldd
+ MAN=	ld.so.1
+ 
+ .include <bsd.own.mk>
+@@ -70,21 +69,15 @@ ELF_LDFLAGS+=--shared -Bsymbolic --no-undefined
+ 
+ .ifdef	RELATIVE_RELOC
+ CHECK_LDSO=c() {					\
+-	! readelf -Wr $$1 |				\
++	! $(READELF) -Wr $$1 |				\
+ 	  egrep -qv '^($$|[ R])| (${RELATIVE_RELOC}) ';	\
+ 	}; c
+ .endif
+ 
+-test_prog=	test-$(PROG)
+-CLEANFILES+=	test-$(PROG)
+ candidate=	$(PROG).test
+ CLEANFILES+=	${candidate}
+ 
+-$(test_prog):
+-	printf '#include <stdio.h>\n#include <pthread.h>\nint main(int argc, char **argv){ pthread_attr_t attr; printf("%%s: ", argv[0]); pthread_attr_init(&attr); printf("%%s!\\n", argv[1] ? argv[1] : "foo"); }\n' | \
+-	$(CC) -P -x c - -Wl,-dynamic-linker,./$(candidate) -o $@ -lpthread
+-
+-$(PROG): $(test_prog) ${VERSION_SCRIPT} $(OBJS) ${LD_SCRIPT}
++$(PROG): ${VERSION_SCRIPT} $(OBJS) ${LD_SCRIPT}
+ .if defined(SYSPATCH_PATH)
+ 	$(LD) -e _dl_start $(ELF_LDFLAGS) -o $(candidate) \
+             `readelf -Ws ${SYSPATCH_PATH}/usr/libexec/${.TARGET} | \
+@@ -96,9 +89,6 @@ $(PROG): $(test_prog) ${VERSION_SCRIPT} $(OBJS) ${LD_SCRIPT}
+ .endif
+ .ifdef	CHECK_LDSO
+ 	${CHECK_LDSO} $(candidate)
+-.endif
+-.ifndef CROSSDIR
+-	ulimit -c 0; [ "`${.OBJDIR}/$(test_prog) ok`" = "${.OBJDIR}/$(test_prog): ok!" ]
+ .endif
+ 	cp $(candidate) $@
+ .endif
+@@ -113,10 +103,4 @@ CLEANFILES+=	ld.so.a
+ all: ld.so.a
+ 
+ ld.so.a: ${OBJS} ${.CURDIR}/Symbols.map ${test_prog} ${LD_SCRIPT}
+-	ar cqD $@ $?
+-
+-afterinstall: ld.so.a
+-	install -d -o root -g wheel -m 755 \
+-	    ${DESTDIR}/usr/share/relink/usr/libexec
+-	install -o ${BINOWN} -g ${BINGRP} -m ${NONBINMODE} \
+-	    ld.so.a ${DESTDIR}/usr/share/relink/usr/libexec/ld.so.a
++	$(AR) cqD $@ $?

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rtld/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rtld/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "libexec/ld.so";
+  extraPaths = [
+    "lib/libc/string"
+    "lib/csu/os-note-elf.h"
+  ];
+  patches = [
+    ./ldso-fix-makefile.patch
+  ];
+
+  libcMinimal = true;
+
+  NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  # DESTDIR is overridden in bsdSetupHook, just fixup afterwards
+  postInstall = ''
+    mv $out/bin $out/libexec
+  '';
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  meta.platforms = lib.platforms.openbsd;
+}


### PR DESCRIPTION
Nixpkgs OpenBSD cross currently defaults to building dynamically linked binaries,
but there is no dynamic linker, so the resulting binaries are useless.

Build the dynamic linker, `ld.so`, and register it as the dynamic linker in `bintools-wrapper`

I've only tested this build cross, and I do not have a nix copy for OpenBSD.

If you'd like to test, you can build a dynamically linked hello in a tar with
```
tar cvf hello.tar $(nix-store -qR $(nix-build --no-out-link . -A pkgsCross.x86_64-openbsd.hello))
```

then decompress it to the root directory of an OpenBSD installation.

Static executables still work, you can build one with:
```
nix-build . -A pkgsCross.x86_64-openbsd.pkgsStatic.hello
```
then copy it to an OpenBSD system and test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
