### PR TITLE
python3Packages.*Hook: support `__structuredAttrs = true` (the easier ones)

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
@@ -1,22 +1,27 @@
 # Setup hook to use for pip projects
-echo "Sourcing pip-build-hook"
+# shellcheck shell=bash
 
-declare -a pipBuildFlags
+echo "Sourcing pip-build-hook"
 
 pipBuildPhase() {
     echo "Executing pipBuildPhase"
     runHook preBuild
 
     mkdir -p dist
+
+    local -a flagsArray=(
+        --verbose
+        --no-index
+        --no-deps
+        --no-clean
+        --no-build-isolation
+        --wheel-dir dist
+    )
+    concatTo flagsArray pipBuildFlags
+
     echo "Creating a wheel..."
-    @pythonInterpreter@ -m pip wheel \
-        --verbose \
-        --no-index \
-        --no-deps \
-        --no-clean \
-        --no-build-isolation \
-        --wheel-dir dist \
-        $pipBuildFlags .
+    echoCmd 'pip build flags' "${flagsArray[@]}"
+    @pythonInterpreter@ -m pip wheel "${flagsArray[@]}" .
     echo "Finished creating a wheel..."
 
     runHook postBuild

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -1,17 +1,27 @@
 # Setup hook for pip.
-echo "Sourcing pip-install-hook"
+# shellcheck shell=bash
 
-declare -a pipInstallFlags
+echo "Sourcing pip-install-hook"
 
 pipInstallPhase() {
     echo "Executing pipInstallPhase"
     runHook preInstall
 
+    # shellcheck disable=SC2154
     mkdir -p "$out/@pythonSitePackages@"
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
+    local -a flagsArray=(
+        --no-index
+        --no-warn-script-location
+        --prefix="$out"
+        --no-cache
+    )
+    concatTo flagsArray pipInstallFlags
+
     pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
+    echoCmd 'pip install flags' "${flagsArray[@]}"
+    @pythonInterpreter@ -m pip install ./*.whl "${flagsArray[@]}"
     popd || return 1
 
     runHook postInstall

--- a/pkgs/development/interpreters/python/hooks/pypa-build-hook-test.nix
+++ b/pkgs/development/interpreters/python/hooks/pypa-build-hook-test.nix
@@ -10,9 +10,9 @@
     '';
     # the source of the example project
     projectSource = runCommand "my-project-source" {} ''
-      mkdir -p $out/src
+      mkdir -p $out/src/my_project
       cp ${pyprojectToml} $out/pyproject.toml
-      touch $out/src/__init__.py
+      touch $out/src/my_project/__init__.py
     '';
     in
     # this build must never triger conflicts
@@ -20,11 +20,13 @@
       pname = "dont-propagate-conflicting-deps";
       version = "0.0.0";
       src = projectSource;
-      format = "pyproject";
-      propagatedBuildInputs = [
+      pyproject = true;
+      dependencies = [
         # At least one dependency of `build` should be included here to
         # keep the test meaningful
         (mkConflict pythonOnBuildForHost.pkgs.tomli)
+      ];
+      build-system = [
         # setuptools is also needed to build the example project
         pythonOnBuildForHost.pkgs.setuptools
       ];

--- a/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
@@ -1,4 +1,6 @@
 # Setup hook to use for pypa/build projects
+# shellcheck shell=bash
+
 echo "Sourcing pypa-build-hook"
 
 pypaBuildPhase() {

--- a/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
@@ -5,8 +5,16 @@ pypaBuildPhase() {
     echo "Executing pypaBuildPhase"
     runHook preBuild
 
+    local -a flagsArray=(
+        --no-isolation
+        --outdir dist/
+        --wheel
+    )
+    concatTo flagsArray pypaBuildFlags
+
     echo "Creating a wheel..."
-    @build@/bin/pyproject-build --no-isolation --outdir dist/ --wheel $pypaBuildFlags
+    echoCmd 'pypa build flags' "${flagsArray[@]}"
+    @build@/bin/pyproject-build "${flagsArray[@]}"
     echo "Finished creating a wheel..."
 
     runHook postBuild

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -4,15 +4,16 @@ echo "Sourcing python-imports-check-hook.sh"
 pythonImportsCheckPhase() {
     echo "Executing pythonImportsCheckPhase"
 
-    if [ -n "$pythonImportsCheck" ]; then
-        echo "Check whether the following modules can be imported: $pythonImportsCheck"
-        pythonImportsCheckOutput=$out
-        if [ -n "$python" ]; then
+    if [ -n "${pythonImportsCheck[*]-}" ]; then
+        echo "Check whether the following modules can be imported: ${pythonImportsCheck[*]}"
+        # shellcheck disable=SC2154
+        pythonImportsCheckOutput="$out"
+        if [ -n "${python-}" ]; then
             echo "Using python specific output \$python for imports check"
             pythonImportsCheckOutput=$python
         fi
         export PYTHONPATH="$pythonImportsCheckOutput/@pythonSitePackages@:$PYTHONPATH"
-        (cd $pythonImportsCheckOutput && @pythonCheckInterpreter@ -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ["pythonImportsCheck"].split()))')
+        (cd "$pythonImportsCheckOutput" && @pythonCheckInterpreter@ -c 'import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))' ${pythonImportsCheck[*]})
     fi
 }
 

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -1,23 +1,28 @@
+# shellcheck shell=bash
+
 # Setup hook for checking whether Python imports succeed
 echo "Sourcing python-imports-check-hook.sh"
 
 pythonImportsCheckPhase() {
     echo "Executing pythonImportsCheckPhase"
 
-    if [ -n "${pythonImportsCheck[*]-}" ]; then
+    if [[ -n "${pythonImportsCheck[*]-}" ]]; then
         echo "Check whether the following modules can be imported: ${pythonImportsCheck[*]}"
         # shellcheck disable=SC2154
         pythonImportsCheckOutput="$out"
-        if [ -n "${python-}" ]; then
+        if [[ -n "${python-}" ]]; then
             echo "Using python specific output \$python for imports check"
             pythonImportsCheckOutput=$python
         fi
         export PYTHONPATH="$pythonImportsCheckOutput/@pythonSitePackages@:$PYTHONPATH"
+        # Python modules and namespaces names are Python identifiers, which must not contain spaces.
+        # See https://docs.python.org/3/reference/lexical_analysis.html
+        # shellcheck disable=SC2048,SC2086
         (cd "$pythonImportsCheckOutput" && @pythonCheckInterpreter@ -c 'import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))' ${pythonImportsCheck[*]})
     fi
 }
 
-if [ -z "${dontUsePythonImportsCheck-}" ]; then
+if [[ -z "${dontUsePythonImportsCheck-}" ]]; then
     echo "Using pythonImportsCheckPhase"
     appendToVar preDistPhases pythonImportsCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-namespaces-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-namespaces-hook.sh
@@ -1,20 +1,26 @@
 # Clean up __init__.py's found in namespace directories
+# shellcheck shell=bash
+
 echo "Sourcing python-namespaces-hook"
 
 pythonNamespacesHook() {
     echo "Executing pythonNamespacesHook"
 
-    for namespace in ${pythonNamespaces[@]}; do
+    # Python namespaces names are Python identifiers, which must not contain spaces.
+    # See https://docs.python.org/3/reference/lexical_analysis.html
+    # shellcheck disable=SC2048
+    for namespace in ${pythonNamespaces[*]-}; do
         echo "Enforcing PEP420 namespace: ${namespace}"
 
         # split namespace into segments. "azure.mgmt" -> "azure mgmt"
-        IFS='.' read -ra pathSegments <<<$namespace
+        IFS='.' read -ra pathSegments <<<"$namespace"
+        # shellcheck disable=SC2154
         constructedPath=$out/@pythonSitePackages@
 
         # Need to remove the __init__.py at each namespace level
         # E.g `azure/__init__.py` and `azure/mgmt/__init__.py`
         # The __pycache__ entry also needs to be removed
-        for pathSegment in ${pathSegments[@]}; do
+        for pathSegment in "${pathSegments[@]}"; do
             constructedPath=${constructedPath}/${pathSegment}
             pathToRemove=${constructedPath}/__init__.py
             pycachePath=${constructedPath}/__pycache__/
@@ -30,9 +36,9 @@ pythonNamespacesHook() {
             # event of a "meta-package" package, which will just install
             # other packages, but not produce anything in site-packages
             # besides meta information
-            if [ -d "${constructedPath}/../" -a -z ${dontRemovePth-} ]; then
+            if [[ -d "${constructedPath}/../" ]] && [[ -z "${dontRemovePth-}" ]]; then
                 # .pth files are located in the parent directory of a module
-                @findutils@/bin/find ${constructedPath}/../ -name '*-nspkg.pth' -exec rm -v "{}" +
+                @findutils@/bin/find "${constructedPath}/../" -name '*-nspkg.pth' -exec rm -v "{}" +
             fi
 
             # remove __pycache__/ entry, can be interpreter specific. E.g. __init__.cpython-38.pyc
@@ -46,6 +52,6 @@ pythonNamespacesHook() {
     echo "Finished executing pythonNamespacesHook"
 }
 
-if [ -z "${dontUsePythonNamespacesHook-}" -a -n "${pythonNamespaces-}" ]; then
+if [[ -z "${dontUsePythonNamespacesHook-}" ]] && [[ -n "${pythonNamespaces-}" ]]; then
     postFixupHooks+=(pythonNamespacesHook)
 fi

--- a/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
@@ -1,9 +1,12 @@
 # Setup hook for storing dist folder (wheels/sdists) in a separate output
+# shellcheck shell=bash
+
 echo "Sourcing python-catch-conflicts-hook.sh"
 
 pythonOutputDistPhase() {
     echo "Executing pythonOutputDistPhase"
     if [[ -d dist ]]; then
+        # shellcheck disable=SC2154
         mv "dist" "$dist"
     else
         cat >&2 <<EOF

--- a/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
@@ -21,4 +21,4 @@ EOF
     echo "Finished executing pythonOutputDistPhase"
 }
 
-preFixupPhases+=" pythonOutputDistPhase"
+appendToVar preFixupPhases pythonOutputDistPhase

--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -48,6 +48,7 @@ _pythonRelaxDeps() {
         sed -i "$metadata_file" -r \
             -e 's/(Requires-Dist: [a-zA-Z0-9_.-]+\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/'
     else
+        # shellcheck disable=SC2048
         for dep in ${pythonRelaxDeps[*]}; do
             sed -i "$metadata_file" -r \
                 -e "s/(Requires-Dist: $dep\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/i"
@@ -64,6 +65,7 @@ _pythonRemoveDeps() {
         sed -i "$metadata_file" \
             -e '/Requires-Dist:.*/d'
     else
+        # shellcheck disable=SC2048
         for dep in ${pythonRemoveDeps[*]-}; do
             sed -i "$metadata_file" \
                 -e "/Requires-Dist: $dep/d"
@@ -86,11 +88,14 @@ pythonRelaxDepsHook() {
         rm -rf "$wheel"
 
         # Using no quotes on purpose since we need to expand the glob from `$metadata_file`
+        # shellcheck disable=SC2086
         _pythonRelaxDeps $metadata_file
+        # shellcheck disable=SC2086
         _pythonRemoveDeps $metadata_file
 
         if (("${NIX_DEBUG:-0}" >= 1)); then
             echo "pythonRelaxDepsHook: resulting METADATA for '$wheel':"
+            # shellcheck disable=SC2086
             cat $metadata_file
         fi
 

--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -42,13 +42,13 @@
 _pythonRelaxDeps() {
     local -r metadata_file="$1"
 
-    if [[ -z "${pythonRelaxDeps:-}" ]] || [[ "$pythonRelaxDeps" == 0 ]]; then
+    if [[ -z "${pythonRelaxDeps[*]-}" ]] || [[ "$pythonRelaxDeps" == 0 ]]; then
         return
     elif [[ "$pythonRelaxDeps" == 1 ]]; then
         sed -i "$metadata_file" -r \
             -e 's/(Requires-Dist: [a-zA-Z0-9_.-]+\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/'
     else
-        for dep in $pythonRelaxDeps; do
+        for dep in ${pythonRelaxDeps[*]}; do
             sed -i "$metadata_file" -r \
                 -e "s/(Requires-Dist: $dep\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/i"
         done
@@ -58,13 +58,13 @@ _pythonRelaxDeps() {
 _pythonRemoveDeps() {
     local -r metadata_file="$1"
 
-    if [[ -z "${pythonRemoveDeps:-}" ]] || [[ "$pythonRemoveDeps" == 0 ]]; then
+    if [[ -z "${pythonRemoveDeps[*]-}" ]] || [[ "$pythonRemoveDeps" == 0 ]]; then
         return
     elif [[ "$pythonRemoveDeps" == 1 ]]; then
         sed -i "$metadata_file" \
             -e '/Requires-Dist:.*/d'
     else
-        for dep in $pythonRemoveDeps; do
+        for dep in ${pythonRemoveDeps[*]-}; do
             sed -i "$metadata_file" \
                 -e "/Requires-Dist: $dep/d"
         done

--- a/pkgs/development/interpreters/python/hooks/python-remove-tests-dir-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-remove-tests-dir-hook.sh
@@ -1,11 +1,14 @@
 # Clean up top-level tests directory in site-package installation.
+# shellcheck shell=bash
+
 echo "Sourcing python-remove-tests-dir-hook"
 
 pythonRemoveTestsDir() {
     echo "Executing pythonRemoveTestsDir"
 
-    rm -rf $out/@pythonSitePackages@/tests
-    rm -rf $out/@pythonSitePackages@/test
+    # shellcheck disable=SC2154
+    rm -rf "$out/@pythonSitePackages@/tests"
+    rm -rf "$out/@pythonSitePackages@/test"
 
     echo "Finished executing pythonRemoveTestsDir"
 }

--- a/pkgs/development/interpreters/python/hooks/setuptools-rust-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-rust-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 echo "Sourcing setuptools-rust-hook"
 
 setuptoolsRustSetup() {

--- a/pkgs/development/python-modules/meson-python/add-build-flags.sh
+++ b/pkgs/development/python-modules/meson-python/add-build-flags.sh
@@ -3,7 +3,7 @@ mesonPythonBuildFlagsHook() {
   for f in $mesonFlags; do
     pypaBuildFlags+=" -Csetup-args=$f"
     # This requires pip>23.0.1, see: https://meson-python.readthedocs.io/en/latest/how-to-guides/config-settings.html
-    pipBuildFlags+=" --config-settings=setup-args=$f"
+    appendToVar pipBuildFlags "--config-settings=setup-args=$f"
   done
 }
 

--- a/pkgs/development/python-modules/meson-python/add-build-flags.sh
+++ b/pkgs/development/python-modules/meson-python/add-build-flags.sh
@@ -1,7 +1,7 @@
 mesonPythonBuildFlagsHook() {
   # Add all of mesonFlags to -Csetup-args for pypa builds
   for f in $mesonFlags; do
-    pypaBuildFlags+=" -Csetup-args=$f"
+    appendToVar pypaBuildFlags "-Csetup-args=$f"
     # This requires pip>23.0.1, see: https://meson-python.readthedocs.io/en/latest/how-to-guides/config-settings.html
     appendToVar pipBuildFlags "--config-settings=setup-args=$f"
   done


### PR DESCRIPTION
This are the easier, less controversial part of the effort to make `buildPythonPackage` and `buildPythonApplication` support both `__structuredAttrs = true` and `structuredAttrs = false`.

Each modified Bash script is linted with ShellCheck.

It also fixes some leftovers of #339117 among Python-related hooks.

Split from #347194

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
