### PR TITLE
spread: init at 0-unstable-2023-03-01

### DIFF
--- a/pkgs/by-name/sp/spread/local-script-path.patch
+++ b/pkgs/by-name/sp/spread/local-script-path.patch
@@ -1,0 +1,13 @@
+diff --git a/spread/client.go b/spread/client.go
+index c72d48a..e927567 100644
+--- a/spread/client.go
++++ b/spread/client.go
+@@ -791,7 +791,7 @@ func (s *localScript) run() (stdout, stderr []byte, err error) {
+ 	buf.WriteString("NOMATCH() { { set +xu; } 2> /dev/null; local stdin=$(cat); if echo $stdin | grep -q -E \"$@\"; then echo \"NOMATCH pattern='$@' found in:\n$stdin\">&2; return 1; fi }\n")
+ 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
+ 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
+-	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")
++	buf.WriteString(fmt.Sprintf("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:%s\n", os.Getenv("PATH")))
+ 
+ 	for _, k := range s.env.Keys() {
+ 		v := s.env.Get(k)

--- a/pkgs/by-name/sp/spread/package.nix
+++ b/pkgs/by-name/sp/spread/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  bash,
+  coreutils,
+  gnutar,
+  gzip,
+  makeWrapper,
+}:
+
+buildGoModule {
+  pname = "spread";
+  version = "0-unstable-2023-03-01";
+
+  src = fetchFromGitHub {
+    owner = "snapcore";
+    repo = "spread";
+    rev = "ded9133cdbceaf01f8a1c9decf6ff9ea56e194d6";
+    hash = "sha256-uHBzVABfRCyBAGP9f+2GS49Qc8R9d1HaRr6bYPeVSU4=";
+  };
+
+  vendorHash = "sha256-SULAfCLtNSnuUXvA33I48hnhU0Ixq79HhADPIKYkWNU=";
+
+  subPackages = [ "cmd/spread" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [
+    # The upstream project statically assigns a PATH when running scripts in the
+    # local machine context. This patch keeps that static PATH assignment, but also
+    # appends the PATH from the environment context in which spread was run, so
+    # that nix-installed binaries are also available.
+    ./local-script-path.patch
+  ];
+
+  postPatch = ''
+    # Replace direct calls to /bin/bash
+    substituteInPlace spread/lxd.go --replace-fail '"/bin/bash", ' '"/usr/bin/env", "bash", '
+    substituteInPlace spread/client.go --replace-fail '"/bin/bash", ' '"/usr/bin/env", "bash", '
+    substituteInPlace spread/project.go --replace-fail '"/bin/bash", ' '"/usr/bin/env", "bash", '
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/spread --prefix PATH : ${
+      lib.makeBinPath [
+        bash
+        coreutils
+        gnutar
+        gzip
+      ]
+    }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "spread";
+    license = lib.licenses.gpl3Only;
+    description = "Convenient full-system test (task) distribution";
+    homepage = "https://github.com/snapcore/spread";
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR adds the `spread` package to `nixpkgs`. Spread is a convenient method of distributing tasks to remote machines - most commonly in the context of integration testing. It provides a common language for describing a set of tasks, and how those tasks should be prepared for, and rolled back from.

The version implies the tool is not frequently maintained, though it is far from abandoned and in heavy daily use at Canonical and wider.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
