### PR TITLE
glaze: init at 4.0.0

### DIFF
--- a/pkgs/by-name/gl/glaze/0001-Do-not-fetch-external-resources-via-Git.patch
+++ b/pkgs/by-name/gl/glaze/0001-Do-not-fetch-external-resources-via-Git.patch
@@ -1,0 +1,33 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index a3bb3998..8c90058d 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -5,9 +5,7 @@ set(BOOST_UT_DISABLE_MODULE ON CACHE INTERNAL "")
+ 
+ FetchContent_Declare(
+   ut
+-  GIT_REPOSITORY https://github.com/openalgz/ut
+-  GIT_TAG v0.0.3
+-  GIT_SHALLOW TRUE
++  SOURCE_DIR @UT_DIR@
+ )
+ 
+ message(STATUS "Fetching dependencies...")
+diff --git a/tests/asio_repe/CMakeLists.txt b/tests/asio_repe/CMakeLists.txt
+index 70417b38..265e49c9 100644
+--- a/tests/asio_repe/CMakeLists.txt
++++ b/tests/asio_repe/CMakeLists.txt
+@@ -2,9 +2,7 @@ project(asio_repe)
+ 
+ FetchContent_Declare(
+     asio
+-    GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+-    GIT_TAG asio-1-30-1
+-    GIT_SHALLOW TRUE
++    SOURCE_DIR @ASIO_DIR@
+ )
+ FetchContent_GetProperties(asio)
+ if(NOT asio_POPULATED)
+-- 
+2.44.1
+

--- a/pkgs/by-name/gl/glaze/package.nix
+++ b/pkgs/by-name/gl/glaze/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  cmake,
+  eigen,
+  asio,
+  boost,
+}:
+
+let
+  # Very recent library, probably specific to glaze, by the same author
+  #
+  # Description: "A stripped down fork of boost-ext ut2"
+  # Homepage: "https://github.com/openalgz/ut"
+  ut_src = fetchFromGitHub {
+    owner = "openalgz";
+    repo = "ut";
+    rev = "v0.0.3";
+    hash = "sha256-lhq8Wy/Y7yehs5KgMAvLvsu09YCO6LPabfkjSDH56/Y=";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "glaze";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stephenberry";
+    repo = "glaze";
+    rev = "v${version}";
+    hash = "sha256-zaGKYEnYTyAhtP0Hywxp8Y33wvjB1RkEoOGF41CaVnY=";
+  };
+
+  patches = [ ./0001-Do-not-fetch-external-resources-via-Git.patch ];
+
+  postPatch = ''
+    substituteInPlace tests/CMakeLists.txt --subst-var-by UT_DIR ${ut_src}
+
+    mkdir -p $TMPDIR/asio
+    tar xf ${asio.src} -C $TMPDIR/asio --strip-components 1
+    substituteInPlace tests/asio_repe/CMakeLists.txt --subst-var-by ASIO_DIR $TMPDIR/asio
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost ];
+
+  doCheck = true;
+
+  checkInputs = [ eigen ];
+
+  meta = with lib; {
+    description = "Extremely fast, in memory, JSON and interface library for modern C++";
+    homepage = "https://github.com/stephenberry/glaze";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}


### PR DESCRIPTION
## Things done

https://github.com/stephenberry/glaze/releases/tag/v4.0.0

> Extremely fast, in memory, JSON and interface library for modern C++

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
