### PR TITLE
lomiri.lomiri-url-dispatcher: Split library into separate output

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "lib"
   ];
 
   patches = [
@@ -148,6 +149,11 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ qtdeclarative.dev ]}
     )
     wrapQtApp $out/bin/lomiri-url-dispatcher-gui
+  '';
+
+  postFixup = ''
+    moveToOutput share $out
+    moveToOutput libexec $out
   '';
 
   passthru = {


### PR DESCRIPTION
... plus general maintenance and upstreaming our ~~hack~~ improvement, while I'm here.

Addresses one of the known issues in #260859, where `libayatana-common` pulls in outputs of Gtk, Qt, the Lomiri UI Toolkit, ... purely because of `lomiri-url-dispatcher`'s GUI tools.

Before & after:

```
↪ nix --extra-experimental-features nix-command path-info -Sh /nix/store/m0v5h2ylvqjmhlwxk454r7vjzamrz428-libayatana-common-0.9.10
/nix/store/m0v5h2ylvqjmhlwxk454r7vjzamrz428-libayatana-common-0.9.10	 962.7M

↪ nix --extra-experimental-features nix-command path-info -Sh /nix/store/c2a66rxi6j1831mndip4n5vdzzcr3qi8-libayatana-common-0.9.10
/nix/store/c2a66rxi6j1831mndip4n5vdzzcr3qi8-libayatana-common-0.9.10	  63.2M

↪ nix --extra-experimental-features nix-command path-info -Shr /nix/store/c2a66rxi6j1831mndip4n5vdzzcr3qi8-libayatana-common-0.9.10
/nix/store/v2fdaykfy6ldp5wzn8hm2hb74nd35anw-xgcc-13.3.0-libgcc             	 147.4K
/nix/store/a0mbpky7hll3ljg1cnp5apc4y1bgb9hl-libunistring-1.2               	   1.8M
/nix/store/y9n3vjmh0iarg25ngv6bzbhbqam5rxch-libidn2-2.3.7                  	   2.2M
/nix/store/qii6jadf3xrhg4y0f5m09k11lh5ymwnv-glibc-2.40-36                  	  42.1M
/nix/store/z16jwhhg1pavcrjk5sfihjn6lnz93sfw-pcre2-10.44                    	  43.9M
/nix/store/cqli57dgmwfl40s690j640hdd4v5w9m0-libselinux-3.7                 	  45.4M
/nix/store/h887yq6z05ynslzqbqd125flw251j4hr-util-linux-minimal-2.39.4-lib  	  44.2M
/nix/store/raxk9vwg1raq7v90x27y4a0b0djfsi2v-libffi-3.4.6                   	  42.3M
/nix/store/rgsl4wpi5m4kql5gbqm3qrqbkm4kxr6q-zlib-1.3.1                     	  42.3M
/nix/store/cw9qz08zwd1li8vd8lm0laywa6rsi3gs-glib-2.80.4                    	  62.9M
/nix/store/1xwyvv9s8s5hn6j1fc3d155zxjl9sdm3-lomiri-url-dispatcher-0.1.3-lib	  63.0M
/nix/store/c2a66rxi6j1831mndip4n5vdzzcr3qi8-libayatana-common-0.9.10       	  63.2M

```

No more dependency on Qt & Lomiri outputs for any future consumers of the library. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
