### PR TITLE
httpdirfs: 1.2.5 -> 1.2.6

### DIFF
--- a/pkgs/by-name/ht/httpdirfs/package.nix
+++ b/pkgs/by-name/ht/httpdirfs/package.nix
@@ -2,11 +2,13 @@
   curl,
   expat,
   fetchFromGitHub,
-  fuse,
+  fuse3,
   gumbo,
   help2man,
   lib,
   libuuid,
+  meson,
+  ninja,
   nix-update-script,
   pkg-config,
   stdenv,
@@ -15,46 +17,35 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "httpdirfs";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "fangfufu";
     repo = "httpdirfs";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-PUYsT0VDEzerPqwrLJrET4kSsWsQhtnfmLepeaqtA+I=";
+    hash = "sha256-4Tp9DTYWUHElO0YNeINgzmbI0tpXxmKfZ1Jhz5UYn5M=";
   };
-
-  postPatch = lib.optional stdenv.hostPlatform.isDarwin ''
-    substituteInPlace Makefile --replace-fail '-fanalyzer' '-Xanalyzer'
-  '';
 
   nativeBuildInputs = [
     help2man
+    meson
+    ninja
     pkg-config
   ];
 
   buildInputs = [
     curl
     expat
-    fuse
+    fuse3
     gumbo
     libuuid
   ];
 
-  makeFlags = [ "prefix=${placeholder "out"}" ];
-
-  postBuild = ''
-    make man
-  '';
-
   passthru = {
-    # Disabled for Darwin because requires macFUSE installed outside NixOS
-    tests.version = lib.optionalAttrs stdenv.hostPlatform.isLinux (
-      testers.testVersion {
-        command = "${lib.getExe finalAttrs.finalPackage} --version";
-        package = finalAttrs.finalPackage;
-      }
-    );
+    tests.version = testers.testVersion {
+      command = "${lib.getExe finalAttrs.finalPackage} --version";
+      package = finalAttrs.finalPackage;
+    };
     updateScript = nix-update-script { };
   };
 
@@ -65,6 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "httpdirfs";
     maintainers = with lib.maintainers; [ sbruder schnusch anthonyroussel ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
https://github.com/fangfufu/httpdirfs/compare/1.2.5...1.2.6

Note for reviewers: MacOS support has been removed upstream with 1.2.6 release.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
