### PR TITLE
home-assistant: 2024.10.3 -> 2024.10.4

### DIFF
--- a/pkgs/applications/networking/cluster/luigi/default.nix
+++ b/pkgs/applications/networking/cluster/luigi/default.nix
@@ -12,6 +12,8 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = [ python3.pkgs.setuptools ];
 
+  pythonRelaxDeps = [ "tenacity" ];
+
   dependencies = with python3.pkgs; [ python-dateutil tornado python-daemon tenacity ];
 
   pythonImportsCheck = [ "luigi" ];

--- a/pkgs/by-name/of/offat/package.nix
+++ b/pkgs/by-name/of/offat/package.nix
@@ -18,7 +18,10 @@ python3.pkgs.buildPythonApplication rec {
 
   sourceRoot = "${src.name}/src";
 
-  pythonRelaxDeps = [ "setuptools" ];
+  pythonRelaxDeps = [
+    "setuptools"
+    "tenacity"
+  ];
 
   build-system = with python3.pkgs; [ poetry-core ];
 

--- a/pkgs/development/python-modules/doorbirdpy/default.nix
+++ b/pkgs/development/python-modules/doorbirdpy/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   setuptools,
   aiohttp,
+  tenacity,
   aioresponses,
   pytest-asyncio,
   pytestCheckHook,
@@ -11,24 +12,32 @@
 
 buildPythonPackage rec {
   pname = "doorbirdpy";
-  version = "3.0.3";
+  version = "3.0.5";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "klikini";
     repo = "doorbirdpy";
     rev = "refs/tags/${version}";
-    hash = "sha256-0UvzMFYKM/Sb9B2XwZwl+a9v7lTxAc1H59vR88VwDww=";
+    hash = "sha256-SVkprX9fMy1uGixsxsE7gbUJndvl+V/kle3Rq34S6Hs=";
   };
 
   build-system = [ setuptools ];
 
-  dependencies = [ aiohttp ];
+  dependencies = [
+    aiohttp
+    tenacity
+  ];
 
   nativeCheckInputs = [
     aioresponses
     pytest-asyncio
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # connection error on mock host
+    "test_info_auth_fails"
   ];
 
   pythonImportsCheck = [ "doorbirdpy" ];

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -48,6 +48,8 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [ "tenacity" ];
+
   dependencies = [
     jsonpatch
     langsmith

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -58,6 +58,8 @@ buildPythonPackage rec {
 
   buildInputs = [ bash ];
 
+  pythonRelaxDeps = [ "tenacity" ];
+
   dependencies = [
     aiohttp
     langchain-core

--- a/pkgs/development/python-modules/linear-garage-door/default.nix
+++ b/pkgs/development/python-modules/linear-garage-door/default.nix
@@ -23,13 +23,9 @@ buildPythonPackage rec {
     hash = "sha256-ibOCqy7krIVC7N75SwEyUII3Tknb60nwA+zGbjOENv4=";
   };
 
-  postPatch = ''
-    sed -i pyproject.toml \
-      -e "/--cov/d" \
-      -e "/--no-cov/d"
-  '';
-
   build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [ "tenacity" ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/osxphotos/default.nix
+++ b/pkgs/development/python-modules/osxphotos/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage rec {
     "more-itertools"
     "objexplore"
     "textx"
+    "tenacity"
   ];
 
   pythonImportsCheck = [ "osxphotos" ];

--- a/pkgs/development/python-modules/py-aosmith/default.nix
+++ b/pkgs/development/python-modules/py-aosmith/default.nix
@@ -22,9 +22,11 @@ buildPythonPackage rec {
     hash = "sha256-TjBjyWxBPrZEY/o1DZ+GiFTHTW37WwFN0oyJSyGru28=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [ "tenacity" ];
+
+  dependencies = [
     aiohttp
     tenacity
   ];

--- a/pkgs/development/python-modules/pytibber/default.nix
+++ b/pkgs/development/python-modules/pytibber/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pytibber";
-  version = "0.30.2";
+  version = "0.30.3";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "Danielhiversen";
     repo = "pyTibber";
     rev = "refs/tags/${version}";
-    hash = "sha256-9Tnn68RxKwEruYEGo2pZQTQTlYnVMfa3MRzA55HlBRc=";
+    hash = "sha256-4MkREdeYqAA+MpM9JQyiVVDPpefVTNT0x0ptR33K6yU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage rec {
     "httpx"
     "iso8601"
     "pydantic"
+    "tenacity"
   ];
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/tenacity/default.nix
+++ b/pkgs/development/python-modules/tenacity/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pbr,
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
@@ -13,20 +12,17 @@
 
 buildPythonPackage rec {
   pname = "tenacity";
-  version = "8.4.1";
-  format = "pyproject";
+  version = "9.0.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-VLFBK4eN334fFXfNSVJ7rYze8yQhvVmb6sDGw/EFgv0=";
+    hash = "sha256-gH83ypfWKqNhJk1Jew4x6SuAJwRJQr+nVhYNkIMg1zs=";
   };
 
-  nativeBuildInputs = [
-    pbr
-    setuptools-scm
-  ];
+  build-system = [ setuptools-scm ];
 
   nativeCheckInputs = [
     pytest-asyncio
@@ -39,6 +35,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/jd/tenacity";
+    changelog = "https://github.com/jd/tenacity/releases/tag/${version}";
     description = "Retrying library for Python";
     license = licenses.asl20;
     maintainers = with maintainers; [ jakewaksbaum ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2024.10.3";
+  version = "2024.10.4";
   components = {
     "3_day_blinds" = ps: with ps; [
     ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -100,16 +100,6 @@ let
         ];
       });
 
-      geojson = super.geojson.overridePythonAttrs (oldAttrs: rec {
-        version = "2.5.0";
-        src = fetchFromGitHub {
-          inherit (oldAttrs.src) owner repo;
-          rev = "refs/tags/${version}";
-          hash = "sha256-AcImffYki1gnIaZp/1eacNjdDgjn6qinPJXq9jYtoRg=";
-        };
-        doCheck = false;
-      });
-
       gspread = super.gspread.overridePythonAttrs (oldAttrs: rec {
         version = "5.12.4";
         src = fetchFromGitHub {
@@ -171,15 +161,6 @@ let
           pname = "poolsense";
           inherit version;
           hash = "sha256-17MHrYRmqkH+1QLtgq2d6zaRtqvb9ju9dvPt9gB2xCc=";
-        };
-      });
-
-      pyasn1 = super.pyasn1.overridePythonAttrs (oldAttrs: rec {
-        version = "0.4.8";
-        src = fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-rvd8n7lKOsWI6HhBIIvexGRHHZhxvVBQoofMmkdc0Lo=";
         };
       });
 
@@ -323,6 +304,7 @@ let
         doCheck = false; # Tests changed a lot for > 3
       });
 
+      # pinned for sigstore
       tuf = super.tuf.overridePythonAttrs rec {
         version = "2.1.0";
         src = fetchFromGitHub {
@@ -408,7 +390,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2024.10.3";
+  hassVersion = "2024.10.4";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -426,13 +408,13 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-kxxa7FI2wIpE3bEifNyjtEHj7rsuImQvxGd6I46ySqM=";
+    hash = "sha256-uaGGt5qCdyFXuEtg20MzmFd4PXkdPP8h4HJBvRV6sz8=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-DhDdCvov5/Yf2MnY2veV8W/lYk3LTDzxYpbAsbjxWcg=";
+    hash = "sha256-al45WS8SIgOM2TqGPIptZU7iNMapYUg+fK2MLh68lxs=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20241002.3";
+  version = "20241002.4";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-O1Yb5bCaKoS/Owwb0I0bF2neN2YTOnu28ruVA1cnFzk=";
+    hash = "sha256-b1/VrN0r/7rvSCjSn9HugKLaA40yl4AsFugzmCZKzd8=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2024.10.2";
+  version = "2024.10.4";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     rev = "refs/tags/${version}";
-    hash = "sha256-6aFZiJKPuUdnC3YzSHyJgn2iTHfP8MCwx17I7uxVTNg=";
+    hash = "sha256-MjHqX1OP1mEEypAxZ8Xc+ZWBsfj4yiFG9oItFnf/svk=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -3,26 +3,20 @@
 }:
 
 let
+  getComponentDeps = component: home-assistant.getPackages component home-assistant.python.pkgs;
+
   # some components' tests have additional dependencies
   extraCheckInputs = with home-assistant.python.pkgs; {
-    airzone_cloud = [
-      aioairzone
-    ];
-    androidtv = home-assistant.getPackages "asuswrt" home-assistant.python.pkgs;
-    bluetooth = [
-      pyswitchbot
-    ];
+    axis = getComponentDeps "deconz";
     govee_ble = [
       ibeacon-ble
     ];
+    hassio = getComponentDeps "homeassistant_yellow";
     lovelace = [
       pychromecast
     ];
     matrix = [
       pydantic
-    ];
-    mopeka = [
-      pyswitchbot
     ];
     onboarding = [
       pymetno
@@ -41,9 +35,6 @@ let
     system_log = [
       isal
     ];
-    tilt_ble = [
-      ibeacon-ble
-    ];
     xiaomi_miio = [
       arrow
     ];
@@ -59,22 +50,6 @@ let
   };
 
   extraDisabledTests = {
-    advantage_air = [
-      # AssertionError: assert 2 == 1 (Expected two calls, got one)
-      "test_binary_sensor_async_setup_entry"
-    ];
-    hassio = [
-      # fails to load the hardware component
-      "test_device_registry_calls"
-    ];
-    husqvarna_automower = [
-      # snapshot mismatch
-      "test_device_diagnostics"
-    ];
-    recorder = [
-      # call not happening, likely due to timezone issues
-      "test_auto_purge"
-    ];
     shell_command = [
       # tries to retrieve file from github
       "test_non_text_stdout_capture"
@@ -84,16 +59,12 @@ let
       "test_sensor_entities"
     ];
     websocket_api = [
-      # racy
+      # AssertionError: assert 'unknown_error' == 'template_error'
       "test_render_template_with_timeout"
     ];
   };
 
   extraPytestFlagsArray = {
-    cloud = [
-      # Tries to connect to alexa-api.nabucasa.com:443
-      "--deselect tests/components/cloud/test_http_api.py::test_websocket_update_preferences_alexa_report_state"
-    ];
     dnsip = [
       # Tries to resolve DNS entries
       "--deselect tests/components/dnsip/test_config_flow.py::test_options_flow"
@@ -109,10 +80,13 @@ let
       # aioserial mock produces wrong state
       "--deselect tests/components/modem_callerid/test_init.py::test_setup_entry"
     ];
-    velux = [
-      # uses unmocked sockets
-      "--deselect tests/components/velux/test_config_flow.py::test_user_success"
-      "--deselect tests/components/velux/test_config_flow.py::test_import_valid_config"
+    sql = [
+      "-W"
+      "ignore::sqlalchemy.exc.SAWarning"
+    ];
+    vicare = [
+      # Snapshot 'test_all_entities[sensor.model0_electricity_consumption_today-entry]' does not exist!
+      "--deselect=tests/components/vicare/test_sensor.py::test_all_entities"
     ];
   };
 in lib.listToAttrs (map (component: lib.nameValuePair component (


### PR DESCRIPTION
https://github.com/jd/tenacity/releases/tag/8.4.2
https://github.com/jd/tenacity/releases/tag/8.5.0
https://github.com/jd/tenacity/releases/tag/9.0.0

https://gitlab.com/klikini/doorbirdpy/-/tags/3.0.4
https://gitlab.com/klikini/doorbirdpy/-/tags/3.0.5

https://github.com/Danielhiversen/pyTibber/releases/tag/0.30.3

https://github.com/home-assistant/core/releases/tag/2024.10.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
