### PR TITLE
nixos-rebuild: add --arg, --argstr

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -189,6 +189,16 @@ while [ "$#" -gt 0 ]; do
       --json)
         json=1
         ;;
+      --arg)
+        j="$1"; shift 1
+        k="$1"; shift 1
+        extraBuildFlags+=("--arg" "$j" "$k")
+        ;;
+      --argstr)
+        j="$1"; shift 1
+        k="$1"; shift 1
+        extraBuildFlags+=("--argstr" "$j" "$k")
+        ;;
       *)
         log "$0: unknown option \`$i'"
         exit 1


### PR DESCRIPTION
Another logical step in the same vein as https://github.com/NixOS/nixpkgs/pull/320462 . Since we're making `nixos-rebuild` a bit more similar to `nix-build`, I figured it might be cool to have `--arg`/`--argstr`, so one can do things like:

```nix
{ hostname ? "default" }:
let
  nixpkgs = builtins.fetchGit {
    name = "nixos-24.05-2024-05-31";
    url = "https://github.com/NixOS/nixpkgs";
    ref = "refs/heads/nixos-24.05";
    rev = "805a384895c696f802a9bf5bf4720f37385df547";
  };
in
import "${nixpkgs}/nixos/lib/eval-config.nix" {
  system = null;
  modules = [
    ./configuration.nix
    {
      networking.hostName = hostname;
      nixpkgs.hostPlatform = "x86_64-linux";
    }
  ];
}
```

```console
$ nixos-rebuild -f system.nix --argstr hostname foobar switch
```

This is currently still missing the manpage changes, tests, etc. I'm creating the PR early to get some initial feedback.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
