### PR TITLE
just: fix cross-compilation

### DIFF
--- a/pkgs/by-name/ju/just/package.nix
+++ b/pkgs/by-name/ju/just/package.nix
@@ -9,8 +9,11 @@
   libiconv,
   mdbook,
   nix-update-script,
+  # run the compiled `just` to build the completions
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  # run the compiled `just` to build the man pages
   installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  # run the compiled `generate-book` utility to prepare the files for mdbook
   withDocumentation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 

--- a/pkgs/by-name/ju/just/package.nix
+++ b/pkgs/by-name/ju/just/package.nix
@@ -9,16 +9,22 @@
   libiconv,
   mdbook,
   nix-update-script,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  withDocumentation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
   version = "1.38.0";
-  outputs = [
-    "out"
-    "man"
-    "doc"
-  ];
+  outputs =
+    [
+      "out"
+    ]
+    ++ lib.optionals installManPages [
+      "man"
+    ]
+    ++ lib.optionals withDocumentation [ "doc" ];
 
   src = fetchFromGitHub {
     owner = "casey";
@@ -29,10 +35,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-JHLkjMy5b1spJrAqFCCzqgnlYTAKA1Z9Tx4w1WWuiAI=";
 
-  nativeBuildInputs = [
-    installShellFiles
-    mdbook
-  ];
+  nativeBuildInputs =
+    lib.optionals (installShellCompletions || installManPages) [ installShellFiles ]
+    ++ lib.optionals withDocumentation [ mdbook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   preCheck = ''
@@ -61,22 +66,9 @@ rustPlatform.buildRustPackage rec {
     ./fix-just-path-in-tests.patch
   ];
 
-  postBuild = ''
-    cargo run --package generate-book
-
-    mkdir -p completions man
-
-    cargo run -- --man > man/just.1
-
-    for shell in bash fish zsh; do
-        cargo run -- --completions $shell > completions/just.$shell
-    done
-
-    # No linkcheck in sandbox
-    echo 'optional = true' >> book/en/book.toml
-    mdbook build book/en
-    find .
-  '';
+  cargoBuildFlags = [
+    "--package=just"
+  ] ++ (lib.optionals withDocumentation [ "--package=generate-book" ]);
 
   checkFlags = [
     "--skip=backticks::trailing_newlines_are_stripped" # Wants to use python3 as alternate shell
@@ -87,16 +79,26 @@ rustPlatform.buildRustPackage rec {
     "--skip=shebang::run_shebang" # test case very rarely fails with "Text file busy"
   ];
 
-  postInstall = ''
-    mkdir -p $doc/share/doc/$name
-    mv ./book/en/build/html $doc/share/doc/$name
-    installManPage man/just.1
-
-    installShellCompletion --cmd just \
-      --bash completions/just.bash \
-      --fish completions/just.fish \
-      --zsh completions/just.zsh
-  '';
+  postInstall =
+    lib.optionalString withDocumentation ''
+      $out/bin/generate-book
+      rm $out/bin/generate-book
+      # No linkcheck in sandbox
+      echo 'optional = true' >> book/en/book.toml
+      mdbook build book/en
+      mkdir -p $doc/share/doc/$name
+      mv ./book/en/build/html $doc/share/doc/$name
+    ''
+    + lib.optionalString installManPages ''
+      $out/bin/just --man > ./just.1
+      installManPage ./just.1
+    ''
+    + lib.optionalString installShellCompletions ''
+      installShellCompletion --cmd just \
+        --bash <($out/bin/just --completions bash) \
+        --fish <($out/bin/just --completions fish) \
+        --zsh <($out/bin/just --completions zsh)
+    '';
 
   setupHook = ./setup-hook.sh;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #320569.

Get rid of calls to `cargo run` in a, which lead to cargo TARGET and CC
to be out of sync for cross-compilation.

Use emulator to build man pages, shell completions and source for the docs.

With this change I'm able to build `pkgsCross.aarch64-multiplatform.just` as well as `pkgsCross.aarch64-multiplatform.pkgsStatic.just` from `x86_64-linux`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
