### PR TITLE
Update http_proxy_connect_module_generic to allow HTTP CONNECT in NGINX v1.26 & v1.27

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -315,6 +315,14 @@ let self = {
     supports = with lib.versions; version: major version == "1" && minor version == "25";
   };
 
+  http_proxy_connect_module_v26 = http_proxy_connect_module_generic "proxy_connect_rewrite_102101" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "26";
+  };
+
+  http_proxy_connect_module_v27 = http_proxy_connect_module_generic "proxy_connect_rewrite_102101" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "27";
+  };
+
   ipscrub = {
     name = "ipscrub";
     src = fetchFromGitHub {

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -42,9 +42,9 @@ let
       name = "http_proxy_connect_module_generic";
       owner = "chobits";
       repo = "ngx_http_proxy_connect_module";
-      # 2023-06-19
-      rev = "dcb9a2c614d376b820d774db510d4da12dfe1e5b";
-      hash = "sha256-AzMhTSzmk3osSYy2q28/hko1v2AOTnY/dP5IprqGlQo=";
+      # 2024-10-28
+      rev = "4f0b6c2297862148c59a0d585d6c46ccb7e58a39";
+      hash = "sha256-Yob2Z+a3ex3Ji6Zz8J0peOYnKpYn5PlC9KsQNcHCL9o=";
     };
 
     patches = [


### PR DESCRIPTION
Nginx has 
https://github.com/NixOS/nixpkgs/blob/cd3e8833d70618c4eea8df06f95b364b016d4950/nixos/modules/services/web-servers/nginx/default.nix#L661

to allow additional modules. Among those is https://github.com/chobits/ngx_http_proxy_connect_module , which allows `HTTP_CONNECT`, a highly important yet basic HTTP command for many proxy setups. But NixOS's nginx only defined that module to be used up to nginx `v1.25`. With the nginx in the main nixos channel being `v1.26`, this broke installation where this module was used.

With commit https://github.com/chobits/ngx_http_proxy_connect_module/commit/4f0b6c2297862148c59a0d585d6c46ccb7e58a39 support for up to nginx `v1.27.1` was added. This small PR allows this to be setup with NixOS's official option for that by merely bumping the allowed versions + commit and hash.

As for now, I use a custom patch in my NixOS config to allow support for that module:
```nix
  http_proxy_connect_module = pkgs.stdenv.mkDerivation {
    pname = "http_proxy_connect_module";
    version = "4f0b6c2297862148c59a0d585d6c46ccb7e58a39";
    src = pkgs.fetchFromGitHub {
      owner = "chobits";
      repo = "ngx_http_proxy_connect_module";
      rev = "4f0b6c2297862148c59a0d585d6c46ccb7e58a39";
      sha256 = "sha256-Yob2Z+a3ex3Ji6Zz8J0peOYnKpYn5PlC9KsQNcHCL9o=";
    };
    patches = [ "${pkgs.fetchFromGitHub { 
      owner = "chobits"; 
      repo = "ngx_http_proxy_connect_module"; 
      rev = "4f0b6c2297862148c59a0d585d6c46ccb7e58a39"; 
      sha256 = "sha256-Yob2Z+a3ex3Ji6Zz8J0peOYnKpYn5PlC9KsQNcHCL9o=";
    }}/patch/proxy_connect_rewrite_102101.patch" ];
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
