### PR TITLE
tinysparql: upstream patch to fix a test that is broken on some platforms

### DIFF
--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, fetchpatch2
 , fetchurl
 , gettext
 , meson
@@ -106,13 +107,15 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsystemd_user_services=false"
   ];
 
-  doCheck =
-    # https://gitlab.gnome.org/GNOME/tinysparql/-/issues/402
-    !stdenv.hostPlatform.isDarwin
-    # https://gitlab.gnome.org/GNOME/tinysparql/-/issues/398
-    && !stdenv.hostPlatform.is32bit
-    # https://gitlab.gnome.org/GNOME/tinysparql/-/issues/474
-    && !stdenv.hostPlatform.isMusl;
+  patches = [
+    # https://gitlab.gnome.org/GNOME/tinysparql/-/merge_requests/730
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/tinysparql/commit/12ed969913cb579f638fa0aa0853aeb6c6c6f536.patch";
+      hash = "sha256-jyx9hdWUUxfCSTGn7lZL4RUiQAF4pkf4gfCP8g9Ep3U=";
+    })
+  ];
+
+  doCheck = true;
 
   postPatch = ''
     chmod +x \


### PR DESCRIPTION
Adds the [upstream fix](https://gitlab.gnome.org/GNOME/tinysparql/-/merge_requests/730) of the [upstream issue 474](https://gitlab.gnome.org/GNOME/tinysparql/-/issues/474) as a patch. It also enabled checking unconditionally because the other issues have been fixed upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @emilazy as follow up from https://github.com/NixOS/nixpkgs/pull/343907

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (gnu)
  - [X] x86_64-linux (musl)
  - [X] aarch64-linux (gnu)
  - [X] riscv64-linux (gnu)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
