### PR TITLE
mpiCheckPhaseHook: disable openmpi's ssh plugin

### DIFF
--- a/pkgs/build-support/setup-hooks/mpi-check-hook/mpi-check-hook.sh
+++ b/pkgs/build-support/setup-hooks/mpi-check-hook/mpi-check-hook.sh
@@ -6,7 +6,6 @@ setupMpiCheck() {
   # Find out which MPI implementation we are using
   # and set safe defaults that are guaranteed to run
   # on any build machine
-
   mpiType="NONE"
 
   # OpenMPI signature
@@ -40,6 +39,10 @@ setupMpiCheck() {
       # Make sure the test starts even if we have less than the requested amount of cores
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export PRTE_MCA_rmaps_default_mapping_policy=node:oversubscribe
+
+      # Make sure we do not need openssh in the checkPhase
+      export OMPI_MCA_plm_ssh_agent=false
+      export PRRTE_MCA_plm_ssh_agent=false
 
       # Disable CPU pinning
       export OMPI_MCA_hwloc_base_binding_policy=none

--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -18,7 +18,6 @@
   mpi,
   gsl,
   scalapack,
-  openssh,
   makeWrapper,
   libxsmm,
   spglib,
@@ -83,7 +82,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     python3
     which
-    openssh
     makeWrapper
     pkg-config
   ] ++ lib.optional (gpuBackend == "cuda") cudaPackages.cuda_nvcc;
@@ -225,7 +223,6 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [
     mpiCheckPhaseHook
-    openssh
   ];
 
   checkPhase = ''

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -10,7 +10,6 @@
   mpiSupport ? true,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  openssh, # required for openmpi tests
   petsc-withp4est ? false,
   hdf5-support ? false,
   hdf5,
@@ -42,7 +41,7 @@ stdenv.mkDerivation rec {
     python3
     gfortran
     pkg-config
-  ] ++ lib.optional mpiSupport mpi ++ lib.optional (mpiSupport && mpi.pname == "openmpi") openssh;
+  ] ++ lib.optional mpiSupport mpi;
   buildInputs = [
     blas
     lapack

--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -5,7 +5,6 @@
 , pkg-config
 , mpi
 , mpiCheckPhaseHook
-, openssh
 , gfortran
 , blas
 , lapack
@@ -139,7 +138,6 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [
     mpiCheckPhaseHook
-    openssh
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, autoreconfHook, mpiCheckPhaseHook
-, perl, mpi, blas, lapack, scalapack, openssh
+, perl, mpi, blas, lapack, scalapack
 # CPU optimizations
 , avxSupport ? stdenv.hostPlatform.avxSupport
 , avx2Support ? stdenv.hostPlatform.avx2Support
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
 
   doCheck = !enableCuda;
 
-  nativeCheckInputs = [ mpiCheckPhaseHook openssh ];
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
   preCheck = ''
     #patchShebangs ./
 

--- a/pkgs/development/libraries/science/math/dbcsr/default.nix
+++ b/pkgs/development/libraries/science/math/dbcsr/default.nix
@@ -11,7 +11,6 @@
 , python3
 , libxsmm
 , mpi
-, openssh
 }:
 
 stdenv.mkDerivation rec {
@@ -62,7 +61,6 @@ stdenv.mkDerivation rec {
   ];
 
   checkInputs = [
-    openssh
     mpiCheckPhaseHook
   ];
 

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -1,14 +1,13 @@
 { lib, stdenv, fetchFromGitHub, mpiCheckPhaseHook
 , autoreconfHook, pkg-config
 , p4est-sc-debugEnable ? true, p4est-sc-mpiSupport ? true
-, mpi, openssh, zlib
+, mpi, zlib
 }:
 
 let
   dbg = lib.optionalString debugEnable "-dbg";
   debugEnable = p4est-sc-debugEnable;
   mpiSupport = p4est-sc-mpiSupport;
-  isOpenmpi = mpiSupport && mpi.pname == "openmpi";
 in
 stdenv.mkDerivation {
   pname = "p4est-sc${dbg}";
@@ -24,9 +23,7 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  propagatedNativeBuildInputs = lib.optional mpiSupport mpi
-    ++ lib.optional isOpenmpi openssh
-  ;
+  propagatedNativeBuildInputs = lib.optional mpiSupport mpi ;
   propagatedBuildInputs = [ zlib ];
   inherit debugEnable mpiSupport;
 
@@ -49,7 +46,6 @@ stdenv.mkDerivation {
 
   nativeCheckInputs = lib.optionals mpiSupport [
     mpiCheckPhaseHook
-    openssh
   ];
 
   # disallow Darwin checks due to prototype incompatibility of qsort_r

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake
-, openssh, mpiCheckPhaseHook, mpi, blas, lapack
+, mpiCheckPhaseHook, mpi, blas, lapack
 } :
 
 assert blas.isILP64 == lapack.isILP64;
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ];
-  nativeCheckInputs = [ openssh mpiCheckPhaseHook ];
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
   buildInputs = [ blas lapack ];
   propagatedBuildInputs = [ mpi ];
   hardeningDisable = lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin) [ "stackprotector" ];

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -18,7 +18,6 @@
   harminv,
   libctl,
   libGDSII,
-  openssh,
   guile,
   python,
   numpy,
@@ -125,7 +124,6 @@ buildPythonPackage rec {
   doCheck = true;
   nativeCheckInputs = [
     mpiCheckPhaseHook
-    openssh
   ];
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -5,7 +5,6 @@
   cython,
   setuptools,
   mpi,
-  openssh,
   pytestCheckHook,
   mpiCheckPhaseHook,
 }:
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    openssh
     mpiCheckPhaseHook
   ];
   # Most tests pass, (besides `test_spawn.py`), but when reaching ~80% tests


### PR DESCRIPTION
mpirun requires openssh to be present even if it not used. Turning this behavior off allows to remove openssh from the `checkPhaseInputs` of mpi related packages. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
