### PR TITLE
tideways-cli: init at 1.2.2

### DIFF
--- a/pkgs/by-name/ti/tideways-cli/package.nix
+++ b/pkgs/by-name/ti/tideways-cli/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  curl,
+  common-updater-scripts,
+  writeShellApplication,
+  gnugrep,
+  installShellFiles,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-cli";
+  version = "1.2.2";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp tideways $out/bin/tideways
+    chmod +x $out/bin/tideways
+
+    installShellCompletion --cmd tideways \
+      --bash <($out/bin/tideways completion bash) \
+      --zsh <($out/bin/tideways completion zsh) \
+      --fish <($out/bin/tideways completion fish)
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${finalAttrs.version}/tideways-cli_linux_amd64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-g06PE464P/A0PDGG7xMa644ztcIRMAU/ueee2IOhiHc=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${finalAttrs.version}/tideways-cli_linux_arm64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-nbC9vMXA5vHKxEpINDQJTUqh7YOe0T0x5MbbQg03gk4=";
+      };
+      "x86_64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${finalAttrs.version}/tideways-cli_macos_amd64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-RfCTl61r/zfWy/3W+zmrSaAjIWe52POfZnzsmm5loD4=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/cli/${finalAttrs.version}/tideways-cli_macos_arm64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-4N4hUvbf8b9BnKUY4YTsB76Z35DmSTyWv6BC+bqJNCI=";
+      };
+    };
+
+    updateScript = "${
+      writeShellApplication {
+        name = "update-tideways-cli";
+        runtimeInputs = [
+          curl
+          gnugrep
+          common-updater-scripts
+        ];
+        text = ''
+          NEW_VERSION=$(curl --fail -L -s https://tideways.com/profiler/downloads | grep -E 'https://tideways.s3.amazonaws.com/cli/([0-9]+\.[0-9]+\.[0-9]+)/tideways-cli_linux_amd64-\1.tar.gz' | grep -oP 'cli/\K[0-9]+\.[0-9]+\.[0-9]+')
+
+          if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+              echo "The new version same as the old version."
+              exit 0
+          fi
+
+          for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+            update-source-version "tideways-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+          done
+        '';
+      }
+    }/bin/update-tideways-cli";
+  };
+
+  meta = with lib; {
+    description = "Tideways Profiler CLI";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "tideways";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+  };
+})

--- a/pkgs/by-name/ti/tideways-daemon/package.nix
+++ b/pkgs/by-name/ti/tideways-daemon/package.nix
@@ -1,0 +1,75 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  curl,
+  common-updater-scripts,
+  writeShellApplication,
+  gnugrep,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-daemon";
+  version = "1.9.18";
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform for tideways-cli: ${stdenvNoCC.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp tideways-daemon $out/bin/tideways-daemon
+    chmod +x $out/bin/tideways-daemon
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://tideways.s3.amazonaws.com/daemon/${finalAttrs.version}/tideways-daemon_linux_amd64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-CFVHD2CfY1yOP621PzkflvapCrIuqY0rtTgm20xW41E=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://tideways.s3.amazonaws.com/daemon/${finalAttrs.version}/tideways-daemon_linux_aarch64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-59quxF5rClfw8xd8mT2jU1/DVatrZyJw7Rj6pikKXF0=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://tideways.s3.amazonaws.com/daemon/${finalAttrs.version}/tideways-daemon_macos_arm64-${finalAttrs.version}.tar.gz";
+        hash = "sha256-4h7Vn9s8Y63M1BnzwjcxSV8ydRqhNeJnFvG9Cs1Cq8Q=";
+      };
+    };
+    updateScript = "${
+      writeShellApplication {
+        name = "update-tideways-daemon";
+        runtimeInputs = [
+          curl
+          gnugrep
+          common-updater-scripts
+        ];
+        text = ''
+          NEW_VERSION=$(curl --fail -L -s https://tideways.com/profiler/downloads | grep -E 'https://tideways.s3.amazonaws.com/daemon/([0-9]+\.[0-9]+\.[0-9]+)/tideways-daemon_linux_amd64-\1.tar.gz' | grep -oP 'daemon/\K[0-9]+\.[0-9]+\.[0-9]+')
+
+          if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+              echo "The new version same as the old version."
+              exit 0
+          fi
+
+          for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+            update-source-version "tideways-daemon" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+          done
+        '';
+      }
+    }/bin/update-tideways-daemon";
+  };
+
+  meta = with lib; {
+    description = "Tideways Daemon";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "tideways-daemon";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+  };
+})

--- a/pkgs/development/php-packages/tideways/default.nix
+++ b/pkgs/development/php-packages/tideways/default.nix
@@ -1,0 +1,90 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  php,
+  writeShellApplication,
+  curl,
+  gnugrep,
+  common-updater-scripts,
+}:
+
+let
+  soFile =
+    {
+      "8.0" = "tideways-php-8.0.so";
+      "8.1" = "tideways-php-8.1.so";
+      "8.2" = "tideways-php-8.2.so";
+      "8.3" = "tideways-php-8.3.so";
+    }
+    .${lib.versions.majorMinor php.version} or (throw "Unsupported PHP version.");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tideways-php";
+  extensionName = "tideways";
+  version = "5.13.0";
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform for tideways-php: ${stdenvNoCC.hostPlatform.system}");
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.isLinux [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D ${soFile} $out/lib/php/extensions/tideways.so
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${finalAttrs.version}/tideways-php-${finalAttrs.version}-x86_64.tar.gz";
+        hash = "sha256-HiH7EjAOqHIYaIRlp/cemhU+QX9Q66ZX8RpX1qcctZ0=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${finalAttrs.version}/tideways-php-${finalAttrs.version}-arm64.tar.gz";
+        hash = "sha256-kntNr8KMrOBK2ZZT/EMTR7MCuRt3rJAqhpt5B0m5qVM=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${finalAttrs.version}/tideways-php-${finalAttrs.version}-macos-arm.tar.gz";
+        hash = "sha256-zNVBTXKwCRLKmDlEUUUpP7feB/n2fMevEuKZrgdyAkw=";
+      };
+    };
+
+    updateScript = "${
+      writeShellApplication {
+        name = "update-tideways-probe";
+        runtimeInputs = [
+          curl
+          gnugrep
+          common-updater-scripts
+        ];
+        text = ''
+          NEW_VERSION=$(curl --fail -L https://tideways.com/profiler/downloads | grep -E 'https://tideways.s3.amazonaws.com/extension/[0-9]+\.[0-9]+\.[0-9]+/tideways-php-[0-9]+\.[0-9]+\.[0-9]+-x86_64.tar.gz' | grep -oP 'extension/\K[0-9]+\.[0-9]+\.[0-9]+')
+
+          if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+              echo "The new version same as the old version."
+              exit 0
+          fi
+
+          for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+            update-source-version "php82Extensions.tideways" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+          done
+        '';
+      }
+    }/bin/update-tideways-probe";
+  };
+
+  meta = with lib; {
+    description = "Tideways PHP Probe";
+    homepage = "https://tideways.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ shyim ];
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+  };
+})

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -357,6 +357,8 @@ in {
 
     swoole = callPackage ../development/php-packages/swoole { };
 
+    tideways = callPackage ../development/php-packages/tideways { };
+
     uv = callPackage ../development/php-packages/uv { };
 
     vld = callPackage ../development/php-packages/vld { };


### PR DESCRIPTION
Adds Tideways CLI and Daemon for PHP Profiling.

The PR contains also a updateScript to the bot will create PR to update it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
