### PR TITLE
openleadr-rs: init at 0.1.3

### DIFF
--- a/pkgs/by-name/op/openleadr-rs/package.nix
+++ b/pkgs/by-name/op/openleadr-rs/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "openleadr-rs";
+  version = "v0.1.3";
+  src = fetchFromGitHub {
+    owner = "OpenLEADR";
+    repo = "openleadr-rs";
+    rev = version;
+    hash = "sha256-GaP3D711xahPHTfmr6m0Gty0qB/ceyoCpc8w/fTIOVM=";
+  };
+  cargoHash = "sha256-x3nQfwkz0R5ILgyaECtKqBsxSXFoSEqRdbs4Zp7taFM=";
+  # Disable sqlx crate's compile-time checks that require a live database.
+  # See https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md#force-building-in-offline-mode
+  # and https://docs.rs/sqlx/latest/sqlx/macro.query.html#offline-mode
+  SQLX_OFFLINE = "true";
+  # Disable tests. Several tests in the client require a live database
+  # connection. We avoid this by disabling all tests. This is bad, and there
+  # is an outstanding issue on the upstream project's board to avoid depending
+  # on live database connections inside tests. Perhaps there's a good way to
+  # spin up a database in the context of the nix build for testing, but I
+  # don't know it.
+  # See https://github.com/orgs/OpenLEADR/projects/1?pane=issue&itemId=83420564
+  doCheck = false;
+  meta = {
+    description = "OpenADR 3.0 VTN and VEN implementation in Rust";
+    longDescription = ''
+      OpenADR is a protocol for automated demand-response in electricity
+      grids, like dynamic pricing or load shedding. The OpenADR alliance is
+      responsible for the standard, which can be downloaded free of charge.
+      This is an OpenADR 3.0 client (VEN) library and a server (VTN)
+      implementation, both written in Rust.
+    '';
+    homepage = "https://github.com/OpenLEADR/openleadr-rs";
+    license = with lib.licenses; [ mit ]; # Also licensed under Apache 2.0.
+    maintainers = with lib.maintainers; [ benjaminedwardwebb ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
openleadr-rs is an implementation of the OpenADR 3.0 standard, which allows distributed energy resources (DERs) to communicate price and control signals to electric power utilities and system operators as part of a smart grid. It's an upgrade of the existing openleadr-python project that supported the OpenADR 2.0 standard. It's backed by the Linux Foundation.

The package builds both client (virtual end node) and server (virtual top node) binaries. The service is compiled with the project's builtin oauth functionality and with postgres as the expected storage backend.

Following upstream instructions, the virtual top node (VTN) server can be started with

	rm -rf /tmp/openleadr-rs
	git clone git@github.com:OpenLEADR/openleadr-rs.git /tmp/openleadr-rs >/dev/null 2>&1
	nixpkgsRepository="$PWD"
	cd /tmp/openleadr-rs || exit 1
	# I encountered an issue starting the postgres 18 image, so downgraded to 16.
	sed --in-place s/postgres:18/postgres:16/ docker-compose.yml
	docker image rm ghcr.io/tweedegolf/postgres:16 >/dev/null 2>&1
	. /tmp/openleadr-rs/.env
	docker compose up db --detach >/dev/null 2>&1
	cargo sqlx migrate run
	cd "$nixpkgsRepository" || exit 1
	storePath=$(nix-build -A openleadr-rs)
	DATABASE_URL="$DATABASE_URL" "$storePath/bin/openleadr-vtn" &
	vtnPid="$!"
	curl --fail http://127.0.0.1:3000/health && echo ""
	kill "$vtnPid"

These commands must be run from nixpkgs repository at this commit and with git, rust toolchain, and docker available.

See: https://github.com/OpenLEADR/openleadr-rs
See: https://github.com/OpenLEADR/openleadr-python
See: https://openleadr.org/
See: https://fosdem.org/2026/schedule/event/XXYDHM-openleadr/
See: https://lfenergy.org/projects/openleadr/
See: https://www.openadr.org/overview
See: https://en.wikipedia.org/wiki/Distributed_generation

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
