### PR TITLE
treewide: fix links to `specifications.freedesktop.org`

### DIFF
--- a/doc/languages-frameworks/gnome.section.md
+++ b/doc/languages-frameworks/gnome.section.md
@@ -64,7 +64,7 @@ To avoid costly file system access when locating icons, GTK, [as well as Qt](htt
 
 ### Packaging icon themes {#ssec-icon-theme-packaging}
 
-Icon themes may inherit from other icon themes. The inheritance is specified using the `Inherits` key in the `index.theme` file distributed with the icon theme. According to the [icon theme specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html), icons not provided by the theme are looked for in its parent icon themes. Therefore the parent themes should be installed as dependencies for a more complete experience regarding the icon sets used.
+Icon themes may inherit from other icon themes. The inheritance is specified using the `Inherits` key in the `index.theme` file distributed with the icon theme. According to the [icon theme specification](https://specifications.freedesktop.org/icon-theme-spec/latest), icons not provided by the theme are looked for in its parent icon themes. Therefore the parent themes should be installed as dependencies for a more complete experience regarding the icon sets used.
 
 The package `hicolor-icon-theme` provides a setup hook which makes symbolic links for the parent themes into the directory `share/icons` of the current theme directory in the nix store, making sure they can be found at runtime. For that to work the packages providing parent icon themes should be listed as propagated build dependencies, together with `hicolor-icon-theme`.
 

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -10,7 +10,7 @@
       default = true;
       description = ''
         Whether to install files to support the
-        [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html).
+        [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest).
       '';
     };
   };

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -10,7 +10,7 @@
       default = true;
       description = ''
         Whether to install files to support the
-        [XDG Icon Theme specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html).
+        [XDG Icon Theme specification](https://specifications.freedesktop.org/icon-theme-spec/latest).
       '';
     };
     xdg.icons.fallbackCursorThemes = lib.mkOption {

--- a/nixos/modules/config/xdg/menus.nix
+++ b/nixos/modules/config/xdg/menus.nix
@@ -10,7 +10,7 @@
       default = true;
       description = ''
         Whether to install files to support the
-        [XDG Desktop Menu specification](https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html).
+        [XDG Desktop Menu specification](https://specifications.freedesktop.org/menu-spec/latest).
       '';
     };
   };

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -17,8 +17,8 @@ in
       default = true;
       description = ''
         Whether to install files to support the
-        [XDG Shared MIME-info specification](https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html) and the
-        [XDG MIME Applications specification](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html).
+        [XDG Shared MIME-info specification](https://specifications.freedesktop.org/shared-mime-info-spec/latest) and the
+        [XDG MIME Applications specification](https://specifications.freedesktop.org/mime-apps-spec/latest).
       '';
     };
 
@@ -32,7 +32,7 @@ in
       description = ''
         Adds associations between mimetypes and applications. See the
         [
-        specifications](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html#associations) for more information.
+        specifications](https://specifications.freedesktop.org/mime-apps-spec/latest/associations) for more information.
       '';
     };
 
@@ -46,7 +46,7 @@ in
       description = ''
         Sets the default applications for given mimetypes. See the
         [
-        specifications](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html#default) for more information.
+        specifications](https://specifications.freedesktop.org/mime-apps-spec/latest/default) for more information.
       '';
     };
 
@@ -60,7 +60,7 @@ in
       description = ''
         Removes associations between mimetypes and applications. See the
         [
-        specifications](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html#associations) for more information.
+        specifications](https://specifications.freedesktop.org/mime-apps-spec/latest/associations) for more information.
       '';
     };
   };

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -97,7 +97,7 @@ let
     # Following XDG spec [1], XDG_DATA_DIRS should default to "/usr/local/share:/usr/share".
     # In nix, it is commonly set without containing these values, so we add them as fallback.
     #
-    # [1] <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+    # [1] <https://specifications.freedesktop.org/basedir-spec/latest>
     case ":$XDG_DATA_DIRS:" in
       *:/usr/local/share:*) ;;
       *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/local/share" ;;

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -67,7 +67,7 @@ let
     # Following XDG spec [1], XDG_DATA_DIRS should default to "/usr/local/share:/usr/share".
     # In nix, it is commonly set without containing these values, so we add them as fallback.
     #
-    # [1] <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+    # [1] <https://specifications.freedesktop.org/basedir-spec/latest>
     case ":$XDG_DATA_DIRS:" in
       *:/usr/local/share:*) ;;
       *) export XDG_DATA_DIRS="$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/usr/local/share" ;;

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -3,7 +3,7 @@
 # All possible values as defined by the spec, version 1.4.
 # Please keep in spec order for easier maintenance.
 # When adding a new value, don't forget to update the Version field below!
-# See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+# See https://specifications.freedesktop.org/desktop-entry-spec/latest
 lib.makeOverridable ({ name # The name of the desktop file
 , type ? "Application"
 # version is hardcoded

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -37,7 +37,7 @@ convertIconTheme() {
     local -ra scales=([1]="" [2]="@2")
 
     # Based loosely on the algorithm at:
-    # https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup
+    # https://specifications.freedesktop.org/icon-theme-spec/latest/icon_lookup
     # Assumes threshold = 2 for ease of implementation.
     function findIcon() {
         local -r iconSize=$1

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -37,7 +37,7 @@ convertIconTheme() {
     local -ra scales=([1]="" [2]="@2")
 
     # Based loosely on the algorithm at:
-    # https://specifications.freedesktop.org/icon-theme-spec/latest/icon_lookup
+    # https://specifications.freedesktop.org/icon-theme-spec/latest/#icon_lookup
     # Assumes threshold = 2 for ease of implementation.
     function findIcon() {
         local -r iconSize=$1

--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -26,7 +26,7 @@
 
 let
   # Finds data files using the XDG Base Directory Specification
-  # See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+  # See https://specifications.freedesktop.org/basedir-spec/latest
   find-xdg-data-files = writeScriptBin "find-xdg-data-files" ''
     #!${bash}/bin/sh
     IFS=:


### PR DESCRIPTION
Links to `specifications.freedesktop.org` docs are broken.
This PR fixes them all.