### PR TITLE
xppen_{3,4}: init at {3.4.9-240607,4.0.7-250117}; nixos/xppen: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17602,6 +17602,12 @@
     name = "Nasir Hussain";
     keys = [ { fingerprint = "7A10 AB8E 0BEC 566B 090C  9BE3 D812 6E55 9CE7 C35D"; } ];
   };
+  nasrally = {
+    email = "suffer.ring@ya.ru";
+    github = "nasrally";
+    githubId = 50599445;
+    name = "Nikita Grishko";
+  };
   nat-418 = {
     github = "nat-418";
     githubId = 93013864;

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -31,6 +31,8 @@
 
 - [Homebridge](https://github.com/homebridge/homebridge), a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API. Available as [services.homebridge](#opt-services.homebridge.enable).
 
+- [XPPen](https://www.xp-pen.com/), the official closed-source driver for XP Pen tablets. Available as [programs.xppen](#opt-programs.xppen.enable).
+
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
   Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -357,6 +357,7 @@
   ./programs/xfconf.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix
+  ./programs/xppen.nix
   ./programs/xss-lock.nix
   ./programs/xwayland.nix
   ./programs/yazi.nix

--- a/nixos/modules/programs/xppen.nix
+++ b/nixos/modules/programs/xppen.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.xppen;
+in
+
+{
+  options.programs.xppen = {
+    enable = lib.mkEnableOption "XPPen PenTablet application";
+    package = lib.mkPackageOption pkgs "xppen_4" {
+      example = "pkgs.xppen_3";
+      extraDescription = ''
+        Use xppen_4 for newer and xppen_3 for older tablets.
+        To check which version of the driver you need, go to
+        https://www.xp-pen.com/download/ then select your tablet
+        and look for the major version in the available files for Linux.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.uinput.enable = true;
+
+    environment.systemPackages = [ cfg.package ];
+
+    services.udev.packages = [ cfg.package ];
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/pentablet/conf/xppen 0777 - - -"
+    ];
+
+    systemd.services.xppen-create-config-dir = {
+      restartTriggers = [ cfg.package ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutSec = 60;
+        ExecStart = pkgs.writeShellScript "xppen-create-config-dir" ''
+          readarray -d "" files < <(find ${cfg.package}/usr/lib/pentablet/conf -type f -print0)
+          for file in "''${files[@]}"; do
+            file_new="/var''${file#${cfg.package + "/usr"}}"
+            if [ ! -f $file_new ]; then
+              install -m 666 "''$file" "''$file_new"
+            fi
+          done
+        '';
+      };
+    };
+  };
+}

--- a/pkgs/applications/misc/xppen/default.nix
+++ b/pkgs/applications/misc/xppen/default.nix
@@ -1,0 +1,19 @@
+{
+  callPackage,
+}:
+
+# to update: try to find the latest 3.x.x or 4.x.x .tar.gz on https://www.xp-pen.com/download
+{
+  xppen_3 = callPackage ./generic.nix {
+    pname = "xppen_3";
+    version = "3.4.9-240607";
+    url = "https://www.xp-pen.com/download/file.html?id=2901&pid=819&ext=gz";
+    hash = "sha256-ZXeTlDjhryXamb7x2LxDdOtf8R9rgKPyUsdx96XchWM=";
+  };
+  xppen_4 = callPackage ./generic.nix {
+    pname = "xppen_4";
+    version = "4.0.7-250117";
+    url = "https://www.xp-pen.com/download/file.html?id=3652&pid=1211&ext=gz";
+    hash = "sha256-sH05Qquo2u0npSlv8Par/mn1w/ESO9g42CCGwBauHhU=";
+  };
+}

--- a/pkgs/applications/misc/xppen/generic.nix
+++ b/pkgs/applications/misc/xppen/generic.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  qt5,
+  libusb1,
+  pname,
+  version,
+  url,
+  hash,
+}:
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchzip {
+    name = "XPPenLinux${version}.tar.gz";
+    extension = "tar.gz";
+    inherit url hash;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    libusb1
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -r App/usr/lib/pentablet/{lib,platforms,PenTablet.sh}
+    mkdir -p $out/{bin,usr}
+    cp -r App/lib $out/lib
+    cp -r App/usr/share $out/share
+    cp -r App/usr/lib $out/usr/lib
+
+    # hack: edit the binary directly
+    # TODO: replace it with buildFHSEnv if possible? last time it caused other issues
+    sed -i 's#/usr/lib/pentablet#/var/lib/pentablet#g' $out/usr/lib/pentablet/PenTablet
+    ln -s $out/usr/lib/pentablet/PenTablet $out/bin/PenTablet
+
+    substituteInPlace $out/share/applications/xppentablet.desktop \
+      --replace-fail "/usr/lib/pentablet/PenTablet.sh" "PenTablet" \
+      --replace-fail "/usr/share/icons/hicolor/256x256/apps/xppentablet.png" "xppentablet"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "XPPen driver";
+    downloadPage = "https://www.xp-pen.com/download/";
+    homepage = "https://www.xp-pen.com/";
+    license = lib.licenses.unfree;
+    mainProgram = "PenTablet";
+    maintainers = with lib.maintainers; [
+      gepbird
+      nasrally
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14077,6 +14077,11 @@ with pkgs;
 
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix { };
 
+  inherit (callPackage ../applications/misc/xppen { })
+    xppen_3
+    xppen_4
+    ;
+
   xygrib = libsForQt5.callPackage ../applications/misc/xygrib { };
 
   ydiff = with python3.pkgs; toPythonApplication ydiff;


### PR DESCRIPTION
## Summary

Add the official [XP Pen tablet](https://www.xp-pen.com/) drivers:`xppen_3`, `xppen_4` packages and `xppen` NixOS module.

## Prior work

This PR is based on #285660, thanks for @nasrally's, the reviewers'  and the testers'  work!

Closes #285660, closes #347984.
Related: #213263, #277176

## Testing

**I belive this was sufficiently tested by @damiankorcz, many thanks!**

I don't have any XP Pen tablets, the most I can do is check whether the GUI opens. If you own a tablet, please test whether this works for you, feel free to ask for help if you're unsure how to do it.

cc @damiankorcz and @misumisumi for testing the version 3 driver
cc @HangedFool for testing the version 4 driver

To test it, you can build your system with this PR and with this extra config and you should see the `xppentablet` desktop entry or `PenTablet` binary:
```nix
programs.xppen = {
  enable = true;
  package = pkgs.xppen_3; # or `pkgs.xppen_4` for the newer driver
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
