### PR TITLE
zip2hashcat: init at 1.0

### DIFF
--- a/pkgs/by-name/zi/zip2hashcat/package.nix
+++ b/pkgs/by-name/zi/zip2hashcat/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zip2hashcat";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "hashstation";
+    repo = "zip2hashcat";
+    # Upstream 1.0 tag has no content
+    rev = "462bd94ea30d69a0810ca9bb3d056aa0f5393d57";
+    hash = "sha256-+hbDTGSDUxA7M8gBI/TViJ2ZvheNxlonYC/aFLvgPW8=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CC zip2hashcat.c -o zip2hashcat
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv zip2hashcat $out/bin/zip2hashcat
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Processes input ZIP files into a format suitable for use with hashcat";
+    homepage = "https://github.com/hashstation/zip2hashcat";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/hashstation/zip2hashcat/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    mainProgram = "zip2hashcat";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
adds [zip2hashcat](https://github.com/hashstation/zip2hashcat), a tool for generating zip file hashes to process with hashcat.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
