### PR TITLE
tor: 0.4.8.12 -> 0.4.8.13

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -30,11 +30,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "tor";
-  version = "0.4.8.12";
+  version = "0.4.8.13";
 
   src = fetchurl {
     url = "https://dist.torproject.org/${pname}-${version}.tar.gz";
-    sha256 = "sha256-ynzHNdmON0e1jy88wU+ATdeJ+g+zM6hNy2vXCtu4yHQ=";
+    sha256 = "sha256-m68mw4eiggs5QtpXIUbm63fCvGaGKvYpfNAqB05vuig=";
   };
 
   outputs = [ "out" "geoip" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
Changes in version 0.4.8.13 - 2024-10-24
  This is minor release fixing an important client circuit building (Conflux
  related) bug which lead to performance degradation and extra load on the
  network. Some minor memory leaks fixes as well as an important minor feature
  for pluggable transports. We strongly recommend to update as soon as possible
  for clients in order to neutralize this conflux bug.

  o Major bugfixes (circuit building):
    - Conflux circuit building was ignoring the "predicted ports"
      feature, which aims to make Tor stop building circuits if there
      have been no user requests lately. This bug led to every idle Tor
      on the network building and discarding circuits every 30 seconds,
      which added overall load to the network, used bandwidth and
      battery from clients that weren't actively using their Tor, and
      kept sockets open on guards which added connection padding
      essentially forever. Fixes bug 40981; bugfix on 0.4.8.1-alpha;

  o Minor feature (bridges, pluggable transport):
    - Add STATUS TYPE=version handler for Pluggable Transport. This
      allows us to gather version statistics on Pluggable Transport
      usage from bridge servers on our metrics portal. Closes
      ticket 11101.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on October 24, 2024.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2024/10/24.

  o Minor bugfixes (memleak, authority):
    - Fix a small memleak when computing a new consensus. This only
      affects directory authorities. Fixes bug 40966; bugfix
      on 0.3.5.1-alpha.

  o Minor bugfixes (memory):
    - Fix memory leaks of the CPU worker code during shutdown. Fixes bug
      833; bugfix on 0.3.5.1-alpha.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
