### PR TITLE
libpsl-with-scripts: init as override of libpsl

### DIFF
--- a/pkgs/by-name/li/libpsl-with-scripts/package.nix
+++ b/pkgs/by-name/li/libpsl-with-scripts/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  libpsl,
+  python3,
+  lzip,
+}:
+
+stdenv.mkDerivation {
+  pname = "libpsl-with-scripts";
+  inherit (libpsl) src version patches;
+  outputs = libpsl.outputs ++ [ "bin" ];
+
+  nativeBuildInputs = [
+    lzip
+  ];
+
+  buildInputs = [
+    python3
+  ];
+
+  postPatch = ''
+    patchShebangs src/psl-make-dafsa
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase =
+    let
+      linkOutput = oldOutput: newOutput: ''
+        cd ${oldOutput}
+        find . -type d -print0 | xargs -0 -I{} mkdir -p ${newOutput}/{}
+        find . \( -type f -o -type l \) -print0 | xargs -0 -I{} ln -s ${oldOutput}/{} ${newOutput}/{}
+        cd -
+      '';
+      links = lib.concatMapStrings (
+        output: linkOutput libpsl.${output} (builtins.placeholder output)
+      ) libpsl.outputs;
+    in
+    ''
+      runHook preInstall
+
+      ${links}
+
+      install -D src/psl-make-dafsa $bin/bin/psl-make-dafsa
+      install -D -m 555 src/psl-make-dafsa.1 $out/share/man/man1/psl-make-dafsa.1
+
+      runHook postInstall
+    '';
+
+  dontFixup = true;
+}

--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -12,7 +12,6 @@
   libunistring,
   libxslt,
   pkg-config,
-  python3,
   buildPackages,
   publicsuffix-list,
 }:
@@ -40,9 +39,7 @@ stdenv.mkDerivation rec {
     [
       "out"
       "dev"
-    ]
-    # bin/psl-make-dafsa brings a large runtime closure through python3
-    ++ lib.optional (!stdenv.hostPlatform.isStatic) "bin";
+    ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -58,18 +55,16 @@ stdenv.mkDerivation rec {
     libidn2
     libunistring
     libxslt
-  ] ++ lib.optional (
-    !stdenv.hostPlatform.isStatic
-    && !stdenv.hostPlatform.isWindows
-    && (stdenv.hostPlatform.isDarwin -> stdenv.buildPlatform == stdenv.hostPlatform)
-   ) python3;
+  ];
 
   propagatedBuildInputs = [
     publicsuffix-list
   ];
 
-  postPatch = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-    patchShebangs src/psl-make-dafsa
+  # bin/psl-make-dafsa brings a large runtime closure through python3
+  # use the libpsl-with-scripts package if you need this
+  postInstall = ''
+    rm $out/bin/psl-make-dafsa $out/share/man/man1/psl-make-dafsa*
   '';
 
   preAutoreconf = ''


### PR DESCRIPTION
psl-make-dafsa pulls in a runtime python3 dependency which seems to have given various build configurations no end of trouble. This solves the problem in the least subtle manner imaginable, by removing it for all platforms and re-adding it in a new package which currently has no dependencies. Switch your dependency from libpsl to libpsl-with-scripts if you are impacted by this.

ref https://github.com/NixOS/nixpkgs/pull/347007 https://github.com/NixOS/nixpkgs/pull/344211 https://github.com/NixOS/nixpkgs/pull/344209 https://github.com/NixOS/nixpkgs/pull/344157 https://github.com/NixOS/nixpkgs/pull/335458

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross from linux)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
