### PR TITLE
nqptp: copy systemd service and add capability

### DIFF
--- a/pkgs/tools/networking/nqptp/default.nix
+++ b/pkgs/tools/networking/nqptp/default.nix
@@ -18,8 +18,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # this patch should be removed when > 1.2.4
+    # these patches should be removed when > 1.2.4
     ./remove-setcap.patch
+    ./systemd-service-capability.patch
   ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -27,6 +28,11 @@ stdenv.mkDerivation rec {
   passthru.updateScript = gitUpdater {
     ignoredVersions = ".*(-dev|d0)";
   };
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    cp nqptp.service $out/lib/systemd/system
+  '';
 
   meta = {
     homepage = "https://github.com/mikebrady/nqptp";

--- a/pkgs/tools/networking/nqptp/systemd-service-capability.patch
+++ b/pkgs/tools/networking/nqptp/systemd-service-capability.patch
@@ -1,0 +1,12 @@
+diff --git a/nqptp.service.in b/nqptp.service.in
+index 6f1eb0c..53e6a2e 100644
+--- a/nqptp.service.in
++++ b/nqptp.service.in
+@@ -8,6 +8,7 @@ Before=shairport-sync.service
+ ExecStart=@prefix@/bin/nqptp
+ User=nqptp
+ Group=nqptp
++AmbientCapabilities=CAP_NET_BIND_SERVICE
+ 
+ [Install]
+ WantedBy=multi-user.target


### PR DESCRIPTION
The binary has its capability to listen on ports removed, and upstream has already moved to AmbientCapabilities in the systemd service instead of using setcap. Copying the systemd service allows using the package with `systemd.packages`.

The patch should be removed after version 1.2.4, along with the other patch. The patch is taken from [commit 050a8c2][1] in the upstream repository.

[1]: https://github.com/mikebrady/nqptp/commit/050a8c2de9f3e1f4859abf9b36d2f18afd4c34d7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
