### PR TITLE
dhcpcd: fix more permissions errors

### DIFF
--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -161,9 +161,12 @@ in
 
         script = ''
           ${lib.getExe cfg.package} -u
-          files=(/run/resolvconf ${lib.escapeShellArgs cfg.subscriberFiles})
-          chgrp -R resolvconf "''${files[@]}"
-          chmod -R g=u "''${files[@]}"
+          chgrp resolvconf ${lib.escapeShellArgs cfg.subscriberFiles}
+          chmod g=u ${lib.escapeShellArgs cfg.subscriberFiles}
+          ${lib.getExe' pkgs.acl "setfacl"} -R \
+            -m group:resolvconf:rwx \
+            -m default:group:resolvconf:rwx \
+            /run/resolvconf
         '';
       };
 

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -249,7 +249,7 @@ in
             ExecReload = "${dhcpcd}/sbin/dhcpcd --rebind";
             Restart = "always";
             AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_NET_RAW" "CAP_NET_BIND_SERVICE" ];
-            ReadWritePaths = [ "/proc/sys/net/ipv6" ]
+            ReadWritePaths = [ "/proc/sys/net/ipv4" "/proc/sys/net/ipv6" ]
               ++ lib.optionals useResolvConf ([ "/run/resolvconf" ] ++ config.networking.resolvconf.subscriberFiles);
             DeviceAllow = "";
             LockPersonality = true;


### PR DESCRIPTION
Fixes for a couple more issues reported in https://github.com/NixOS/nixpkgs/pull/336988.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- Tested via
  - [x] `dhcpcd.tests`
  - [x] `nixosTests.simple`
  - [ ] `nixosTests.networking.scripted`
  - [ ] `nixosTests.networking.networkd`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
