### PR TITLE
Mumps: refactor coin-or-mumps related code while keeping compatible.

### DIFF
--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -52,6 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/casadi/casadi/pull/3792/commits/28bc1b03e67ae06dea0c8557057020f5651be7ad.patch";
       hash = "sha256-t0+RnXoFakmoX93MhN08RWAbCg6Nerh42LicBBgAkRQ=";
     })
+    (fetchpatch {
+      name = "fix-FindMUMPS.cmake.patch";
+      url = "https://github.com/casadi/casadi/pull/3899/commits/274f4b23f73e60c5302bec0479fe1e92682b63d2.patch";
+      hash = "sha256-3GWEWlN8dKLD6htpnOQLChldcT3hE09JWLeuCfAhY+4=";
+    })
   ];
 
   postPatch =
@@ -70,11 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace casadi/interfaces/fatrop/fatrop_conic_interface.hpp --replace-fail \
         "<ocp/" \
         "<fatrop/ocp/"
-
-      # fix mumps lib name. No idea where this comes from.
-      substituteInPlace cmake/FindMUMPS.cmake --replace-fail \
-        "mumps_seq" \
-        "mumps"
 
       # help casadi find its own libs
       substituteInPlace casadi/core/casadi_os.cpp --replace-fail \

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -18,25 +18,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZnIfAuvOBJDYqCtKGlWs0r39nG6X2lAVRuUmeIJenZw=";
   };
 
-  patches = [
-    # Compatibility with coin-or-mumps version
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/coin-or-tools/ThirdParty-Mumps/bd0bdf9baa3f3677bd34fb36ce63b2b32cc6cc7d/mumps_mpi.patch";
-      hash = "sha256-70qZUKBVBpJOSRxYxng5Y6ct1fdCUQUGur3chDhGabQ=";
-    })
-  ];
-
-  postPatch =
-    ''
-      # Compatibility with coin-or-mumps version
-      # https://github.com/coin-or-tools/ThirdParty-Mumps/blob/stable/3.0/get.Mumps#L66
-      cp libseq/mpi.h libseq/mumps_mpi.h
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace src/Makefile --replace-fail \
-        "-Wl,\''$(SONAME),libmumps_common" \
-        "-Wl,-install_name,$out/lib/libmumps_common"
-    '';
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/Makefile --replace-fail \
+      "-Wl,\''$(SONAME),libmumps_common" \
+      "-Wl,-install_name,$out/lib/libmumps_common"
+  '';
 
   configurePhase = ''
     cp Make.inc/Makefile.debian.SEQ ./Makefile.inc
@@ -63,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Add some compatibility with coin-or-mumps
     ln -s $out/include $out/include/mumps
-    cp libseq/mumps_mpi.h $out/include
+    cp libseq/mpi.h $out/include/mumps_mpi.h
   '';
 
   nativeBuildInputs = [ gfortran ];

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -8,6 +8,7 @@
   metis,
   scotch,
   stdenv,
+  fixDarwinDylibNames,
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "mumps";
@@ -54,7 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/include/mumps_seq/mpi.h $out/include/mumps_mpi.h
   '';
 
-  nativeBuildInputs = [ gfortran ];
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ]
+    ++ [
+      gfortran
+    ];
 
   buildInputs = [
     blas
@@ -62,55 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     metis
     scotch
   ];
-
-  preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install_name_tool \
-      -change    libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib \
-      -change    libpord.dylib \
-        $out/lib/libpord.dylib \
-        $out/lib/libmumps_common.dylib
-    install_name_tool \
-      -change    libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib \
-      -change    libpord.dylib \
-        $out/lib/libpord.dylib \
-      -id \
-        $out/lib/libcmumps.dylib \
-        $out/lib/libcmumps.dylib
-    install_name_tool \
-      -change    libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib \
-      -change    libpord.dylib \
-        $out/lib/libpord.dylib \
-      -id \
-        $out/lib/libdmumps.dylib \
-        $out/lib/libdmumps.dylib
-    install_name_tool \
-      -change    libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib \
-      -change    libpord.dylib \
-        $out/lib/libpord.dylib \
-      -id \
-        $out/lib/libsmumps.dylib \
-        $out/lib/libsmumps.dylib
-    install_name_tool \
-      -change    libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib \
-      -change    libpord.dylib \
-        $out/lib/libpord.dylib \
-      -id \
-        $out/lib/libzmumps.dylib \
-        $out/lib/libzmumps.dylib
-    install_name_tool \
-      -id \
-        $out/lib/libmpiseq.dylib \
-        $out/lib/libmpiseq.dylib
-    install_name_tool \
-      -id \
-        $out/lib/libpord.dylib \
-        $out/lib/libpord.dylib
-  '';
 
   doInstallCheck = true;
   installCheckPhase =

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp Make.inc/Makefile.debian.SEQ ./Makefile.inc
   '';
 
+  enableParallelBuilding = true;
+
   makeFlags =
     lib.optionals stdenv.hostPlatform.isDarwin [
       "SONAME="

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm 444 -t $out/include/mumps_seq libseq/*.h
 
     # Add some compatibility with coin-or-mumps
-    ln -s $out/include $out/include/mumps
     ln -s $out/include/mumps_seq/mpi.h $out/include/mumps_mpi.h
   '';
 

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -112,6 +112,27 @@ stdenv.mkDerivation (finalAttrs: {
         $out/lib/libpord.dylib
   '';
 
+  doInstallCheck = true;
+  installCheckPhase =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export DYLD_LIBRARY_PATH=$out/lib
+    ''
+    + ''
+      cd examples
+      make all
+      ./ssimpletest <input_simpletest_real
+      ./dsimpletest <input_simpletest_real
+      ./csimpletest <input_simpletest_cmplx
+      ./zsimpletest <input_simpletest_cmplx
+      ./c_example
+      ./multiple_arithmetics_example
+      ./ssimpletest_save_restore <input_simpletest_real
+      ./dsimpletest_save_restore <input_simpletest_real
+      ./csimpletest_save_restore <input_simpletest_cmplx
+      ./zsimpletest_save_restore <input_simpletest_cmplx
+      ./c_example_save_restore
+    '';
+
   meta = {
     description = "MUltifrontal Massively Parallel sparse direct Solver";
     homepage = "http://mumps-solver.org/";

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -47,9 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out
     cp -r include lib $out
 
+    # Install mumps_seq headers
+    install -Dm 444 -t $out/include/mumps_seq libseq/*.h
+
     # Add some compatibility with coin-or-mumps
     ln -s $out/include $out/include/mumps
-    cp libseq/mpi.h $out/include/mumps_mpi.h
+    ln -s $out/include/mumps_seq/mpi.h $out/include/mumps_mpi.h
   '';
 
   nativeBuildInputs = [ gfortran ];


### PR DESCRIPTION
## Motivation
nixpkgs#mumps is mainly used by ipopt and casadi, which use a coin-or-mumps compatible varient.
However those coin-or-mumps related code makes nixpkgs#mumps hard to maintain and contribute by other users.
This pr keep nixpkgs#mumps in parrallel with mumps-seq in Debian while keeping the minimal coinmumps compatible file
"mumps_mpi.h". Fix to upstream casadi should work with the new nixpkgs#mumps.

@nim65s
@abbradar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
