### PR TITLE
(nixos/)rkvm: take over maintainership, add server./client.passwordFile/.useOwnSlice options

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15395,6 +15395,11 @@
     githubId = 6391776;
     name = "Nikita Voloboev";
   };
+  NiklasGollenstede = {
+    name = "Niklas Gollenstede";
+    github = "NiklasGollenstede";
+    githubId = 10552031;
+  };
   niklashh = {
     email = "niklas.2.halonen@aalto.fi";
     github = "xhalo32";

--- a/nixos/modules/services/misc/rkvm.nix
+++ b/nixos/modules/services/misc/rkvm.nix
@@ -7,7 +7,7 @@ let
   toml = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [ lib.maintainers.NiklasGollenstede ];
 
   options.services.rkvm = {
     enable = mkOption {

--- a/nixos/modules/services/misc/rkvm.nix
+++ b/nixos/modules/services/misc/rkvm.nix
@@ -109,7 +109,7 @@ in
         description = ''
           A list of keys that, when pressed simultaneously, switch between the clients registered at the server (for this, the server itself is considered a client).
 
-          _A list of available key names is available at <https://github.com/htrefil/rkvm/blob/${cfg.package.version}/switch-keys.md>._
+          _A list of available key names is available at <https://github.com/htrefil/rkvm/blob/master/switch-keys.md>._
         '';
       };
 
@@ -120,7 +120,7 @@ in
         type = types.str;
         example = "192.168.0.123:5258";
         description = ''
-          An RKVM server's internet socket address, either IPv4 or IPv6.
+          Hostname or IPv4/6 address and port number of the `rkvm` server to connect to.
         '';
       };
     };

--- a/nixos/modules/services/misc/rkvm.nix
+++ b/nixos/modules/services/misc/rkvm.nix
@@ -1,134 +1,112 @@
 { options, config, pkgs, lib, ... }:
-
-with lib;
 let
   opt = options.services.rkvm;
   cfg = config.services.rkvm;
   toml = pkgs.formats.toml { };
+  inherit (lib) mkOption mkEnableOption types mkIf;
 in
 {
   meta.maintainers = [ lib.maintainers.NiklasGollenstede ];
 
-  options.services.rkvm = {
+  options.services.rkvm = let
+
     enable = mkOption {
       default = cfg.server.enable || cfg.client.enable;
-      defaultText = literalExpression "config.${opt.server.enable} || config.${opt.client.enable}";
+      defaultText = lib.literalExpression "config.${opt.server.enable} || config.${opt.client.enable}";
       type = types.bool;
       description = ''
         Whether to enable rkvm, a Virtual KVM switch for Linux machines.
       '';
     };
 
-    package = mkPackageOption pkgs "rkvm" { };
+    package = lib.mkPackageOption pkgs "rkvm" { };
 
-    server = {
-      enable = mkEnableOption "the rkvm server daemon (input transmitter)";
+    mkCommonOptions = component: extraSettings: {
+      enable = mkEnableOption "the rkvm ${component} daemon (input ${
+        if component == "server" then "transmitter" else "receiver"
+      })";
 
       settings = mkOption {
-        type = types.submodule
-          {
-            freeformType = toml.type;
-            options = {
-              listen = mkOption {
-                type = types.str;
-                default = "0.0.0.0:5258";
-                description = ''
-                  An internet socket address to listen on, either IPv4 or IPv6.
-                '';
-              };
-
-              switch-keys = mkOption {
-                type = types.listOf types.str;
-                default = [ "left-alt" "left-ctrl" ];
-                description = ''
-                  A key list specifying a host switch combination.
-
-                  _A list of key names is available in <https://github.com/htrefil/rkvm/blob/master/switch-keys.md>._
-                '';
-              };
-
-              certificate = mkOption {
-                type = types.path;
-                default = "/etc/rkvm/certificate.pem";
-                description = ''
-                  TLS certificate path.
-
-                  ::: {.note}
-                  This should be generated with {command}`rkvm-certificate-gen`.
-                  :::
-                '';
-              };
-
-              key = mkOption {
-                type = types.path;
-                default = "/etc/rkvm/key.pem";
-                description = ''
-                  TLS key path.
-
-                  ::: {.note}
-                  This should be generated with {command}`rkvm-certificate-gen`.
-                  :::
-                '';
-              };
-
-              password = mkOption {
-                type = types.str;
-                description = ''
-                  Shared secret token to authenticate the client.
-                  Make sure this matches your client's config.
-                '';
-              };
-            };
-          };
-
+        description = "Structured ${component} daemon configuration";
         default = { };
-        description = "Structured server daemon configuration";
-      };
-    };
+        type = types.submodule {
+          freeformType = toml.type;
+          options = ({
 
-    client = {
-      enable = mkEnableOption "the rkvm client daemon (input receiver)";
+            certificate = mkOption {
+              type = types.path; default = "/etc/rkvm/certificate.pem";
+              description = ''
+                Path to the TLS public certificate file.
 
-      settings = mkOption {
-        type = types.submodule
-          {
-            freeformType = toml.type;
-            options = {
-              server = mkOption {
-                type = types.str;
-                example = "192.168.0.123:5258";
-                description = ''
-                  An RKVM server's internet socket address, either IPv4 or IPv6.
-                '';
-              };
-
-              certificate = mkOption {
-                type = types.path;
-                default = "/etc/rkvm/certificate.pem";
-                description = ''
-                  TLS ceritficate path.
-
-                  ::: {.note}
-                  This should be generated with {command}`rkvm-certificate-gen`.
-                  :::
-                '';
-              };
-
-              password = mkOption {
-                type = types.str;
-                description = ''
-                  Shared secret token to authenticate the client.
-                  Make sure this matches your server's config.
-                '';
-              };
+                ::: {.note}
+                This can be generated with {command}`rkvm-certificate-gen`.
+                :::
+              '';
             };
-          };
 
-        default = {};
-        description = "Structured client daemon configuration";
+            password = mkOption {
+              type = types.nullOr types.str; default = null;
+              description = ''
+                Shared **secret** token to authenticate the client.
+
+                ::: {.warning}
+                You should NOT set this option directly, since this is a secret and all options set in nix itself will be world-readable.
+                Use {option}`..passwordFile` instead.
+                :::
+              '';
+            };
+
+          } // extraSettings);
+        };
+
       };
     };
 
+  in {
+    inherit enable package;
+
+    server = mkCommonOptions "server" {
+
+      listen = mkOption {
+        type = types.str;
+        default = "0.0.0.0:5258";
+        description = ''
+          Hostname or IPv4/6 address and port number to listen on.
+        '';
+      };
+
+      key = mkOption {
+        type = types.path; default = "/etc/rkvm/key.pem";
+        description = ''
+          Path to the TLS private key file (that matches the {option}`.certificate`).
+
+          ::: {.warning}
+          As a secret, this should not be stored in the nix store. Do not add the (unencrypted) file to your repository, and do not use an unquoted path to reference it.
+          :::
+        '';
+      };
+
+      switch-keys = mkOption {
+        type = types.listOf types.str;
+        default = [ "left-alt" "left-ctrl" ];
+        description = ''
+          A list of keys that, when pressed simultaneously, switch between the clients registered at the server (for this, the server itself is considered a client).
+
+          _A list of available key names is available at <https://github.com/htrefil/rkvm/blob/${cfg.package.version}/switch-keys.md>._
+        '';
+      };
+
+    };
+
+    client = mkCommonOptions "client" {
+      server = mkOption {
+        type = types.str;
+        example = "192.168.0.123:5258";
+        description = ''
+          An RKVM server's internet socket address, either IPv4 or IPv6.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {

--- a/nixos/tests/rkvm/default.nix
+++ b/nixos/tests/rkvm/default.nix
@@ -70,6 +70,7 @@ in
           certificate = snakeoil-cert;
         };
         passwordFile = snakeoil-password;
+        useOwnSlice = true;
       };
     };
   };

--- a/nixos/tests/rkvm/default.nix
+++ b/nixos/tests/rkvm/default.nix
@@ -6,6 +6,7 @@ let
   #
   snakeoil-cert = ./cert.pem;
   snakeoil-key = ./key.pem;
+  snakeoil-password = builtins.path { path = ./password.txt; };
 in
 {
   name = "rkvm";
@@ -67,9 +68,8 @@ in
         settings = {
           server = "10.0.0.1:5258";
           certificate = snakeoil-cert;
-          key = snakeoil-key;
-          password = "snakeoil";
         };
+        passwordFile = snakeoil-password;
       };
     };
   };

--- a/nixos/tests/rkvm/default.nix
+++ b/nixos/tests/rkvm/default.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({ pkgs, ... }:
+import ../make-test-python.nix ({ pkgs, lib, ... }:
 let
   # Generated with
   #
@@ -9,6 +9,10 @@ let
 in
 {
   name = "rkvm";
+
+  meta = {
+    maintainers = [ lib.maintainers.NiklasGollenstede ];
+  };
 
   nodes = {
     server = { pkgs, ... }: {

--- a/nixos/tests/rkvm/password.txt
+++ b/nixos/tests/rkvm/password.txt
@@ -1,0 +1,1 @@
+snakeoil

--- a/pkgs/tools/misc/rkvm/default.nix
+++ b/pkgs/tools/misc/rkvm/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, nix-update-script
 , rustPlatform
 , pkg-config
 , libevdev
@@ -18,6 +19,7 @@ rustPlatform.buildRustPackage rec {
     rev = version;
     hash = "sha256-pGCoNmGOeV7ND4kcRjlJZbEMnmKQhlCtyjMoWIwVZrM=";
   };
+  passthru.updateScript = nix-update-script { };
 
   cargoHash = "sha256-aq8Ky29jXY0cW5s0E4NDs29DY8RIA0Fvy2R72WPAYsk=";
 
@@ -42,6 +44,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/htrefil/rkvm/releases/tag/${version}";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.NiklasGollenstede ];
   };
 }


### PR DESCRIPTION
The first part of my NixCon 2024 hackday work :)

I thought this would be a single commit, but then I saw the `rkvm` module and package have recently become unmainteined, and decided it's time for me to become a maintainer.
I am using `rkvm` and think it works impressively well (with these additions/fixes):

* **`passwordFile`**: This one should be quite obvious: Don;t store secrets in the Nix store.
* **`useOwnSlice`**: When using `rkvm` on a system under heavy load (say, you are playing a game on the client, or nix decides it's time to rebuild `*-with-cuda`), the cursor can stutter even on low jitter networks. Since I implemented this (for myself first), the cursor is perfectly responsive.

I did the checks on the maintainers list, successfully used `nix-update` (after manually downgrading the package), and ran and extended the existing `nixpkgsTest` before and after each change.
I have used the additional options in my own config for a while before and re-tested them on my hosts now. 

All changes I made are backwards-compatible. It might be a good idea to explicitly remove the plaintext (in-store) `settings.password` option, though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
