### PR TITLE
openmolcas: 24.06 -> 24.10, make qcmaquis optional

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/qcmaquis.patch
+++ b/pkgs/applications/science/chemistry/openmolcas/qcmaquis.patch
@@ -22,25 +22,26 @@ index 789739ec8..6c86a7b8c 100644
                      INSTALL_DIR "${PROJECT_BINARY_DIR}/qcmaquis"
                     )
 diff --git a/cmake/custom/qcmaquis.cmake b/cmake/custom/qcmaquis.cmake
-index 176d02761..e160b7bc8 100644
+index 5fd1ef207..8d2957c6e 100644
 --- a/cmake/custom/qcmaquis.cmake
 +++ b/cmake/custom/qcmaquis.cmake
-@@ -78,6 +78,7 @@ list(APPEND QCMaquisCMakeArgs
-   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-   -DCMAKE_CXX_FLAGS=${QCM_CMake_CXX_FLAGS}
-   -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-+  -DCMAKE_SKIP_BUILD_RPATH=ON
-   )
- if(HDF5_ROOT)
-   list(APPEND QCMaquisCMakeArgs
-@@ -278,9 +279,7 @@ set (CMAKE_DISABLE_SOURCE_CHANGES OFF)
+@@ -77,6 +77,7 @@ list (APPEND QCMaquisCMakeArgs
+       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+       -DCMAKE_CXX_FLAGS=${QCM_CMake_CXX_FLAGS}
+       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
++      -DCMAKE_SKIP_BUILD_RPATH=ON
+ )
+ if (HDF5_ROOT)
+   list (APPEND QCMaquisCMakeArgs
+@@ -274,10 +275,7 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
  
-     ExternalProject_Add(${EP_PROJECT}
-         PREFIX ${extprojpath}
--        GIT_REPOSITORY ${reference_git_repo}
--        GIT_TAG ${reference_git_commit}
--        UPDATE_DISCONNECTED ${EP_SkipUpdate}
-+        URL @qcmaquis_src_url@
- 
-         SOURCE_SUBDIR dmrg
-         CMAKE_ARGS ${EP_CMAKE_ARGS}
+   ExternalProject_Add (${EP_PROJECT}
+                        PREFIX ${extprojpath}
+-                       GIT_REPOSITORY ${reference_git_repo}
+-                       GIT_TAG ${reference_git_commit}
+-                       UPDATE_DISCONNECTED ${EP_SkipUpdate}
+-
++                       URL @qcmaquis_src_url@
+                        SOURCE_SUBDIR dmrg
+                        CMAKE_ARGS ${EP_CMAKE_ARGS}
+                        CMAKE_CACHE_ARGS ${EP_CMAKE_CACHE_ARGS}


### PR DESCRIPTION
Update of OpenMolcas to its latest release: https://gitlab.com/Molcas/OpenMolcas/-/releases

This includes an update to the QCMaquis submodule, which now strictly requires MKL. Thus, I've made the QCMaquis support optional and assert MKL as blas provider in that case.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
