### PR TITLE
linuxPackages.tsme-test: init at 6.6.68-unstable-2022-12-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13634,6 +13634,12 @@
     githubId = 7910815;
     name = "Alex McGrath";
   };
+  lyn = {
+    name = "Lyn";
+    matrix = "@lynatic:catgirl.cloud";
+    github = "lynatic1337";
+    githubId = 39234676;
+  };
   lyndeno = {
     name = "Lyndon Sanche";
     email = "lsanche@lyndeno.ca";

--- a/pkgs/os-specific/linux/tsme-test/default.nix
+++ b/pkgs/os-specific/linux/tsme-test/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+}:
+
+stdenv.mkDerivation {
+  pname = "tsme-test";
+  version = "${kernel.version}-unstable-2022-12-07";
+
+  src = fetchFromGitHub {
+    owner = "AMDESE";
+    repo = "mem-encryption-tests";
+    rev = "7abb072ffc50ceb0b4145ae84105ce6c91bd1ff4";
+    hash = "sha256-v0KAGlo6ci0Ij1NAiMUK0vWDHBiFnpQG4Er6ArIKncQ=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 -t $out/lib/modules/${kernel.modDirVersion}/extra tsme-test.ko
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Kernel driver to test the status of AMD TSME (Transparent Secure Memory Encryption)";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ lyn ];
+    platforms = lib.platforms.linux;
+    homepage = "https://github.com/AMDESE/mem-encryption-tests";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -615,6 +615,8 @@ in {
 
     msi-ec = callPackage ../os-specific/linux/msi-ec { };
 
+    tsme-test = callPackage ../os-specific/linux/tsme-test { };
+
   } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
     hid-nintendo = throw "hid-nintendo was added in mainline kernel version 5.16"; # Added 2023-07-30


### PR DESCRIPTION
## Things done
Add https://github.com/AMDESE/mem-encryption-tests to nixpkgs. This adds a kernel module that allows to check whether TSME is enabled and working as intended on supported systems while booted.
Note: Testing this requires an supported AMD CPU and supported BIOS. For testing, please load the kernel module and check whether /sys/kernel/tsme exists.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
