### PR TITLE
pytubefix: 6.4.2 -> 8.0.0

### DIFF
--- a/pkgs/development/python-modules/pytubefix/default.nix
+++ b/pkgs/development/python-modules/pytubefix/default.nix
@@ -1,36 +1,36 @@
 {
   lib,
-  buildPythonPackage,
+  python3,
   fetchFromGitHub,
-  setuptools,
-  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+python3.pkgs.buildPythonPackage rec {
   pname = "pytubefix";
-  version = "6.4.2";
+  version = "8.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "JuanBindez";
     repo = "pytubefix";
     rev = "refs/tags/v${version}";
-    hash = "sha256-FbmVQ+nt/WEwE5vRMo2610TO463CT8nCseqB30uXjSM=";
+    hash = "sha256-jZHSvOB0kCeiguLmYDjXcMbMqLWCOO/5+spV5p6Hl3I=";
   };
 
-  build-system = [ setuptools ];
+  build-system = with python3.pkgs; [ setuptools ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
 
   disabledTestPaths = [
     # require network access
     "tests/test_captions.py"
     "tests/test_cli.py"
+    "tests/test_cipher.py"
     "tests/test_exceptions.py"
     "tests/test_extract.py"
     "tests/test_main.py"
     "tests/test_query.py"
     "tests/test_streams.py"
+    "tests/contrib/test_playlist.py"
   ];
 
   pythonImportsCheck = [ "pytubefix" ];


### PR DESCRIPTION
changelog/diffs https://github.com/JuanBindez/pytubefix/compare/v6.4.2...v8.0.0

## Things done

updated package, made changes to how python package were called, original syntax wouldnt build with new version. reason unknown.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


