### PR TITLE
Revert "stayrtr: 0.5.1 -> 0.6.1"

### DIFF
--- a/pkgs/servers/stayrtr/default.nix
+++ b/pkgs/servers/stayrtr/default.nix
@@ -1,28 +1,30 @@
-{
-  lib,
-  fetchFromGitHub,
-  buildGoModule,
-  stayrtr,
-  testers,
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, stayrtr
+, testers
 }:
 
 buildGoModule rec {
   pname = "stayrtr";
-  version = "0.6.1";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "bgp";
     repo = "stayrtr";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-uNZe3g8hs9c0uXrkWSTA+e/gziOpWqx5oFIJ2ZPgEzU=";
+    rev = "v${version}";
+    hash = "sha256-/KwL/SEnHquFhPcYXpvQs71W4K1BrbqTPakatTNF47Q=";
   };
+  vendorHash = "sha256-ndMME9m3kbv/c1iKlU2Pn/YoiRQy7jfVQri3M+qhujk=";
 
-  vendorHash = "sha256-0PtQzwBhUoASUMnAAVZ4EIDmqIEaH0nct2ngyIkR+Qg=";
+  patches = [
+    ./go.mod.patch
+  ];
 
   ldflags = [
     "-s"
     "-w"
-    "-X=main.version=${version}"
+    "-X main.version=${version}"
   ];
 
   passthru.tests.version = testers.testVersion {
@@ -30,11 +32,9 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "Simple RPKI-To-Router server";
+    description = "Simple RPKI-To-Router server. (Hard fork of GoRTR)";
     homepage = "https://github.com/bgp/stayrtr/";
-    changelog = "https://github.com/bgp/stayrtr/releases/tag/v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ _0x4A6F ];
-    mainProgram = "stayrtr";
   };
 }

--- a/pkgs/servers/stayrtr/go.mod.patch
+++ b/pkgs/servers/stayrtr/go.mod.patch
@@ -1,0 +1,30 @@
+diff --git a/go.mod b/go.mod
+index 0116218..3e31f0e 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/bgp/stayrtr
+ 
+-go 1.16
++go 1.17
+ 
+ require (
+ 	github.com/google/go-cmp v0.5.6
+@@ -10,3 +10,17 @@ require (
+ 	golang.org/x/crypto v0.6.0
+ 	golang.org/x/sys v0.5.0
+ )
++
++require (
++	github.com/beorn7/perks v1.0.1 // indirect
++	github.com/cespare/xxhash/v2 v2.1.1 // indirect
++	github.com/davecgh/go-spew v1.1.1 // indirect
++	github.com/golang/protobuf v1.4.3 // indirect
++	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
++	github.com/pmezard/go-difflib v1.0.0 // indirect
++	github.com/prometheus/client_model v0.2.0 // indirect
++	github.com/prometheus/common v0.26.0 // indirect
++	github.com/prometheus/procfs v0.6.0 // indirect
++	google.golang.org/protobuf v1.26.0-rc.1 // indirect
++	gopkg.in/yaml.v2 v2.3.0 // indirect
++)


### PR DESCRIPTION
Reverts NixOS/nixpkgs#351637

Please look at already open pull request and also leave some time for maintainers to give feedback.

Reverting this because there is already an open PR https://github.com/NixOS/nixpkgs/pull/348291 and this is a self-merge.

I'll incorporate changes, that I deem relevant and attribute you, if you wish so.

Thanks for your contributions.