### PR TITLE
buildEnv: support ignoreFileOutputs

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -77,7 +77,7 @@ for my $p (@pathsToLink) {
 sub findFiles;
 
 sub findFilesInDir {
-    my ($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
+    my ($relName, $target, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority) = @_;
 
     opendir DIR, "$target" or die "cannot open `$target': $!";
     my @names = readdir DIR or die;
@@ -85,7 +85,7 @@ sub findFilesInDir {
 
     foreach my $name (@names) {
         next if $name eq "." || $name eq "..";
-        findFiles("$relName/$name", "$target/$name", $name, $ignoreCollisions, $checkCollisionContents, $priority);
+        findFiles("$relName/$name", "$target/$name", $name, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority);
     }
 }
 
@@ -115,11 +115,16 @@ sub prependDangling {
 }
 
 sub findFiles {
-    my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
+    my ($relName, $target, $baseName, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority) = @_;
 
-    # The store path must not be a file
+    # The store path must not be a file when not ignoreFileOutputs
     if (-f $target && isStorePath $target) {
-        die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
+        if ($ignoreFileOutputs) {
+            warn "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv";
+            return;
+        } else {
+            die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
+        }
     }
 
     # Urgh, hacky...
@@ -188,8 +193,8 @@ sub findFiles {
         }
     }
 
-    findFilesInDir($relName, $oldTarget, $ignoreCollisions, $checkCollisionContents, $oldPriority) unless $oldTarget eq "";
-    findFilesInDir($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority);
+    findFilesInDir($relName, $oldTarget, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $oldPriority) unless $oldTarget eq "";
+    findFilesInDir($relName, $target, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority);
 
     $symlinks{$relName} = ["", $priority]; # denotes directory
 }
@@ -199,12 +204,12 @@ my %done;
 my %postponed;
 
 sub addPkg {
-    my ($pkgDir, $ignoreCollisions, $checkCollisionContents, $priority)  = @_;
+    my ($pkgDir, $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority)  = @_;
 
     return if (defined $done{$pkgDir});
     $done{$pkgDir} = 1;
 
-    findFiles("", $pkgDir, "", $ignoreCollisions, $checkCollisionContents, $priority);
+    findFiles("", $pkgDir, "", $ignoreCollisions, $ignoreFileOutputs, $checkCollisionContents, $priority);
 
     my $propagatedFN = "$pkgDir/nix-support/propagated-user-env-packages";
     if (-e $propagatedFN) {

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -23,6 +23,9 @@ lib.makeOverridable
 , # Whether to ignore collisions or abort.
   ignoreCollisions ? false
 
+  # Whether to outputs that is a single file instead of a directory.
+, ignoreFileOutputs ? false
+
 , # Whether to include closures of all input paths.
   includeClosures ? false
 
@@ -76,7 +79,7 @@ let
   ];
 in runCommand name
   rec {
-    inherit manifest ignoreCollisions checkCollisionContents passthru
+    inherit manifest ignoreCollisions checkCollisionContents ignoreFileOutputs passthru
             meta pathsToLink extraPrefix postBuild
             nativeBuildInputs buildInputs;
     pkgs = builtins.toJSON chosenOutputs;


### PR DESCRIPTION
Add option to ignore single-file output instead of failing, which would be useful to fix Mic92/nixpkgs-review#408.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
