### PR TITLE
maintainers/README: add guidelines for committers

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -175,3 +175,54 @@ for further information.
 
 # nixpkgs-merge-bot
 To streamline autoupdates, leverage the nixpkgs-merge-bot by commenting `@NixOS/nixpkgs-merge-bot merge` if the package resides in pkgs-by-name and the commenter is among the package maintainers. The bot ensures that all ofborg checks, except for darwin, are successfully completed before merging the pull request. Should the checks still be underway, the bot patiently waits for ofborg to finish before attempting the merge again.
+
+# Guidelines for Committers
+
+When merging pull requests, care must be taken to reduce impact to the `master`
+branch. If a commit breaks evaluation, it will affect Ofborg evaluation results
+in other pull requests and block Hydra CI, thus introducing chaos to our
+workflow.
+
+One approach to avoid merging such problematic changes is to wait for
+successful Ofborg evaluation. Additionally, using tools like
+[nixpkgs-review](https://github.com/Mic92/nixpkgs-review) can help spot issues
+early, before Ofborg finishes evaluation.
+
+## Breaking changes
+
+In general breaking changes to `master` and `staging` branches are permitted,
+as long as they are documented in the release notes. Though restrictions might
+apply towards the end of a NixOS release cycle, due to our feature freeze
+mechanism. This is to avoid large-scale breakages shortly before and during
+a Zero Hydra Failures (ZHF) campaign. These restrictions also intend to
+decrease the likelihood of a delayed NixOS release. The feature freeze period
+is documented in the announcement of each release schedule.
+
+> These are some example changes and if they are considered a breaking change
+> during a freeze period:
+>
+> - `foo: 1.2.3 -> 1.2.4` - Assuming this package follows semantic versioning
+>   and none of its dependent packages fail to build because of this change, it
+>   can be safely merged. Otherwise, if it can be confirmed that there is no
+>   major change in its functionality or API, but only adding new features or
+>   fixing bugs, it
+>   can also be merged.
+> - `unmaintained-software: drop` - If this PR removes a leaf package or the
+>   removal doesn't otherwise break other packages, it can be merged.
+> - `cool-tool: rename from fancy-tool` - As long as this PR replaces all
+>   references to the old attribute name with the new name and adds an alias,
+>   it can be merged.
+> - `libpopular: 4.3.2 -> 5.0.0` - If this PR would trigger many rebuilds
+>   and/or target `staging`, it should probably be delayed until after the
+>   freeze-period is over. Alternatively, if this PR is for a popular package
+>   and doesn't cause many rebuilds, it should also be delayed to reduce risk
+>   of breakage. If a PR includes important changes, such as security fixes, it
+>   should be brought up to
+>   release managers.
+> - `nixos/transmission: refactor` - If this PR adjusts the type, default value
+>   or effect of options in the NixOS module, so that users must rewrite their
+>   configuration to keep the current behavior unchanged, it should not be
+>   merged, as we don't have enough time to collect user feedback and avoid
+>   possible breakage. However, it should be accepted if the current behavior
+>   is
+>   considered broken and is fixed by the PR.


### PR DESCRIPTION
This PR adds some guidelines for (new) committers. Notably this tries to describe what a breaking change is.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
