### PR TITLE
xfce.xfce4-dev-tools: Remove unused xdtEnvHook

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-dev-tools/setup-hook.sh
+++ b/pkgs/desktops/xfce/core/xfce4-dev-tools/setup-hook.sh
@@ -1,9 +1,3 @@
-xdtEnvHook() {
-    addToSearchPath ACLOCAL_PATH $1/share/aclocal
-}
-
-envHooks+=(xdtEnvHook)
-
 xdtAutogenPhase() {
     mkdir -p m4
     NOCONFIGURE=1 xdt-autogen


### PR DESCRIPTION
A `grep -nr envHooks` run shows that nothing picks up `envHooks`. automake's setup-hook should already take care of `ACLOCAL_PATH`.

Fixes: 046f091e0d98

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>xmonad_log_applet_xfce</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 123 packages built:</summary>
  <ul>
    <li>budgie-analogue-clock-applet</li>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>budgie-desktop</li>
    <li>budgie-desktop-with-plugins</li>
    <li>budgie-desktop.dev</li>
    <li>budgie-desktop.man</li>
    <li>budgie-gsettings-overrides</li>
    <li>budgie-user-indicator-redux</li>
    <li>caffeine-ng</li>
    <li>fastfetch</li>
    <li>fastfetch.man</li>
    <li>lightdm-gtk-greeter</li>
    <li>pragha</li>
    <li>xfce.catfish</li>
    <li>xfce.catfish.dist</li>
    <li>xfce.exo</li>
    <li>xfce.exo.dev</li>
    <li>xfce.garcon</li>
    <li>xfce.garcon.dev</li>
    <li>xfce.gigolo</li>
    <li>xfce.gigolo.dev</li>
    <li>xfce.libxfce4ui</li>
    <li>xfce.libxfce4ui.dev</li>
    <li>xfce.libxfce4util</li>
    <li>xfce.libxfce4util.dev</li>
    <li>xfce.libxfce4windowing</li>
    <li>xfce.libxfce4windowing.dev</li>
    <li>xfce.mousepad</li>
    <li>xfce.mousepad.dev</li>
    <li>xfce.orage</li>
    <li>xfce.orage.dev</li>
    <li>xfce.parole</li>
    <li>xfce.parole.dev</li>
    <li>xfce.ristretto</li>
    <li>xfce.ristretto.dev</li>
    <li>xfce.thunar</li>
    <li>xfce.thunar-archive-plugin</li>
    <li>xfce.thunar-archive-plugin.dev</li>
    <li>xfce.thunar-dropbox-plugin</li>
    <li>xfce.thunar-media-tags-plugin</li>
    <li>xfce.thunar-media-tags-plugin.dev</li>
    <li>xfce.thunar-volman</li>
    <li>xfce.thunar-volman.dev</li>
    <li>xfce.thunar.dev</li>
    <li>xfce.tumbler</li>
    <li>xfce.tumbler.dev</li>
    <li>xfce.xfburn</li>
    <li>xfce.xfburn.dev</li>
    <li>xfce.xfce4-appfinder</li>
    <li>xfce.xfce4-appfinder.dev</li>
    <li>xfce.xfce4-battery-plugin</li>
    <li>xfce.xfce4-battery-plugin.dev</li>
    <li>xfce.xfce4-clipman-plugin</li>
    <li>xfce.xfce4-clipman-plugin.dev</li>
    <li>xfce.xfce4-cpufreq-plugin</li>
    <li>xfce.xfce4-cpufreq-plugin.dev</li>
    <li>xfce.xfce4-cpugraph-plugin</li>
    <li>xfce.xfce4-cpugraph-plugin.dev</li>
    <li>xfce.xfce4-datetime-plugin</li>
    <li>xfce.xfce4-datetime-plugin.dev</li>
    <li>xfce.xfce4-dev-tools</li>
    <li>xfce.xfce4-dev-tools.dev</li>
    <li>xfce.xfce4-dict</li>
    <li>xfce.xfce4-dict.dev</li>
    <li>xfce.xfce4-dockbarx-plugin</li>
    <li>xfce.xfce4-docklike-plugin</li>
    <li>xfce.xfce4-docklike-plugin.dev</li>
    <li>xfce.xfce4-eyes-plugin</li>
    <li>xfce.xfce4-fsguard-plugin</li>
    <li>xfce.xfce4-genmon-plugin</li>
    <li>xfce.xfce4-i3-workspaces-plugin</li>
    <li>xfce.xfce4-mailwatch-plugin</li>
    <li>xfce.xfce4-mpc-plugin</li>
    <li>xfce.xfce4-netload-plugin</li>
    <li>xfce.xfce4-netload-plugin.dev</li>
    <li>xfce.xfce4-notes-plugin</li>
    <li>xfce.xfce4-notifyd</li>
    <li>xfce.xfce4-notifyd.dev</li>
    <li>xfce.xfce4-panel</li>
    <li>xfce.xfce4-panel-profiles</li>
    <li>xfce.xfce4-panel.dev</li>
    <li>xfce.xfce4-power-manager</li>
    <li>xfce.xfce4-power-manager.dev</li>
    <li>xfce.xfce4-pulseaudio-plugin</li>
    <li>xfce.xfce4-pulseaudio-plugin.dev</li>
    <li>xfce.xfce4-screensaver</li>
    <li>xfce.xfce4-screensaver.dev</li>
    <li>xfce.xfce4-screenshooter</li>
    <li>xfce.xfce4-screenshooter.dev</li>
    <li>xfce.xfce4-sensors-plugin</li>
    <li>xfce.xfce4-session</li>
    <li>xfce.xfce4-session.dev</li>
    <li>xfce.xfce4-settings</li>
    <li>xfce.xfce4-settings.dev</li>
    <li>xfce.xfce4-systemload-plugin</li>
    <li>xfce.xfce4-taskmanager</li>
    <li>xfce.xfce4-taskmanager.dev</li>
    <li>xfce.xfce4-terminal</li>
    <li>xfce.xfce4-terminal.dev</li>
    <li>xfce.xfce4-time-out-plugin</li>
    <li>xfce.xfce4-time-out-plugin.dev</li>
    <li>xfce.xfce4-timer-plugin</li>
    <li>xfce.xfce4-verve-plugin</li>
    <li>xfce.xfce4-verve-plugin.dev</li>
    <li>xfce.xfce4-volumed-pulse</li>
    <li>xfce.xfce4-volumed-pulse.dev</li>
    <li>xfce.xfce4-weather-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin.dev</li>
    <li>xfce.xfce4-windowck-plugin</li>
    <li>xfce.xfce4-xkb-plugin</li>
    <li>xfce.xfce4-xkb-plugin.dev</li>
    <li>xfce.xfconf</li>
    <li>xfce.xfconf.dev</li>
    <li>xfce.xfdashboard</li>
    <li>xfce.xfdashboard.dev</li>
    <li>xfce.xfdesktop</li>
    <li>xfce.xfdesktop.dev</li>
    <li>xfce.xfmpc</li>
    <li>xfce.xfmpc.dev</li>
    <li>xfce.xfwm4</li>
    <li>xfce.xfwm4.dev</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

