### PR TITLE
etcd.nix: minor fixes

### DIFF
--- a/nixos/tests/etcd/etcd.nix
+++ b/nixos/tests/etcd/etcd.nix
@@ -1,15 +1,22 @@
 # This test runs simple etcd node
-
 import ../make-test-python.nix ({ pkgs, ... } : {
   name = "etcd";
-
   meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 
   nodes = {
     node = { ... }: {
-      services.etcd.enable = true;
+      services.etcd = {
+        enable = true;
+        # Ensure etcd is ready to accept connections
+        extraConf = {
+          "initial-advertise-peer-urls" = "http://localhost:2380";
+          "listen-peer-urls" = "http://localhost:2380";
+          "listen-client-urls" = "http://localhost:2379";
+          "advertise-client-urls" = "http://localhost:2379";
+        };
+      };
     };
   };
 
@@ -17,9 +24,11 @@ import ../make-test-python.nix ({ pkgs, ... } : {
     with subtest("should start etcd node"):
         node.start()
         node.wait_for_unit("etcd.service")
+        # Add additional wait for actual readiness
+        node.wait_until_succeeds("etcdctl endpoint health")
 
     with subtest("should write and read some values to etcd"):
-        node.succeed("etcdctl put /foo/bar 'Hello world'")
-        node.succeed("etcdctl get /foo/bar | grep 'Hello world'")
+        node.succeed("etcdctl --endpoints=http://localhost:2379 put /foo/bar 'Hello world'")
+        node.succeed("etcdctl --endpoints=http://localhost:2379 get /foo/bar | grep 'Hello world'")
   '';
 })


### PR DESCRIPTION
- Adds explicit network configuration for etcd service 
- Waits for etcd to be fully healthy before running tests 
- Makes endpoint configuration explicit in etcdctl commands

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
