### PR TITLE
python3Packages.torch.tests: MPS tests for darwin

### DIFF
--- a/pkgs/development/python-modules/torch/darwin-check.py
+++ b/pkgs/development/python-modules/torch/darwin-check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import torch
+
+
+def opt_foo2(x, y):
+    a = torch.sin(x)
+    b = torch.cos(y)
+    return a + b
+
+
+print("Testing CPU")
+print(
+  opt_foo2(
+    torch.randn(10, 10),
+    torch.randn(10, 10)))
+
+print("Testing MPS")
+assert torch.backends.mps.is_built(), "PyTorch not built with MPS enabled"
+if not torch.backends.mps.is_available():
+    print("MPS not available because the current MacOS version is not 12.3+ "
+          "and/or you do not have an MPS-enabled device on this machine.")
+
+else:
+    print(
+      opt_foo2(
+        torch.randn(10, 10, device="mps"),
+        torch.randn(10, 10, device="mps")))

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -367,6 +367,8 @@ buildPythonPackage rec {
   # Explicitly enable MPS for Darwin
   USE_MPS = setBool stdenv.hostPlatform.isDarwin;
 
+  USE_DISTRIBUTED = setBool true;
+
   cmakeFlags =
     [
       # (lib.cmakeBool "CMAKE_FIND_DEBUG_MODE" true)

--- a/pkgs/development/python-modules/torch/mk-darwin-check.nix
+++ b/pkgs/development/python-modules/torch/mk-darwin-check.nix
@@ -1,0 +1,12 @@
+{
+  libraries,
+  python,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "test-torch-darwin";
+  runtimeInputs = [ (python.withPackages libraries) ];
+  text = ''
+    python ${./darwin-check.py}
+  '';
+}

--- a/pkgs/development/python-modules/torch/tests.nix
+++ b/pkgs/development/python-modules/torch/tests.nix
@@ -28,4 +28,7 @@ rec {
     feature = "rocm";
     libraries = ps: [ ps.torchWithRocm ];
   };
+  tester-darwin = callPackage ./mk-darwin-check.nix {
+    libraries = ps: [ ps.torch ];
+  };
 }


### PR DESCRIPTION
## Things done

Depends on #351778. Add new test to pytorch for Darwin platform. It tests CPU without torch.compile decorator, and MPS if MPS device is present.

<strike>Modify pytorch tests so it also tests MPS during CPU tests on Darwin. I'm not sure is this the right way to do this but at least this is a good starting point for discussion. I was also unsure do the tests work for other platforms. MPS is built for macOS by default if #351778 gets merged in its current state, so it does not need specific torchWithMps build.</strike>

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
