### PR TITLE
[Backport release-24.05] guix: backport build user takeover commits

### DIFF
--- a/pkgs/by-name/gu/guix/guix-build-user-takeover-fix.patch
+++ b/pkgs/by-name/gu/guix/guix-build-user-takeover-fix.patch
@@ -1,0 +1,42 @@
+diff --git a/nix/libstore/build.cc b/nix/libstore/build.cc
+index c5383bc..50d1abc 100644
+--- a/nix/libstore/build.cc
++++ b/nix/libstore/build.cc
+@@ -2312,15 +2312,6 @@ void DerivationGoal::registerOutputs()
+         Path actualPath = path;
+         if (useChroot) {
+             actualPath = chrootRootDir + path;
+-            if (pathExists(actualPath)) {
+-                /* Move output paths from the chroot to the store. */
+-                if (buildMode == bmRepair)
+-                    replaceValidPath(path, actualPath);
+-                else
+-                    if (buildMode != bmCheck && rename(actualPath.c_str(), path.c_str()) == -1)
+-                        throw SysError(format("moving build output `%1%' from the chroot to the store") % path);
+-            }
+-            if (buildMode != bmCheck) actualPath = path;
+         } else {
+             Path redirected = redirectedOutputs[path];
+             if (buildMode == bmRepair
+@@ -2360,6 +2351,21 @@ void DerivationGoal::registerOutputs()
+                something like that. */
+             canonicalisePathMetaData(actualPath, buildUser.enabled() ? buildUser.getUID() : -1, inodesSeen);
+ 
++            if (useChroot) {
++                if (pathExists(actualPath)) {
++                    /* Now that output paths have been canonicalized (in particular
++                    there are no setuid files left), move them outside of the
++                    chroot and to the store. */
++                    if (buildMode == bmRepair)
++                        replaceValidPath(path, actualPath);
++                    else
++                        if (buildMode != bmCheck && rename(actualPath.c_str(), path.c_str()) == -1)
++                            throw SysError(format("moving build output `%1%' from the chroot to the store") % path);
++                }
++                if (buildMode != bmCheck) actualPath = path;
++            }
++
++
+             /* FIXME: this is in-memory. */
+             StringSink sink;
+             dumpPath(actualPath, sink);

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -1,38 +1,39 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchpatch
-, autoreconfHook
-, disarchive
-, git
-, glibcLocales
-, guile
-, guile-avahi
-, guile-gcrypt
-, guile-git
-, guile-gnutls
-, guile-json
-, guile-lib
-, guile-lzlib
-, guile-lzma
-, guile-semver
-, guile-ssh
-, guile-sqlite3
-, guile-zlib
-, guile-zstd
-, help2man
-, makeWrapper
-, pkg-config
-, po4a
-, scheme-bytestructures
-, texinfo
-, bzip2
-, libgcrypt
-, sqlite
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  autoreconfHook,
+  disarchive,
+  git,
+  glibcLocales,
+  guile,
+  guile-avahi,
+  guile-gcrypt,
+  guile-git,
+  guile-gnutls,
+  guile-json,
+  guile-lib,
+  guile-lzlib,
+  guile-lzma,
+  guile-semver,
+  guile-ssh,
+  guile-sqlite3,
+  guile-zlib,
+  guile-zstd,
+  help2man,
+  makeWrapper,
+  pkg-config,
+  po4a,
+  scheme-bytestructures,
+  texinfo,
+  bzip2,
+  libgcrypt,
+  sqlite,
 
-, stateDir ? "/var"
-, storeDir ? "/gnu/store"
-, confDir ? "/etc"
+  stateDir ? "/var",
+  storeDir ? "/gnu/store",
+  confDir ? "/etc",
 }:
 
 stdenv.mkDerivation rec {
@@ -151,7 +152,10 @@ stdenv.mkDerivation rec {
     homepage = "http://www.gnu.org/software/guix";
     license = licenses.gpl3Plus;
     mainProgram = "guix";
-    maintainers = with maintainers; [ cafkafk foo-dogsquared ];
+    maintainers = with maintainers; [
+      cafkafk
+      foo-dogsquared
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=ff1251de0bc327ec478fc66a562430fbf35aef42";
       hash = "sha256-f4KWDVrvO/oI+4SCUHU5GandkGtHrlaM1BWygM/Qlao=";
     })
+    # manual port of build user takeover remediation commit
+    # see https://guix.gnu.org/en/blog/2024/build-user-takeover-vulnerability
+    ./guix-build-user-takeover-fix.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
~Bot-based~ Manual backport to `release-24.05`, triggered by a label in #351655.

* [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
