### PR TITLE
haskellPackages.password: use crypton, disable scrypt on non-x86

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -829,8 +829,6 @@ supported-platforms:
   midi-alsa:                                    [ platforms.linux ] # alsa-core only supported on linux
   midisurface:                                  [ platforms.linux ] # alsa-core only supported on linux
   OrderedBits:                                  [ platforms.x86 ] # lacks implementations for non-x86: https://github.com/choener/OrderedBits/blob/401cbbe933b1635aa33e8e9b29a4a570b0a8f044/lib/Data/Bits/Ordered.hs#L316
-  password:                                     [ platforms.x86 ] # uses scrypt, which requries x86
-  password-instances:                           [ platforms.x86 ] # uses scrypt, which requries x86
   reactivity:                                   [ platforms.windows ]
   reflex-libtelnet:                             [ platforms.linux ] # pkgs.libtelnet only supports linux
   scat:                                         [ platforms.x86 ] # uses scrypt, which requries x86

--- a/pkgs/development/haskell-modules/patches/password-3.0.4.0-scrypt-conditional.patch
+++ b/pkgs/development/haskell-modules/patches/password-3.0.4.0-scrypt-conditional.patch
@@ -1,0 +1,21 @@
+diff --git a/password/password.cabal b/password/password.cabal
+index 506457e..8fa978b 100644
+--- a/password.cabal
++++ b/password.cabal
+@@ -186,6 +186,8 @@ test-suite password-tasty
+     other-modules:
+       Scrypt
+       Data.Password.Scrypt
++    build-depends:
++      scrypt
+   ghc-options:
+       -threaded -O2 -rtsopts -with-rtsopts=-N
+   build-depends:
+@@ -195,7 +197,6 @@ test-suite password-tasty
+     , bytestring
+     , memory
+     , quickcheck-instances
+-    , scrypt
+     , tasty
+     , tasty-hunit
+     , tasty-quickcheck


### PR DESCRIPTION
- crypton is maintained, contrary to cryptonite
- since the Hackage scrypt package uses SSE2, we can't build it on non-x86 platforms (non x86_64 even probably). The best option is to disable the Scrypt module. To prevent cabal from pulling in scrypt in spite of that, we need to patch build-depends to respect the flag.

~~Currently untested, waiting for cache to catch up.~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
