### PR TITLE
less: adopt and rewrite (master)

### DIFF
--- a/pkgs/by-name/le/less/package.nix
+++ b/pkgs/by-name/le/less/package.nix
@@ -1,17 +1,22 @@
-{ lib
-, stdenv
-, fetchurl
-, ncurses
-, pcre2
-, withSecure ? false
+{
+  lib,
+  fetchurl,
+  ncurses,
+  pcre2,
+  stdenv,
+  # Boolean options
+  withSecure ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "less";
   version = "668";
 
-  # Only tarballs on the website are valid releases,
-  # other versions, e.g. git tags are considered snapshots.
+  # `less` is provided by the following sources:
+  # - meta.homepage
+  # - GitHub: https://github.com/gwsw/less/
+  # The releases recommended for general consumption are only those from
+  # homepage, and only those not marked as beta.
   src = fetchurl {
     url = "https://www.greenwoodsoftware.com/less/less-${finalAttrs.version}.tar.gz";
     hash = "sha256-KBn1VWTYbVQqu+yv2C/2HoGaPuyWf6o2zT5o8VlqRLg=";
@@ -22,13 +27,18 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   configureFlags = [
-    # Look for 'sysless' in /etc.
-    "--sysconfdir=/etc"
-    "--with-regex=pcre2"
-  ] ++ lib.optional withSecure "--with-secure";
+    "--sysconfdir=/etc" # Look for 'sysless' in /etc
+    (lib.withFeatureAs true "regex" "pcre2")
+    (lib.withFeature withSecure "secure")
+  ];
+
+  strictDeps = true;
 
   meta = {
     homepage = "https://www.greenwoodsoftware.com/less/";
@@ -36,7 +46,11 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://www.greenwoodsoftware.com/less/news.${finalAttrs.version}.html";
     license = lib.licenses.gpl3Plus;
     mainProgram = "less";
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = with lib.maintainers; [
+      AndersonTorres
+      # not active
+      dtzWill
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
- nixfmt-rfc-style
- a better comment about source provenance
- strictDeps
- marking dtzWill as not active

Staging: https://github.com/NixOS/nixpkgs/pull/347958

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
