### PR TITLE
pianoteq: refactor, bump versions

### DIFF
--- a/pkgs/applications/audio/pianoteq/default.nix
+++ b/pkgs/applications/audio/pianoteq/default.nix
@@ -209,7 +209,7 @@ let
 
   version6 = "6.7.3";
   version7 = "7.5.4";
-  version8 = "8.3.2";
+  version8 = "8.4.0";
 
   mkStandard = version: hash: mkPianoteq {
     name = "standard";
@@ -253,10 +253,10 @@ let
   };
 in
 {
-  standard_8 = mkStandard version8 "sha256-U9i9XgZKed8KxDL1fwGbRs30wj0IQwMjP+GH2JpdrJ0=";
+  standard_8 = mkStandard version8 "sha256-ZDGB/SOOz+sWz7P+sNzyaipEH452n8zq5LleO3ztSXc=";
   stage_8 = mkStage version8 "";
-  standard-trial_8 = mkStandardTrial version8 "sha256-nYhTtPtkmYwVV5N1XIGBNU9YBbeIxLOjw2bA29ObXps=";
-  stage-trial_8 = mkStageTrial version8 "sha256-dkSG1PZgVds4fTir/77TSKhd3pBMJaOcWnLtZHsPqWo=";
+  standard-trial_8 = mkStandardTrial version8 "sha256-K3LbAWxciXt9hVAyRayxSoE/IYJ38Fd03+j0s7ZsMuw=";
+  stage-trial_8 = mkStageTrial version8 "sha256-k0p7SnkEq90bqIlT7PTYAQuhKEDVi+srHwYrpMUtIbM=";
 
   standard_7 = mkStandard version7 "sha256-TA9CiuT21fQedlMUGz7bNNxYun5ArmRjvIxjOGqXDCs=";
   stage_7 = mkStage version7 "";

--- a/pkgs/applications/audio/pianoteq/default.nix
+++ b/pkgs/applications/audio/pianoteq/default.nix
@@ -1,23 +1,26 @@
 { lib
 , stdenv
-, curl
-, jq
-, htmlq
-, xorg
 , alsa-lib
-, freetype
-, p7zip
 , autoPatchelfHook
-, writeShellScript
-, zlib
-, libjack2
-, makeWrapper
 , copyDesktopItems
-, makeDesktopItem
+, curl
+, freetype
+, htmlq
+, jq
+, libglvnd
 , librsvg
+, makeDesktopItem
+, makeWrapper
+, p7zip
+, writeShellScript
 }:
 let
   versionForFile = v: builtins.replaceStrings [ "." ] [ "" ] v;
+
+  archdirs =
+    if stdenv.hostPlatform.isx86_64 then ["x86-64bit" "amd64"]
+    else if stdenv.hostPlatform.isAarch64 then ["arm-64bit" "arm"]
+    else throw "unsupported platform";
 
   mkPianoteq =
     { name
@@ -25,7 +28,6 @@ let
     , startupWMClass
     , src
     , version
-    , archdir ? if (stdenv.hostPlatform.system == "aarch64-linux") then "arm-64bit" else "x86-64bit"
     , ...
     }:
     stdenv.mkDerivation rec {
@@ -45,11 +47,10 @@ let
       ];
 
       buildInputs = [
-        (lib.getLib stdenv.cc.cc)
-        xorg.libX11 # libX11.so.6
-        xorg.libXext # libXext.so.6
+        (lib.getLib stdenv.cc.cc) # libgcc_s.so.1, libstdc++.so.6
         alsa-lib # libasound.so.2
         freetype # libfreetype.so.6
+        libglvnd # libGL.so.1
       ];
 
       desktopItems = [
@@ -68,20 +69,7 @@ let
       installPhase = ''
         runHook preInstall
         mkdir -p $out/bin
-        mv -t $out/bin Pianoteq*/${archdir}/*
-        for f in $out/bin/Pianoteq*; do
-          if [ -x "$f" ] && [ -f "$f" ]; then
-            wrapProgram "$f" --prefix LD_LIBRARY_PATH : ${
-              lib.makeLibraryPath (buildInputs ++ [
-                xorg.libXcursor
-                xorg.libXinerama
-                xorg.libXrandr
-                libjack2
-                zlib
-              ])
-            }
-          fi
-        done
+        mv -t $out/bin ${builtins.concatStringsSep " " (builtins.map (dir: "Pianoteq*/${dir}/*") archdirs)}
         install -Dm644 ${./pianoteq.svg} $out/share/icons/hicolor/scalable/apps/pianoteq.svg
         for size in 16 22 32 48 64 128 256; do
           dir=$out/share/icons/hicolor/"$size"x"$size"/apps
@@ -219,59 +207,64 @@ let
       '';
     };
 
-in
-{
-  # TODO currently can't install more than one because `lame` clashes
-  stage-trial = mkPianoteq rec {
-    name = "stage-trial";
-    mainProgram = "Pianoteq 8 STAGE";
-    startupWMClass = "Pianoteq STAGE Trial";
-    version = "8.2.0";
-    src = fetchPianoteqTrial {
-      name = "pianoteq_stage_linux_trial_v${versionForFile version}.7z";
-      hash = "sha256-66xbcqNrnVJ+C9FQ8Bg8A7nj/bFrjt6jKheusrXVWvI=";
-    };
-  };
-  standard-trial = mkPianoteq rec {
-    name = "standard-trial";
-    mainProgram = "Pianoteq 8";
-    startupWMClass = "Pianoteq Trial";
-    version = "8.2.0";
-    src = fetchPianoteqTrial {
-      name = "pianoteq_linux_trial_v${versionForFile version}.7z";
-      hash = "sha256-IFFQMn8EFo5X8sUZV2/vtQOA83NHEFrUsU++CvYbN1c=";
-    };
-  };
-  stage-6 = mkPianoteq rec {
-    name = "stage-6";
-    mainProgram = "Pianoteq 6 STAGE";
-    startupWMClass = "Pianoteq STAGE";
-    version = "6.7.3";
-    archdir = if (stdenv.hostPlatform.system == "aarch64-linux") then throw "Pianoteq stage-6 is not supported on aarch64-linux" else "amd64";
-    src = fetchPianoteqWithLogin {
-      name = "pianoteq_stage_linux_v${versionForFile version}.7z";
-      hash = "0jy0hkdynhwv0zhrqkby0hdphgmcc09wxmy74rhg9afm1pzl91jy";
-    };
-  };
-  stage-7 = mkPianoteq rec {
-    name = "stage-7";
-    mainProgram = "Pianoteq 7 STAGE";
-    startupWMClass = "Pianoteq STAGE";
-    version = "7.3.0";
-    src = fetchPianoteqWithLogin {
-      name = "pianoteq_stage_linux_v${versionForFile version}.7z";
-      hash = "05w7sv9v38r6ljz9xai816w5z2qqwx88hcfjm241fvgbs54125hx";
-    };
-  };
-  standard-8 = mkPianoteq rec {
-    name = "standard-8";
-    mainProgram = "Pianoteq 8";
+  version6 = "6.7.3";
+  version7 = "7.5.4";
+  version8 = "8.3.2";
+
+  mkStandard = version: hash: mkPianoteq {
+    name = "standard";
+    mainProgram = "Pianoteq ${lib.versions.major version}";
     startupWMClass = "Pianoteq";
-    version = "8.2.0";
+    inherit version;
     src = fetchPianoteqWithLogin {
       name = "pianoteq_linux_v${versionForFile version}.7z";
-      hash = "sha256-ME0urUc1jwUKpg+5BdawYo9WhvMsrztYTVOrJTVxtkY=";
+      inherit hash;
     };
   };
-  # TODO other paid binaries, I don't own that so I don't know their hash.
+  mkStage = version: hash: mkPianoteq {
+    name = "stage";
+    mainProgram = "Pianoteq ${lib.versions.major version} STAGE";
+    startupWMClass = "Pianoteq STAGE";
+    inherit version;
+    src = fetchPianoteqWithLogin {
+      name = "pianoteq_stage_linux_v${versionForFile version}.7z";
+      inherit hash;
+    };
+  };
+  mkStandardTrial = version: hash: mkPianoteq {
+    name = "standard-trial";
+    mainProgram = "Pianoteq ${lib.versions.major version}";
+    startupWMClass = "Pianoteq Trial";
+    inherit version;
+    src = fetchPianoteqTrial {
+      name = "pianoteq_linux_trial_v${versionForFile version}.7z";
+      inherit hash;
+    };
+  };
+  mkStageTrial = version: hash: mkPianoteq {
+    name = "stage-trial";
+    mainProgram = "Pianoteq ${lib.versions.major version} STAGE";
+    startupWMClass = "Pianoteq STAGE Trial";
+    inherit version;
+    src = fetchPianoteqTrial {
+      name = "pianoteq_stage_linux_trial_v${versionForFile version}.7z";
+      inherit hash;
+    };
+  };
+in
+{
+  standard_8 = mkStandard version8 "sha256-U9i9XgZKed8KxDL1fwGbRs30wj0IQwMjP+GH2JpdrJ0=";
+  stage_8 = mkStage version8 "";
+  standard-trial_8 = mkStandardTrial version8 "sha256-nYhTtPtkmYwVV5N1XIGBNU9YBbeIxLOjw2bA29ObXps=";
+  stage-trial_8 = mkStageTrial version8 "sha256-dkSG1PZgVds4fTir/77TSKhd3pBMJaOcWnLtZHsPqWo=";
+
+  standard_7 = mkStandard version7 "sha256-TA9CiuT21fQedlMUGz7bNNxYun5ArmRjvIxjOGqXDCs=";
+  stage_7 = mkStage version7 "";
+  standard-trial_7 = mkStandardTrial version7 "sha256-3a3+SKTEhvDtqK5Kg4E6KiLvn5+j6JN6ntIb72u2bdQ=";
+  stage-trial_7 = mkStageTrial version7 "sha256-ybtq+hjnaQxpLxv2KE0ZcbQXtn5DJJsnMwCmh3rlrIc=";
+
+  standard_6 = mkStandard version6 "sha256-u6ZNpmHFVOk+r+6Q8OURSfAi41cxMoDvaEXrTtHEAVY=";
+  stage_6 = mkStage version6 "";
+  standard-trial_6 = mkStandardTrial version6 "sha256-nHTAqosOJqC0VnRw2/xVpZ6y02vvau6CgfNmgiN/AHs=";
+  stage-trial_6 = mkStageTrial version6 "sha256-zrv0c/Mxt1EysR7ZvmxtksXAF5MyXTFMNj4KAdO3QnE=";
 }


### PR DESCRIPTION
- Update to the latest versions of Pianoteq 6, 7, 8
- Refactor the code to be easier to maintain

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
