### PR TITLE
numbat: 1.13.0 -> 1.14.0

### DIFF
--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   testers,
   fetchFromGitHub,
-  fetchpatch,
   rustPlatform,
   darwin,
   numbat,
@@ -12,24 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "numbat";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "sharkdp";
     repo = "numbat";
     rev = "v${version}";
-    hash = "sha256-o3EYhMFBgs/Ni+YCM3+RdUYlwRt+nMaEP/cAkDXMVHc=";
+    hash = "sha256-TmzM541S2W5Cy8zHEWKRE2Zj2bSgrM4vbsWw3zbi3LQ=";
   };
 
-  cargoHash = "sha256-rK9RPd/hww2F87l/dd14pB4izE58NuqaewYaqMimV1M=";
-
-  patches = [
-    # https://github.com/sharkdp/numbat/pull/562
-    (fetchpatch {
-      url = "https://github.com/sharkdp/numbat/commit/4756a1989ecdab35fd05ca18c721ed15d8cde2b1.patch";
-      hash = "sha256-22+yePjy+MxJQ60EdvgaTw/IVV0d/wS2Iqza1p1xmfk=";
-    })
-  ];
+  cargoHash = "sha256-exvJJsGIj6KhmMcwhPjXMELvisuUtl17BAO6XEJSJmI=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk.frameworks.Security

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, stdenv
-, testers
-, fetchFromGitHub
-, fetchpatch
-, rustPlatform
-, darwin
-, numbat
-, tzdata
+{
+  lib,
+  stdenv,
+  testers,
+  fetchFromGitHub,
+  fetchpatch,
+  rustPlatform,
+  darwin,
+  numbat,
+  tzdata,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -60,9 +61,15 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://numbat.dev";
     changelog = "https://github.com/sharkdp/numbat/releases/tag/v${version}";
-    license = with licenses; [ asl20 mit ];
+    license = with licenses; [
+      asl20
+      mit
+    ];
     mainProgram = "numbat";
-    maintainers = with maintainers; [ giomf atemu ];
+    maintainers = with maintainers; [
+      giomf
+      atemu
+    ];
     # Failing tests on Darwin.
     broken = stdenv.isDarwin;
   };


### PR DESCRIPTION
Updated to: https://github.com/sharkdp/numbat/releases/tag/v1.14.0
Also, removed the patch that is not needed anymore since it is included in v1.14.0 now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
