### PR TITLE
OpenJDK/OpenJFX updates

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-openjdk-updater/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-openjdk-updater/package.nix
@@ -43,11 +43,17 @@ python3Packages.buildPythonApplication {
       featureVersionPrefix,
     }:
     let
-      # TODO: Tighten up after update scripts are run.
-      src = fetchFromGitHub (lib.importJSON sourceFile);
+      sourceInfo = lib.importJSON sourceFile;
     in
     {
-      inherit src;
+      src = fetchFromGitHub {
+        inherit (sourceInfo)
+          owner
+          repo
+          rev
+          hash
+          ;
+      };
 
       updateScript = {
         command = [
@@ -57,10 +63,10 @@ python3Packages.buildPythonApplication {
           sourceFile
 
           "--owner"
-          src.owner
+          sourceInfo.owner
 
           "--repo"
-          src.repo
+          sourceInfo.repo
 
           "--feature-version-prefix"
           featureVersionPrefix

--- a/pkgs/by-name/op/openjfx/17/deps.json
+++ b/pkgs/by-name/op/openjfx/17/deps.json
@@ -7,8 +7,8 @@
   }
  },
  "https://github.com": {
-  "unicode-org/icu/releases/download/release-71-1/icu4c-71_1-data-bin-l": {
-   "zip": "sha256-pVWIy0BkICsthA5mxhR9SJQHleMNnaEcGl/AaLi5qZM="
+  "unicode-org/icu/releases/download/release-73-1/icu4c-73_1-data-bin-l": {
+   "zip": "sha256-QDgpjuAqDDiRcYXvj/Tr3pyLVSx3f9A+TfbGtLGCXiA="
   }
  },
  "https://repo.maven.apache.org/maven2": {

--- a/pkgs/by-name/op/openjfx/17/source.json
+++ b/pkgs/by-name/op/openjfx/17/source.json
@@ -1,6 +1,6 @@
 {
+  "hash": "sha256-WV8NHlYlt7buGbirLSorLnS2TnyBD17zUquFfwSL3xE=",
   "owner": "openjdk",
   "repo": "jfx17u",
-  "rev": "17.0.11-ga",
-  "sha256": "sha256-9VfXk2EfMebMyVKPohPRP2QXRFf8XemUtfY0JtBCHyw="
+  "rev": "refs/tags/17.0.11+3"
 }

--- a/pkgs/by-name/op/openjfx/21/source.json
+++ b/pkgs/by-name/op/openjfx/21/source.json
@@ -2,5 +2,5 @@
   "hash": "sha256-7z0GIbkQwG9mXY9dssaicqaKpMo3FkNEpyAvkswoQQ4=",
   "owner": "openjdk",
   "repo": "jfx21u",
-  "rev": "21.0.3-ga"
+  "rev": "refs/tags/21.0.3+2"
 }

--- a/pkgs/by-name/op/openjfx/23/source.json
+++ b/pkgs/by-name/op/openjfx/23/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-a/ev91Rq7D3z9O56ZZQCgvvbfj5GBt5Lonow2NH3s/E=",
+  "hash": "sha256-H3BPLo7yKWBiiI8sd3wkLJDN9h6jbWj5119cs2YHLwU=",
   "owner": "openjdk",
   "repo": "jfx23u",
-  "rev": "23-ga"
+  "rev": "refs/tags/23.0.1+4"
 }

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -69,17 +69,8 @@ stdenv.mkDerivation {
 
   inherit (source) src;
 
-  patches =
-    if featureVersion == "23" then
-      [
-        # 8338701: Provide media support for libavcodec version 61
-        # <https://github.com/openjdk/jfx23u/pull/18>
-        (fetchpatch2 {
-          url = "https://github.com/openjdk/jfx23u/commit/aba60fda1c82f00e8e685107592305c403a31287.patch?full_index=1";
-          hash = "sha256-+aRhTwi4VQthAq1SH1jxPl0mTosNMKoTY52jm+jiKso=";
-        })
-      ]
-    else if atLeast21 then
+  patches = lib.optionals (!atLeast23) (
+    if atLeast21 then
       [
         ./21/patches/backport-ffmpeg-7-support-jfx21.patch
       ]
@@ -87,7 +78,8 @@ stdenv.mkDerivation {
       [
         ./17/patches/backport-ffmpeg-6-support-jfx11.patch
         ./17/patches/backport-ffmpeg-7-support-jfx11.patch
-      ];
+      ]
+  );
 
   nativeBuildInputs = [
     gradle_openjfx

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -140,11 +140,6 @@ stdenv.mkDerivation {
            modules/javafx.web/src/main/native/Source/bmalloc/bmalloc/IsoSharedPageInlines.h
 
     ''
-    + lib.optionalString (!atLeast21) ''
-      substituteInPlace modules/javafx.web/src/main/native/Source/JavaScriptCore/offlineasm/parser.rb \
-        --replace-fail "File.exists?" "File.exist?"
-
-    ''
     + ''
       ln -s $config gradle.properties
     '';

--- a/pkgs/development/compilers/openjdk/11/source.json
+++ b/pkgs/development/compilers/openjdk/11/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-H/VmT6NYbbZBba7Js8xk+epVZ2kLfvlwTNgg5SQ4ljA=",
+  "hash": "sha256-HqFm4qESB5T4Y1FLgfHZxURi7l7NkLzx2w8GzmB1jSY=",
   "owner": "openjdk",
   "repo": "jdk11u",
-  "rev": "jdk-11.0.24+8"
+  "rev": "refs/tags/jdk-11.0.25+9"
 }

--- a/pkgs/development/compilers/openjdk/17/patches/fix-library-path-jdk17.patch
+++ b/pkgs/development/compilers/openjdk/17/patches/fix-library-path-jdk17.patch
@@ -1,6 +1,8 @@
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index 7c951cee51..bcc61ff43d 100644
 --- a/src/hotspot/os/linux/os_linux.cpp
 +++ b/src/hotspot/os/linux/os_linux.cpp
-@@ -412,18 +412,8 @@ void os::init_system_properties_values() {
+@@ -416,18 +416,8 @@
    //        1: ...
    //        ...
    //        7: The default directories, normally /lib and /usr/lib.
@@ -18,8 +20,8 @@
 -#define SYS_EXT_DIR     "/usr/java/packages"
  #define EXTENSIONS_DIR  "/lib/ext"
  
-   // Buffer that fits several sprintfs.
-@@ -431,7 +421,7 @@ void os::init_system_properties_values() {
+   // Buffer that fits several snprintfs.
+@@ -435,7 +425,7 @@
    // by the nulls included by the sizeof operator.
    const size_t bufsize =
      MAX2((size_t)MAXPATHLEN,  // For dll_dir & friends.
@@ -28,28 +30,26 @@
    char *buf = NEW_C_HEAP_ARRAY(char, bufsize, mtInternal);
  
    // sysclasspath, java_home, dll_dir
-@@ -478,26 +468,22 @@ void os::init_system_properties_values() {
+@@ -482,24 +472,20 @@
      // should always exist (until the legacy problem cited above is
      // addressed).
      const char *v = ::getenv("LD_LIBRARY_PATH");
 -    const char *v_colon = ":";
 -    if (v == NULL) { v = ""; v_colon = ""; }
+-    // That's +1 for the colon and +1 for the trailing '\0'.
+-    size_t pathsize = strlen(v) + 1 + sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1;
 +    if (v == NULL) { v = ""; }
-     // That's +1 for the colon and +1 for the trailing '\0'.
-     char *ld_library_path = NEW_C_HEAP_ARRAY(char,
--                                             strlen(v) + 1 +
--                                             sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
-+                                             strlen(v) + 1,
-                                              mtInternal);
--    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
-+    sprintf(ld_library_path, "%s", v);
++    size_t pathsize = strlen(v) + 1;
+     char *ld_library_path = NEW_C_HEAP_ARRAY(char, pathsize, mtInternal);
+-    os::snprintf_checked(ld_library_path, pathsize, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
++    os::snprintf_checked(ld_library_path, pathsize, "%s", v);
      Arguments::set_library_path(ld_library_path);
      FREE_C_HEAP_ARRAY(char, ld_library_path);
    }
  
    // Extensions directories.
--  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
-+  sprintf(buf, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
+-  os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
++  os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
    Arguments::set_ext_dirs(buf);
  
    FREE_C_HEAP_ARRAY(char, buf);
@@ -58,3 +58,4 @@
 -#undef SYS_EXT_DIR
  #undef EXTENSIONS_DIR
  }
+ 

--- a/pkgs/development/compilers/openjdk/17/source.json
+++ b/pkgs/development/compilers/openjdk/17/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-9UB1H3gd+b4wWxOMgsdDPgX/IGWNORKk1gMsSjYoZMw=",
+  "hash": "sha256-wHJlCmaE8titkfcWb2WboqemekPBn3JWc4bGyWskmoY=",
   "owner": "openjdk",
   "repo": "jdk17u",
-  "rev": "jdk-17.0.12+7"
+  "rev": "refs/tags/jdk-17.0.13+11"
 }

--- a/pkgs/development/compilers/openjdk/21/source.json
+++ b/pkgs/development/compilers/openjdk/21/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-+xpQtQ1IQ7btVWnENT9XS5A/2VP101/+XR3BMo8BqYI=",
+  "hash": "sha256-H28Hp1SzANkrgnC6xdkiSEcRK6bm8BcT/lbJDEUvRYY=",
   "owner": "openjdk",
   "repo": "jdk21u",
-  "rev": "jdk-21.0.4+7"
+  "rev": "refs/tags/jdk-21.0.5+11"
 }

--- a/pkgs/development/compilers/openjdk/23/source.json
+++ b/pkgs/development/compilers/openjdk/23/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-lcLnWAiskWindOqWmOWiIHiYKXGSJZK4d20k19QZfrE=",
+  "hash": "sha256-Sl0aEtndzlyuwMtcjOeDe2CVls89ONzicP5IXhAU2FA=",
   "owner": "openjdk",
   "repo": "jdk23u",
-  "rev": "jdk-23-ga"
+  "rev": "refs/tags/jdk-23.0.1+11"
 }

--- a/pkgs/development/compilers/openjdk/8/source.json
+++ b/pkgs/development/compilers/openjdk/8/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-uMo1DIkji+FPTbFRwURXybkLE5xv+teSClWP9RfAvfo=",
+  "hash": "sha256-48DyJXD7D28LFa+4ONeMgSddqrCLn6FLwEGWGeP4upM=",
   "owner": "openjdk",
   "repo": "jdk8u",
-  "rev": "jdk8u422-ga"
+  "rev": "refs/tags/jdk8u432-b06"
 }

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -221,15 +221,6 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-Qcm3ZmGCOYLZcskNjj7DYR85R4v07vYvvavrVOYL8vg=";
       })
     ]
-    ++ lib.optionals (featureVersion == "17") [
-      # Backport fixes for musl 1.2.4 which are already applied in jdk21+
-      # Fetching patch from chimera because they already went through the effort of rebasing it onto jdk17
-      (fetchurl {
-        name = "lfs64.patch";
-        url = "https://raw.githubusercontent.com/chimera-linux/cports/4614075d19e9c9636f3f7e476687247f63330a35/contrib/openjdk17/patches/lfs64.patch";
-        hash = "sha256-t2mRbdEiumBAbIAC0zsJNwCn59WYWHsnRtuOSL6bWB4=";
-      })
-    ]
     ++ lib.optionals (!headless && enableGtk) [
       (
         if atLeast17 then

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -99,12 +99,8 @@ let
   atLeast23 = lib.versionAtLeast featureVersion "23";
 
   tagPrefix = if atLeast11 then "jdk-" else "jdk";
-  # TODO: Merge these `lib.removePrefix` calls once update scripts have
-  # been run.
-  version = lib.removePrefix tagPrefix (lib.removePrefix "refs/tags/" source.src.rev);
-  versionSplit =
-    # TODO: Remove `-ga` logic once update scripts have been run.
-    builtins.match (if atLeast11 then "(.+)[-+](.+)" else "(.+)-b?(.+)") version;
+  version = lib.removePrefix "refs/tags/${tagPrefix}" source.src.rev;
+  versionSplit = builtins.match (if atLeast11 then "(.+)+(.+)" else "(.+)-b(.+)") version;
   versionBuild = lib.elemAt versionSplit 1;
 
   # The JRE 8 libraries are in directories that depend on the CPU.


### PR DESCRIPTION
The first round of update script runs. The `openjfx17` commit is *fun*.

I have elected not to do any thorough clean‐up beyond dropping support for the now‐absent `ga` version suffixes, with the 24.11 freeze deadline in a few hours and these derivations so baroque; this is it for the upcoming release cycle, modulo version bumps. I already have plans to rewrite large portions of these packages for 25.05, so it’s not worth spending the churn and risk (albeit slight) to refactor the derivations further, when anyway superficial clean‐ups would just further expose the need for deeper ones.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
