### PR TITLE
lldb_{14,15,16,17,18,19}: fix x64 darwin

### DIFF
--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -24,6 +24,8 @@
 , patches ? [ ]
 , enableManpages ? false
 , devExtraCmakeFlags ? [ ]
+, apple-sdk_11
+, darwinMinVersionHook
 , ...
 }:
 
@@ -90,33 +92,16 @@ stdenv.mkDerivation (rec {
     # buildInputs cc-wrapper will set up rpath correctly for us.
     (lib.getLib libclang)
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.libobjc
-    darwin.apple_sdk.libs.xpc
-    darwin.apple_sdk.frameworks.Foundation
     darwin.bootstrap_cmds
-    darwin.apple_sdk.frameworks.Carbon
-    darwin.apple_sdk.frameworks.Cocoa
   ]
-  # The older libSystem used on x86_64 macOS is missing the
-  # `<bsm/audit_session.h>` header which `lldb` uses.
-  #
-  # We copy this header over from macOS 10.12 SDK.
-  #
-  # See here for context:
-  # https://github.com/NixOS/nixpkgs/pull/194634#issuecomment-1272129132
-  ++ lib.optional
+  ++ lib.optionals
     (
       stdenv.targetPlatform.isDarwin
         && lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "11.0"
-        && (lib.versionAtLeast release_version "15")
-    )
-    (
-      runCommand "bsm-audit-session-header" { } ''
-        install -Dm444 \
-          "${lib.getDev darwin.apple_sdk.sdk}/include/bsm/audit_session.h" \
-          "$out/include/bsm/audit_session.h"
-      ''
-    );
+    ) [
+    apple-sdk_11
+    (darwinMinVersionHook "10.15")
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
x64 darwin doesn't build with 10.12 sdk after the sdk refactor due to compile errors. bumping the sdk to 11 fixes the build.

missing header error:
https://hydra.nixos.org/build/276149143 -> https://hydra.nixos.org/build/276206742/nixlog/4
that error is easy enough to fix by pointing the build to the header location in `$SDKROOT`

however, once fixed, builds will fail with the error shown below:
https://hydra.nixos.org/build/276126566

using apple-sdk_11 fixes and lldb_14 requires an increase in the min deployment version

note lldb_14 is still broken due to the same error seen in aarch64 below:
https://hydra.nixos.org/build/276197063

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
