### PR TITLE
guix: backport build user takeover commits

### DIFF
--- a/pkgs/by-name/gu/guix/guix-build-user-takeover-fix.patch
+++ b/pkgs/by-name/gu/guix/guix-build-user-takeover-fix.patch
@@ -1,0 +1,42 @@
+diff --git a/nix/libstore/build.cc b/nix/libstore/build.cc
+index c5383bc..50d1abc 100644
+--- a/nix/libstore/build.cc
++++ b/nix/libstore/build.cc
+@@ -2312,15 +2312,6 @@ void DerivationGoal::registerOutputs()
+         Path actualPath = path;
+         if (useChroot) {
+             actualPath = chrootRootDir + path;
+-            if (pathExists(actualPath)) {
+-                /* Move output paths from the chroot to the store. */
+-                if (buildMode == bmRepair)
+-                    replaceValidPath(path, actualPath);
+-                else
+-                    if (buildMode != bmCheck && rename(actualPath.c_str(), path.c_str()) == -1)
+-                        throw SysError(format("moving build output `%1%' from the chroot to the store") % path);
+-            }
+-            if (buildMode != bmCheck) actualPath = path;
+         } else {
+             Path redirected = redirectedOutputs[path];
+             if (buildMode == bmRepair
+@@ -2360,6 +2351,21 @@ void DerivationGoal::registerOutputs()
+                something like that. */
+             canonicalisePathMetaData(actualPath, buildUser.enabled() ? buildUser.getUID() : -1, inodesSeen);
+ 
++            if (useChroot) {
++                if (pathExists(actualPath)) {
++                    /* Now that output paths have been canonicalized (in particular
++                    there are no setuid files left), move them outside of the
++                    chroot and to the store. */
++                    if (buildMode == bmRepair)
++                        replaceValidPath(path, actualPath);
++                    else
++                        if (buildMode != bmCheck && rename(actualPath.c_str(), path.c_str()) == -1)
++                            throw SysError(format("moving build output `%1%' from the chroot to the store") % path);
++                }
++                if (buildMode != bmCheck) actualPath = path;
++            }
++
++
+             /* FIXME: this is in-memory. */
+             StringSink sink;
+             dumpPath(actualPath, sink);

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -1,39 +1,40 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchpatch
-, autoreconfHook
-, disarchive
-, git
-, glibcLocales
-, guile
-, guile-avahi
-, guile-gcrypt
-, guile-git
-, guile-gnutls
-, guile-json
-, guile-lib
-, guile-lzlib
-, guile-lzma
-, guile-semver
-, guile-ssh
-, guile-sqlite3
-, guile-zlib
-, guile-zstd
-, help2man
-, makeWrapper
-, pkg-config
-, po4a
-, scheme-bytestructures
-, texinfo
-, bzip2
-, libgcrypt
-, sqlite
-, nixosTests
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  autoreconfHook,
+  disarchive,
+  git,
+  glibcLocales,
+  guile,
+  guile-avahi,
+  guile-gcrypt,
+  guile-git,
+  guile-gnutls,
+  guile-json,
+  guile-lib,
+  guile-lzlib,
+  guile-lzma,
+  guile-semver,
+  guile-ssh,
+  guile-sqlite3,
+  guile-zlib,
+  guile-zstd,
+  help2man,
+  makeWrapper,
+  pkg-config,
+  po4a,
+  scheme-bytestructures,
+  texinfo,
+  bzip2,
+  libgcrypt,
+  sqlite,
+  nixosTests,
 
-, stateDir ? "/var"
-, storeDir ? "/gnu/store"
-, confDir ? "/etc"
+  stateDir ? "/var",
+  storeDir ? "/gnu/store",
+  confDir ? "/etc",
 }:
 
 stdenv.mkDerivation rec {
@@ -157,7 +158,10 @@ stdenv.mkDerivation rec {
     changelog = "https://git.savannah.gnu.org/cgit/guix.git/plain/NEWS?h=v${version}";
     license = licenses.gpl3Plus;
     mainProgram = "guix";
-    maintainers = with maintainers; [ cafkafk foo-dogsquared ];
+    maintainers = with maintainers; [
+      cafkafk
+      foo-dogsquared
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -57,6 +57,9 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=ff1251de0bc327ec478fc66a562430fbf35aef42";
       hash = "sha256-f4KWDVrvO/oI+4SCUHU5GandkGtHrlaM1BWygM/Qlao=";
     })
+    # manual port of build user takeover remediation commit
+    # see https://guix.gnu.org/en/blog/2024/build-user-takeover-vulnerability
+    ./guix-build-user-takeover-fix.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Things done

guix has recently announced a security vulnerability that allows local users to
gain priveleges of build users, and further manipulate output of any build
(including with setguid).

This commit fixes the issue by backporting the remediation commits pushed to
guix main to 1.4.0 as a patch.

Users will still have to reboot and follow other remediation steps as described
in the guix blogpost.

This also formats the guix package with the RFC style, for easier reviewing,
consider reviewing each commit individually to make diffs more digestible.

- **guix: format with rfc-style**
- **guix: build user takeover patch**

see: 
- https://guix.gnu.org/en/blog/2024/build-user-takeover-vulnerability/

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
