### PR TITLE
graalvm-ce: fix native-image standalone usage by wrapping Nix env variables

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation ({
   buildPhase = args.buildPhase or ''
     runHook preBuild
 
-    native-image -jar "$jar" $(export -p | sed -n 's/^declare -x \([^=]\+\)=.*$/ -E\1/p' | tr -d \\n) ''${nativeImageBuildArgs[@]}
+    native-image -jar "$jar" ''${nativeImageBuildArgs[@]}
 
     runHook postBuild
   '';


### PR DESCRIPTION
closes #350909

Addresses the problem introduced by the upstream. GraalVM started sanitizing the environment, so Nix wrappers fail: https://github.com/oracle/graal/issues/7502