### PR TITLE
`recutils`: Encryption support, UUID support, Bash builtins

### DIFF
--- a/pkgs/by-name/re/recutils/package.nix
+++ b/pkgs/by-name/re/recutils/package.nix
@@ -4,6 +4,16 @@
 , bc
 , check
 , curl
+
+, withEncryption ? true
+, libgcrypt
+, libgpg-error
+
+, withUuid ? true
+, libuuid
+
+, withBashBuiltins ? true
+, bash
 }:
 
 stdenv.mkDerivation rec {
@@ -17,8 +27,20 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = lib.optional stdenv.cc.isClang "format";
 
+  configureFlags =
+    lib.optionals withBashBuiltins [
+      "--with-bash-headers=${bash.dev}/include/bash"
+    ];
+
   buildInputs = [
     curl
+  ] ++ lib.optionals withEncryption [
+    libgpg-error.dev
+    libgcrypt.dev
+  ] ++ lib.optionals withUuid [
+    libuuid
+  ] ++ lib.optionals withBashBuiltins [
+    bash.dev
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
The `recutils` package has optional features which are enabled by default but are skipped if the dependency is not found.
This PR adds these dependencies to `buildInputs` so they can be discovered by the configure script.
These dependencies are enabled by default, but can be manually disabled to recover the previous behavior.

The current version will dump the bash builtin libraries `readrec.so` and `testrec.so` in the `lib` directory.
This may not be desired if Bash builtins have some notion of Nix discovery, though I am not aware if this is the case.

The `mdb2rec` binary has not been added in this PR. Unfortunately it looks like support for that would require patching the library, and considering the fact that Debian does not package it, I would assume it is not that useful to provide.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
