### PR TITLE
neovim: improve lpeg patch for darwin

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -1,69 +1,92 @@
-{ lib, stdenv, fetchFromGitHub, removeReferencesTo, cmake, gettext, msgpack-c, darwin
-, libuv, lua, pkg-config
-, unibilium
-, libvterm-neovim
-, tree-sitter
-, fetchurl
-, buildPackages
-, treesitter-parsers ? import ./treesitter-parsers.nix { inherit fetchurl; }
-, fixDarwinDylibNames
-, glibcLocales ? null, procps ? null
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  removeReferencesTo,
+  cmake,
+  gettext,
+  msgpack-c,
+  darwin,
+  libuv,
+  lua,
+  pkg-config,
+  unibilium,
+  libvterm-neovim,
+  tree-sitter,
+  fetchurl,
+  buildPackages,
+  treesitter-parsers ? import ./treesitter-parsers.nix { inherit fetchurl; },
+  fixDarwinDylibNames,
+  glibcLocales ? null,
+  procps ? null,
 
-# now defaults to false because some tests can be flaky (clipboard etc), see
-# also: https://github.com/neovim/neovim/issues/16233
-, nodejs ? null, fish ? null, python3 ? null
+  # now defaults to false because some tests can be flaky (clipboard etc), see
+  # also: https://github.com/neovim/neovim/issues/16233
+  nodejs ? null,
+  fish ? null,
+  python3 ? null,
 }:
-stdenv.mkDerivation (finalAttrs:
+stdenv.mkDerivation (
+  finalAttrs:
   let
-  nvim-lpeg-dylib = luapkgs: if stdenv.hostPlatform.isDarwin
-    then (luapkgs.lpeg.overrideAttrs (oa: {
-      preConfigure = ''
-        # neovim wants clang .dylib
-        sed -i makefile -e "s/CC = gcc/CC = clang/"
-        sed -i makefile -e "s/-bundle/-dynamiclib/"
-      '';
-      preBuild = ''
-        # there seems to be implicit calls to Makefile from luarocks, we need to
-        # add a stage to build our dylib
-        make macosx
-        mkdir -p $out/lib
-        mv lpeg.so $out/lib/lpeg.dylib
-      '';
-      nativeBuildInputs =
-        oa.nativeBuildInputs
-        ++ (
-          lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames
-        );
-    }))
-    else luapkgs.lpeg;
-  requiredLuaPkgs = ps: (with ps; [
-    (nvim-lpeg-dylib ps)
-    luabitop
-    mpack
-  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
-    luv
-    coxpcall
-    busted
-    luafilesystem
-    penlight
-    inspect
-  ]
-  );
-  neovimLuaEnv = lua.withPackages requiredLuaPkgs;
-  neovimLuaEnvOnBuild = lua.luaOnBuild.withPackages requiredLuaPkgs;
-  codegenLua =
-    if lua.luaOnBuild.pkgs.isLuaJIT
-      then
-        let deterministicLuajit =
-          lua.luaOnBuild.override {
+    nvim-lpeg-dylib =
+      luapkgs:
+      if stdenv.hostPlatform.isDarwin then
+        (luapkgs.lpeg.overrideAttrs (oa: {
+          preConfigure = ''
+            # neovim wants clang .dylib
+            sed -i makefile -e "s/CC = gcc/CC = clang/"
+            sed -i makefile -e "s/-bundle/-dynamiclib/"
+          '';
+          preBuild = ''
+            # there seems to be implicit calls to Makefile from luarocks, we need to
+            # add a stage to build our dylib
+            make macosx
+            mkdir -p $out/lib
+            mv lpeg.so $out/lib/lpeg.dylib
+          '';
+          nativeBuildInputs =
+            oa.nativeBuildInputs ++ (lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames);
+        }))
+      else
+        luapkgs.lpeg;
+    requiredLuaPkgs =
+      ps:
+      (
+        with ps;
+        [
+          (nvim-lpeg-dylib ps)
+          luabitop
+          mpack
+        ]
+        ++ lib.optionals finalAttrs.finalPackage.doCheck [
+          luv
+          coxpcall
+          busted
+          luafilesystem
+          penlight
+          inspect
+        ]
+      );
+    neovimLuaEnv = lua.withPackages requiredLuaPkgs;
+    neovimLuaEnvOnBuild = lua.luaOnBuild.withPackages requiredLuaPkgs;
+    codegenLua =
+      if lua.luaOnBuild.pkgs.isLuaJIT then
+        let
+          deterministicLuajit = lua.luaOnBuild.override {
             deterministicStringIds = true;
             self = deterministicLuajit;
           };
-        in deterministicLuajit.withPackages(ps: [ ps.mpack (nvim-lpeg-dylib ps) ])
-      else lua.luaOnBuild;
+        in
+        deterministicLuajit.withPackages (ps: [
+          ps.mpack
+          (nvim-lpeg-dylib ps)
+        ])
+      else
+        lua.luaOnBuild;
 
-
-in {
+  in
+  {
     pname = "neovim-unwrapped";
     version = "0.10.2";
 
@@ -86,26 +109,39 @@ in {
     dontFixCmake = true;
 
     inherit lua;
-    treesitter-parsers = treesitter-parsers //
-      { markdown = treesitter-parsers.markdown // { location = "tree-sitter-markdown"; }; } //
-      { markdown_inline = treesitter-parsers.markdown // { language = "markdown_inline"; location = "tree-sitter-markdown-inline"; }; }
-      ;
+    treesitter-parsers =
+      treesitter-parsers
+      // {
+        markdown = treesitter-parsers.markdown // {
+          location = "tree-sitter-markdown";
+        };
+      }
+      // {
+        markdown_inline = treesitter-parsers.markdown // {
+          language = "markdown_inline";
+          location = "tree-sitter-markdown-inline";
+        };
+      };
 
-    buildInputs = [
-      libuv
-      libvterm-neovim
-      # This is actually a c library, hence it's not included in neovimLuaEnv,
-      # see:
-      # https://github.com/luarocks/luarocks/issues/1402#issuecomment-1080616570
-      # and it's definition at: pkgs/development/lua-modules/overrides.nix
-      lua.pkgs.libluv
-      msgpack-c
-      neovimLuaEnv
-      tree-sitter
-      unibilium
-    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.libutil ]
-      ++ lib.optionals finalAttrs.finalPackage.doCheck [ glibcLocales procps ]
-    ;
+    buildInputs =
+      [
+        libuv
+        libvterm-neovim
+        # This is actually a c library, hence it's not included in neovimLuaEnv,
+        # see:
+        # https://github.com/luarocks/luarocks/issues/1402#issuecomment-1080616570
+        # and it's definition at: pkgs/development/lua-modules/overrides.nix
+        lua.pkgs.libluv
+        msgpack-c
+        neovimLuaEnv
+        tree-sitter
+        unibilium
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.libutil ]
+      ++ lib.optionals finalAttrs.finalPackage.doCheck [
+        glibcLocales
+        procps
+      ];
 
     doCheck = false;
 
@@ -125,66 +161,87 @@ in {
     ];
 
     # extra programs test via `make functionaltest`
-    nativeCheckInputs = let
-      pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
-    in [
-      fish
-      nodejs
-      pyEnv      # for src/clint.py
-    ];
+    nativeCheckInputs =
+      let
+        pyEnv = python3.withPackages (
+          ps: with ps; [
+            pynvim
+            msgpack
+          ]
+        );
+      in
+      [
+        fish
+        nodejs
+        pyEnv # for src/clint.py
+      ];
 
     # nvim --version output retains compilation flags and references to build tools
-    postPatch = ''
-      substituteInPlace src/nvim/version.c --replace NVIM_VERSION_CFLAGS "";
-    '' + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      sed -i runtime/CMakeLists.txt \
-        -e "s|\".*/bin/nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
-      sed -i src/nvim/po/CMakeLists.txt \
-        -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
-    '';
+    postPatch =
+      ''
+        substituteInPlace src/nvim/version.c --replace NVIM_VERSION_CFLAGS "";
+      ''
+      + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        sed -i runtime/CMakeLists.txt \
+          -e "s|\".*/bin/nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
+        sed -i src/nvim/po/CMakeLists.txt \
+          -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
+      '';
     postInstall = ''
       find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
     '';
     # check that the above patching actually works
-    outputChecks = let
-      disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
-    in {
-      out = { inherit disallowedRequisites; };
-      debug = { inherit disallowedRequisites; };
-    };
+    outputChecks =
+      let
+        disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
+      in
+      {
+        out = {
+          inherit disallowedRequisites;
+        };
+        debug = {
+          inherit disallowedRequisites;
+        };
+      };
 
-    cmakeFlags = [
-      # Don't use downloaded dependencies. At the end of the configurePhase one
-      # can spot that cmake says this option was "not used by the project".
-      # That's because all dependencies were found and
-      # third-party/CMakeLists.txt is not read at all.
-      "-DUSE_BUNDLED=OFF"
-    ]
-    ++ lib.optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"
-    ++ lib.optionals lua.pkgs.isLuaJIT [
-      "-DLUAC_PRG=${codegenLua}/bin/luajit -b -s %s -"
-      "-DLUA_GEN_PRG=${codegenLua}/bin/luajit"
-      "-DLUA_PRG=${neovimLuaEnvOnBuild}/bin/luajit"
-    ];
+    cmakeFlags =
+      [
+        # Don't use downloaded dependencies. At the end of the configurePhase one
+        # can spot that cmake says this option was "not used by the project".
+        # That's because all dependencies were found and
+        # third-party/CMakeLists.txt is not read at all.
+        "-DUSE_BUNDLED=OFF"
+      ]
+      ++ lib.optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"
+      ++ lib.optionals lua.pkgs.isLuaJIT [
+        "-DLUAC_PRG=${codegenLua}/bin/luajit -b -s %s -"
+        "-DLUA_GEN_PRG=${codegenLua}/bin/luajit"
+        "-DLUA_PRG=${neovimLuaEnvOnBuild}/bin/luajit"
+      ];
 
-    preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace src/nvim/CMakeLists.txt --replace "    util" ""
-    '' + ''
-      mkdir -p $out/lib/nvim/parser
-    '' + lib.concatStrings (lib.mapAttrsToList
-      (language: grammar: ''
-        ln -s \
-          ${tree-sitter.buildGrammar {
-            inherit (grammar) src;
-            version = "neovim-${finalAttrs.version}";
-            language = grammar.language or language;
-            location = grammar.location or null;
-          }}/parser \
-          $out/lib/nvim/parser/${language}.so
-      '')
-      finalAttrs.treesitter-parsers);
+    preConfigure =
+      lib.optionalString stdenv.hostPlatform.isDarwin ''
+        substituteInPlace src/nvim/CMakeLists.txt --replace "    util" ""
+      ''
+      + ''
+        mkdir -p $out/lib/nvim/parser
+      ''
+      + lib.concatStrings (
+        lib.mapAttrsToList (language: grammar: ''
+          ln -s \
+            ${
+              tree-sitter.buildGrammar {
+                inherit (grammar) src;
+                version = "neovim-${finalAttrs.version}";
+                language = grammar.language or language;
+                location = grammar.location or null;
+              }
+            }/parser \
+            $out/lib/nvim/parser/${language}.so
+        '') finalAttrs.treesitter-parsers
+      );
 
-    shellHook=''
+    shellHook = ''
       export VIMRUNTIME=$PWD/runtime
     '';
 
@@ -200,15 +257,22 @@ in {
           modifications to the core source
         - Improve extensibility with a new plugin architecture
       '';
-      homepage    = "https://www.neovim.io";
+      homepage = "https://www.neovim.io";
       mainProgram = "nvim";
       # "Contributions committed before b17d96 by authors who did not sign the
       # Contributor License Agreement (CLA) remain under the Vim license.
       # Contributions committed after b17d96 are licensed under Apache 2.0 unless
       # those contributions were copied from Vim (identified in the commit logs
       # by the vim-patch token). See LICENSE for details."
-      license = with lib.licenses; [ asl20 vim ];
-      maintainers = with lib.maintainers; [ manveru rvolosatovs ];
-      platforms   = lib.platforms.unix;
+      license = with lib.licenses; [
+        asl20
+        vim
+      ];
+      maintainers = with lib.maintainers; [
+        manveru
+        rvolosatovs
+      ];
+      platforms = lib.platforms.unix;
     };
-  })
+  }
+)


### PR DESCRIPTION
## Description

> Note: Please review each commit individually as the formatting has lead the overall diff to balloon.

Since [this neovim commit](https://github.com/neovim/neovim/commit/e178331488a0fb6a9c48152511a21a3f95d66750), [the current change we make to the `lpeg` derivation when building neovim on darwin](https://github.com/NixOS/nixpkgs/blob/072f2eef83e8bd45be52ea6fdbb8ea488867a945/pkgs/by-name/ne/neovim-unwrapped/package.nix#L19-L38) has stopped working.
We have noticed it in the [neovim-nightly-overlay project](https://github.com/nix-community/neovim-nightly-overlay/pull/682).
[This modification](https://github.com/nix-community/neovim-nightly-overlay/pull/683) by @hurricanehrndz solves the issue and is the object of this PR.

## Ping relevant people
neovim derivation maintainers: cc @manveru @rvolosatovs
co-maintainer of [neovim-nightly-overlay](https://github.com/nix-community/neovim-nightly-overlay): cc @willruggiano 

## Commits

- **neovim: format derivation**
- ~~**neovim: remove uneffective substituteInPlace patches**~~
- **neovim: improve lpeg patch for darwin**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
