### PR TITLE
doc: lib/textClosures

### DIFF
--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -46,18 +46,29 @@ let
     concatStringsSep
     head
     isAttrs
-    listToAttrs
     tail
     ;
 in
 rec {
 
-  /* !!! The interface of this function is kind of messed up, since
-     it's way too overloaded and almost but not quite computes a
-     topological sort of the depstrings. */
+  /**
+    :::{.note}
+    If you are the maintainer or user of this function.
+    Please document it. Or remove in case it is unused.
+    :::
 
+    :::{.note}
+    The interface of this function is kind of messed up, since
+    it's way too overloaded and almost but not quite computes a
+    topological sort of the depstrings.
+    :::
+  */
   textClosureList = predefined: arg:
     let
+      # Types are:
+      #
+      # Todo :: [ String | { deps :: Todo; text :: string; } ]
+      # f :: { ... } -> Todo -> { result :: [ String ]; done :: { ... }  }
       f = done: todo:
         if todo == [] then {result = []; inherit done;}
         else
@@ -69,7 +80,7 @@ rec {
                  done = y.done;
                }
           else if done ? ${entry} then f done (tail todo)
-          else f (done // listToAttrs [{name = entry; value = 1;}]) ([predefined.${entry}] ++ tail todo);
+          else f (done // { ${entry} = 1; }) ([predefined.${entry}] ++ tail todo);
     in (f {} arg).result;
 
   textClosureMap = f: predefined: names:


### PR DESCRIPTION
@dasJ can you help me to document this function? Its used in the activation script through 
`textClosureMap`

I think most of the stuff is described in the header. But i dont know the details what a `textClosure` refers to, and the other descriptions are either incorrect or i dont  understand them.

The usage could also be simplified by just using `lib.concatLines` instead of mapping with `lib.id` ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
