### PR TITLE
lib/systems: elaborate properly with non-matching system / config / parsed args

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -6,9 +6,9 @@ let
     filterAttrs
     foldl
     hasInfix
+    isAttrs
     isFunction
     isList
-    isString
     mapAttrs
     optional
     optionalAttrs
@@ -55,24 +55,34 @@ let
   */
   flakeExposed = import ./flake-systems.nix { };
 
+  # Turn localSystem or crossSystem, which could be system-string or attrset, into
+  # attrset.
+  systemToAttrs = systemOrArgs:
+    if isAttrs systemOrArgs then systemOrArgs else { system = systemOrArgs; };
+
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.
   #
   # `parsed` is inferred from args, both because there are two options with one
   # clearly preferred, and to prevent cycles. A simpler fixed point where the RHS
   # always just used `final.*` would fail on both counts.
-  elaborate = args': let
-    args = if isString args' then { system = args'; }
-           else args';
+  elaborate = systemOrArgs: let
+    allArgs = systemToAttrs systemOrArgs;
+
+    # Those two will always be derived from "config", if given, so they should NOT
+    # be overridden further down with "// args".
+    args = builtins.removeAttrs allArgs [ "parsed" "system" ];
 
     # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
     rust = args.rust or args.rustc or {};
 
     final = {
       # Prefer to parse `config` as it is strictly more informative.
-      parsed = parse.mkSystemFromString (if args ? config then args.config else args.system);
-      # Either of these can be losslessly-extracted from `parsed` iff parsing succeeds.
+      parsed = parse.mkSystemFromString (args.config or allArgs.system);
+      # This can be losslessly-extracted from `parsed` iff parsing succeeds.
       system = parse.doubleFromSystem final.parsed;
+      # TODO: This currently can't be losslessly-extracted from `parsed`, for example
+      # because of -mingw32.
       config = parse.tripleFromSystem final.parsed;
       # Determine whether we can execute binaries built for the provided platform.
       canExecute = platform:
@@ -435,5 +445,6 @@ in
     inspect
     parse
     platforms
+    systemToAttrs
     ;
 }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -78,6 +78,18 @@ lib.runTests (
     expr = toLosslessStringMaybe (lib.systems.elaborate "x86_64-linux" // { something = "extra"; });
     expected = null;
   };
+  test_elaborate_config_over_system = {
+    expr = (lib.systems.elaborate { config = "i686-unknown-linux-gnu"; system = "x86_64-linux"; }).system;
+    expected = "i686-linux";
+  };
+  test_elaborate_config_over_parsed = {
+    expr = (lib.systems.elaborate { config = "i686-unknown-linux-gnu"; parsed = (lib.systems.elaborate "x86_64-linux").parsed; }).parsed.cpu.arch;
+    expected = "i686";
+  };
+  test_elaborate_system_over_parsed = {
+    expr = (lib.systems.elaborate { system = "i686-linux"; parsed = (lib.systems.elaborate "x86_64-linux").parsed; }).parsed.cpu.arch;
+    expected = "i686";
+  };
 }
 
 # Generate test cases to assert that a change in any non-function attribute makes a platform unequal

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -246,7 +246,7 @@ let
       })] ++ overlays;
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
-        parsed = makeMuslParsedPlatform stdenv.hostPlatform.parsed;
+        config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
       };
     } else throw "Musl libc only supports 64-bit Linux systems.";
 
@@ -258,9 +258,9 @@ let
       })] ++ overlays;
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
-        parsed = stdenv.hostPlatform.parsed // {
+        config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.i686;
-        };
+        });
       };
     } else throw "i686 Linux package set can only be used with the x86 family.";
 
@@ -270,9 +270,9 @@ let
         pkgsx86_64Darwin = super';
       })] ++ overlays;
       localSystem = {
-        parsed = stdenv.hostPlatform.parsed // {
+        config = lib.systems.parse.tripleFromSystem (stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.x86_64;
-        };
+        });
       };
     } else throw "x86_64 Darwin package set can only be used on Darwin systems.";
 
@@ -311,10 +311,11 @@ let
       })] ++ overlays;
       crossSystem = {
         isStatic = true;
-        parsed =
+        config = lib.systems.parse.tripleFromSystem (
           if stdenv.hostPlatform.isLinux
           then makeMuslParsedPlatform stdenv.hostPlatform.parsed
-          else stdenv.hostPlatform.parsed;
+          else stdenv.hostPlatform.parsed
+        );
         gcc = lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; } //
           stdenv.hostPlatform.gcc or {};
       };


### PR DESCRIPTION
This is broken out of #303849, because even if that PR has stalled for now, imho it's still useful to fix `lib.systems.elaborate`.

---

When elaborating a system with both `config` and `system` arguments given, they might not match the `parsed` results.  Example:

```
elaborate {
  config = "i686-unknown-linux-gnu";
  system = "x86_64-linux";
}
```

This would result in a parsed system for i686, because the `config` argument is preferred.  But since `// args //` comes **after** system has been inferred from parsed, it is overwritten again.  This results in `config` and `parsed` all pointing to i686, while `system` still tells the story of x86_64.

Inconsistent arguments can also be given when passing `parsed` directly. This happened in stage.nix for the various package sets.

The solution is simple: One of the three arguments needs to be treated as the ultimate source of truth.  `system` can already be losslessly extracted from `parsed`.  However, `config` currently can not, for example for various -mingw32 cases.  Thus everything must be derived from `config`.

To do so, `system` and `parsed` arguments are made non-overrideable for `lib.systems.elaborate`.  This means, that `system` will be used to parse when `config` is not given - and `parsed` will be ignored entirely (why elaborate an already elaborated system anyway?).

The `systemToAttrs` helper is exposed on `lib.systems`, because it's useful to deal with top-level `localSystem` / `crossSystem` arguments elsewhere (not in this PR).

@NixOS/stdenv 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
