### PR TITLE
noriskclient-launcher: init at 0.5.16

### DIFF
--- a/pkgs/by-name/no/noriskclient-launcher/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+
+  fetchNpmDeps,
+  npmHooks,
+  nodejs,
+
+  rustPlatform,
+  cargo-tauri_1,
+
+  pkg-config,
+  wrapGAppsHook3,
+
+  openssl,
+  libsoup_2_4,
+  webkitgtk_4_0,
+  glib-networking,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "noriskclient-launcher";
+  version = "0.5.16";
+
+  src = fetchFromGitHub {
+    owner = "NoRiskClient";
+    repo = "noriskclient-launcher";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-nM8yO7UYpSN8iC8DWbpUmrQHTERiqve2AwUt0w/bOTk=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    name = "${pname}-${version}-npm-deps";
+    inherit src;
+    forceGitDeps = true;
+    hash = "sha256-tk/pZlub+rRDgEB51FA+MmXl6ihoFqBXGc8GaLP8Hu4=";
+  };
+
+  forceGitDeps = true;
+
+  makeCacheWritable = true;
+
+  cargoRoot = "src-tauri";
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rm0s4GD+aSI9ilfY+8yrR1uuiNC1C9P7BnaEnCCTBQQ=";
+
+  buildAndTestSubdir = cargoRoot;
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+
+    cargo-tauri_1.hook
+
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    openssl
+    libsoup_2_4
+    webkitgtk_4_0
+    glib-networking
+  ];
+
+  meta = {
+    description = "Minecraft client application made using svelte + tauri";
+    homepage = "https://norisk.gg";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ genga898 ];
+    mainProgram = "no-risk-client";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes https://github.com/NixOS/nixpkgs/issues/348132

A minecraft client built using tauri [Noriskclient-launcher](https://norisk.gg/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
