### PR TITLE
tabby-agent: init at 0.18.0

### DIFF
--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs,
+  pnpm,
+  wrapGAppsHook3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tabby-agent";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "TabbyML";
+    repo = "tabby";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-8clEBWAT+HI2eecOsmldgRcA58Ehq9bZT4ZwUMm494g=";
+  };
+
+  nativeBuildInputs = [
+    pnpm.configHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=tabby-agent build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r ./clients/tabby-agent/dist $out/dist
+    ln -s $out/dist/node/index.js $out/bin/tabby-agent
+    chmod +x $out/bin/tabby-agent
+
+    runHook postInstall
+  '';
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-WBhkrgLTTR5f8ZVmUfzMbFw/6jIGoLcUspHCsNpOxx4=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v([0-9.]+)$"
+    ];
+  };
+
+  meta = {
+    homepage = "https://github.com/TabbyML/tabby";
+    changelog = "https://github.com/TabbyML/tabby/releases/tag/v${finalAttrs.version}";
+    description = "Language server used to communicate with Tabby server";
+    mainProgram = "tabby-agent";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.khaneliman ];
+  };
+})


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/350323 and predecessor for vim-tabby update https://github.com/NixOS/nixpkgs/pull/350532#issuecomment-2430070025

https://github.com/TabbyML/tabby/tree/main/clients/tabby-agent

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
