### PR TITLE
zramSwap: by default disable zSwap and set sysctls

### DIFF
--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -24,10 +24,21 @@ in
         type = lib.types.bool;
         description = ''
           Enable in-memory compressed devices and swap space provided by the zram
-          kernel module.
+          kernel module. This is useful if you prefer to avoid setting up a
+          swap partition or swap file stored on a storage device.
+
           See [
             https://www.kernel.org/doc/Documentation/blockdev/zram.txt
           ](https://www.kernel.org/doc/Documentation/blockdev/zram.txt).
+
+          If you intend to use swap on-disk as well, then instead of using zramSwap,
+          consider enabling
+          [zswap](https://www.kernel.org/doc/html/latest/admin-guide/mm/zswap.html).
+          Zswap applies more suitable heuristics in this case when using disk swap.
+
+          Zswap can be enabled using `boot.kernelParams = [ "zswap.enabled=1" ];`.
+
+          Do keep zswap disabled when using this zramSwap module though.
         '';
       };
 
@@ -92,6 +103,29 @@ in
           as there's no gain from keeping them in RAM.
         '';
       };
+
+      recommendedTuningSettings = lib.mkOption {
+        default = true;
+        type = lib.types.bool;
+        description = ''
+          Applies some sysctls to optimize the virtual memory subsystem
+          for zramSwap.
+
+          - `vm.swappiness = 150` increase swapping aka compression to be
+            able to cache more file page data
+          - `vm.watermark_boost_factor = 0` watermark boosting can cause unpredictable stalls as seen here:
+            https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1861359
+          - `vm.watermark_scale_factor = 125` initiate kswapd much earlier
+            as zram will also apply pressure when requesting memory for
+            compressed swap
+          - `vm.page-cluster = 0` disables page prefetching
+
+          This option when enabled, sets these sysctls when you also
+          enable the zramSwap module.
+
+          When zramSwap is enabled, this defaults to `true`.
+        '';
+      };
     };
 
   };
@@ -125,6 +159,11 @@ in
         })
         devices);
 
+    boot.kernel.sysctl = lib.mkIf cfg.recommendedTuningSettings {
+        "vm.swappiness" = 150;
+        "vm.watermark_boost_factor" = 0;
+        "vm.watermark_scale_factor" = 125;
+        "vm.page-cluster" = 0;
+    };
   };
-
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I am adding two improvements to the zramSwap module. The module can configure a NixOS machine such that it creates a zram block device which is then mounted as swap. This is useful in situations where it makes sense to avoid storing swap onto a physical storage device. The kernel starts to swap anonymous memory pages (like application data) when a lot of memory is either requested by applications and / or when files from physical storage are accessed frequently while application memory is never touched. By creating this setup, anonymous pages can be compressed in memory instead of forcing the kernel to try other memory freeing techniques like compaction and reclaiming. Applications will pretty much always waste memory for example by allocating a variable on the stack when launching and initializing but never touching it again until the program exits. Also most program data is highly compressible.

These changes are taken and / or inspired by the [Archwiki page on Zram](https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram) and the discussions linked in this [Pop_OS! PR](https://github.com/pop-os/default-settings/pull/163).

So here are the main new options I added and enabled by default:

- _Add a kernel parameter that disables zswap_: the idea of zswap is to keep memory pages that are intended to be swapped out to a physical disk and try compressing them in RAM instead. This is non-sense when your swap is also just compressed in RAM.
- _Set sysctls to trigger swapping and hence compression much earlier_: these are tunables and the value you set is an opinion and not absolute. Their defaults however are assuming swap on a physical storage device.
    * `vm.swappiness = 150` getting file data even from a fast SSD is gonna be much slower than decompressing some pages, so let's swap more frequently
    * `vm.watermark_boost_factor = 0` watermark boosting kicks off kswapd when there is memory fragmentation and someone needs a continous area. Even when using a swapfile this seems to maybe [cause longer pauses as seen here](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1861359). But because swapping is gonna lead to more allocations this seems counterproductive. Let reclaim do its thing instead.
    * `vm.watermark_scale_factor = 125` again let's kick off kswapd earlier rather than wait for memory starved situations as swapping to zram will increase pressure more.
    * `vm.page-cluster = 0` prefetching multiple pages from swap seems silly when we are in RAM anyway

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
