### PR TITLE
python312Packages.insightface: disable tests on aarch64

### DIFF
--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -4,6 +4,7 @@
   immich,
   python3,
   nixosTests,
+  stdenv,
 }:
 let
   python = python3.override {
@@ -56,12 +57,14 @@ python.pkgs.buildPythonApplication rec {
     ]
     ++ uvicorn.optional-dependencies.standard;
 
-  nativeCheckInputs = with python.pkgs; [
-    httpx
-    pytest-asyncio
-    pytest-mock
-    pytestCheckHook
-  ];
+  nativeCheckInputs =
+    with python.pkgs;
+    [
+      httpx
+      pytest-asyncio
+      pytest-mock
+    ]
+    ++ lib.optionals (stdenv.buildPlatform.system != "aarch64-linux") [ pytestCheckHook ];
 
   postInstall = ''
     mkdir -p $out/share/immich

--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -57,14 +57,16 @@ python.pkgs.buildPythonApplication rec {
     ]
     ++ uvicorn.optional-dependencies.standard;
 
-  nativeCheckInputs =
-    with python.pkgs;
-    [
-      httpx
-      pytest-asyncio
-      pytest-mock
-    ]
-    ++ lib.optionals (stdenv.buildPlatform.system != "aarch64-linux") [ pytestCheckHook ];
+  # aarch64-linux tries to get cpu information from /sys, which isn't available
+  # inside the nix build sandbox.
+  doCheck = stdenv.buildPlatform.system != "aarch64-linux";
+
+  nativeCheckInputs = with python.pkgs; [
+    httpx
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
 
   postInstall = ''
     mkdir -p $out/share/immich

--- a/pkgs/development/python-modules/insightface/default.nix
+++ b/pkgs/development/python-modules/insightface/default.nix
@@ -58,12 +58,13 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  pythonImportsCheck = [
+  # aarch64-linux tries to get cpu information from /sys, which isn't available
+  # inside the nix build sandbox.
+  pythonImportsCheck = lib.optionals (stdenv.buildPlatform.system != "aarch64-linux") [
     "insightface"
     "insightface.app"
     "insightface.data"
   ];
-
   passthru.tests.version = testers.testVersion {
     package = insightface;
     command = "insightface-cli --help";
@@ -80,7 +81,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepinsight/insightface";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ oddlama ];
-    # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
-    broken = stdenv.system == "aarch64-linux";
   };
 }

--- a/pkgs/development/python-modules/insightface/default.nix
+++ b/pkgs/development/python-modules/insightface/default.nix
@@ -60,22 +60,23 @@ buildPythonPackage rec {
 
   # aarch64-linux tries to get cpu information from /sys, which isn't available
   # inside the nix build sandbox.
-  pythonImportsCheck = lib.optionals (stdenv.buildPlatform.system != "aarch64-linux") [
+  dontUsePythonImportsCheck = stdenv.buildPlatform.system == "aarch64-linux";
+
+  passthru.tests = lib.optionalAttrs (stdenv.buildPlatform.system != "aarch64-linux") {
+    version = testers.testVersion {
+      package = insightface;
+      command = "insightface-cli --help";
+      # Doesn't support --version but we still want to make sure the cli is executable
+      # and returns the help output
+      version = "help";
+    };
+  };
+
+  pythonImportsCheck = [
     "insightface"
     "insightface.app"
     "insightface.data"
   ];
-  passthru.tests.version =
-    if (stdenv.buildPlatform.system != "aarch64-linux") then
-      testers.testVersion {
-        package = insightface;
-        command = "insightface-cli --help";
-        # Doesn't support --version but we still want to make sure the cli is executable
-        # and returns the help output
-        version = "help";
-      }
-    else
-      null;
 
   doCheck = false; # Upstream has no tests
 

--- a/pkgs/development/python-modules/insightface/default.nix
+++ b/pkgs/development/python-modules/insightface/default.nix
@@ -65,13 +65,17 @@ buildPythonPackage rec {
     "insightface.app"
     "insightface.data"
   ];
-  passthru.tests.version = testers.testVersion {
-    package = insightface;
-    command = "insightface-cli --help";
-    # Doesn't support --version but we still want to make sure the cli is executable
-    # and returns the help output
-    version = "help";
-  };
+  passthru.tests.version =
+    if (stdenv.buildPlatform.system != "aarch64-linux") then
+      testers.testVersion {
+        package = insightface;
+        command = "insightface-cli --help";
+        # Doesn't support --version but we still want to make sure the cli is executable
+        # and returns the help output
+        version = "help";
+      }
+    else
+      null;
 
   doCheck = false; # Upstream has no tests
 


### PR DESCRIPTION
The package was marked as broken in the commit [05e03db](https://github.com/NixOS/nixpkgs/commit/05e03dbdc709c8c522b7aed04010bd7da9febee8). However, it has not actually been broken on aarch64. The issue was that the pythonImportsCheck build step failed and threw an onnxruntime::OnnxRuntimeException.

The cause of this exception is as follows:

The insightface library uses the onnxruntime library ([repository link](https://github.com/microsoft/onnxruntime)), which in turn relies on the PyTorch cpuinfo library ([repository link](https://github.com/pytorch/cpuinfo)) to gather CPU information.

Details on how the cpuinfo library retrieves CPU information can be found [here](https://github.com/pytorch/cpuinfo/blob/dff2616ddd49122b63abcf44d2c097483b77f861/src/linux/processors.c#L51).

As you can see, it accesses /sys/devices/system/cpu/possible and /sys/devices/system/cpu/present. The /sys path is not accessible from the Nix build sandbox environment, which causes the import of onnxruntime from insightface to fail ([see code line](https://github.com/deepinsight/insightface/blob/a1eb8523fbe50b0c0e39a9fa96d4e2a6936b46be/python-package/insightface/__init__.py#L8)).

This error does not occur once the program is installed, as the kernel creates the /sys path, allowing access to it.

You can confirm that the build and imports pass by adding the /sys path to the sandbox with the following command:

`
nix build --option extra-sandbox-paths /sys <<your-insightface-derivation-for-aarch64>>
`

This pull request disables the Python import test for aarch64, which was the architecture attempting to access /sys. (I have not investigated why onnxruntime does not require this information on x86_64.)

I am adding @oddlama as assignee (since he is the insightface mantainer) and @jvanbruegge (because immich-machine-learning also uses insightface) and I had to disable the tests for aarch64 for the reason explained above.

PD: It seems I can't add assignees to the PR, sorry for bothering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).