### PR TITLE
cdparanoia: fix darwin

### DIFF
--- a/pkgs/applications/audio/cdparanoia/default.nix
+++ b/pkgs/applications/audio/cdparanoia/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch
 , updateAutotoolsGnuConfigScriptsHook, autoreconfHook
-, IOKit, Carbon
 }:
 
 stdenv.mkDerivation rec {
@@ -14,8 +13,8 @@ stdenv.mkDerivation rec {
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {
-      url = "https://trac.macports.org/export/70964/trunk/dports/audio/cdparanoia/files/osx_interface.patch";
-      sha256 = "0hq3lvfr0h1m3p0r33jij0s1aspiqlpy533rwv19zrfllb39qvr8";
+      url = "https://github.com/macports/macports-ports/raw/c8e15973bc3c1e1ab371bc0ee2de14209e639f17/audio/cdparanoia/files/osx_interface.patch";
+      hash = "sha256-9p4+9dRvqLHkpR0RWLQcNL1m7fb7L6r+c9Q2tt4jh0U=";
       # Our configure patch will subsume it, but we want our configure
       # patch to be used on all platforms so we cannot just start where
       # this leaves off.
@@ -23,26 +22,44 @@ stdenv.mkDerivation rec {
     })
     (fetchurl {
       url = "https://trac.macports.org/export/70964/trunk/dports/audio/cdparanoia/files/patch-paranoia_paranoia.c.10.4.diff";
-      sha256 = "17l2qhn8sh4jy6ryy5si6ll6dndcm0r537rlmk4a6a8vkn852vad";
+      hash = "sha256-TW1RkJ0bKaPIrDSfUTKorNlmKDVRF++z8ZJAjSzEgp4=";
+    })
+    # add missing include files needed for function prototypes
+    (fetchpatch {
+      url = "https://github.com/macports/macports-ports/raw/f210a6061bc53c746730a37922399c6de6d69cb7/audio/cdparanoia/files/fixing-include.patch";
+      hash = "sha256-6a/u4b8/H/4XjyFup23xySgyAI9SMVMom4PLvH8KzhE=";
     })
   ] ++ [
     # Has to come after darwin patches
     ./fix_private_keyword.patch
     # Order does not matter
     ./configure.patch
+    # labs for long
+    (fetchpatch {
+      url = "https://github.com/macports/macports-ports/raw/f210a6061bc53c746730a37922399c6de6d69cb7/audio/cdparanoia/files/fixing-labs.patch";
+      hash = "sha256-BMMQ5bbPP3eevuwWUVjQCtRBiWbkAHD+O0C0fp+BPaw=";
+    })
+    # use "%s" for passing a buffer to fprintf
+    (fetchpatch {
+      url = "https://github.com/macports/macports-ports/raw/f210a6061bc53c746730a37922399c6de6d69cb7/audio/cdparanoia/files/fixing-fprintf.patch";
+      hash = "sha256-2dJl16p+f5l3wxVOJhsuLiQ9a4prq7jsRZP8/ygEae4=";
+    })
+    # add support for IDE4-9
+    (fetchpatch {
+      url = "https://salsa.debian.org/optical-media-team/cdparanoia/-/raw/bbf353721834b3784ccc0fd54a36a6b25181f5a4/debian/patches/02-ide-devices.patch";
+      hash = "sha256-S6OzftUIPPq9JHsoAE2K51ltsI1WkVaQrpgCjgm5AG4=";
+    })
+    # check buffer is non-null before dereferencing
+    (fetchpatch {
+      url = "https://salsa.debian.org/optical-media-team/cdparanoia/-/raw/f7bab3024c5576da1fdb7497abbd6abc8959a98c/debian/patches/04-endian.patch";
+      hash = "sha256-krfprwls0L3hsNfoj2j69J5k1RTKEQtzE0fLYG9EJKo=";
+    })
   ] ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch;
 
   nativeBuildInputs = [
     updateAutotoolsGnuConfigScriptsHook
     autoreconfHook
   ];
-
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    Carbon
-    IOKit
-  ];
-
-  hardeningDisable = [ "format" ];
 
   # Build system reuses the same object file names for shared and static
   # library. Occasionally fails in the middle:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28383,10 +28383,7 @@ with pkgs;
 
   cdparanoia = cdparanoiaIII;
 
-  cdparanoiaIII = callPackage ../applications/audio/cdparanoia {
-    inherit (darwin) IOKit;
-    inherit (darwin.apple_sdk.frameworks) Carbon;
-  };
+  cdparanoiaIII = callPackage ../applications/audio/cdparanoia { };
 
   celeste = callPackage ../applications/networking/sync/celeste { };
 


### PR DESCRIPTION
patches are from macports and debian:
https://github.com/macports/macports-ports/tree/master/audio/cdparanoia/files
https://salsa.debian.org/optical-media-team/cdparanoia/-/tree/master/debian/patches?ref_type=heads

- add patches to include files containing function prototypes on darwin
- fix fprintf format error -- use "%s" buffer
- check buffer for null before dereferencing
- use labs for long
- scan additional ides 4-9

https://hydra.nixos.org/build/276138155
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] pkgsCross.aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
