### PR TITLE
pkgs.wrapFish: document with doc-comments

### DIFF
--- a/pkgs/shells/fish/wrapper.nix
+++ b/pkgs/shells/fish/wrapper.nix
@@ -6,6 +6,95 @@
 }:
 
 lib.makeOverridable (
+  /**
+    Creates a wrapped fish shell binary with some plugins, completions,
+    configuration snippets and functions sourced from the function
+    arguments.
+
+    This can for example be used as a convenient way to test fish plugins
+    and scripts without having to alter the environment.
+
+    # Type
+
+    ```pseudocode
+    wrapFish :: {
+      completionDirs :: [Path] ?,
+      functionDirs :: [Path] ?,
+      confDirs :: [Path] ?,
+      pluginPkgs :: [Derivation] ?,
+      localConfig :: String ?,
+      shellAliases :: {
+        [ N :: T ] :: String
+      } ?,
+      runtimeInputs :: [Derivation] ?,
+    } -> Derivation
+    ```
+
+    # Example
+
+    ::: {.example}
+    ```nix
+    wrapFish {
+      pluginPkgs = with fishPlugins; [
+        pure
+        foreign-env
+      ];
+      completionDirs = [ ];
+      functionDirs = [ ];
+      confDirs = [ "/path/to/some/fish/init/dir/" ];
+      shellAliases = {
+        hello = "echo 'Hello World!'";
+        bye = "echo 'Bye World!'; exit";
+      };
+      runtimeInputs = with pkgs; [
+        curl
+        w3m
+      ];
+    }
+    ```
+    :::
+
+    # Arguments
+
+    All arguments are optional.
+
+    ## `completionDirs` (list of paths)
+
+    Directories containing fish completions which will be prepended to
+    {env}`fish_complete_paths` in the environment of the resulting wrapped
+    fish binary.
+
+    ## `functionDirs` (list of paths)
+
+    Directories containing fish functions which will be prepended to
+    {env}`fish_function_path` in the environment of the resulting wrapped
+    fish binary.
+
+    ## `confDirs` (list of paths)
+
+    Directories containing fish code which will be sourced by the resulting
+    wrapped fish binary.
+
+    ## `pluginPkgs` (list of derivations)
+
+    Derivations, usually from the package set `fishPlugins`, that will be
+    added to the resulting wrapped fish binary.
+
+    ## `localConfig` (string)
+
+    String containing a fish script which will be sourced by the resulting
+    wrapped fish binary.
+
+    ## `shellAliases` (attribute set of strings)
+
+    Shell aliases that will be made available in the resulting wrapped fish
+    binary.
+
+    ## `runtimeInputs` (list of derivations)
+
+    A list of Derivations that will be added to the {env}`PATH` of the
+    resulting wrapped fish binary.
+  */
   {
     completionDirs ? [ ],
     functionDirs ? [ ],


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
