### PR TITLE
python312Packages.{magic-wormhole-transit-relay: 0.2.1 -> 0.3.1, magic-wormhole: 0.16.0 -> 0.17.0}

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -6,20 +6,26 @@
   autobahn,
   mock,
   twisted,
-  pythonOlder,
-  pythonAtLeast,
+  python,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "magic-wormhole-transit-relay";
-  version = "0.2.1";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-y0gBtGiQ6v+XKG4OP+xi0dUv/jF9FACDtjNqH7To+l4=";
+    hash = "sha256-LvLvvk008OYkhw+EIln9czuncVLtMQr0NJd0piiEkA4=";
   };
+
+  postPatch = ''
+    # Passing the environment to twistd is necessary to preserve Python's site path.
+    substituteInPlace src/wormhole_transit_relay/test/test_backpressure.py --replace-fail \
+      'reactor.spawnProcess(proto, exe, args)' \
+      'reactor.spawnProcess(proto, exe, args, None)'
+  '';
 
   build-system = [ setuptools ];
 
@@ -39,13 +45,16 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
+  postCheck = ''
+    # Avoid collision with twisted's plugin cache (#164775).
+    rm "$out/${python.sitePackages}/twisted/plugins/dropin.cache"
+  '';
+
   meta = {
     description = "Transit Relay server for Magic-Wormhole";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-transit-relay";
     changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/${version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
-    # Python 3.12 support: https://github.com/magic-wormhole/magic-wormhole-transit-relay/issues/35
-    broken = pythonOlder "3.7" || pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
-  pythonAtLeast,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
@@ -35,35 +34,16 @@
   pytestCheckHook,
 }:
 
-let
-  # magic-wormhole relies on the internal API of
-  # magic-wormhole-transit-relay < 0.3.0 for testing.
-  magic-wormhole-transit-relay_0_2_1 =
-    magic-wormhole-transit-relay.overridePythonAttrs
-      (oldAttrs: rec {
-        version = "0.2.1";
-
-        src = fetchPypi {
-          pname = "magic-wormhole-transit-relay";
-          inherit version;
-          hash = "sha256-y0gBtGiQ6v+XKG4OP+xi0dUv/jF9FACDtjNqH7To+l4=";
-        };
-
-        postPatch = "";
-
-        postCheck = "";
-
-        meta.broken = pythonAtLeast "3.12";
-      });
-in
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.16.0";
+  version = "0.17.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-FObBRomNvaem0ZAmJiOmlBmVU2Pn5DTWSq0tIz1tlMk=";
+  src = fetchFromGitHub {
+    owner = "magic-wormhole";
+    repo = "magic-wormhole";
+    rev = "refs/tags/${version}";
+    hash = "sha256-BxPF4iQ91wLBagdvQ/Y89VIZBkMxFiEHnK+BU55Bwr4=";
   };
 
   postPatch =
@@ -104,10 +84,10 @@ buildPythonPackage rec {
     # For Python 3.12, remove magic-wormhole-mailbox-server and magic-wormhole-transit-relay from test dependencies,
     # which are not yet supported with this version.
     lib.optionals
-      (!magic-wormhole-mailbox-server.meta.broken && !magic-wormhole-transit-relay_0_2_1.meta.broken)
+      (!magic-wormhole-mailbox-server.meta.broken && !magic-wormhole-transit-relay.meta.broken)
       [
         magic-wormhole-mailbox-server
-        magic-wormhole-transit-relay_0_2_1
+        magic-wormhole-transit-relay
       ]
     ++ [
       mock
@@ -122,7 +102,7 @@ buildPythonPackage rec {
     # For Python 3.12, remove the tests depending on magic-wormhole-mailbox-server and magic-wormhole-transit-relay,
     # which are not yet supported with this version.
     lib.optionals
-      (magic-wormhole-mailbox-server.meta.broken || magic-wormhole-transit-relay_0_2_1.meta.broken)
+      (magic-wormhole-mailbox-server.meta.broken || magic-wormhole-transit-relay.meta.broken)
       [
         "src/wormhole/test/dilate/test_full.py"
         "src/wormhole/test/test_args.py"


### PR DESCRIPTION
## Description of changes

https://github.com/magic-wormhole/magic-wormhole-transit-relay/compare/refs/tags/0.2.1...refs/tags/0.3.1
https://github.com/magic-wormhole/magic-wormhole/compare/refs/tags/0.16.0...refs/tags/0.17.0

## `nixpkgs-review` result

`tahoe-lafs` is already broken on master

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc