### PR TITLE
openslide: 3.4.1 -> 4.0.0

### DIFF
--- a/pkgs/development/libraries/openslide/default.nix
+++ b/pkgs/development/libraries/openslide/default.nix
@@ -1,6 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook
-, pkg-config, cairo, glib, gdk-pixbuf, libjpeg
-, libpng, libtiff, libxml2, openjpeg, sqlite, zlib
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  cairo,
+  glib,
+  gdk-pixbuf,
+  libjpeg,
+  libpng,
+  libtiff,
+  libxml2,
+  openjpeg,
+  sqlite,
+  zlib,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,9 +27,23 @@ stdenv.mkDerivation rec {
     sha256 = "1g4hhjr4cbx754cwi9wl84k33bkg232w8ajic7aqhzm8x182hszp";
   };
 
-  buildInputs = [ cairo glib gdk-pixbuf libjpeg libpng libtiff libxml2 openjpeg sqlite zlib ];
+  buildInputs = [
+    cairo
+    glib
+    gdk-pixbuf
+    libjpeg
+    libpng
+    libtiff
+    libxml2
+    openjpeg
+    sqlite
+    zlib
+  ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   meta = with lib; {
     homepage = "https://openslide.org";

--- a/pkgs/development/libraries/openslide/default.nix
+++ b/pkgs/development/libraries/openslide/default.nix
@@ -2,11 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoreconfHook,
+  meson,
+  ninja,
   pkg-config,
   cairo,
+  doxygen,
   glib,
   gdk-pixbuf,
+  libdicom,
   libjpeg,
   libpng,
   libtiff,
@@ -14,23 +17,32 @@
   openjpeg,
   sqlite,
   zlib,
+  zstd,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openslide";
-  version = "3.4.1";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "openslide";
     repo = "openslide";
-    rev = "v${version}";
-    sha256 = "1g4hhjr4cbx754cwi9wl84k33bkg232w8ajic7aqhzm8x182hszp";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-9LvQ7FG/0E0WpFyIUyrL4Fvn60iYWejjbgdKHMVOFdI=";
   };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    doxygen
+  ];
 
   buildInputs = [
     cairo
     glib
     gdk-pixbuf
+    libdicom
     libjpeg
     libpng
     libtiff
@@ -38,18 +50,16 @@ stdenv.mkDerivation rec {
     openjpeg
     sqlite
     zlib
-  ];
-
-  nativeBuildInputs = [
-    autoreconfHook
-    pkg-config
+    zstd
   ];
 
   meta = with lib; {
     homepage = "https://openslide.org";
     description = "C library that provides a simple interface to read whole-slide images";
     license = licenses.lgpl21;
+    changelog = "https://github.com/openslide/openslide/releases/tag/v${finalAttrs.version}";
     platforms = platforms.unix;
     maintainers = with maintainers; [ lromor ];
+    mainProgram = "slidetool";
   };
-}
+})


### PR DESCRIPTION
Routine update (changes build system to meson+ninja from autotools); minor refactor.

[changelog](https://github.com/openslide/openslide/releases/tag/v4.0.0)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
