### PR TITLE
 tests.cc-wrapper.default: reduce rebuild amount from `429` to `319`

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -8,7 +8,7 @@ let
     || (stdenv.cc.isGNU && stdenv.hostPlatform.isLinux)
   );
   staticLibc = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
-  emulator = stdenv.hostPlatform.emulator buildPackages;
+  emulator = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) (stdenv.hostPlatform.emulator buildPackages);
   isCxx = stdenv.cc.libcxx != null;
   libcxxStdenvSuffix = lib.optionalString isCxx "-libcxx";
   CC = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}cc"}";


### PR DESCRIPTION
On native the `emulator` is now `execline` which adds `110` more derivations to deps.