### PR TITLE
python312Packages: cleanup instances of `doCheck = true`

### DIFF
--- a/pkgs/development/python-modules/anitopy/default.nix
+++ b/pkgs/development/python-modules/anitopy/default.nix
@@ -16,7 +16,6 @@ buildPythonPackage rec {
   };
 
   pythonImportsCheck = [ "anitopy" ];
-  doCheck = true;
 
   meta = with lib; {
     description = "Python library for parsing anime video filenames";

--- a/pkgs/development/python-modules/beziers/default.nix
+++ b/pkgs/development/python-modules/beziers/default.nix
@@ -24,7 +24,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyclipper ];
 
-  doCheck = true;
   nativeCheckInputs = [
     dotmap
     matplotlib

--- a/pkgs/development/python-modules/collidoscope/default.nix
+++ b/pkgs/development/python-modules/collidoscope/default.nix
@@ -30,7 +30,6 @@ buildPythonPackage rec {
     uharfbuzz
   ];
 
-  doCheck = true;
   nativeCheckInputs = [ unittestCheckHook ];
   unittestFlagsArray = [
     "-s"

--- a/pkgs/development/python-modules/commandlines/default.nix
+++ b/pkgs/development/python-modules/commandlines/default.nix
@@ -18,7 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-x3iUeOTAaTKNW5Y5foMPMJcWVxu52uYZoY3Hhe3UvQ4=";
   };
 
-  doCheck = true;
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/commitizen/default.nix
+++ b/pkgs/development/python-modules/commitizen/default.nix
@@ -77,8 +77,6 @@ buildPythonPackage rec {
     pytest7CheckHook
   ];
 
-  doCheck = true;
-
   pythonImportsCheck = [ "commitizen" ];
 
   # The tests require a functional git installation

--- a/pkgs/development/python-modules/dehinter/default.nix
+++ b/pkgs/development/python-modules/dehinter/default.nix
@@ -21,7 +21,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ fonttools ];
 
-  doCheck = true;
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dissect-jffs/default.nix
+++ b/pkgs/development/python-modules/dissect-jffs/default.nix
@@ -33,9 +33,6 @@ buildPythonPackage rec {
     dissect-util
   ];
 
-  # Test file handling fails
-  doCheck = true;
-
   pythonImportsCheck = [ "dissect.jffs" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -52,8 +52,6 @@ buildPythonPackage rec {
       --replace "'pytest-runner==5.2.0'," ""
   '';
 
-  doCheck = true;
-
   pythonImportsCheck = [ "dropbox" ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -50,7 +50,6 @@ buildPythonPackage rec {
     numpy
   ];
 
-  doCheck = true;
   pythonImportsCheck = [ "eigenpy" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -26,7 +26,6 @@ buildPythonPackage rec {
     gitpython
   ];
 
-  doCheck = true;
   nativeCheckInputs = [
     git
     pytestCheckHook

--- a/pkgs/development/python-modules/fontfeatures/default.nix
+++ b/pkgs/development/python-modules/fontfeatures/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage rec {
     youseedee
   ];
 
-  doCheck = true;
   nativeCheckInputs = [ pytestCheckHook ];
   disabledTestPaths = [
     # These tests require babelfont but we have to leave it out and skip them

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -53,8 +53,6 @@ buildPythonPackage rec {
     "-Dpython=${python.pythonOnBuildForHost.interpreter}"
   ];
 
-  doCheck = true;
-
   # TODO: Meson setup hook does not like buildPythonPackage
   # https://github.com/NixOS/nixpkgs/issues/47390
   installCheckPhase = "meson test --print-errorlogs";

--- a/pkgs/development/python-modules/iwlib/default.nix
+++ b/pkgs/development/python-modules/iwlib/default.nix
@@ -23,7 +23,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pytest ];
   pythonImportsCheck = [ "iwlib" ];
 
-  doCheck = true;
   checkInputs = [ pytest ];
   checkPhase = "python iwlib/_iwlib_build.py; pytest -v";
 

--- a/pkgs/development/python-modules/kinparse/default.nix
+++ b/pkgs/development/python-modules/kinparse/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage {
     sha256 = "1nrjnybwzy93c79yylcwmb4lvkx7hixavnjwffslz0zwn32l0kx3";
   };
 
-  doCheck = true;
   pythonImportsCheck = [ "kinparse" ];
 
   nativeCheckInputs = [ pytest ];

--- a/pkgs/development/python-modules/kurbopy/default.nix
+++ b/pkgs/development/python-modules/kurbopy/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
     hash = "sha256-W0BebCXC1wqwtQP+zHjISxSJjXHD9U6p9eNS12Nfb2Y=";
   };
 
-  doCheck = true;
   nativeCheckInputs = [ pytestCheckHook ];
   preCheck = ''
     # pytestCheckHook puts . at the front of Python's sys.path, due to:

--- a/pkgs/development/python-modules/lcov-cobertura/default.nix
+++ b/pkgs/development/python-modules/lcov-cobertura/default.nix
@@ -22,7 +22,6 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
   dependencies = [ distutils ];
 
-  doCheck = true;
   pythonImportsCheck = [ "lcov_cobertura" ];
 
   meta = {

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -122,7 +122,6 @@ buildPythonPackage rec {
     (calls `sim.run()`), as only then MPI will be initialised and MPI linking
     errors can be caught.
   */
-  doCheck = true;
   nativeCheckInputs = [
     mpiCheckPhaseHook
     openssh

--- a/pkgs/development/python-modules/opentypespec/default.nix
+++ b/pkgs/development/python-modules/opentypespec/default.nix
@@ -15,7 +15,6 @@ buildPythonPackage rec {
     hash = "sha256-fOEHmtlCkFhn1jyIA+CsHIfud7x3PPb7UWQsnrVyDqY=";
   };
 
-  doCheck = true;
   nativeCheckInputs = [ unittestCheckHook ];
   unittestFlagsArray = [
     "-s"

--- a/pkgs/development/python-modules/ots-python/default.nix
+++ b/pkgs/development/python-modules/ots-python/default.nix
@@ -32,7 +32,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ opentype-sanitizer ];
   nativeBuildInputs = [ setuptools-scm ];
 
-  doCheck = true;
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pid/default.nix
+++ b/pkgs/development/python-modules/pid/default.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Pidfile featuring stale detection and file-locking";
     homepage = "https://github.com/trbs/pid/";

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -80,7 +80,6 @@ buildPythonPackage rec {
   PARQUET_HOME = arrow-cpp;
 
   ARROW_TEST_DATA = lib.optionalString doCheck arrow-cpp.ARROW_TEST_DATA;
-
   doCheck = true;
 
   dontUseCmakeConfigure = true;

--- a/pkgs/development/python-modules/pycangjie/default.nix
+++ b/pkgs/development/python-modules/pycangjie/default.nix
@@ -43,8 +43,6 @@ buildPythonPackage {
 
   configureScript = "./autogen.sh";
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Python wrapper to libcangjie";
     homepage = "http://cangjians.github.io/projects/pycangjie/";

--- a/pkgs/development/python-modules/pymoo/default.nix
+++ b/pkgs/development/python-modules/pymoo/default.nix
@@ -70,7 +70,6 @@ buildPythonPackage rec {
     scipy
   ];
 
-  doCheck = true;
   preCheck = ''
     substituteInPlace pymoo/config.py \
       --replace-fail "https://raw.githubusercontent.com/anyoptimization/pymoo-data/main/" \

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -130,7 +130,6 @@ buildPythonPackage rec {
   dontConfigure = true;
 
   # Checked using pythonImportsCheck, has no tests
-  doCheck = true;
 
   pythonImportsCheck =
     [

--- a/pkgs/development/python-modules/pyqt6-webengine/default.nix
+++ b/pkgs/development/python-modules/pyqt6-webengine/default.nix
@@ -73,7 +73,6 @@ buildPythonPackage rec {
   dontConfigure = true;
 
   # Checked using pythonImportsCheck, has no tests
-  doCheck = true;
 
   pythonImportsCheck = [
     "PyQt6.QtWebEngineCore"

--- a/pkgs/development/python-modules/python-barbicanclient/default.nix
+++ b/pkgs/development/python-modules/python-barbicanclient/default.nix
@@ -60,8 +60,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  doCheck = true;
-
   nativeCheckInputs = [
     requests-mock
     stestr

--- a/pkgs/development/python-modules/python-musicpd/default.nix
+++ b/pkgs/development/python-modules/python-musicpd/default.nix
@@ -19,8 +19,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  doCheck = true;
-
   meta = with lib; {
     description = "MPD (Music Player Daemon) client library written in pure Python";
     homepage = "https://gitlab.com/kaliko/python-musicpd";

--- a/pkgs/development/python-modules/pyytlounge/default.nix
+++ b/pkgs/development/python-modules/pyytlounge/default.nix
@@ -13,6 +13,7 @@
 buildPythonPackage rec {
   pname = "pyytlounge";
   version = "2.1.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "FabioGNR";
@@ -20,10 +21,6 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-0QPa3EzOBv5fuw3FGgmoN4KiC4KHo1Z+Svjcneoe0pc=";
   };
-
-  pyproject = true;
-
-  doCheck = true;
 
   build-system = [ hatchling ];
 

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -88,8 +88,6 @@ buildPythonPackage rec {
     shapely
   ];
 
-  doCheck = true;
-
   preCheck = ''
     rm -r rasterio # prevent importing local rasterio
   '';

--- a/pkgs/development/python-modules/rouge-score/default.nix
+++ b/pkgs/development/python-modules/rouge-score/default.nix
@@ -52,8 +52,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  doCheck = true;
-
   disabledTests = [
     # https://github.com/google-research/google-research/issues/1203
     "testRougeLSumSentenceSplitting"

--- a/pkgs/development/python-modules/rstr/default.nix
+++ b/pkgs/development/python-modules/rstr/default.nix
@@ -23,7 +23,6 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  doCheck = true;
   nativeCheckInputs = [ unittestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     scipy
   ] ++ lib.optionals (!isPy3k) [ enum34 ];
 
-  doCheck = true;
   nativeCheckInputs = [ pytest ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -42,7 +42,6 @@ buildPythonPackage rec {
     scikit-build
   ];
 
-  doCheck = true;
   # I'm not modifying the checkPhase nor adding a pytestCheckHook because the pytest is called
   # within the cmake test phase
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sip/4.x.nix
+++ b/pkgs/development/python-modules/sip/4.x.nix
@@ -57,8 +57,6 @@ buildPythonPackage rec {
     "sipconfig"
   ];
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Creates C++ bindings for Python modules";
     mainProgram = "sip";

--- a/pkgs/development/python-modules/skyfield/default.nix
+++ b/pkgs/development/python-modules/skyfield/default.nix
@@ -49,8 +49,6 @@ buildPythonPackage rec {
     assay
   ];
 
-  doCheck = true;
-
   checkPhase = ''
     runHook preCheck
 

--- a/pkgs/development/python-modules/spacy-transformers/annotation-test/default.nix
+++ b/pkgs/development/python-modules/spacy-transformers/annotation-test/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation {
 
   dontConfigure = true;
   dontBuild = true;
-  doCheck = true;
 
   nativeCheckInputs = [
     pytest

--- a/pkgs/development/python-modules/spacy/annotation-test/default.nix
+++ b/pkgs/development/python-modules/spacy/annotation-test/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation {
 
   dontConfigure = true;
   dontBuild = true;
-  doCheck = true;
 
   nativeCheckInputs = [
     pytest

--- a/pkgs/development/python-modules/sre-yield/default.nix
+++ b/pkgs/development/python-modules/sre-yield/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  doCheck = true;
   nativeCheckInputs = [ unittestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/telegraph/default.nix
+++ b/pkgs/development/python-modules/telegraph/default.nix
@@ -34,8 +34,6 @@ buildPythonPackage rec {
 
   disabledTests = [ "test_get_page" ];
 
-  doCheck = true;
-
   pythonImportsCheck = [ "telegraph" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -81,8 +81,6 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  doCheck = true;
-
   nativeCheckInputs = [
     pytestCheckHook
     tpm2-tools

--- a/pkgs/development/python-modules/turnt/default.nix
+++ b/pkgs/development/python-modules/turnt/default.nix
@@ -24,8 +24,6 @@ buildPythonPackage rec {
     tomli
   ];
 
-  doCheck = true;
-
   checkPhase = ''
     runHook preCheck
     $out/bin/turnt test/*/*.t

--- a/pkgs/development/python-modules/ufolint/default.nix
+++ b/pkgs/development/python-modules/ufolint/default.nix
@@ -27,7 +27,6 @@ buildPythonPackage rec {
     fonttools
   ];
 
-  doCheck = true;
   nativeBuildInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/xapian/default.nix
+++ b/pkgs/development/python-modules/xapian/default.nix
@@ -34,8 +34,6 @@ buildPythonPackage rec {
     xapian
   ];
 
-  doCheck = true;
-
   checkPhase = ''
     ${python.interpreter} python${pythonSuffix}/pythontest.py
   '';

--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -60,8 +60,6 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Interactive viewer for graphs written in Graphviz's dot";
     mainProgram = "xdot";

--- a/pkgs/development/python-modules/youseedee/default.nix
+++ b/pkgs/development/python-modules/youseedee/default.nix
@@ -32,7 +32,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  doCheck = true;
   # Package has no unit tests, but we can check an example as per README.rst:
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
This is implicitly the case, and unless `doCheck` is referenced it makes no sense setting it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
