### PR TITLE
Add licenses to moby and c-util

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -24,6 +24,16 @@ rec {
       , knownVulnerabilities ? []
     }:
   let
+    docker-meta = {
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [
+        offline
+        vdemeester
+        periklis
+        teutat3s
+      ];
+    };
+
     docker-runc = runc.overrideAttrs {
       pname = "docker-runc";
       inherit version;
@@ -160,6 +170,11 @@ rec {
         ++ lib.optional (!withBtrfs) "exclude_graphdriver_btrfs"
         ++ lib.optional (!withLvm) "exclude_graphdriver_devicemapper"
         ++ lib.optional withSeccomp "seccomp";
+
+      meta = docker-meta // {
+          homepage = "https://mobyproject.org/";
+          description = "A collaborative project for the container ecosystem to assemble container-based systems.";
+        };
     });
 
     plugins = lib.optional buildxSupport docker-buildx
@@ -257,7 +272,7 @@ rec {
       tests = lib.optionals (!clientOnly) { inherit (nixosTests) docker; };
     };
 
-    meta = with lib; {
+    meta = docker-meta // {
       homepage = "https://www.docker.com/";
       description = "Open source project to pack, ship and run any application as a lightweight container";
       longDescription = ''
@@ -265,8 +280,6 @@ rec {
 
         To enable the docker daemon on NixOS, set the `virtualisation.docker.enable` option to `true`.
       '';
-      license = licenses.asl20;
-      maintainers = with maintainers; [ offline vdemeester periklis teutat3s ];
       mainProgram = "docker";
       inherit knownVulnerabilities;
     };

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -11,6 +11,10 @@
 }:
 
 let
+  meta = {
+    maintainers = with lib.maintainers; [ peterhoeg ];
+    platforms = lib.platforms.linux;
+  };
 
   dep = { pname, version, hash, rev ? "v${version}", buildInputs ? [ ] }:
     stdenv.mkDerivation {
@@ -22,6 +26,14 @@ let
       };
       nativeBuildInputs = [ meson ninja pkg-config ];
       inherit buildInputs;
+      meta = meta // {
+        description = "The C-Util Project is a collection of utility libraries for the C11 language.";
+        homepage = "https://c-util.github.io/";
+        license = [
+          lib.licenses.asl20
+          lib.licenses.lgpl21Plus
+        ];
+      };
     };
 
   # These libraries are not used outside of dbus-broker.
@@ -89,11 +101,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = meta // {
     description = "Linux D-Bus Message Broker";
     homepage = "https://github.com/bus1/dbus-broker/wiki";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.linux;
+    license = lib.licenses.asl20;
   };
 })


### PR DESCRIPTION
The `docker` and `dbus-broker` packages create internal dependency derivations that do not contain licenses or other meta information. This is not openly exposed when using something like https://search.nixos.org but does come up when building SBOMs or investigating dependencies in another way.

This PR adds meta info to those dependencies.

I kept the other meta information (maintainer, ...) from the main package derivation of the corresponding file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
