### PR TITLE
rsstail: 2.1 -> 2.2 and libiconv darwin fix

### DIFF
--- a/pkgs/applications/networking/feedreaders/rsstail/default.nix
+++ b/pkgs/applications/networking/feedreaders/rsstail/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (final: {
       detects a new entry it'll emit only that new entry.
     '';
     homepage = "https://www.vanheusden.com/rsstail/";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.Necior ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/networking/feedreaders/rsstail/default.nix
+++ b/pkgs/applications/networking/feedreaders/rsstail/default.nix
@@ -1,24 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, libmrss, libiconv }:
+{ lib, stdenv, fetchFromGitHub, libmrss }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (final: {
   pname = "rsstail";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "folkertvanheusden";
     repo = "rsstail";
-    rev = "6f2436185372b3f945a4989406c4b6a934fe8a95";
-    sha256 = "12p69i3g1fwlw0bds9jqsdmzkid3k5a41w31d227i7vm12wcvjf6";
+    rev = "v${final.version}";
+    hash = "sha256-wbdf9zhwMN7QhJ5WoJo1Csu0EcKUTON8Q2Ic5scbn7I=";
   };
 
-  buildInputs = [ libmrss ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
-
-  postPatch = ''
-    substituteInPlace Makefile --replace -liconv_hook ""
-  '';
+  buildInputs = [ libmrss ];
 
   makeFlags = [ "prefix=$(out)" ];
   enableParallelBuilding = true;
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-liconv";
+  };
 
   # just runs cppcheck linter
   doCheck = false;
@@ -35,4 +35,4 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.Necior ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
update build and fix darwin linking with libiconv

https://hydra.nixos.org/build/276113446

https://github.com/folkertvanheusden/rsstail/compare/6f2436185372b3f945a4989406c4b6a934fe8a95...v2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
