### PR TITLE
xeus-cling: fix improper linking with LLVM

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
@@ -1,6 +1,9 @@
 { callPackage
 , cling
 , fetchurl
+, jq
+, makeWrapper
+, python3
 , stdenv
 }:
 
@@ -11,48 +14,81 @@
 # nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions = { cpp17 = cpp17-kernel; }; }'
 
 let
-  xeus-cling = callPackage ./xeus-cling.nix {};
+  xeus-cling-unwrapped = callPackage ./xeus-cling.nix {};
 
-  mkDefinition = std:
-    let
-      versionSuffix =
-        if std == "c++11" then " 11"
-        else if std == "c++14" then " 14"
-        else if std == "c++17" then " 17"
-        else if std == "c++17" then " 17"
-        else if std == "c++2a" then " 2a"
-        else throw "Unexpected C++ std for cling: ${std}";
-    in
+  xeus-cling = xeus-cling-unwrapped.overrideAttrs (oldAttrs: {
+    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [makeWrapper];
+
+    # xcpp needs a collection of flags to start up properly, so wrap it by default.
+    # We'll provide the unwrapped version as a passthru
+    flags = cling.flags ++ [
+      "-resource-dir" "${cling.unwrapped}"
+      "-L" "${cling.unwrapped}/lib"
+      "-l" "${cling.unwrapped}/lib/cling.so"
+    ];
+
+    fixupPhase = ''
+      runHook preFixup
+
+      wrapProgram $out/bin/xcpp --add-flags "$flags"
+
+      runHook postFixup
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preCheck
+
+      # Smoke check: run a test notebook using Papermill by creating a simple kernelspec
+      mkdir -p kernels/cpp17
+      export JUPYTER_PATH="$(pwd)"
+      cat << EOF > kernels/cpp17/kernel.json
       {
-        displayName = "C++" + versionSuffix;
-        argv = [
-          "${xeus-cling}/bin/xcpp"
-        ]
-        ++ cling.flags
-        ++ [
-          "-resource-dir" "${cling.unwrapped}"
-          "-L" "${cling.unwrapped}/lib"
-          "-l" "${cling.unwrapped}/lib/cling.so"
-          "-std=${std}"
-          # "-v"
-          "-f" "{connection_file}"
-        ];
-        language = "cpp";
-        logo32 = fetchurl {
-          url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/32px-ISO_C%2B%2B_Logo.svg.png";
-          hash = "sha256-cr0TB8/j2mkcFhfCkz9F7ZANOuTlWA2OcWtDcXyOjHw=";
-        };
-        logo64 = fetchurl {
-          url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/64px-ISO_C%2B%2B_Logo.svg.png";
-          hash = "sha256-nZtJ4bR7GmQttvqEJC9KejOxphrjjxT36L9yOIITFLk=";
-        };
-      };
+        "argv": ["$out/bin/xcpp", "-std=c++17", "-f", "{connection_file}"],
+        "language": "cpp17"
+      }
+      EOF
+
+      ${python3.pkgs.papermill}/bin/papermill ${./test.ipynb} out.ipynb
+      result="$(cat out.ipynb | ${jq}/bin/jq -r '.cells[0].outputs[0].text[0]')"
+      if [[ "$result" != "Hello world." ]]; then
+        echo "Kernel test gave '$result'. Expected: 'Hello world.'"
+        exit 1
+      fi
+
+      runHook postCheck
+    '';
+
+    passthru = (oldAttrs.passthru or {}) // {
+      unwrapped = xeus-cling-unwrapped;
+    };
+  });
+
+  mkKernelSpec = std: {
+    displayName = builtins.replaceStrings ["c++"] ["C++ "] std;
+    argv = [
+      "${xeus-cling}/bin/xcpp"
+      "-std=${std}"
+      "-f" "{connection_file}"
+    ];
+    language = "cpp";
+    logo32 = fetchurl {
+      url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/32px-ISO_C%2B%2B_Logo.svg.png";
+      hash = "sha256-+TKtwXybKw4oAHfgOsDxvL4ucItPguF76HJHdFTd3s0=";
+    };
+    logo64 = fetchurl {
+      url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/64px-ISO_C%2B%2B_Logo.svg.png";
+      hash = "sha256-7SjOcSaSPUHIKnjBxMdn+KSjviL69IXhX7eJsacYeGE=";
+    };
+  };
 
 in
 
 {
-  cpp11-kernel = mkDefinition "c++11";
-  cpp14-kernel = mkDefinition "c++14";
-  cpp17-kernel = mkDefinition "c++17";
-  cpp2a-kernel = mkDefinition "c++2a";
+  cpp11-kernel = mkKernelSpec "c++11";
+  cpp14-kernel = mkKernelSpec "c++14";
+  cpp17-kernel = mkKernelSpec "c++17";
+  cpp2a-kernel = mkKernelSpec "c++2a";
+
+  inherit xeus-cling;
 }

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/test.ipynb
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/test.ipynb
@@ -1,0 +1,24 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "574ed398-7bfe-4a34-a7dd-9fa85535aed2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <iostream>\n",
+    "std::cout << \"Hello world.\";"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "C++ 17",
+   "language": "cpp",
+   "name": "cpp17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pkgs/by-name/cl/cling/package.nix
+++ b/pkgs/by-name/cl/cling/package.nix
@@ -42,6 +42,8 @@ let
     sparseCheckout = ["clang"];
   };
 
+  llvm = llvmPackages_13.llvm.override { enableSharedLibraries = false; };
+
   unwrapped = stdenv.mkDerivation rec {
     pname = "cling-unwrapped";
     version = "1.0";
@@ -72,12 +74,12 @@ let
     strictDeps = true;
 
     cmakeFlags = [
-      "-DLLVM_BINARY_DIR=${llvmPackages_13.llvm.out}"
-      "-DLLVM_CONFIG=${llvmPackages_13.llvm.dev}/bin/llvm-config"
-      "-DLLVM_LIBRARY_DIR=${llvmPackages_13.llvm.lib}/lib"
-      "-DLLVM_MAIN_INCLUDE_DIR=${llvmPackages_13.llvm.dev}/include"
-      "-DLLVM_TABLEGEN_EXE=${llvmPackages_13.llvm.out}/bin/llvm-tblgen"
-      "-DLLVM_TOOLS_BINARY_DIR=${llvmPackages_13.llvm.out}/bin"
+      "-DLLVM_BINARY_DIR=${llvm.out}"
+      "-DLLVM_CONFIG=${llvm.dev}/bin/llvm-config"
+      "-DLLVM_LIBRARY_DIR=${llvm.lib}/lib"
+      "-DLLVM_MAIN_INCLUDE_DIR=${llvm.dev}/include"
+      "-DLLVM_TABLEGEN_EXE=${llvm.out}/bin/llvm-tblgen"
+      "-DLLVM_TOOLS_BINARY_DIR=${llvm.out}/bin"
       "-DLLVM_BUILD_TOOLS=Off"
       "-DLLVM_TOOL_CLING_BUILD=ON"
 
@@ -139,7 +141,7 @@ let
     "-nostdinc"
     "-nostdinc++"
 
-    "-resource-dir" "${llvmPackages_13.llvm.lib}/lib"
+    "-resource-dir" "${llvm.lib}/lib"
 
     "-isystem" "${lib.getLib unwrapped}/lib/clang/${llvmPackages_13.clang.version}/include"
   ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7247,8 +7247,7 @@ with pkgs;
   };
 
   inherit (callPackage ../applications/editors/jupyter-kernels/xeus-cling { })
-    cpp11-kernel cpp14-kernel cpp17-kernel cpp2a-kernel;
-  xeus-cling = callPackage ../applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix { };
+    cpp11-kernel cpp14-kernel cpp17-kernel cpp2a-kernel xeus-cling;
 
   clojure = callPackage ../development/interpreters/clojure {
     # set this to an LTS version of java


### PR DESCRIPTION
This is a fix for #306782. The solution, as recommended by the upstream Cling maintainer, is to turn off the shared library flag for LLVM when building Cling.

The second commit here adds a smoke check for `xeus-cling`, using Papermill to run a test notebook.

I also changed the default `xeus-cling` derivation to include the various library flags it expects, since it's fairly useless without them. You can still get the unwrapped `xeus-cling` version via the passthru `xeus-cling.unwrapped`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
