### PR TITLE
cmake: Fix the FindCURL module

### DIFF
--- a/pkgs/by-name/cm/cmake/008-FindCURL-Add-more-target-properties-from-pkg-config.diff
+++ b/pkgs/by-name/cm/cmake/008-FindCURL-Add-more-target-properties-from-pkg-config.diff
@@ -1,0 +1,32 @@
+diff --git a/Modules/FindCURL.cmake b/Modules/FindCURL.cmake
+index 5ce8a9046b..f7361308b7 100644
+--- a/Modules/FindCURL.cmake
++++ b/Modules/FindCURL.cmake
+@@ -239,9 +239,24 @@ if(CURL_FOUND)
+         IMPORTED_LOCATION_DEBUG "${CURL_LIBRARY_DEBUG}")
+     endif()
+ 
+-    if(CURL_USE_STATIC_LIBS AND MSVC)
+-       set_target_properties(CURL::libcurl PROPERTIES
+-           INTERFACE_LINK_LIBRARIES "normaliz.lib;ws2_32.lib;wldap32.lib")
++    if(PC_CURL_FOUND)
++      if(PC_CURL_LINK_LIBRARIES)
++        set_property(TARGET CURL::libcurl PROPERTY
++                     INTERFACE_LINK_LIBRARIES "${PC_CURL_LINK_LIBRARIES}")
++      endif()
++      if(PC_CURL_LDFLAGS_OTHER)
++        set_property(TARGET CURL::libcurl PROPERTY
++                     INTERFACE_LINK_OPTIONS "${PC_CURL_LDFLAGS_OTHER}")
++      endif()
++      if(PC_CURL_CFLAGS_OTHER)
++        set_property(TARGET CURL::libcurl PROPERTY
++                     INTERFACE_COMPILE_OPTIONS "${PC_CURL_CFLAGS_OTHER}")
++      endif()
++    else()
++      if(CURL_USE_STATIC_LIBS AND MSVC)
++         set_target_properties(CURL::libcurl PROPERTIES
++             INTERFACE_LINK_LIBRARIES "normaliz.lib;ws2_32.lib;wldap32.lib")
++      endif()
+     endif()
+ 
+   endif()

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -76,7 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteAll {
       src = ./007-darwin-bsd-ps-abspath.diff;
       ps = lib.getExe ps;
-    });
+    })
+  ++ [
+    # Backport of https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9900
+    # Needed to corretly link curl in pkgsStatic.
+    ./008-FindCURL-Add-more-target-properties-from-pkg-config.diff
+  ];
 
   outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" "info" ];
   separateDebugInfo = true;


### PR DESCRIPTION
This helps building `pkgsStatic` executables that link in `libcurl.a`. Before this patch linker options for curl's own dependencies were simply missing.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I tested this patch by creating a `cmakeWithPatch` attribute and used that to build `pkgsStatic.google-cloud-cpp`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
