### PR TITLE
treewide: don’t set `ulimit -n` in builds

### DIFF
--- a/pkgs/by-name/bl/blockbook/package.nix
+++ b/pkgs/by-name/bl/blockbook/package.nix
@@ -54,10 +54,6 @@ buildGoModule rec {
     "-lstdc++"
   ];
 
-  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    ulimit -n 8192
-  '';
-
   subPackages = [ "." ];
 
   postInstall = ''

--- a/pkgs/by-name/ca/cargo-raze/package.nix
+++ b/pkgs/by-name/ca/cargo-raze/package.nix
@@ -38,12 +38,6 @@ rustPlatform.buildRustPackage {
     curl
   ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Security;
 
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Darwin issue: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
-    # https://github.com/google/cargo-raze/issues/544
-    ulimit -n 1024
-  '';
-
   __darwinAllowLocalNetworking = true;
 
   meta = {

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -39,8 +39,6 @@
 
   preCheck = ''
     export PATH=$PATH:$PWD/target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release
-    # Tests want to open many files.
-    ulimit -n 4096
   '';
   checkFlags = [
     "--skip=service::message::tests::test_node_announcement_validate"

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     in
     ''
       runHook preInstallCheck
-      (($(ulimit -n) < 1024)) && ulimit -n 1024
 
       HOME="$(mktemp -d)" ${LD_LIBRARY_PATH}="$lib/lib" ./test/unittest ${toString excludes}
 

--- a/pkgs/development/libraries/glibc/darwin-cross-build.patch
+++ b/pkgs/development/libraries/glibc/darwin-cross-build.patch
@@ -1,5 +1,4 @@
 enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
-* increase ulimit for open files: macOS default of 256 is too low for glibc build system
 * use host version of ar, which is given by environment variable
 * build system uses stamp.os and stamp.oS files, which only differ in case;
   this fails on macOS, so replace .oS with .o_S
@@ -10,11 +9,9 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  
  all .DEFAULT:
 -	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
-+	ulimit -n 1024; \
 +	$(MAKE) -r AR=$$AR PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
  
  install:
-+	ulimit -n 1024; \
  	LC_ALL=C; export LC_ALL; \
  	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
  

--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -61,7 +61,6 @@ buildPythonPackage rec {
   # The tests require the generation of code before execution. This requires
   # the protoc-gen-python_betterproto script from the package to be on PATH.
   preCheck = ''
-    (($(ulimit -n) < 1024)) && ulimit -n 1024
     export PATH=$PATH:$out/bin
     patchShebangs src/betterproto/plugin/main.py
     ${python.interpreter} -m tests.generate

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -141,7 +141,6 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "-x" ];
 
   preCheck = ''
-    (($(ulimit -n) < 1024)) && ulimit -n 1024
     export HOME=$(mktemp -d)
   '';
 

--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -37,11 +37,6 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  # On darwin: Too many open files
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    ulimit -n 1024
-  '';
-
   disabledTests = [
     # these tests raise circus.tests.support.TimeoutException
     "test_add_start"

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -160,15 +160,10 @@ buildPythonPackage rec {
 
   # Add a pytest hook skipping tests that access network, marking them as "Expected fail" (xfail).
   # We additionally xfail FileNotFoundError, since the gradio devs often fail to upload test assets to pypi.
-  preCheck =
-    ''
-      export HOME=$TMPDIR
-      cat ${./conftest-skip-network-errors.py} >> test/conftest.py
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # OSError: [Errno 24] Too many open files
-      ulimit -n 4096
-    '';
+  preCheck = ''
+    export HOME=$TMPDIR
+    cat ${./conftest-skip-network-errors.py} >> test/conftest.py
+  '';
 
   disabledTests =
     [

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -144,17 +144,12 @@ buildPythonPackage rec {
 
   dontUseSetuptoolsCheck = true;
 
-  preCheck =
-    ''
-      shopt -s extglob
-      rm -r pyarrow/!(conftest.py|tests)
-      mv pyarrow/conftest.py pyarrow/tests/parent_conftest.py
-      substituteInPlace pyarrow/tests/conftest.py --replace ..conftest .parent_conftest
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # OSError: [Errno 24] Too many open files
-      ulimit -n 1024
-    '';
+  preCheck = ''
+    shopt -s extglob
+    rm -r pyarrow/!(conftest.py|tests)
+    mv pyarrow/conftest.py pyarrow/tests/parent_conftest.py
+    substituteInPlace pyarrow/tests/conftest.py --replace ..conftest .parent_conftest
+  '';
 
   pythonImportsCheck =
     [ "pyarrow" ]

--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -52,11 +52,6 @@ buildPythonPackage rec {
   # Fixes hanging tests on Darwin
   __darwinAllowLocalNetworking = true;
 
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Darwin issue: OSError: [Errno 24] Too many open files
-    ulimit -n 1024
-  '';
-
   pythonImportsCheck = [ "pygls" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -33,10 +33,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    ulimit -n 1024
-  '';
-
   disabledTests = [
     # RuntimeError: no running event loop
     "test_blank_line_fix"

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -73,19 +73,14 @@ buildPythonPackage rec {
 
   inherit doCheck;
 
-  preCheck =
-    ''
-      # Some tests depends on sanic on PATH
-      PATH="$out/bin:$PATH"
-      PYTHONPATH=$PWD:$PYTHONPATH
+  preCheck = ''
+    # Some tests depends on sanic on PATH
+    PATH="$out/bin:$PATH"
+    PYTHONPATH=$PWD:$PYTHONPATH
 
-      # needed for relative paths for some packages
-      cd tests
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # OSError: [Errno 24] Too many open files
-      ulimit -n 1024
-    '';
+    # needed for relative paths for some packages
+    cd tests
+  '';
 
   # uvloop usage is buggy
   #SANIC_NO_UVLOOP = true;

--- a/pkgs/servers/polaris/default.nix
+++ b/pkgs/servers/polaris/default.nix
@@ -49,11 +49,6 @@ rustPlatform.buildRustPackage rec {
     cp -a docs/swagger $out/share/polaris-swagger
   '';
 
-  preCheck = ''
-    # 'Err' value: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
-    ulimit -n 4096
-  '';
-
   __darwinAllowLocalNetworking = true;
 
   passthru.tests = nixosTests.polaris;


### PR DESCRIPTION
~~This avoids having to work around the incredibly low Darwin default in a bunch of builds. The Nix daemon is meant to get a higher limit from launchd, but it seems to not work or not be passed down to builds for whatever reason. For now, this is a simple and expedient fix for a recurring problem.~~

This was a problem on the NixOS infra that was fixed so now these are redundant even without the `stdenv` patch.

See:

* <https://github.com/NixOS/nixpkgs/issues/173657>
* <https://github.com/NixOS/nix/issues/6557>
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
