### PR TITLE
ci/OWNERS: Fix path of codeowners.yml

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -11,13 +11,13 @@
 # - There is no need for user/team listed here to have write access.
 # - No reviews will be requested for PRs that target the wrong base branch.
 #
-# Processing of this file is implemented in workflows/codeowners.yml
+# Processing of this file is implemented in workflows/codeowners-v2.yml
 
 # CI
 /.github/workflows @NixOS/Security @Mic92 @zowoq
 /.github/workflows/check-nix-format.yml @infinisil
 /.github/workflows/nixpkgs-vet.yml @infinisil @philiptaron
-/.github/workflows/codeowners.yml @infinisil
+/.github/workflows/codeowners-v2.yml @infinisil
 /ci/OWNERS @infinisil
 /ci @infinisil @philiptaron @NixOS/Security
 


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/pull/351446

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
