### PR TITLE
spotlight-downloader: init at 1.5.0

### DIFF
--- a/pkgs/by-name/sp/spotlight-downloader/package.nix
+++ b/pkgs/by-name/sp/spotlight-downloader/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  msbuild,
+  mono,
+  makeWrapper,
+}:
+
+let
+  pname = "spotlight-downloader";
+  version = "1.5.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "ORelio";
+    repo = "Spotlight-Downloader";
+    tag = "v${version}";
+    hash = "sha256-wGblbLBfH/sjUsz+hcg7OOWFavJ0k4piU/ypBEodvpY=";
+  };
+
+  nativeBuildInputs = [
+    msbuild
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    msbuild /p:Configuration=Release SpotlightDownloader/SpotlightDownloader.csproj
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share
+    cp -r SpotlightDownloader/bin/Release $out/share/SpotlightDownloader
+    makeWrapper ${lib.getExe mono} $out/bin/SpotlightDownloader \
+      --add-flags "$out/share/SpotlightDownloader/SpotlightDownloader.exe"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Retrieve Windows Spotlight images from the Microsoft Spotlight API";
+    license = lib.licenses.cddl;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    homepage = "https://github.com/ORelio/Spotlight-Downloader";
+    platforms = lib.platforms.unix;
+    mainProgram = "SpotlightDownloader";
+  };
+}


### PR DESCRIPTION
Adds package spotlight-downloader. [Website.](https://github.com/ORelio/Spotlight-Downloader) Installs command `SpotlightDownloader`.

I didn't use `buildDotnetModule` because I need to use msbuild.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
