### PR TITLE
ipe:7.2.27 -> 7.2.30

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , makeDesktopItem
-, fetchurl
+, fetchFromGitHub
 , pkg-config
 , copyDesktopItems
 , cairo
@@ -25,9 +25,11 @@ stdenv.mkDerivation rec {
   pname = "ipe";
   version = "7.2.30";
 
-  src = fetchurl {
-    url = "https://github.com/otfried/ipe/archive/refs/tags/v${version}.tar.gz";
-    sha256 = "sha256-kihlDtxIrV3uq12SJy4kLpBvkNKSyQrxMqPyDZNUc1o=";
+  src = fetchFromGitHub {
+    owner = "otfried";
+    repo = "ipe";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bvwEgEP/cinigixJr8e964sm6secSK+7Ul7WFfwM0gE=";
   };
 
   nativeBuildInputs = [ pkg-config copyDesktopItems wrapQtAppsHook ];

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ipe";
-  version = "7.2.27";
+  version = "7.2.30";
 
   src = fetchurl {
-    url = "https://github.com/otfried/ipe/releases/download/v${version}/ipe-${version}-src.tar.gz";
-    sha256 = "sha256-wx/bZy8kB7dpZsz58BeRGdS1BzbrIoafgEmLyFg7wZU=";
+    url = "https://github.com/otfried/ipe/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256-kihlDtxIrV3uq12SJy4kLpBvkNKSyQrxMqPyDZNUc1o=";
   };
 
   nativeBuildInputs = [ pkg-config copyDesktopItems wrapQtAppsHook ];


### PR DESCRIPTION
Updating to the most recent version of ipe. https://github.com/otfried/ipe/releases/tag/v7.2.30

The url used in fetchUrl had to be changed due to an  change in the repo.


## Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
