### PR TITLE
python312Packages.openslide: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/openslide/default.nix
+++ b/pkgs/development/python-modules/openslide/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  openslide,
+  pillow,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "openslide";
+  version = "1.3.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "openslide";
+    repo = "openslide-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GokWpRuon8lnxNzxsYGYrQBQDhGPxl8HDaO7fR+2Ldo=";
+  };
+
+  postPatch = ''
+    substituteInPlace openslide/lowlevel.py \
+      --replace-fail "return cdll.LoadLibrary(name)" "return cdll.LoadLibrary(f'${lib.getLib openslide}/lib/{name}')"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pillow ];
+
+  pythonImportsCheck = [ "openslide" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''rm -rf openslide/'';
+
+  meta = {
+    description = "Python bindings to the OpenSlide library for reading whole-slide microscopy images";
+    homepage = "https://github.com/openslide/openslide-python";
+    changelog = "https://github.com/openslide/openslide-python/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9379,6 +9379,8 @@ self: super: with self; {
 
   opensimplex = callPackage ../development/python-modules/opensimplex { };
 
+  openslide = callPackage ../development/python-modules/openslide { inherit (pkgs) openslide; };
+
   openstackdocstheme = callPackage ../development/python-modules/openstackdocstheme { };
 
   openstacksdk = callPackage ../development/python-modules/openstacksdk { };


### PR DESCRIPTION
Init python312Packages.openslide, official/first-party [Python bindings](https://github.com/openslide/openslide-python/tree/main) to the [openslide C library](https://github.com/openslide/openslide) for reading microscopy images.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
