### PR TITLE
{bintools-wrapper,cc-wrapper}: factor out Darwin SDK logic, allow paths relative to the Darwin SDK

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
@@ -79,9 +79,3 @@ if [ ! "$havePlatformVersionFlag" ]; then
         extraBefore+=(-@darwinPlatform@_version_min "${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@}")
     fi
 fi
-
-mangleVarSingle DEVELOPER_DIR ${role_suffixes[@]+"${role_suffixes[@]}"}
-
-# Allow wrapped bintools to do something useful when no `DEVELOPER_DIR` is set, which can happen when
-# the compiler is run outside of a stdenv or intentionally in an environment with no environment variables set.
-DEVELOPER_DIR=${DEVELOPER_DIR_@suffixSalt@:-@fallback_sdk@}

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -372,24 +372,15 @@ stdenvNoCC.mkDerivation {
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
+      substituteAll ${../wrapper-common/darwin-sdk-setup.bash} $out/nix-support/darwin-sdk-setup.bash
     ''
 
     ###
     ### Ensure consistent LC_VERSION_MIN_MACOSX
     ###
-    + optionalString targetPlatform.isDarwin (
-      let
-        inherit (targetPlatform)
-          darwinPlatform darwinSdkVersion
-          darwinMinVersion darwinMinVersionVariable;
-      in ''
-        export darwinPlatform=${darwinPlatform}
-        export darwinMinVersion=${darwinMinVersion}
-        export darwinSdkVersion=${darwinSdkVersion}
-        export darwinMinVersionVariable=${darwinMinVersionVariable}
-        substituteAll ${./add-darwin-ldflags-before.sh} $out/nix-support/add-local-ldflags-before.sh
-      ''
-    )
+    + optionalString targetPlatform.isDarwin ''
+      substituteAll ${./add-darwin-ldflags-before.sh} $out/nix-support/add-local-ldflags-before.sh
+    ''
 
     ##
     ## Extra custom steps
@@ -407,6 +398,11 @@ stdenvNoCC.mkDerivation {
     inherit dynamicLinker targetPrefix suffixSalt coreutils_bin;
     inherit bintools_bin libc_bin libc_dev libc_lib;
     default_hardening_flags_str = builtins.toString defaultHardeningFlags;
+  } // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {
+    # These will become empty strings when not targeting Darwin.
+    inherit (targetPlatform)
+      darwinPlatform darwinSdkVersion
+      darwinMinVersion darwinMinVersionVariable;
   } // lib.optionalAttrs (apple-sdk != null && stdenvNoCC.targetPlatform.isDarwin) {
     # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
     fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -16,6 +16,8 @@ fi
 
 source @out@/nix-support/utils.bash
 
+source @out@/nix-support/darwin-sdk-setup.bash
+
 if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -44,9 +44,9 @@ if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
     while (( "$n" < "$nParams" )); do
         p=${params[n]}
         p2=${params[n+1]:-} # handle `p` being last one
-        if [ "${p:0:3}" = -L/ ] && badPath "${p:2}"; then
+        if [ "${p:0:3}" = -L/ ] && badPathWithDarwinSdk "${p:2}"; then
             skip "${p:2}"
-        elif [ "$p" = -L ] && badPath "$p2"; then
+        elif [ "$p" = -L ] && badPathWithDarwinSdk "$p2"; then
             n+=1; skip "$p2"
         elif [ "$p" = -rpath ] && badPath "$p2"; then
             n+=1; skip "$p2"

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -78,23 +78,12 @@ if [ -e @out@/nix-support/cc-cflags-before ]; then
     NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="$(< @out@/nix-support/cc-cflags-before) $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
 fi
 
-# Only add darwin min version flag and set up `DEVELOPER_DIR` if a default darwin min version is set,
+# Only add darwin min version flag if a default darwin min version is set,
 # which is a signal that we're targetting darwin.
 if [ "@darwinMinVersion@" ]; then
     mangleVarSingle @darwinMinVersionVariable@ ${role_suffixes[@]+"${role_suffixes[@]}"}
 
     NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="-m@darwinPlatformForCC@-version-min=${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
-
-    # `DEVELOPER_DIR` is used to dynamically locate libSystem (and the SDK frameworks) based on the SDK at that path.
-    mangleVarSingle DEVELOPER_DIR ${role_suffixes[@]+"${role_suffixes[@]}"}
-
-    # Allow wrapped compilers to do something useful when no `DEVELOPER_DIR` is set, which can happen when
-    # the compiler is run outside of a stdenv or intentionally in an environment with no environment variables set.
-    DEVELOPER_DIR=${DEVELOPER_DIR_@suffixSalt@:-@fallback_sdk@}
-
-    # xcbuild needs `SDKROOT` to be the name of the SDK, which it sets in its own wrapper,
-    # but compilers expect it to point to the absolute path.
-    SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
 fi
 
 # That way forked processes will not extend these environment variables again.

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -17,6 +17,8 @@ fi
 
 source @out@/nix-support/utils.bash
 
+source @out@/nix-support/darwin-sdk-setup.bash
+
 
 # Parse command line options and set several variables.
 # For instance, figure out if linker flags should be passed.

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -103,7 +103,7 @@ if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
             -[IL] | -isystem) path=$p2 skipNext=true ;;
         esac
 
-        if [[ -n $path ]] && badPath "$path"; then
+        if [[ -n $path ]] && badPathWithDarwinSdk "$path"; then
             skip "$path"
             $skipNext && n+=1
             continue

--- a/pkgs/build-support/wrapper-common/darwin-sdk-setup.bash
+++ b/pkgs/build-support/wrapper-common/darwin-sdk-setup.bash
@@ -1,0 +1,16 @@
+accumulateRoles
+
+# Only set up `DEVELOPER_DIR` if a default darwin min version is set,
+# which is a signal that we're targetting darwin.
+if [[ "@darwinMinVersion@" ]]; then
+    # `DEVELOPER_DIR` is used to dynamically locate libSystem (and the SDK frameworks) based on the SDK at that path.
+    mangleVarSingle DEVELOPER_DIR ${role_suffixes[@]+"${role_suffixes[@]}"}
+
+    # Allow wrapped compilers to do something useful when no `DEVELOPER_DIR` is set, which can happen when
+    # the compiler is run outside of a stdenv or intentionally in an environment with no environment variables set.
+    DEVELOPER_DIR=${DEVELOPER_DIR_@suffixSalt@:-@fallback_sdk@}
+
+    # xcbuild needs `SDKROOT` to be the name of the SDK, which it sets in its own wrapper,
+    # but compilers expect it to point to the absolute path.
+    SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+fi

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -118,6 +118,21 @@ badPath() {
         "${p#"${TEMPDIR:-/tmp}"}" = "$p"
 }
 
+# Like `badPath`, but handles paths that may be interpreted relative to
+# `$SDKROOT` on Darwin. For example, `-L/usr/lib/swift` is interpreted
+# as `-L$SDKROOT/usr/lib/swift` when `$SDKROOT` is set and
+# `$SDKROOT/usr/lib/swift` exists.
+badPathWithDarwinSdk() {
+    path=$1
+    if [[ "@darwinMinVersion@" ]]; then
+        sdkPath=$SDKROOT/$path
+        if [[ -e $sdkPath ]]; then
+            path=$sdkPath
+        fi
+    fi
+    badPath "$path"
+}
+
 expandResponseParams() {
     declare -ga params=("$@")
     local arg


### PR DESCRIPTION
`-L` and `-I` are interpreted relative to the `$SDKROOT` by the Darwin toolchain, so we have to avoid filtering out such paths in the purity filter hacks in order to not break e.g. the .NET Core build system. It’s also just the correct thing to do for the platform.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
