### PR TITLE
ssldump: 1.7 -> 1.8-unstable-2024-10-16; fix darwin

### DIFF
--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
-, autoreconfHook
 , fetchFromGitHub
+, cmake
 , json_c
 , libnet
 , libpcap
@@ -10,17 +10,17 @@
 
 stdenv.mkDerivation rec {
   pname = "ssldump";
-  version = "1.7";
+  version = "1.8-unstable-2024-10-16";
 
   src = fetchFromGitHub {
     owner = "adulau";
     repo = "ssldump";
-    rev = "v${version}";
-    sha256 = "sha256-BFE42wWqnGGTTjwej3LkH4XW2M4jP7XNSKHLnF2GFJo=";
+    rev = "a7534300bb09184fec991b3b4f19a40538b8adea";
+    hash = "sha256-6jmIPkyT5QCqQw07unc6nKTlxpajiLO05IFshWtCh7w=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
   ];
 
   buildInputs = [
@@ -28,18 +28,6 @@ stdenv.mkDerivation rec {
     libnet
     libpcap
     openssl
-  ];
-
-  prePatch = ''
-    sed -i -e 's|#include.*net/bpf.h|#include <pcap/bpf.h>|' \
-      base/pcap-snoop.c
-  '';
-
-  configureFlags = [
-    "--with-pcap-lib=${libpcap}/lib"
-    "--with-pcap-inc=${libpcap}/include"
-    "--with-openssl-lib=${openssl}/lib"
-    "--with-openssl-inc=${openssl}/include"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
update to latest release which builds unmodified on linux and darwin. tagged release would require fixes for nix (gnu-install-dirs) and fdatasync symbol on darwin.

https://github.com/adulau/ssldump/compare/v1.7...a7534300bb09184fec991b3b4f19a40538b8adea
https://hydra.nixos.org/build/276124665

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
