### PR TITLE
inkscape: 1.3.2 -> 1.4

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -184,12 +184,14 @@ stdenv.mkDerivation rec {
 
   passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
 
-  meta = with lib; {
+  meta = {
     description = "Vector graphics editor";
     homepage = "https://www.inkscape.org";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.jtojnar ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      jtojnar
+    ];
+    platforms = lib.platforms.all;
     mainProgram = "inkscape";
     longDescription = ''
       Inkscape is a feature-rich vector graphics editor that edits

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -190,6 +190,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       jtojnar
+      x123
     ];
     platforms = lib.platforms.all;
     mainProgram = "inkscape";

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -6,8 +6,8 @@
 , callPackage
 , cmake
 , desktopToDarwinBundle
+, double-conversion
 , fetchurl
-, fetchpatch
 , gettext
 , ghostscript
 , glib
@@ -65,15 +65,16 @@ let
       pyserial
       requests
       pygobject3
+      tinycss2
     ] ++ inkex.propagatedBuildInputs);
 in
 stdenv.mkDerivation rec {
   pname = "inkscape";
-  version = "1.3.2";
+  version = "1.4";
 
   src = fetchurl {
     url = "https://inkscape.org/release/inkscape-${version}/source/archive/xz/dl/inkscape-${version}.tar.xz";
-    sha256 = "sha256-29GETcRD/l4Q0+mohxROX7ciOFL/8ZHPte963qsOCGs=";
+    sha256 = "sha256-xZqFRTtpmt3rzVHB3AdoTdlqEMiuxxaxlVHbUFYuE/U=";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -93,22 +94,6 @@ stdenv.mkDerivation rec {
       # Fix path to ps2pdf binary
       src = ./fix-ps2pdf-path.patch;
       inherit ghostscript;
-    })
-
-    # Fix build with libxml2 2.12
-    # https://gitlab.com/inkscape/inkscape/-/merge_requests/6089
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/694d8ae43d06efff21adebf377ce614d660b24cd.patch";
-      hash = "sha256-9IXJzpZbNU5fnt7XKgqCzUDrwr08qxGwo8TqnL+xc6E=";
-    })
-
-    # Improve distribute along path precision
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
     })
   ];
 
@@ -141,6 +126,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boehmgc
     boost
+    double-conversion
     gettext
     glib
     glibmm

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   inkscape,
-  fetchpatch,
   poetry-core,
   cssselect,
   lxml,
@@ -14,6 +13,7 @@
   pyparsing,
   pyserial,
   scour,
+  tinycss2,
   gobject-introspection,
   pytestCheckHook,
   gtk3,
@@ -27,17 +27,6 @@ buildPythonPackage {
 
   inherit (inkscape) src;
 
-  patches = [
-    # Fix “distribute along path” test with Python 3.12.
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
-    })
-  ];
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
@@ -46,6 +35,7 @@ buildPythonPackage {
     numpy
     pygobject3
     pyserial
+    tinycss2
   ];
 
   pythonImportsCheck = [ "inkex" ];
@@ -88,7 +78,6 @@ buildPythonPackage {
 
     substituteInPlace pyproject.toml \
       --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"' \
-      --replace-fail 'lxml = "^4.5.0"' 'lxml = "^4.5.0 || ^5.0.0"'
   '';
 
   meta = {

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -51,5 +51,6 @@ buildPythonPackage rec {
       dotlambda
       gal_bolle
     ];
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

- light refactor of `meta`
- add x123 as maintainer
- update inkscape from 1.3.2 -> 1.4
- update inkex patches and deps
- mark svg2tikz as broken due to upstream not handling inkscape/inkex 1.4

*NOTE*: `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` had broken deps related to `svg2tikz`. This appears to be an upstream issue with `svg2tikz` in that the code references functions that are no longer available in 1.4 (or are otherwise renamed). I'm not sure what the best practice is here, but I feel it would be a bit silly to hold back some major improvements brought by 1.4 over a single extension. I've marked svg2tikz as broken and will create an issue for it.

I've tested the binary on `x86_64-linux` and on `aarch64-darwin` and the program appears to function as it should.

---

The results from `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (**after** marking `svg2tikz` as broken):
```console
┏━ Dependency Graph:
┃ ✔ review-shell
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 1 │ ⏸ 0 │ Finished at 21:44:04 after 3s
--------- Report for 'x86_64-linux' ---------
8 packages marked as broken and skipped:
python311Packages.svg2tikz python311Packages.svg2tikz.dist python312Packages.svg2tikz python312Packages.svg2tikz.dist spring springLobby svg2tikz svg2tikz.dist

125 packages built:
adapta-gtk-theme arc-theme arx-libertatis asciidoc-full asciidoc-full-with-plugins asciidoc-full-with-plugins.dist asciidoc-full.dist ayu-theme-gtk breeze-hacked-cursor-theme capitaine-cursors catppuccin-cursors catppuccin-cursors.frappeBlue catppuccin-cursors.frappeDark catppuccin-cursors.frappeFlamingo catppuccin-cursors.frappeGreen catppuccin-cursors.frappeLavender catppuccin-cursors.frappeLight catppuccin-cursors.frappeMaroon catppuccin-cursors.frappeMauve catppuccin-cursors.frappePeach catppuccin-cursors.frappePink catppuccin-cursors.frappeRed catppuccin-cursors.frappeRosewater catppuccin-cursors.frappeSapphire catppuccin-cursors.frappeSky catppuccin-cursors.frappeTeal catppuccin-cursors.frappeYellow catppuccin-cursors.latteBlue catppuccin-cursors.latteDark catppuccin-cursors.latteFlamingo catppuccin-cursors.latteGreen catppuccin-cursors.latteLavender catppuccin-cursors.latteLight catppuccin-cursors.latteMaroon catppuccin-cursors.latteMauve catppuccin-cursors.lattePeach catppuccin-cursors.lattePink catppuccin-cursors.latteRed catppuccin-cursors.latteRosewater catppuccin-cursors.latteSapphire catppuccin-cursors.latteSky catppuccin-cursors.latteTeal catppuccin-cursors.latteYellow catppuccin-cursors.macchiatoBlue catppuccin-cursors.macchiatoDark catppuccin-cursors.macchiatoFlamingo catppuccin-cursors.macchiatoGreen catppuccin-cursors.macchiatoLavender catppuccin-cursors.macchiatoLight catppuccin-cursors.macchiatoMaroon catppuccin-cursors.macchiatoMauve catppuccin-cursors.macchiatoPeach catppuccin-cursors.macchiatoPink catppuccin-cursors.macchiatoRed catppuccin-cursors.macchiatoRosewater catppuccin-cursors.macchiatoSapphire catppuccin-cursors.macchiatoSky catppuccin-cursors.macchiatoTeal catppuccin-cursors.macchiatoYellow catppuccin-cursors.mochaBlue catppuccin-cursors.mochaDark catppuccin-cursors.mochaFlamingo catppuccin-cursors.mochaGreen catppuccin-cursors.mochaLavender catppuccin-cursors.mochaLight catppuccin-cursors.mochaMaroon catppuccin-cursors.mochaMauve catppuccin-cursors.mochaPeach catppuccin-cursors.mochaPink catppuccin-cursors.mochaRed catppuccin-cursors.mochaRosewater catppuccin-cursors.mochaSapphire catppuccin-cursors.mochaSky catppuccin-cursors.mochaTeal catppuccin-cursors.mochaYellow cinnamon-screensaver clevis clevis.man coreboot-configurator dblatexFull diagrams-as-code diagrams-as-code.dist disorderfs emojione fim find-billy hackneyed hikounomizu inkscape inkscape-extensions.applytransforms inkscape-extensions.silhouette inkscape-extensions.silhouette.dist inkscape-extensions.textext inkscape-extensions.textext.dist inkscape-with-extensions iso-flags iso-flags-png-320x240 k40-whisperer kakounePlugins.rep luksmeta mate.mate-panel-with-applets mate.mate-utils material-cursors mojave-gtk-theme numix-cursor-theme numix-solarized-gtk-theme plata-theme pop-gtk-theme python311Packages.diagrams python311Packages.diagrams.dist python311Packages.inkex python311Packages.inkex.dist python311Packages.osc-diagram python311Packages.osc-diagram.dist python312Packages.diagrams python312Packages.diagrams.dist python312Packages.inkex python312Packages.inkex.dist python312Packages.osc-diagram python312Packages.osc-diagram.dist tang tang.man vimix-cursors volantes-cursors wpa_supplicant_gui
```

---

The results from `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (**before** marking `svg2tikz` as broken):
```console
┏━ 2 Errors:
 ⋮
┃        >             return None
┃        > >       shape = inkex.properties.match_url_and_return_element(url, self.svg)
┃        > E       AttributeError: module 'inkex.properties' has no attribute 'match_url_and_return_e…
┃        >
┃        > svg2tikz/tikz_export.py:822: AttributeError
┃        > =========================== short test summary info ============================
┃        > FAILED tests/test_tikz_path_exporter.py::TestTikZPathExporter::test_get_text - AttributeEr…
┃        > FAILED tests/test_tikz_path_exporter.py::TestTikZPathExporter::test_handle_shape - Attribu…
┃        > =================== 2 failed, 64 passed, 1 skipped in 0.91s ====================
┃        For full logs, run 'nix log /nix/store/vyw4rxkxmynw7gnv7632wx62d395bmyc-python3.12-svg2tikz-…
┣━ Dependency Graph:
┃    ┌─ ✔ adapta-gtk-theme-3.95.0.11 ⏱ 3m12s
┃    ├─ ✔ vimix-cursors-2020-02-24-unstable-2021-09-18 ⏱ 3m18s
┃    ├─ ✔ capitaine-cursors-4 ⏱ 4m37s
┃    ├─ ✔ numix-solarized-gtk-theme-20230408 ⏱ 4m55s
┃    ├─ ✔ catppuccin-cursors-0.4.0 ⏱ 8m20s
┃    ├─ ⚠ python3.11-svg2tikz-3.2.0 failed with exit code 1 after ⏱ 3s in pytestCheckPhase
┃    ├─ ⚠ python3.12-svg2tikz-3.2.0 failed with exit code 1 after ⏱ 2s in pytestCheckPhase
┃ ┌─ ⏸ env
┃ ⏸ review-shell
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 9 │ ⏸ 2 │ ⚠ Exited after 2 build failures at 21:35:26 after 8m24s
--------- Report for 'x86_64-linux' ---------
2 packages marked as broken and skipped:
spring springLobby

4 packages failed to build:
python311Packages.svg2tikz python311Packages.svg2tikz.dist svg2tikz svg2tikz.dist

125 packages built:
adapta-gtk-theme arc-theme arx-libertatis asciidoc-full asciidoc-full-with-plugins asciidoc-full-with-plugins.dist asciidoc-full.dist ayu-theme-gtk breeze-hacked-cursor-theme capitaine-cursors catppuccin-cursors catppuccin-cursors.frappeBlue catppuccin-cursors.frappeDark catppuccin-cursors.frappeFlamingo catppuccin-cursors.frappeGreen catppuccin-cursors.frappeLavender catppuccin-cursors.frappeLight catppuccin-cursors.frappeMaroon catppuccin-cursors.frappeMauve catppuccin-cursors.frappePeach catppuccin-cursors.frappePink catppuccin-cursors.frappeRed catppuccin-cursors.frappeRosewater catppuccin-cursors.frappeSapphire catppuccin-cursors.frappeSky catppuccin-cursors.frappeTeal catppuccin-cursors.frappeYellow catppuccin-cursors.latteBlue catppuccin-cursors.latteDark catppuccin-cursors.latteFlamingo catppuccin-cursors.latteGreen catppuccin-cursors.latteLavender catppuccin-cursors.latteLight catppuccin-cursors.latteMaroon catppuccin-cursors.latteMauve catppuccin-cursors.lattePeach catppuccin-cursors.lattePink catppuccin-cursors.latteRed catppuccin-cursors.latteRosewater catppuccin-cursors.latteSapphire catppuccin-cursors.latteSky catppuccin-cursors.latteTeal catppuccin-cursors.latteYellow catppuccin-cursors.macchiatoBlue catppuccin-cursors.macchiatoDark catppuccin-cursors.macchiatoFlamingo catppuccin-cursors.macchiatoGreen catppuccin-cursors.macchiatoLavender catppuccin-cursors.macchiatoLight catppuccin-cursors.macchiatoMaroon catppuccin-cursors.macchiatoMauve catppuccin-cursors.macchiatoPeach catppuccin-cursors.macchiatoPink catppuccin-cursors.macchiatoRed catppuccin-cursors.macchiatoRosewater catppuccin-cursors.macchiatoSapphire catppuccin-cursors.macchiatoSky catppuccin-cursors.macchiatoTeal catppuccin-cursors.macchiatoYellow catppuccin-cursors.mochaBlue catppuccin-cursors.mochaDark catppuccin-cursors.mochaFlamingo catppuccin-cursors.mochaGreen catppuccin-cursors.mochaLavender catppuccin-cursors.mochaLight catppuccin-cursors.mochaMaroon catppuccin-cursors.mochaMauve catppuccin-cursors.mochaPeach catppuccin-cursors.mochaPink catppuccin-cursors.mochaRed catppuccin-cursors.mochaRosewater catppuccin-cursors.mochaSapphire catppuccin-cursors.mochaSky catppuccin-cursors.mochaTeal catppuccin-cursors.mochaYellow cinnamon-screensaver clevis clevis.man coreboot-configurator dblatexFull diagrams-as-code diagrams-as-code.dist disorderfs emojione fim find-billy hackneyed hikounomizu inkscape inkscape-extensions.applytransforms inkscape-extensions.silhouette inkscape-extensions.silhouette.dist inkscape-extensions.textext inkscape-extensions.textext.dist inkscape-with-extensions iso-flags iso-flags-png-320x240 k40-whisperer kakounePlugins.rep luksmeta mate.mate-panel-with-applets mate.mate-utils material-cursors mojave-gtk-theme numix-cursor-theme numix-solarized-gtk-theme plata-theme pop-gtk-theme python311Packages.diagrams python311Packages.diagrams.dist python311Packages.inkex python311Packages.inkex.dist python311Packages.osc-diagram python311Packages.osc-diagram.dist python312Packages.diagrams python312Packages.diagrams.dist python312Packages.inkex python312Packages.inkex.dist python312Packages.osc-diagram python312Packages.osc-diagram.dist tang tang.man vimix-cursors volantes-cursors wpa_supplicant_gui
```

---

The error in upstream svg2tikz appears to be here:
https://github.com/xyz2tex/svg2tikz/blob/89d17219ac22d80570a8171bb1d4b01700787fba/svg2tikz/tikz_export.py#L822

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
