### PR TITLE
crow-translate: 3.0.0 → 3.1.0

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -16,14 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "crow-translate";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "office";
     repo = "crow-translate";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hdrhxbv44DlxoF1JU1d2auP/vR8a3IJI+hN7PhdPMaY=";
+    hash = "sha256-zL+Ucw6rzIoEaBHi/uqKQB0cnR6aAcF8MPOG3hwK3iA=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/cr/crow-translate/package.nix
+++ b/pkgs/by-name/cr/crow-translate/package.nix
@@ -3,13 +3,10 @@
 , fetchFromGitLab
 , cmake
 , extra-cmake-modules
-, qttools
-, kwayland
 , leptonica
+, libsForQt5
+, qt5
 , tesseract4
-, qtmultimedia
-, qtx11extras
-, wrapQtAppsHook
 , gst_all_1
 , testers
 }:
@@ -29,22 +26,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace data/org.kde.CrowTranslate.desktop.in \
-      --subst-var-by QT_BIN_DIR ${lib.getBin qttools}/bin
+      --subst-var-by QT_BIN_DIR ${lib.getBin qt5.qttools}/bin
   '';
 
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    qttools
-    wrapQtAppsHook
+    qt5.qttools
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    kwayland
+    libsForQt5.kwayland
     leptonica
     tesseract4
-    qtmultimedia
-    qtx11extras
+    qt5.qtmultimedia
+    qt5.qtx11extras
   ] ++ (with gst_all_1; [
     gstreamer
     gst-plugins-base

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -537,8 +537,6 @@ with pkgs;
 
   crackql = callPackage ../tools/security/crackql { };
 
-  crow-translate = libsForQt5.callPackage ../applications/misc/crow-translate { };
-
   dae = callPackage ../tools/networking/dae { };
 
   darling = callPackage ../applications/emulators/darling { };


### PR DESCRIPTION
https://invent.kde.org/office/crow-translate/-/tags/v3.1.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
