### PR TITLE
ocamlPackages.otr: 0.3.10 → 1.0.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -51,5 +51,6 @@ buildDunePackage rec {
     mainProgram = "jackline";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sternenseemann ];
+    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -1,19 +1,19 @@
 { lib, fetchurl, buildDunePackage
-, cstruct, sexplib0, mirage-crypto, mirage-crypto-pk, astring, base64
+, digestif, sexplib0, mirage-crypto, mirage-crypto-pk, astring, base64
 }:
 
 buildDunePackage rec {
   pname = "otr";
-  version = "0.3.10";
+  version = "1.0.0";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.13";
 
   src = fetchurl {
-    url = "https://github.com/hannesm/ocaml-otr/releases/download/v${version}/otr-v${version}.tbz";
-    hash = "sha256:0dssc7p6s7z53n0mddyipjghzr8ld8bb7alaxqrx9gdpspwab1gq";
+    url = "https://github.com/hannesm/ocaml-otr/releases/download/v${version}/otr-${version}.tbz";
+    hash = "sha256-/CcVqLbdylB+LqpKNETkpvQ8SEAIcEFCO1MZqvdmJWU=";
   };
 
-  propagatedBuildInputs = [ cstruct sexplib0 mirage-crypto mirage-crypto-pk
+  propagatedBuildInputs = [ digestif sexplib0 mirage-crypto mirage-crypto-pk
                             astring base64 ];
 
   doCheck = true;
@@ -23,6 +23,5 @@ buildDunePackage rec {
     description = "Off-the-record messaging protocol, purely in OCaml";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sternenseemann ];
-    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }


### PR DESCRIPTION
Unbreak `otr`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
