### PR TITLE
python312Packages.zipfile2: 0.0.12 -> 0.0.12-unstable-2024-09-28, python312Packages.okonomiyaki: 1.4.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/simplesat/default.nix
+++ b/pkgs/development/python-modules/simplesat/default.nix
@@ -1,42 +1,34 @@
 {
-  buildPythonPackage,
-  fetchFromGitHub,
-  writeText,
   lib,
   attrs,
+  buildPythonPackage,
+  fetchFromGitHub,
   mock,
   okonomiyaki,
   pytestCheckHook,
+  pythonOlder,
   pyyaml,
   setuptools,
   six,
 }:
 
-let
-  version = "0.9.0";
-  versionFile = writeText "simplesat_ver" ''
-    version = '${version}'
-    full_version = '${version}'
-    git_revision = '0000000000000000000000000000000000000000'
-    is_released = True
-    msi_version = '${version}.000'
-    version_info = (${lib.versions.major version}, ${lib.versions.minor version}, ${lib.versions.patch version}, 'final', 0)
-  '';
-in
 buildPythonPackage rec {
   pname = "simplesat";
-  inherit version;
+  version = "0.9.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "enthought";
     repo = "sat-solver";
     rev = "refs/tags/v${version}";
-    hash = "sha256-8sUOV42MLM3otG3EKvVzKKGAUpSlaTj850QZxZa62bE=";
+    hash = "sha256-/fBnpf1DtaF+wQYZztcB8Y20/ZMYxrF3fH5qRsMucL0=";
   };
 
-  preConfigure = ''
-    cp ${versionFile} simplesat/_version.py
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace-fail "version = file: VERSION" "version = ${version}"
   '';
 
   build-system = [ setuptools ];
@@ -47,20 +39,26 @@ buildPythonPackage rec {
     six
   ];
 
-  pythonImportsCheck = [ "simplesat" ];
-
   nativeCheckInputs = [
     mock
     pytestCheckHook
     pyyaml
   ];
 
+  pythonImportsCheck = [ "simplesat" ];
+
+  preCheck = ''
+    substituteInPlace simplesat/tests/test_pool.py \
+      --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
+  '';
+
   pytestFlagsArray = [ "simplesat/tests" ];
 
   meta = with lib; {
-    homepage = "https://github.com/enthought/sat-solver";
     description = "Prototype for SAT-based dependency handling";
-    maintainers = with maintainers; [ genericnerdyusername ];
+    homepage = "https://github.com/enthought/sat-solver";
+    changelog = "https://github.com/enthought/sat-solver/blob/v${version}/CHANGES.rst";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ genericnerdyusername ];
   };
 }

--- a/pkgs/development/python-modules/zipfile2/default.nix
+++ b/pkgs/development/python-modules/zipfile2/default.nix
@@ -1,31 +1,43 @@
 {
+  lib,
   buildPythonPackage,
   fetchFromGitHub,
-  lib,
-  pythonAtLeast,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "zipfile2";
-  version = "0.0.12";
-  format = "setuptools";
+  version = "0.0.12-unstable-2024-09-28";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "cournape";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-BwcEgW4XrQqz0Jmtbyxf8q0mWTJXv2dL3Tk7N/IYuMI=";
+    repo = "zipfile2";
+    #rev = "refs/tags/v${version}";
+    rev = "8823f7253772e5c5811343306a591c00c764c6d0";
+    hash = "sha256-jDOyIj0sQS1dIsar4nyk5V2mme3Zc6VTms49/4n93ho=";
   };
 
-  patches = [ ./no-setuid.patch ];
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "zipfile2" ];
 
+  disabledTests = [
+    # PermissionError: [Errno 1] Operation not ...
+    "test_extract"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/cournape/zipfile2";
     description = "Backwards-compatible improved zipfile class";
-    maintainers = with maintainers; [ genericnerdyusername ];
+    homepage = "https://github.com/cournape/zipfile2";
+    changelog = "https://github.com/itziakos/zipfile2/releases/tag/v${version}";
     license = licenses.psfl;
-    broken = pythonAtLeast "3.12"; # tests are failing because the signature of ZipInfo._decodeExtra changed
+    maintainers = with maintainers; [ genericnerdyusername ];
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/enthought/okonomiyaki/releases/tag/2.0.0

Superseds https://github.com/NixOS/nixpkgs/pull/336833

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
