### PR TITLE
nixos/send: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1550,6 +1550,7 @@
   ./services/web-servers/phpfpm/default.nix
   ./services/web-servers/pomerium.nix
   ./services/web-servers/rustus.nix
+  ./services/web-servers/send.nix
   ./services/web-servers/stargazer.nix
   ./services/web-servers/static-web-server.nix
   ./services/web-servers/tomcat.nix

--- a/nixos/modules/services/web-servers/send.nix
+++ b/nixos/modules/services/web-servers/send.nix
@@ -1,0 +1,228 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+  cfg = config.services.send;
+in
+{
+  options = {
+    services.send = {
+      enable = lib.mkEnableOption "Send, a file sharing web sevice for ffsend.";
+
+      package = lib.mkPackageOption pkgs "send" { };
+
+      environment = mkOption {
+        type =
+          with types;
+          attrsOf (
+            nullOr (oneOf [
+              bool
+              int
+              str
+              (listOf int)
+            ])
+          );
+        description = ''
+          All the available config options and their defaults can be found here: https://github.com/timvisee/send/blob/master/server/config.js,
+          some descriptions can found here: https://github.com/timvisee/send/blob/master/docs/docker.md#environment-variables
+
+          Values under {option}`services.send.environment` will override the predefined values in the Send service.
+            - Time/duration should be in seconds
+            - Filesize values should be in bytes
+        '';
+        example = {
+          DEFAULT_DOWNLOADS = 1;
+          DETECT_BASE_URL = true;
+          EXPIRE_TIMES_SECONDS = [
+            300
+            3600
+            86400
+            604800
+          ];
+        };
+      };
+
+      dataDir = lib.mkOption {
+        type = types.path;
+        readOnly = true;
+        default = "/var/lib/send";
+        description = ''
+          Directory for uploaded files.
+          Due to limitations in {option}`systemd.services.send.serviceConfig.DynamicUser`, this item is read only.
+        '';
+      };
+
+      baseUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Base URL for the Send service.
+          Leave it blank to automatically detect the base url.
+        '';
+      };
+
+      host = lib.mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "The hostname or IP address for Send to bind to.";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 1443;
+        description = "Port the Send service listens on.";
+      };
+
+      openFirewall = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to open firewall ports for send";
+      };
+
+      redis = {
+        createLocally = lib.mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether to create a local redis automatically.";
+        };
+
+        name = lib.mkOption {
+          type = types.str;
+          default = "send";
+          description = ''
+            Name of the redis server.
+            Only used if {option}`services.send.redis.createLocally` is set to true.
+          '';
+        };
+
+        host = lib.mkOption {
+          type = types.str;
+          default = "localhost";
+          description = "Redis server address.";
+        };
+
+        port = lib.mkOption {
+          type = types.port;
+          default = 6379;
+          description = "Port of the redis server.";
+        };
+
+        passwordFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/agenix/send-redis-password";
+          description = ''
+            The path to the file containing the Redis password.
+
+            If {option}`services.send.redis.createLocally` is set to true,
+            the content of this file will be used as the password for the locally created Redis instance.
+
+            Leave it blank if no password is required.
+          '';
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    services.send.environment.DETECT_BASE_URL = cfg.baseUrl == null;
+
+    assertions = [
+      {
+        assertion = cfg.redis.createLocally -> cfg.redis.host == "localhost";
+        message = "the redis host must be localhost if services.send.redis.createLocally is set to true";
+      }
+    ];
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+
+    services.redis = lib.optionalAttrs cfg.redis.createLocally {
+      servers."${cfg.redis.name}" = {
+        enable = true;
+        bind = "localhost";
+        port = cfg.redis.port;
+      };
+    };
+
+    systemd.services.send = {
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        StateDirectory = "send";
+        WorkingDirectory = cfg.dataDir;
+        ReadWritePaths = cfg.dataDir;
+        LoadCredential = lib.optionalString (
+          cfg.redis.passwordFile != null
+        ) "redis-password:${cfg.redis.passwordFile}";
+
+        # Hardening
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        AmbientCapabilities = lib.optionalString (cfg.port < 1024) "cap_net_bind_service";
+        DynamicUser = true;
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        RemoveIPC = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = "0077";
+      };
+      environment =
+        {
+          IP_ADDRESS = cfg.host;
+          PORT = toString cfg.port;
+          BASE_URL = if (cfg.baseUrl == null) then "http://${cfg.host}:${toString cfg.port}" else cfg.baseUrl;
+          FILE_DIR = cfg.dataDir + "/uploads";
+          REDIS_HOST = cfg.redis.host;
+          REDIS_PORT = toString cfg.redis.port;
+        }
+        // (lib.mapAttrs (
+          name: value:
+          if lib.isList value then
+            "[" + lib.concatStringsSep ", " (map (x: toString x) value) + "]"
+          else if lib.isBool value then
+            lib.boolToString value
+          else
+            toString value
+        ) cfg.environment);
+      after =
+        [
+          "network.target"
+        ]
+        ++ lib.optionals cfg.redis.createLocally [
+          "redis-${cfg.redis.name}.service"
+        ];
+      description = "Send web service";
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${lib.optionalString (cfg.redis.passwordFile != null) ''
+          export REDIS_PASSWORD="$(cat $CREDENTIALS_DIRECTORY/redis-password)"
+        ''}
+        ${lib.getExe cfg.package}
+      '';
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ moraxyc ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -904,6 +904,7 @@ in {
   seafile = handleTest ./seafile.nix {};
   searx = runTest ./searx.nix;
   seatd = handleTest ./seatd.nix {};
+  send = runTest ./send.nix;
   service-runner = handleTest ./service-runner.nix {};
   sftpgo = runTest ./sftpgo.nix;
   sfxr-qt = handleTest ./sfxr-qt.nix {};

--- a/nixos/tests/send.nix
+++ b/nixos/tests/send.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+{
+  name = "send";
+
+  meta = {
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        curl
+        ffsend
+      ];
+
+      services.send = {
+        enable = true;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("send.service")
+
+    machine.wait_for_open_port(1443)
+
+    machine.succeed("curl --fail --max-time 10 http://127.0.0.1:1443")
+
+    machine.succeed("echo HelloWorld > /tmp/test")
+    url = machine.succeed("ffsend upload -q -h http://127.0.0.1:1443/ /tmp/test")
+    machine.succeed(f'ffsend download --output /tmp/download {url}')
+    machine.succeed("cat /tmp/download | grep HelloWorld")
+  '';
+}


### PR DESCRIPTION
- **nixos/send: init**

must be merged after https://github.com/NixOS/nixpkgs/pull/350931

Closes https://github.com/NixOS/nixpkgs/issues/350025

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
