### PR TITLE
[staging-next] sage: import sympy and numpy update patches

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -74,11 +74,25 @@ stdenv.mkDerivation rec {
   # should come from or be proposed to upstream. This list will probably never
   # be empty since dependencies update all the time.
   packageUpgradePatches = [
-    # https://github.com/sagemath/sage/pull/38500, positively reviewed, to land in 10.5.beta3
+    # https://github.com/sagemath/sage/pull/38500, landed in 10.5.beta3
     (fetchpatch {
       name = "cython-3.0.11-upgrade.patch";
       url = "https://patch-diff.githubusercontent.com/raw/sagemath/sage/pull/38500.diff";
       hash = "sha256-ePfH3Gy1T0UfpoVd3EZowCfy88CbE+yE2MV2itWthsA=";
+    })
+
+    # https://github.com/sagemath/sage/pull/36641, landed in 10.5.beta3
+    (fetchpatch {
+      name = "sympy-1.13.2-update.patch";
+      url = "https://github.com/sagemath/sage/commit/100189fa62f9a40e7aa0d856615366ea99b87aff.diff";
+      sha256 = "sha256-uWr3I15WByQYGVxbJFqG4zUJ7c7+4rjkcgwkAT85O7w=";
+    })
+
+    # https://github.com/sagemath/sage/pull/38250, landed in 10.5.beta0
+    (fetchpatch {
+      name = "numpy-2.0-compat.patch";
+      url = "https://github.com/sagemath/sage/commit/0962e0bcb159d342e7c7d83557a71e7b670fff47.diff";
+      sha256 = "sha256-4SBhgPgT9VsBxcBH8+T5uYtWzYP5tZi9+iKOG55hWgI=";
     })
   ];
 


### PR DESCRIPTION
The following Sage doctest failures are fixed by importing SymPy 1.13.2 and NumPy 2.0 compatibility patches, both of which are required by the recent Python updates in staging-next:

```
sage -t --long --random-seed=128055756589369834360257643034269905038 /nix/store/zs00qzm842nbsh4ikyxyr9p7jjvc8pma-sage-src-10.4/src/sage/doctest/forker.py  # 1 doctest failed
sage -t --long --random-seed=128055756589369834360257643034269905038 /nix/store/zs00qzm842nbsh4ikyxyr9p7jjvc8pma-sage-src-10.4/src/sage/functions/hypergeometric.py  # 1 doctest failed
sage -t --long --random-seed=128055756589369834360257643034269905038 /nix/store/zs00qzm842nbsh4ikyxyr9p7jjvc8pma-sage-src-10.4/src/sage/symbolic/expression.pyx  # 1 doctest failed
sage -t --long --random-seed=128055756589369834360257643034269905038 /nix/store/zs00qzm842nbsh4ikyxyr9p7jjvc8pma-sage-src-10.4/src/sage/typeset/ascii_art.py  # 1 doctest failed
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
