### PR TITLE
Fix codeowners backport

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -367,4 +367,3 @@ nixos/tests/lxd/                        @adamcstephens
 pkgs/by-name/in/incus/                  @adamcstephens
 pkgs/by-name/lx/lxc*                    @adamcstephens
 pkgs/by-name/lx/lxd*                    @adamcstephens
-pkgs/os-specific/linux/lxc/             @adamcstephens


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/348642, all release-24.05 PRs are failing due to

```
    [err] line 370: "pkgs/os-specific/linux/lxc/" does not match any files in repository
```

Because the file was removed since 7e73ead5d0ab1fce66c3122c5e8b9c5bc5bb608a

This fixes that!

Ping @philiptaron 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
