### PR TITLE
symcc: init at 1.0-unstable-2024-07-16

### DIFF
--- a/pkgs/by-name/sy/symcc/package.nix
+++ b/pkgs/by-name/sy/symcc/package.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  llvm_17,
+  clang_17,
+  z3,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation {
+  pname = "symcc";
+  version = "1.0-unstable-2024-07-16";
+
+  src = fetchFromGitHub {
+    owner = "eurecom-s3";
+    repo = "symcc";
+    rev = "65a3633992318ded8939629eda54022932fd582d";
+    hash = "sha256-WzZLeq+if7FyQKkSMDiqxnjtbb7eg8EVuNkCwxyEryM=";
+    fetchSubmodules = true;
+  };
+
+  cmakeFlags = [
+    "-DZ3_TRUST_SYSTEM_VERSION=on"
+    "-DSYMCC_RT_BACKEND=qsym"
+  ];
+
+  postPatch = ''
+    echo 'install(TARGETS SymCC LIBRARY DESTINATION '\$'{CMAKE_INSTALL_LIBDIR})' >> CMakeLists.txt
+  '';
+
+  postInstall = ''
+    cp SymCCRuntime-prefix/src/SymCCRuntime-build/libsymcc-rt.{a,so} $out/lib/
+
+    install -Dm755 symcc sym++ -t $out/bin
+
+    wrapProgram $out/bin/symcc \
+      --set SYMCC_RUNTIME_DIR $out/lib \
+      --set SYMCC_PASS_DIR $out/lib
+
+    wrapProgram $out/bin/sym++ \
+      --set SYMCC_RUNTIME_DIR $out/lib \
+      --set SYMCC_PASS_DIR $out/lib
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    llvm_17
+    clang_17
+    makeWrapper
+  ];
+
+  buildInputs = [
+    llvm_17
+    z3
+  ];
+
+  meta = {
+    description = "Efficient compiler-based symbolic execution";
+    homepage = "https://www.s3.eurecom.fr/tools/symbolic_execution/symcc.html";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.dump_stack ];
+    platforms = lib.platforms.linux;
+    mainProgram = "symcc";
+  };
+}


### PR DESCRIPTION
Adds symcc, compiler-based symbolic execution engine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
