### PR TITLE
fnlfmt: use included `Makefile` for build

### DIFF
--- a/pkgs/development/tools/fnlfmt/default.nix
+++ b/pkgs/development/tools/fnlfmt/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromSourcehut, luaPackages, lua }:
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  lua,
+  luaPackages,
+}:
 
 stdenv.mkDerivation rec {
   pname = "fnlfmt";
@@ -15,26 +21,26 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ lua ];
 
-  buildPhase = ''
-    runHook preBuild
+  makeFlags = [
+    "PREFIX=$(out)"
+    "FENNEL=${luaPackages.fennel}/bin/fennel"
+  ];
+  sourceRoot = [ "${src.name}/tags/${version}" ];
 
-    echo "#!${lua}/bin/lua" > fnlfmt
-    ${luaPackages.fennel}/bin/fennel --require-as-include --compile tags/${version}/cli.fnl >> fnlfmt
-    chmod +x fnlfmt
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
 
-    runHook postBuild
-  '';
+    $out/bin/fnlfmt --help > /dev/null
 
-  installPhase = ''
-    runHook preInstall
-    install -D ./fnlfmt $out/bin/fnlfmt
-    runHook postInstall
+    runHook postInstallCheck
   '';
 
   meta = with lib; {
     description = "Formatter for Fennel";
-    homepage = "https://git.sr.ht/~technomancy/fnlfmt";
-    license = licenses.lgpl3Plus;
+    homepage = src.meta.homepage;
+    changelog = "${src.meta.homepage}/tree/${version}/changelog.md";
+    license = licenses.mit;
     platforms = lua.meta.platforms;
     maintainers = with maintainers; [ chiroptical ];
     mainProgram = "fnlfmt";


### PR DESCRIPTION
Solves missing `fnlfmt` pagkage error since it is not being inlined.

Also corrects the licence (`fnlfmt` was relicensed to MIT in [0.3.1](https://git.sr.ht/~technomancy/fnlfmt/tree/main/item/changelog.md#031--2023-08-03))

Currently, this error is being encountered:
```shell
$ fnlfmt --help

/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/bin/lua: ...65hbid7205ziz5i25vjw3gmixjxyjddh-fnlfmt-0.3.2/bin/fnlfmt:6727: module 'fnlfmt' not found:
        no field package.preload['fnlfmt']
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/share/lua/5.2/fnlfmt.lua'
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/share/lua/5.2/fnlfmt/init.lua'
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/lib/lua/5.2/fnlfmt.lua'
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/lib/lua/5.2/fnlfmt/init.lua'
        no file './fnlfmt.lua'
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/lib/lua/5.2/fnlfmt.so'
        no file '/nix/store/k6ms9frir783p3fs3c3fjb9rc8jkkp2p-lua-5.2.4/lib/lua/5.2/loadall.so'
        no file './fnlfmt.so'
stack traceback:
        [C]: in function 'require'
        ...65hbid7205ziz5i25vjw3gmixjxyjddh-fnlfmt-0.3.2/bin/fnlfmt:6727: in main chunk
        [C]: in ?

$ tree /nix/store/65hbid7205ziz5i25vjw3gmixjxyjddh-fnlfmt-0.3.2/
/nix/store/65hbid7205ziz5i25vjw3gmixjxyjddh-fnlfmt-0.3.2/
└── bin
    └── fnlfmt
```

with the change to use the included `Makefile` then `fnlfmt` executes as expected:
```shell
$ fnlfmt --help

Usage: fnlfmt [--no-comments] [--fix] [--check] FILENAME...
With the --fix or --check argument, multiple files can be specified.
With the --fix argument, formats all the files in-place;
with the --check argument, only checks if all the files are formatted;
otherwise prints the formatted file to stdout.

$ tree /nix/store/7mpxvikyjk4n4vj1v8b2mcr9cj1sclbp-fnlfmt-0.3.2
/nix/store/7mpxvikyjk4n4vj1v8b2mcr9cj1sclbp-fnlfmt-0.3.2
├── bin
│   └── fnlfmt
└── share
    ├── lua
    │   └── 5.2
    │       └── fnlfmt.lua
    └── man
        └── man1
            └── fnlfmt.1.gz
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
