### PR TITLE
vector: stop overriding default features

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -20,28 +20,6 @@
   cmake,
   perl,
   git,
-  # nix has a problem with the `?` in the feature list
-  # enabling kafka will produce a vector with no features at all
-  enableKafka ? false,
-  # TODO investigate adding various "vendor-*"
-  # "disk-buffer" is using leveldb TODO: investigate how useful
-  # it would be, perhaps only for massive scale?
-  features ? (
-    [
-      "api"
-      "api-client"
-      "enrichment-tables"
-      "sinks"
-      "sources"
-      "sources-dnstap"
-      "transforms"
-      "component-validation-runner"
-    ]
-    # the second feature flag is passed to the rdkafka dependency
-    # building on linux fails without this feature flag (both x86_64 and AArch64)
-    ++ lib.optionals enableKafka [ "rdkafka?/gssapi-vendored" ]
-    ++ lib.optional stdenv.hostPlatform.isUnix "unix"
-  ),
   nixosTests,
   nix-update-script,
 }:
@@ -119,9 +97,6 @@ rustPlatform.buildRustPackage {
   CARGO_PROFILE_RELEASE_LTO = "fat";
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
 
-  buildNoDefaultFeatures = true;
-  buildFeatures = features;
-
   # TODO investigate compilation failure for tests
   # there are about 100 tests failing (out of 1100) for version 0.22.0
   doCheck = false;
@@ -158,7 +133,6 @@ rustPlatform.buildRustPackage {
   '';
 
   passthru = {
-    inherit features;
     tests = {
       inherit (nixosTests) vector;
     };


### PR DESCRIPTION
## Things done

This removes the `buildFeatures` / `buildNoDefaultFeatures` overrides from vector.

So far, I think features were overridden to remove unix from the default feature set. However, e.g. `oniguruma` is in the dependency tree and only works on `isUnix` platforms, so the feature was always on anyways.

(Originally, I considered dealing with this by

```diff
diff --git a/pkgs/tools/misc/vector/default.nix b/pkgs/tools/misc/vector/default.nix
index e2282008ce8e..43c7bfa18b85 100644
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -20,12 +20,7 @@
   cmake,
   perl,
   git,
-  # nix has a problem with the `?` in the feature list
-  # enabling kafka will produce a vector with no features at all
-  enableKafka ? false,
-  # TODO investigate adding various "vendor-*"
-  # "disk-buffer" is using leveldb TODO: investigate how useful
-  # it would be, perhaps only for massive scale?
+  # "unix" is in the default feature set which we don't want
   features ? (
     [
       "api"
@@ -36,10 +31,8 @@
       "sources-dnstap"
       "transforms"
       "component-validation-runner"
+      "rdkafka/gssapi-vendored" # vector uses rdkafka?/…, but we know that rdkafka is enabled
     ]
-    # the second feature flag is passed to the rdkafka dependency
-    # building on linux fails without this feature flag (both x86_64 and AArch64)
-    ++ lib.optionals enableKafka [ "rdkafka?/gssapi-vendored" ]
     ++ lib.optional stdenv.hostPlatform.isUnix "unix"
   ),
   nixosTests,
```

or by just setting `features ? [ "default" ]` in the package definition, but I think it's unnecessary. If you do want to mess with the features, you can just override:

```nix
vector.overrideAttrs {
  cargoBuildFeatures = [ … ];
  cargoBuildNoDefaultFeatures = true;
};
```
However, I think leaving the current situation has more cost (e.g. what if upstream changes the default feature set) than it's worth.)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
