### PR TITLE
maelstrom: remove register keyword; fix clang

### DIFF
--- a/pkgs/games/maelstrom/c++17-fixes.diff
+++ b/pkgs/games/maelstrom/c++17-fixes.diff
@@ -1,0 +1,32 @@
+diff --git a/fastrand.cpp b/fastrand.cpp
+index 3714f02..d1cf224 100644
+--- a/fastrand.cpp
++++ b/fastrand.cpp
+@@ -30,10 +30,10 @@ Uint32 GetRandSeed(void)
+ Uint16 FastRandom(Uint16 range)
+ {
+ 	Uint16 result;
+-	register Uint32 calc;
+-	register Uint32 regD0;
+-	register Uint32 regD1;
+-	register Uint32 regD2;
++	Uint32 calc;
++	Uint32 regD0;
++	Uint32 regD1;
++	Uint32 regD2;
+ 
+ #ifdef SERIOUS_DEBUG
+   fprintf(stderr, "FastRandom(%hd)  Seed in: %lu ", range, randomSeed);
+diff --git a/screenlib/SDL_FrameBuf.cpp b/screenlib/SDL_FrameBuf.cpp
+index 2f7b44c..c8e394b 100644
+--- a/screenlib/SDL_FrameBuf.cpp
++++ b/screenlib/SDL_FrameBuf.cpp
+@@ -555,7 +555,7 @@ static inline void memswap(Uint8 *dst, Uint8 *src, Uint8 len)
+ 	}
+ #else
+ 	/* Swap two buffers using a temporary variable */
+-	register Uint8 tmp;
++	Uint8 tmp;
+ 
+ 	while ( len-- ) {
+ 		tmp = *dst;

--- a/pkgs/games/maelstrom/default.nix
+++ b/pkgs/games/maelstrom/default.nix
@@ -9,8 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "0dm0m5wd7amrsa8wnrblkv34sq4v4lglc2wfx8klfkdhyhi06s4k";
   };
 
-  # this fixes a typedef compilation error with gcc-3.x
-  patches = [ ./fix-compilation.patch ];
+  patches = [
+    # this fixes a typedef compilation error with gcc-3.x
+    ./fix-compilation.patch
+    # removes register keyword
+    ./c++17-fixes.diff
+  ];
 
   buildInputs = [ SDL2 SDL2_net ];
 


### PR DESCRIPTION
c++17 doesn't support register keyword. patch out the few uses of it.
https://hydra.nixos.org/build/276114084

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
