### PR TITLE
linuxPackages_latest.prl-tools: 20.1.0-55732 -> 20.1.1-55740

### DIFF
--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -37,13 +37,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prl-tools";
-  version = "20.1.0-55732";
+  version = "20.1.1-55740";
 
   # We download the full distribution to extract prl-tools-lin.iso from
   # => ${dmg}/Parallels\ Desktop.app/Contents/Resources/Tools/prl-tools-lin.iso
   src = fetchurl {
     url = "https://download.parallels.com/desktop/v${lib.versions.major finalAttrs.version}/${finalAttrs.version}/ParallelsDesktop-${finalAttrs.version}.dmg";
-    hash = "sha256-WKYsLcr7m6VAjYZu4BNxaarI7x/a7onlalQpV/Qws0w=";
+    hash = "sha256-3Lo/tAPn3vYvHXV9r8VeMkxKjRPpr8fhADh0vyppC0k=";
   };
 
   hardeningDisable = [ "pic" "format" ];

--- a/pkgs/os-specific/linux/prl-tools/update.sh
+++ b/pkgs/os-specific/linux/prl-tools/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq
+#!nix-shell -i bash -p curl jq libxml2
 
 set -eu -o pipefail
 
@@ -11,13 +11,15 @@ path="$nixpkgs/pkgs/os-specific/linux/prl-tools/default.nix"
 kb_url="https://kb.parallels.com/en/130212"
 content="$(curl -s "$kb_url")"
 
-# Match latest version from Parallels knowledge base
-regex='<meta property="og:description" content="[^"]*Parallels Desktop[\ 0-9]*for Mac ([0-9]+\.[0-9]+\.[0-9+]) \(([0-9]+)\)[^"]*" />'
-if [[ $content =~ $regex ]]; then
+# Parse HTML content and retrieve og:description for header metadata
+description=$(echo "$content" | xmllint --recover --html --xpath 'string(//meta[@property="og:description"]/@content)' - 2>/dev/null)
+regex='[^0-9]+([0-9]+\.[0-9]+\.[0-9]+)[^\(]+\(([0-9]+)\)'
+if [[ $description =~ $regex ]]; then
     version="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
     echo "Found latest version: $version"
 else
     echo "Failed to extract version from $kb_url" >&2
+    echo "Retrived description: $description" >&2
     exit 1
 fi
 


### PR DESCRIPTION
https://kb.parallels.com/en/130212

Updated the update script due to HTML special characters `&nbsp;amp;` being added in their latest webpage. This iteration uses `xmllint` to parse the HTML page instead of regex matching to prevent similar cases in the future.

Package version updated via:

```bash
nix-shell maintainers/scripts/update.nix --argstr package linuxPackages.prl-tools 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
