### PR TITLE
idris2Packages.buildIdris: add retroactive support for building a whole dependency tree with source

### DIFF
--- a/pkgs/development/compilers/idris2/build-idris.nix
+++ b/pkgs/development/compilers/idris2/build-idris.nix
@@ -11,13 +11,17 @@
 #            idrisLibraries = [ ];
 #          };
 #        in {
-#          lib = pkg.library { withSource = true; };
+#          lib1 = pkg.library { withSource = true; };
+#
+#          # implicitly without source:
+#          lib2 = pkg.library';
+#
 #          bin = pkg.executable;
 #        }
 #
 {
   src,
-  ipkgName,
+  ipkgName, # ipkg filename without the extension
   version ? "unversioned",
   idrisLibraries, # Other libraries built with buildIdris
   ...
@@ -44,78 +48,91 @@ let
   ipkgFileName = ipkgName + ".ipkg";
   idrName = "idris2-${idris2.version}";
   libSuffix = "lib/${idrName}";
-  propagatedIdrisLibraries = propagate idrisLibraryLibs;
-  libDirs = (lib.makeSearchPath libSuffix propagatedIdrisLibraries) + ":${idris2}/${idrName}";
+  libDirs = libs: (lib.makeSearchPath libSuffix libs) + ":${idris2}/${idrName}";
   supportDir = "${idris2}/${idrName}/lib";
   drvAttrs = builtins.removeAttrs attrs [
     "ipkgName"
     "idrisLibraries"
   ];
 
-  derivation = stdenv.mkDerivation (
-    finalAttrs:
-    drvAttrs
-    // {
-      pname = ipkgName;
-      inherit version;
-      src = src;
-      nativeBuildInputs = [
-        idris2
-        makeBinaryWrapper
-      ] ++ attrs.nativeBuildInputs or [ ];
-      buildInputs = propagatedIdrisLibraries ++ attrs.buildInputs or [ ];
+  mkDerivation =
+    withSource:
+    let
+      applyWithSource = lib: if withSource then lib.withSource else lib;
+      propagatedIdrisLibraries = map applyWithSource (propagate idrisLibraryLibs);
+    in
+    stdenv.mkDerivation (
+      finalAttrs:
+      drvAttrs
+      // {
+        pname = ipkgName;
+        inherit src version;
+        nativeBuildInputs = [
+          idris2
+          makeBinaryWrapper
+        ] ++ attrs.nativeBuildInputs or [ ];
+        buildInputs = propagatedIdrisLibraries ++ attrs.buildInputs or [ ];
 
-      env.IDRIS2_PACKAGE_PATH = libDirs;
+        env.IDRIS2_PACKAGE_PATH = libDirs propagatedIdrisLibraries;
 
-      buildPhase = ''
-        runHook preBuild
-        idris2 --build ${ipkgFileName}
-        runHook postBuild
+        buildPhase = ''
+          runHook preBuild
+          idris2 --build ${ipkgFileName}
+          runHook postBuild
+        '';
+
+        passthru = {
+          inherit propagatedIdrisLibraries;
+        } // (attrs.passthru or { });
+
+        shellHook = ''
+          export IDRIS2_PACKAGE_PATH="${finalAttrs.env.IDRIS2_PACKAGE_PATH}"
+        '';
+      }
+    );
+
+  mkExecutable =
+    withSource:
+    let
+      derivation = mkDerivation withSource;
+    in
+    derivation.overrideAttrs {
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        scheme_app="$(find ./build/exec -name '*_app')"
+        if [ "$scheme_app" = ''' ]; then
+          mv -- build/exec/* $out/bin/
+          chmod +x $out/bin/*
+          # ^ remove after Idris2 0.8.0 is released. will be superfluous:
+          # https://github.com/idris-lang/Idris2/pull/3189
+        else
+          cd build/exec/*_app
+          rm -f ./libidris2_support.{so,dylib}
+          for file in *.so; do
+            bin_name="''${file%.so}"
+            mv -- "$file" "$out/bin/$bin_name"
+
+            wrapProgram "$out/bin/$bin_name" \
+              --prefix LD_LIBRARY_PATH : ${supportDir} \
+              --prefix DYLD_LIBRARY_PATH : ${supportDir}
+          done
+        fi
+        runHook postInstall
       '';
 
-      passthru = {
-        inherit propagatedIdrisLibraries;
-      } // (attrs.passthru or { });
+      # allow an executable's dependencies to be built with source. this is convenient when
+      # building a development shell for the exectuable using `mkShell`'s `inputsFrom`.
+      passthru = derivation.passthru // {
+        withSource = mkExecutable true;
+      };
+    };
 
-      shellHook = ''
-        export IDRIS2_PACKAGE_PATH="${finalAttrs.env.IDRIS2_PACKAGE_PATH}"
-      '';
-    }
-  );
-
-in
-{
-  executable = derivation.overrideAttrs {
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      scheme_app="$(find ./build/exec -name '*_app')"
-      if [ "$scheme_app" = ''' ]; then
-        mv -- build/exec/* $out/bin/
-        chmod +x $out/bin/*
-        # ^ remove after Idris2 0.8.0 is released. will be superfluous:
-        # https://github.com/idris-lang/Idris2/pull/3189
-      else
-        cd build/exec/*_app
-        rm -f ./libidris2_support.so
-        for file in *.so; do
-          bin_name="''${file%.so}"
-          mv -- "$file" "$out/bin/$bin_name"
-          wrapProgram "$out/bin/$bin_name" \
-            --prefix LD_LIBRARY_PATH : ${supportDir} \
-            --prefix DYLD_LIBRARY_PATH : ${supportDir}
-        done
-      fi
-      runHook postInstall
-    '';
-  };
-
-  library =
-    {
-      withSource ? false,
-    }:
+  mkLibrary =
+    withSource:
     let
       installCmd = if withSource then "--install-with-src" else "--install";
+      derivation = mkDerivation withSource;
     in
     derivation.overrideAttrs {
       installPhase = ''
@@ -125,5 +142,30 @@ in
         idris2 ${installCmd} ${ipkgFileName}
         runHook postInstall
       '';
+
+      # allow a library built without source to be changed to one with source
+      # via a passthru attribute; i.e. `my-pkg.library'.withSource`.
+      # this is convenient because a library derivation can be distributed as
+      # without-source by default but downstream projects can still build it
+      # with-source. We surface this regardless of whether the original library
+      # was built with source because that allows downstream to call this
+      # property unconditionally.
+      passthru = derivation.passthru // {
+        withSource = mkLibrary true;
+      };
     };
+
+in
+{
+  executable = mkExecutable false;
+
+  library =
+    {
+      withSource ? false,
+    }:
+    mkLibrary withSource;
+
+  # Make a library without source; you can still use the `withSource` attribute
+  # on the resulting derivation to build the library with source at a later time.
+  library' = mkLibrary false;
 }


### PR DESCRIPTION
Another refactor that looks like more changes than it is if you glance at the GitHub line-changes.

This PR does two things primarily:
1. Support a passthru `withSource` attribute that can be used to take a derivation that would build without source and instead build it with source. This allows a project to depend on any number of packages built without source but then also have a developer shell that exposes all dependency sources to IDE integrations with a line as simple as `inputsFrom = [ myPkg.withSource ];`
2. Add a `library'` attribute to the output of `buildIdris` alongside the existing `library` attribute to make it less awkward to do the default thing of building without source (which I think is even more appealing now than ever before given the `withSource` attribute). If this were the first iteration of things, I would want `library` to just be what `library'` is, but it's easy enough to maintain compatibility here so I decided to. 

For example, one might have the following `default.nix` and `shell.nix` (note the use of `library'` in `default.nix` and `withSource` in `shell.nix`):
```nix
# default.nix
let
  inherit (pkgs) idris2Packages;

  someIdrisLibrary =
    idris2Packages.buildIdris {
      ipkgName = "some-library";
      src  = ./some-lib;
      idrisLibraries  = [ ];
    };

  myPkg =
    idris2Packages.buildIdris {
      ipkgName = "my-pkg";
      src  = ./.;
      idrisLibraries  = [ someIdrisLibrary ];
    };
in
myPkg.library'
```

```nix
# shell.nix
let
  myPkg = import ./.;
in
mkShell {
  inputsFrom = [ myPkg.withSource ];
}
```

This would conveniently mean no source code is packaged with the library by default but when used in a developer shell source code could be requested (for all dependencies, even indirect ones).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
