### PR TITLE
umoria: unpin from gcc-9

### DIFF
--- a/pkgs/by-name/um/umoria/package.nix
+++ b/pkgs/by-name/um/umoria/package.nix
@@ -1,6 +1,7 @@
 { lib
-, gcc9Stdenv
+, stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , cmake
 , ncurses6
@@ -10,7 +11,7 @@
 let
   savesDir = "~/.umoria";
 in
-gcc9Stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "umoria";
   version = "5.7.15";
 
@@ -20,6 +21,38 @@ gcc9Stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-1j4QkE33UcTzM06qAjk1/PyK5uNA7E/kyDe3bZcFKUM=";
   };
+
+  patches = [
+    # gcc-13 support: https://github.com/dungeons-of-moria/umoria/pull/58
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/dungeons-of-moria/umoria/commit/71dad4103b5c8f3e1f7723eb14d14425755e7ba5.patch";
+      hash = "sha256-5Ka3NTe0sJk6kReG+1hwZPEuB3R+Nn+2zxUXuOG7hm0=";
+    })
+    # clang support: https://github.com/dungeons-of-moria/umoria/pull/72
+    (fetchpatch {
+      name = "clang.patch";
+      url = "https://github.com/dungeons-of-moria/umoria/commit/f294e5880cd21d25c11eee820d629f4ff504ad10.patch";
+      hash = "sha256-se8G4n8codXA9gznyIy337IFyznLnpCY7KA6UryZDls=";
+    })
+    (fetchpatch {
+      name = "clang-p2.patch";
+      url = "https://github.com/dungeons-of-moria/umoria/commit/bf513b05dc34405665a8dd1386292cd70307dce0.patch";
+      hash = "sha256-FXj5Y4G0gnXheXC2bmRbIx3a1IixJ/aGfRMxl2S/vqM=";
+    })
+    # clang crash fix: https://github.com/dungeons-of-moria/umoria/pull/87
+    (fetchpatch {
+      name = "clang-crash.patch";
+      url = "https://github.com/dungeons-of-moria/umoria/commit/d073e8f867c49bb04a02c1995dd3efb0c5cc07e7.patch";
+      hash = "sha256-4uwO8fe4M5jt0IM0z6MjO8UaEezweMA5L+pusel4VUU=";
+    })
+  ];
+
+  postPatch = ''
+    # Do not apply blanket -Werror as it tends to fail on fresher
+    # toolchains.
+    substituteInPlace CMakeLists.txt --replace-fail '-Werror")' '-Wno-error")'
+  '';
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ ncurses6 ];


### PR DESCRIPTION
Needed a small upstream patch to fix the build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
