### PR TITLE
nixos/repart-image: init interactive

### DIFF
--- a/nixos/modules/image/interactive.nix
+++ b/nixos/modules/image/interactive.nix
@@ -1,0 +1,95 @@
+# An interactive image built using systemd-repart.
+#
+# This is a higher-level abstraction built on top of repart.nix but designed
+# to give you an interactive (i.e. with Nix available and working image.) image.
+#
+# You can use this by importing this module in your config.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  rootPartitionLabel = "root";
+
+  closureInfo = pkgs.closureInfo {
+    rootPaths = [ config.system.build.toplevel ];
+  };
+
+  # Build the nix state at /nix/var/nix for the image
+  #
+  # This does two things:
+  # (1) Setup the initial profile
+  # (2) Create an initial Nix DB so that the nix tools work
+  nixState = pkgs.runCommand "nix-state" { nativeBuildInputs = [ pkgs.buildPackages.nix ]; } ''
+    mkdir -p $out/profiles
+    ln -s ${config.system.build.toplevel} $out/profiles/system-1-link
+    ln -s /nix/var/nix/profiles/system-1-link $out/profiles/system
+
+    export NIX_STATE_DIR=$out
+    nix-store --load-db < ${closureInfo}/registration
+  '';
+in
+{
+
+  imports = [ ./repart.nix ];
+
+  assertions = [
+    {
+      assertion = !config.boot.loader.grub.enable;
+      message = "You cannot use an interactive repart image with grub.";
+    }
+  ];
+
+  fileSystems = {
+    "/" = {
+      device = "/dev/disk/by-partlabel/${rootPartitionLabel}";
+      fsType = "ext4";
+    };
+  };
+  # By not providing an entry in fileSystems for the ESP, systemd will
+  # automount it to `/efi`.
+  boot.loader.efi.efiSysMountPoint = "/efi";
+
+  system.image = {
+    id = config.system.name;
+    version = config.system.nixos.version;
+  };
+
+  image.repart = {
+    name = config.system.name;
+    partitions = {
+      "esp" = {
+        # Populate the ESP statically so that we can boot this image.
+        contents =
+          let
+            efiArch = config.nixpkgs.hostPlatform.efiArch;
+          in
+          {
+            "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source = "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+            "/EFI/systemd/systemd-bootx64.efi".source = "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+            "/EFI/Linux/${config.system.boot.loader.ukiFile}".source = "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+          };
+        repartConfig = {
+          Type = "esp";
+          Format = "vfat";
+          SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "96M";
+        };
+      };
+      "root" = {
+        storePaths = [ config.system.build.toplevel ];
+        contents = {
+          "/nix/var/nix".source = nixState;
+        };
+        repartConfig = {
+          Type = "root";
+          Format = config.fileSystems."/".fsType;
+          Label = rootPartitionLabel;
+          Minimize = "guess";
+        };
+      };
+    };
+  };
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -476,6 +476,7 @@ in {
   installer = handleTest ./installer.nix {};
   installer-systemd-stage-1 = handleTest ./installer-systemd-stage-1.nix {};
   intune = handleTest ./intune.nix {};
+  interactive-repart-image = runTest ./interactive-repart-image.nix;
   invoiceplane = handleTest ./invoiceplane.nix {};
   iodine = handleTest ./iodine.nix {};
   ipv6 = handleTest ./ipv6.nix {};

--- a/nixos/tests/interactive-repart-image.nix
+++ b/nixos/tests/interactive-repart-image.nix
@@ -1,0 +1,90 @@
+# Tests building and running an interactive image with repart.
+
+{ lib, ... }:
+
+let
+  common = {
+    imports = [ ../modules/image/interactive.nix ];
+
+    # These options serve to make it properly boot from the provided image.
+    virtualisation = {
+      directBoot.enable = false;
+      mountHostNixStore = false;
+      useEFIBoot = true;
+      fileSystems = lib.mkForce {
+        "/" = {
+          device = "/dev/disk/by-partlabel/root";
+          fsType = "ext4";
+        };
+      };
+    };
+
+    boot.loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+    system.switch.enable = true;
+
+  };
+in
+{
+  name = "interactive-repart-image";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes = {
+    machine =
+      { nodes, ... }:
+      {
+        imports = [ common ];
+        system.extraDependencies = [ nodes.new.system.build.toplevel ];
+      };
+
+    new = {
+      imports = [ common ];
+      system.name = "new";
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      import os
+      import subprocess
+      import tempfile
+
+      tmp_disk_image = tempfile.NamedTemporaryFile()
+
+      subprocess.run([
+        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-b",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.repart.imageFile}",
+        "-F",
+        "raw",
+        tmp_disk_image.name,
+      ])
+
+      # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+
+      # Before switching (and thus creating new boot loader entries) this path shouldn't exist
+      machine.fail("stat /efi/EFI/nixos")
+
+      machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${nodes.new.system.build.toplevel}")
+      machine.succeed("${nodes.new.system.build.toplevel}/bin/switch-to-configuration boot")
+
+      # After switching there should be three files in here, an initrd and a
+      # kernel from the initial generation and a new initrd from the new
+      # generation.
+      files_on_esp = machine.succeed("ls -1 /efi/EFI/nixos/").strip()
+      number_of_files = len(files_on_esp.splitlines())
+
+      print(files_on_esp)
+      print(number_of_files)
+
+      assert number_of_files == 3
+    '';
+}


### PR DESCRIPTION
Add a new module that allows you to build an image with repart that you can use interactively (i.e. use Nix from inside the image). In other words a non-appliance-image.

This can in the future replace some use-cases of make-disk-image but probably not all of them (e.g. legacy boot and ZFS).

The most notable difference to make-disk-image is that this builder doesn't require starting a VM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
