### PR TITLE
libvisual: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/by-name/li/libvisual/package.nix
+++ b/pkgs/by-name/li/libvisual/package.nix
@@ -1,51 +1,35 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , fetchpatch
 , SDL
 , autoreconfHook
+, autoconf-archive
 , glib
 , pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "libvisual";
-  version = "0.4.1";
+  version = "0.4.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libvisual/${pname}-${version}.tar.gz";
-    hash = "sha256-qhKHdBf3bTZC2fTHIzAjgNgzF1Y51jpVZB0Bkopd230=";
+  src = fetchFromGitHub {
+    owner = "Libvisual";
+    repo = "libvisual";
+    rev = "libvisual-${version}";
+    hash = "sha256-bDnpQODXB2Z6hezVoh7c6cklp6qpyDzVBAnwZD8Gros=";
   };
+
+  sourceRoot = "${src.name}/libvisual";
 
   outputs = [ "out" "dev" ];
 
-  patches = [
-    # pull upstream fix for SDL1 cross-compilation.
-    #   https://github.com/Libvisual/libvisual/pull/238
-    (fetchpatch {
-      name = "sdl-cross-prereq.patch";
-      url = "https://github.com/Libvisual/libvisual/commit/7902d24aa1a552619a5738339b3823e90dd3b865.patch";
-      hash = "sha256-84u8klHDAw/q4d+9L4ROAr7XsbXItHrhaEKkTEMSPcc=";
-      # remove extra libvisual prefix
-      stripLen = 1;
-      # pull in only useful configure.ac changes.
-      excludes = [ "Makefile.am" ];
-    })
-    (fetchpatch {
-      name = "sdl-cross-pc.patch";
-      url = "https://github.com/Libvisual/libvisual/commit/f79a2e8d21ad1d7fe26e2aa83cea4c9f48f9e392.patch";
-      hash = "sha256-8c7SdLxXC8K9BAwj7DzozsZAcbs5l1xuBqky9LJ1MfM=";
-      # remove extra libvisual prefix
-      stripLen = 1;
-    })
-  ];
-
   strictDeps = true;
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [ autoreconfHook autoconf-archive pkg-config ];
   buildInputs = [ SDL glib ];
 
   configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # Remove once "sdl-cross-prereq.patch" patch above is removed.
+    # Remove when 0.5.x is published.
     "--disable-lv-tool"
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"


### PR DESCRIPTION
This change swaps libvisual to a different upstream in order to update its version.

The upstream is the exact same one that the prior patches came from.

I have had to fix the comment to remove a flag when the patch is removed (now that the patch is baked into the repo checkout), but I have amended it to point out that in 0.5 they are changing the entire build system anyway so that patch will no longer be present.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
