### PR TITLE
ocamlPackages.tls: 1.0.1 → 1.0.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -4,15 +4,15 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "jackline";
-  version = "unstable-2024-02-28";
+  version = "unstable-2024-10-21";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev  = "31b90275a5f848cfc8c4f5b75e7d1933bec37852";
-    hash = "sha256-G2jjsc/i9Qgo0TP+ZE4gB/1cjuZ9l8R7e59K2DGD5GY=";
+    rev  = "cf6b26e37e37b0b48be9fd2e74fc563375f757f0";
+    hash = "sha256-6QZZ77C1G3x/GOJsUEQMrCatVsyyxNjq36ez/TgeHSY=";
   };
 
   nativeBuildInputs = [
@@ -39,7 +39,6 @@ buildDunePackage rec {
     uuseg
     uutf
     dns-client
-    cstruct
     base64
     happy-eyeballs-lwt
     ppx_sexp_conv
@@ -51,6 +50,5 @@ buildDunePackage rec {
     mainProgram = "jackline";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sternenseemann ];
-    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/kdf/default.nix
+++ b/pkgs/development/ocaml-modules/kdf/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, digestif
+, mirage-crypto
+, alcotest
+, ohex
+}:
+
+buildDunePackage rec {
+  pname = "kdf";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/robur-coop/kdf/releases/download/v${version}/kdf-${version}.tbz";
+    hash = "sha256-0WFYKw7+ZtlY3WuMnCEGjp9kVM4hg3fWz4eCPexi4M4=";
+  };
+
+  propagatedBuildInputs = [ digestif mirage-crypto ];
+
+  checkInputs = [ alcotest ohex ];
+  doCheck = true;
+
+  meta = {
+    description = "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914";
+    homepage = "https://github.com/robur-coop/kdf";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,16 +1,16 @@
 { lib, fetchurl, buildDunePackage
-, domain-name, fmt, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ptime, x509
+, domain-name, fmt, logs, kdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, x509
 , ipaddr
 , alcotest, ounit2
 }:
 
 buildDunePackage rec {
   pname = "tls";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
-    hash = "sha256-2uS1/8gD6ILphIBCWP+KrKe4N9hVbeaEABldpccKjYM=";
+    hash = "sha256-ohdRIAyzFG/+FUf11t4Ye1FH6O5r7RKwnVLAAtQrP+s=";
   };
 
   minimalOCamlVersion = "4.08";
@@ -19,12 +19,11 @@ buildDunePackage rec {
     domain-name
     fmt
     logs
-    hkdf
+    kdf
     mirage-crypto
     mirage-crypto-ec
     mirage-crypto-pk
     mirage-crypto-rng
-    ptime
     x509
     ipaddr
   ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -913,6 +913,8 @@ let
 
     kcas = callPackage ../development/ocaml-modules/kcas { };
 
+    kdf = callPackage ../development/ocaml-modules/kdf { };
+
     ke = callPackage ../development/ocaml-modules/ke { };
 
     kicadsch = callPackage ../development/ocaml-modules/kicadsch { };


### PR DESCRIPTION
Unbreak `jackline`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
