### PR TITLE
arrpc: 3.4.0 -> 3.5.0; add systemd user service

### DIFF
--- a/pkgs/by-name/ar/arrpc/arrpc.service
+++ b/pkgs/by-name/ar/arrpc/arrpc.service
@@ -1,0 +1,13 @@
+# https://aur.archlinux.org/cgit/aur.git/tree/arrpc.service?h=arrpc
+
+[Unit]
+Description=arRPC Discord RPC daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=@arrpc@
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/pkgs/by-name/ar/arrpc/package.nix
+++ b/pkgs/by-name/ar/arrpc/package.nix
@@ -1,7 +1,9 @@
-{ lib
-, buildNpmPackage
-, fetchFromGitHub
-}: buildNpmPackage rec {
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage rec {
   pname = "arrpc";
   version = "3.4.0";
 
@@ -25,7 +27,10 @@
     description = "Open Discord RPC server for atypical setups";
     homepage = "https://arrpc.openasar.dev/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ anomalocaris NotAShelf ];
+    maintainers = with lib.maintainers; [
+      anomalocaris
+      NotAShelf
+    ];
     mainProgram = "arrpc";
   };
 }

--- a/pkgs/by-name/ar/arrpc/package.nix
+++ b/pkgs/by-name/ar/arrpc/package.nix
@@ -5,31 +5,34 @@
 }:
 buildNpmPackage rec {
   pname = "arrpc";
-  version = "3.4.0";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "OpenAsar";
     repo = "arrpc";
-    # Release commits are not tagged
-    # release: 3.4.0
-    rev = "cca93db585dedf8acc1423f5e2db215de95c4c3b";
-    hash = "sha256-SeegrCgbjfVxG/9xfOcdfbVdDssZOhjBRnDipu6L7Wg=";
+    tag = version;
+    hash = "sha256-3xkqWcLhmSIH6Al2SvM9qBpdcLzEqUmUCgwYBPAgVpo=";
   };
 
-  npmDepsHash = "sha256-S9cIyTXqCp8++Yj3VjBbcStOjzjgd0Cq7KL7NNzZFpY=";
+  npmDepsHash = "sha256-lw6pngFC2Pnk+I8818TOTwN4r+8IsjvdMYIyTsTi49g=";
 
   dontNpmBuild = true;
 
+  postInstall = ''
+    mkdir -p $out/lib/systemd/user
+    substitute ${./arrpc.service} $out/lib/systemd/user/arrpc.service \
+      --subst-var-by arrpc $out/bin/arrpc
+  '';
+
   meta = {
-    # ideally we would do blob/${version}/changelog.md here
-    # upstream does not tag releases
-    changelog = "https://github.com/OpenAsar/arrpc/blob/${src.rev}/changelog.md";
+    changelog = "https://github.com/OpenAsar/arrpc/blob/${version}/changelog.md";
     description = "Open Discord RPC server for atypical setups";
     homepage = "https://arrpc.openasar.dev/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       anomalocaris
       NotAShelf
+      ulysseszhan
     ];
     mainProgram = "arrpc";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using tagged releases as OpenAsar/arrpc#48 is resolved now.

Added a systemd user service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
