### PR TITLE
nixos/version: allow overriding, use 24-bit colour code

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -36,7 +36,7 @@ let
       DOCUMENTATION_URL = optionalString isNixos "https://nixos.org/learn.html";
       SUPPORT_URL = optionalString isNixos "https://nixos.org/community.html";
       BUG_REPORT_URL = optionalString isNixos "https://github.com/NixOS/nixpkgs/issues";
-      ANSI_COLOR = optionalString isNixos "1;34";
+      ANSI_COLOR = optionalString isNixos "0;38;2;126;186;228";
       IMAGE_ID = optionalString (config.system.image.id != null) config.system.image.id;
       IMAGE_VERSION = optionalString (config.system.image.version != null) config.system.image.version;
       VARIANT = optionalString (cfg.variantName != null) cfg.variantName;

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -42,8 +42,7 @@ let
       VARIANT = optionalString (cfg.variantName != null) cfg.variantName;
       VARIANT_ID = optionalString (cfg.variant_id != null) cfg.variant_id;
       DEFAULT_HOSTNAME = config.system.nixos.distroId;
-      SUPPORT_END = "2025-06-30";
-    };
+    } // cfg.extraOSReleaseArgs;
 
   initrdReleaseContents = (removeAttrs osReleaseContents [ "BUILD_ID" ]) // {
     PRETTY_NAME = "${osReleaseContents.PRETTY_NAME} (Initrd)";
@@ -143,6 +142,26 @@ in
         default = "NixOS";
         description = "The name of the operating system vendor";
       };
+
+      extraOSReleaseArgs = mkOption {
+        internal = true;
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Additional attributes to be merged with the /etc/os-release generator.";
+        example = {
+          ANSI_COLOR = "1;31";
+        };
+      };
+
+      extraLSBReleaseArgs = mkOption {
+        internal = true;
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Additional attributes to be merged with the /etc/lsb-release generator.";
+        example = {
+          LSB_VERSION = "1.0";
+        };
+      };
     };
 
     image = {
@@ -237,13 +256,13 @@ in
     # https://www.freedesktop.org/software/systemd/man/os-release.html for the
     # format.
     environment.etc = {
-      "lsb-release".text = attrsToText {
+      "lsb-release".text = attrsToText ({
         LSB_VERSION = "${cfg.release} (${cfg.codeName})";
         DISTRIB_ID = "${cfg.distroId}";
         DISTRIB_RELEASE = cfg.release;
         DISTRIB_CODENAME = toLower cfg.codeName;
         DISTRIB_DESCRIPTION = "${cfg.distroName} ${cfg.release} (${cfg.codeName})";
-      };
+      } // cfg.extraLSBReleaseArgs);
 
       "os-release".text = attrsToText osReleaseContents;
     };


### PR DESCRIPTION
<details>
<summary>1. use 24-bit ANSI colour code</summary>

It's almost 2025; we don't need to use 3-bit colour anymore. Let's use the [proper colour code](https://github.com/NixOS/nixos-artwork/blob/ea1384e183f556a94df85c7aa1dcd411f5a69646/logo/README.md#colours) for NixOS' light blue.

Other distributions have already done this:
1. [Fedora Linux](https://bugzilla.redhat.com/show_bug.cgi?id=1823099) (2020)
2. [Arch Linux](https://bugs.archlinux.org/task/66217) (2020) + some Arch forks
3. [Chimera Linux](https://github.com/chimera-linux/cports/commit/6cf871f61daae93631abe9028553891c4b09b5e8) (2022)

</details>

<details>
<summary>2. add <code>extraOSReleaseArgs</code> and <code>extraLSBReleaseArgs</code></summary>

A free-form `attrsOf str` option that is merged with the /etc/os-release
builder, allowing downstreams to customise arbitrary os-release fields.
This is separate from the variant option, as using an attribute set
merge means one gets an infinte recursion when making extraOSReleaseArgs
a recursive set, and the variant attribute is useful to define elsewhere
or multiple times.

This also removes the SUPPORT_END tag that was added erroneously to `unstable`.

</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested basic functionality of all changes.
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  - [ ] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
