### PR TITLE
factorio: 2.0.9 -> 2.0.10

### DIFF
--- a/pkgs/by-name/fa/factorio/versions.json
+++ b/pkgs/by-name/fa/factorio/versions.json
@@ -14,14 +14,14 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.9.tar.xz"
+          "factorio_linux_2.0.10.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.9.tar.xz",
+        "name": "factorio_alpha_x64-2.0.10.tar.xz",
         "needsAuth": true,
-        "sha256": "34c21cd3cbe91b65483786ccb4467b5d4766c748cbbddd2ce3b30d319d163e3b",
+        "sha256": "07508fc5112f95ef5d5afedea66863ea326e039bd872b772b934ed08545c399b",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.9/alpha/linux64",
-        "version": "2.0.9"
+        "url": "https://factorio.com/get-download/2.0.10/alpha/linux64",
+        "version": "2.0.10"
       }
     },
     "demo": {
@@ -62,14 +62,14 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.9.tar.xz"
+          "factorio-space-age_linux_2.0.10.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.9.tar.xz",
+        "name": "factorio_expansion_x64-2.0.10.tar.xz",
         "needsAuth": true,
-        "sha256": "6369d23550a7a721d3de1d34253e8321ee601fa759d1fb5efac9abc28aa7509d",
+        "sha256": "f7d346578c812314be8b72fbf6fd291c53d23ecc2dc6556a8948d26b3b95d71e",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.9/expansion/linux64",
-        "version": "2.0.9"
+        "url": "https://factorio.com/get-download/2.0.10/expansion/linux64",
+        "version": "2.0.10"
       }
     },
     "headless": {
@@ -87,15 +87,15 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.9.tar.xz",
-          "factorio_headless_x64_2.0.9.tar.xz"
+          "factorio-headless_linux_2.0.10.tar.xz",
+          "factorio_headless_x64_2.0.10.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.9.tar.xz",
+        "name": "factorio_headless_x64-2.0.10.tar.xz",
         "needsAuth": false,
-        "sha256": "f499077b3e2c1313452c350f1faf17db31cae2a0fa738f69166e97c3caa3c86d",
+        "sha256": "2d7dd212fa6f715218a5e33bad7d593af8998fa7bf7ce727343159ee1f8c23f4",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.9/headless/linux64",
-        "version": "2.0.9"
+        "url": "https://factorio.com/get-download/2.0.10/headless/linux64",
+        "version": "2.0.10"
       }
     }
   }


### PR DESCRIPTION
### Features

* Galaxy of fame. Offered when the game is finished. (https://www.factorio.com/galaxy)


### Changes

* Non-blocking saving setting is no longer synced over the Steam cloud.


### Minor Features

* Added flying text for more cases of unsuccessful resource mining.


### Bugfixes

* Fixed that blueprint book tooltips did not look correct when in the quickbar. ([116593](https://forums.factorio.com/116593))

* Fixed that movement speed bonus equipment would show garbage values when low on energy. ([116433](https://forums.factorio.com/116433))

* Fixed that some fluid-only recipes would allow quality modules. ([116424](https://forums.factorio.com/116424))

* Fixed that the "kill with artillery" achievement did not work with artillery wagons. ([116517](https://forums.factorio.com/116517))

* Fixed invalid package name in sprite path definition would result in OS error message dialog instead of loading into minimal mode. ([116210](https://forums.factorio.com/116210))

* Fixed that continue host menu option didn't respect the port from the config. ([111288](https://forums.factorio.com/111288))

* From now on, we wont save blueprint-storage to a file when it was not used yet. This might help preventing cloud storage file by a file representing empty blueprint storage. ([113198](https://forums.factorio.com/113198))

* Fixed that the blueprint setup GUI would always confirm to discard changes even if nothing changed when the blueprint had a description. ([116285](https://forums.factorio.com/116285))

* Leaked D3D device and swap chain in attempt to avoid AMD driver crash when closing the game. ([108367](https://forums.factorio.com/108367))

* Fixed LogisticContainerControlBehavior exclusive mode could get out of sync from the ContainerControlBehavior it derives from. ([116669](https://forums.factorio.com/116669))

* Fixed that the debug settings GUI could get stuck behind the normal game logic. ([116413](https://forums.factorio.com/116413))

* Fixed that the elem_tooltip type of "signal" did not work correctly. ([116650](https://forums.factorio.com/116650))

* Instead of aborting when SDL_DXGIGetOutputInfo call fails, the game will try to initialize D3D device using adapter 0. ([109955](https://forums.factorio.com/109955))

* Fixed crashes when using LuaEntity fluid methods when the entity's fluidboxes were not part of a segment. ([116093](https://forums.factorio.com/116093))

* Fixed that LuaEntity::insert_fluid would not work on the output FluidBoxes of a crafting machine.

* Fixed removal of transport belts under cursor which would be normally fast-replaeable while drag traversing underground gap by belt rebuilding. ([113128](https://forums.factorio.com/113128))

* Fixed arithmetic combinator's first constant would not be proposed as parameter. ([116716](https://forums.factorio.com/116716))

* Fixed that on_entity_logistic_slot_changed did not fire for constant combinators. ([116575](https://forums.factorio.com/116575))

* Fixed a crash in the space platform hub GUI when the inventory size changes at the same time as the limit is changed. ([116597](https://forums.factorio.com/116597))

* Fixed turbo underground belts simulation in factoriopedia. ([116695](https://forums.factorio.com/116695))

* Fixed a crash when a segmented unit entity causes the entire segmented unit to die. ([116551](https://forums.factorio.com/116551))

* Fixed a crash when a platform was traveling to the shattered planet using a temporary stop which expired. ([116763](https://forums.factorio.com/116763))

* Fixed fluid conditions not showing fluid amounts. ([116686](https://forums.factorio.com/116686))

* Fixed using a custom surface in PvP was preventing Space Age progression. ([116513](https://forums.factorio.com/116513))

* Fixed a crash when switching preferred audio output device while a variable music track is playing. ([116785](https://forums.factorio.com/116785))

* Fixed train stop GUI being too wide at some smaller resolutions. ([116621](https://forums.factorio.com/116621))

* Fixed driven car being drawn on all surfaces in latency. ([116587](https://forums.factorio.com/116587))

* Fixed dying enemy would not randomize direction of its dying animation.

* Fixed that failed achievement wasn't gettable again without restarting the game. ([116329](https://forums.factorio.com/116329))

* Fixed a crash when defining planet prototypes that don't contain any resources. ([116849](https://forums.factorio.com/116849))

* Fixed logistic section active state was not preserved in a blueprint string. ([116775](https://forums.factorio.com/116775))

* Fixed a crash when showing some modded GUI tables. ([116735](https://forums.factorio.com/116735))

* Fixed an issue where entity flagged as not mineable could be marked for deconstruction using undo.

* Fixed pumpjacks with low yield would show 0 output rate in the tooltip. ([116179](https://forums.factorio.com/116179))

* Fixed Nauvis elevation dropdown missing in map generator GUI, causing incorrect previews from map exchange strings. ([116303](https://forums.factorio.com/116303))

* Fixed that it wasn't possible to parametrise virtual signals and space locations contained in text. ([116292](https://forums.factorio.com/116292))

* Fixed brightness and contrast sliders being reset to 0 when setting the text field to a negative value. ([116613](https://forums.factorio.com/116613))

* Fixed that it wasn't possible to parametrise entities, virtual signals and space locations contained in text. ([116292](https://forums.factorio.com/116292))


## Things done

* Built on platform(s)
  
  * [x]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin

* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  
  * [ ]  `sandbox = relaxed`
  * [ ]  `sandbox = true`

* [ ]  Tested, as applicable:
  
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages

* [ ]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

* [ ]  Tested basic functionality of all binary files (usually in `./result/bin/`)

* [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  
  * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
  * [ ]  (Module updates) Added a release notes entry if the change is significant
  * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module

* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

