### PR TITLE
bb: fix darwin / clang

### DIFF
--- a/pkgs/applications/misc/bb/included-files-updates.diff
+++ b/pkgs/applications/misc/bb/included-files-updates.diff
@@ -1,0 +1,145 @@
+diff --git a/bb.c b/bb.c
+index 95850ef..6a7cc78 100644
+--- a/bb.c
++++ b/bb.c
+@@ -23,6 +23,7 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
++#include <time.h>
+ #include <ctype.h>
+ #include <aalib.h>
+ #include "bb.h"
+diff --git a/credits.c b/credits.c
+index 8514579..b304d8c 100644
+--- a/credits.c
++++ b/credits.c
+@@ -24,7 +24,6 @@
+ #include <math.h>
+ #include <limits.h>
+ #include <string.h>
+-#include <malloc.h>
+ #include <stdlib.h>
+ #include "bb.h"
+ #define STAR 1
+diff --git a/credits2.c b/credits2.c
+index 65d2431..9dcdf2d 100644
+--- a/credits2.c
++++ b/credits2.c
+@@ -25,7 +25,6 @@
+ #include <math.h>
+ #include <ctype.h>
+ #include <string.h>
+-#include <malloc.h>
+ #include <stdlib.h>
+ #include "bb.h"
+ #define STATE (TIME-starttime)
+diff --git a/main.c b/main.c
+index ae852a7..c0648b4 100644
+--- a/main.c
++++ b/main.c
+@@ -21,6 +21,8 @@
+  * 675 Mass Ave, Cambridge, MA 02139, USA.
+  */
+ 
++#include <ctype.h>
++#include <string.h>
+ #include <unistd.h>
+ #include "timers.h"
+ #include "bb.h"
+diff --git a/messager.c b/messager.c
+index 95cc410..5164577 100644
+--- a/messager.c
++++ b/messager.c
+@@ -22,7 +22,7 @@
+  */
+ 
+ #include <string.h>
+-#include <malloc.h>
++#include <stdlib.h>
+ #include "bb.h"
+ 
+ static int cursor_x, cursor_y;
+diff --git a/scene5.c b/scene5.c
+index 8d3c798..4a79258 100644
+--- a/scene5.c
++++ b/scene5.c
+@@ -22,7 +22,7 @@
+  */
+ 
+ #include <string.h>
+-#include <malloc.h>
++#include <stdlib.h>
+ #include <math.h>
+ #include "bb.h"
+ #include "tex.h"
+diff --git a/scene8.c b/scene8.c
+index 2bcba1e..72ea231 100644
+--- a/scene8.c
++++ b/scene8.c
+@@ -22,7 +22,7 @@
+  */
+ 
+ #include <math.h>
+-#include <malloc.h>
++#include <stdlib.h>
+ #include "bb.h"
+ #define STATE1 (TIME-starttime1)
+ #define STATE (time-starttime)
+diff --git a/textform.c b/textform.c
+index 859d367..eb9d1cb 100644
+--- a/textform.c
++++ b/textform.c
+@@ -1,6 +1,6 @@
+ #include <stdio.h>
+ #include <string.h>
+-#include <malloc.h>
++#include <stdlib.h>
+ #include <aalib.h>
+ #include "bb.h"
+ #define MAXLINES 10000
+diff --git a/timers.c b/timers.c
+index ac822f7..6342c1b 100644
+--- a/timers.c
++++ b/timers.c
+@@ -45,12 +45,9 @@
+ #include <time.h>
+ #endif
+    /*HAVE_TIME_H*/
+-#include <malloc.h>
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <unistd.h>
+-#ifndef _MAC
+-#include <malloc.h>
+-#endif
+ #ifdef __BEOS__
+ #include <OS.h>
+ #endif
+diff --git a/uncompfn.c b/uncompfn.c
+index d8eaaea..bc707f8 100644
+--- a/uncompfn.c
++++ b/uncompfn.c
+@@ -21,7 +21,7 @@
+  * 675 Mass Ave, Cambridge, MA 02139, USA.
+  */
+ 
+-#include <malloc.h>
++#include <stdlib.h>
+ #include <aalib.h>
+ #include "bb.h"
+ 
+diff --git a/zoom.c b/zoom.c
+index 7450095..4b37b2d 100644
+--- a/zoom.c
++++ b/zoom.c
+@@ -31,9 +31,6 @@
+ #else
+ #include <stdlib.h>
+ #include <stdio.h>
+-#ifndef _MAC
+-#include <malloc.h>
+-#endif
+ #ifdef __DJGPP__
+ #include "aconfig.dos"
+ #else


### PR DESCRIPTION
- autoreconfHook
- add missing headers needed for function prototypes.
- remove regparm for clang

https://hydra.nixos.org/build/273786787

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
