### PR TITLE
WIP: cudaPackages.hasCudaObjects: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -339,6 +339,33 @@ once to get a derivation hash, and again to produce the final fixed output deriv
 
 :::
 
+## `hasCudaObjects` {#tester-hasCudaObjects}
+
+Check that `package` contains at least one executable file or static
+library with compiled cuda objects. This is achieved using `cuobjdump`.
+Alternative name is `cudaPackages.hasCudaObjects`.
+
+:::{.example #ex-hasCudaObjects}
+
+# Check for cuda artifacts if `cudaSupport=true`
+
+```nix
+stdenv.mkDerivation (finalAttrs: {
+  # ...
+  passthru.tests = lib.optionalAttrs cudaSupport {
+    hasCudaObjects = cudaPackages.hasCudaObjects {
+      package = finalAttrs.finalPackage;
+      # optional arguments:
+      hasPTX = true; # has a PTX that can be compiled at runtime
+      requiredCapabilities = cudaPackages.flags.cudaCapabilities;
+    };
+  };
+  # ...
+})
+```
+
+:::
+
 ## `runCommand` {#tester-runCommand}
 
 `runCommand :: { name, script, stdenv ? stdenvNoCC, hash ? "...", ... } -> Derivation`

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -4,6 +4,7 @@
   callPackage,
   pkgs,
   pkgsLinux,
+  cudaPackages,
 
   diffoscopeMinimal,
   runCommand,
@@ -181,4 +182,9 @@
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
 
   shellcheck = callPackage ./shellcheck/tester.nix { };
+
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
+  # or doc/build-helpers/testers.chapter.md
+  # or pkgs/top-level/cuda-packages.nix
+  inherit (cudaPackages) hasCudaObjects;
 }

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -211,6 +211,9 @@ goBuild {
           inherit version;
           package = ollama;
         };
+        hasCudaObjects = cudaPackages.hasCudaObjects {
+          package = ollama-cuda;
+        };
       }
       // lib.optionalAttrs stdenv.hostPlatform.isLinux {
         inherit ollama-rocm ollama-cuda;

--- a/pkgs/development/cuda-modules/has-cuda-objects.nix
+++ b/pkgs/development/cuda-modules/has-cuda-objects.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  config,
+  runCommand,
+  cudaPackages,
+  fd,
+}:
+{
+  package,
+  hasPTX ? false,
+  requiredCapabilities ? [ ],
+  preferLocalBuild ? true,
+  ...
+}@args:
+
+assert lib.assertMsg (lib.isDerivation package) "provided package is not a derivation";
+
+# `find` will search the whole store if this list is empty
+assert lib.assertMsg (package.outputs != [ ]) "provided package has no outputs";
+
+assert lib.assertMsg (args.__structuredAttrs or true
+) "This test requires __structuredAttrs to be true";
+
+let
+
+  args' = lib.removeAttrs args [ "package" ];
+
+  inherit (cudaPackages.flags) dropDot;
+
+in
+
+runCommand "test-any-cuobjdump-${package.name}"
+  (
+    args'
+    // {
+      inherit preferLocalBuild;
+      nativeBuildInputs = args'.nativeBuildInputs or [ ] ++ [
+        cudaPackages.cuda_cuobjdump
+      ];
+
+      __structuredAttrs = true;
+      package_outputs = lib.forEach package.outputs (output: package.${output});
+    }
+  )
+  ''
+    #set -x
+    any_cuobj_found=false
+    while IFS= read -r -d "" fname; do
+      echo "Checking $fname"
+
+      failed=false
+      cuobjdump_output=$(cuobjdump "$fname" 2>&1 || failed=true)
+
+      if ! $failed && ! grep <<<"$cuobjdump_output" -q "does not contain device code"; then
+        echo "Found cuda objects in $fname"
+        any_cuobj_found=true
+
+        # we could `continue`, but this is way better when debugging
+        all_requirements_found=true
+
+        # TODO: does this work?
+        ${lib.optionalString hasPTX ''
+          # we run cuobjdump again since --list-ptx interferes with requiredCapabilities
+          if cuobjdump --list-ptx "$fname" 1>/dev/null 2>/dev/null; then
+            echo "  Has PTX"
+          else
+            echo "  Does NOT have PTX"
+            all_requirements_found=false
+          fi
+        ''}
+
+        ${
+          lib.concatLines (
+            lib.forEach requiredCapabilities (cap: ''
+              if grep <<<"$cuobjdump_output" -q "^arch = sm_${dropDot cap}$"; then
+                echo "  Has architecture sm_${dropDot cap}"
+              else
+                echo "  Does NOT have architecture sm_${dropDot cap}!"
+                all_requirements_found=false
+              fi
+            '')
+          )
+        }
+
+        if ! "$all_requirements_found"; then
+          continue
+        fi
+
+        touch $out
+        break
+      fi
+
+    done < <(
+      find "''${package_outputs[@]}" -type f -and \( -name '*.a' -or -executable \) -print0
+    )
+
+    if [[ ! -f $out ]]; then
+      if ! "$any_cuobj_found"; then
+        >&2 echo "ERROR: No cuda objects was found in "${lib.escapeShellArg package.name}"!"
+      else
+        >&2 echo "ERROR: No binary satisfying all requirement was found in "${lib.escapeShellArg package.name}"!"
+      fi
+      exit 1
+    fi
+  ''

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -41,7 +41,7 @@ let
     (cudaPackages.cuda_profiler_api or cudaPackages.cuda_nvprof)
   ];
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
   outputs = [ "out" ] ++ lib.optionals pythonSupport [ "dist" ];
@@ -107,6 +107,12 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit cudaSupport cudaPackages pythonSupport;
+
+    tests = lib.optionalAttrs cudaSupport {
+      hasCudaObjects = cudaPackages.hasCudaObjects {
+        package = finalAttrs.finalPackage;
+      };
+    };
   };
 
   meta = {
@@ -117,4 +123,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ SomeoneSerge ];
   };
-}
+})

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -83,6 +83,30 @@ let
     nccl = final.callPackage ../development/cuda-modules/nccl { };
     nccl-tests = final.callPackage ../development/cuda-modules/nccl-tests { };
 
+    /**
+      `hasCudaObjects` checks whether the provided `package` contains at
+      least one executable file or static library with compiled cuda objects,
+      using `cuobjdump`.
+
+      # Example
+
+      ```nix
+      stdenv.mkDerivation (finalAttrs: {
+        # ...
+        passthru.tests = lib.optionalAttrs cudaSupport {
+          hasCudaObjects = cudaPackages.hasCudaObjects {
+            package = finalAttrs.finalPackage;
+            # optional arguments:
+            hasPTX = true; # has a PTX that can be compiled at runtime
+            requiredCapabilities = cudaPackages.flags.cudaCapabilities;
+          };
+        };
+        # ...
+      })
+      ```
+    */
+    hasCudaObjects = final.callPackage ../development/cuda-modules/has-cuda-objects.nix { };
+
     tests =
       let
         bools = [


### PR DESCRIPTION
~~includes some commented code from when i tried to have the function override the provided package to enable CUDA. turns out `finalAttrs.finalPackage` does not have `.override` /shrug~~

@SomeoneSerge is this of any interest?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
