### PR TITLE
release-lib: build packages without `meta.platforms` on all platforms

### DIFF
--- a/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
@@ -36,6 +36,7 @@ let
         cuSPARSE, cuSOLVER, cuFFT, cuRAND, NPP and nvJPEG.
       '';
       license = lib.licenses.bsd3;
+      platforms = [ "x86_64-linux" ];
       maintainers = with lib.maintainers; [ obsidian-systems-maintenance ] ++ lib.teams.cuda.members;
     };
   };

--- a/pkgs/development/cuda-modules/cuda-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-samples/generic.nix
@@ -73,6 +73,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     description = "Samples for CUDA Developers which demonstrates features in CUDA Toolkit";
     # CUDA itself is proprietary, but these sample apps are not.
     license = lib.licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ obsidian-systems-maintenance ] ++ lib.teams.cuda.members;
   };
 })

--- a/pkgs/test/build-environment-info/default.nix
+++ b/pkgs/test/build-environment-info/default.nix
@@ -1,11 +1,39 @@
-{ runCommand }:
+{
+  lib,
+  stdenv,
+  runCommand,
+  getent,
+  xcbuild,
+}:
 
 # Prints information about the state of the build environment for
 # assistance debugging Hydra. Feel free to add anything you would find
 # useful to this.
-runCommand "build-environment-info" { } ''
-  ulimit -a
+runCommand "build-environment-info"
+  {
+    nativeBuildInputs = [ getent ] ++ lib.optionals stdenv.buildPlatform.isDarwin [ xcbuild ];
+  }
+  ''
+    # It’s useful to get more info even if a command fails.
+    set +e
 
-  # Always fail so that this job can easily be restarted.
-  exit 1
-''
+    run() {
+      echoCmd : "$@"
+      "$@"
+    }
+
+    run uname -a
+
+    ${lib.optionalString stdenv.buildPlatform.isDarwin ''
+      run env SYSTEM_VERSION_COMPAT=0 plutil -p /System/Library/CoreServices/SystemVersion.plist
+    ''}
+
+    run id
+
+    run getent passwd "$(id -un)"
+
+    run ulimit -a
+
+    # Always fail so that this job can easily be restarted.
+    run exit 1
+  ''

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -17,15 +17,13 @@ let
     versionSuffix = "test";
     label = "test";
   };
-in lib.optionalAttrs stdenv.hostPlatform.isLinux (
-  pkgs.recurseIntoAttrs {
+in pkgs.recurseIntoAttrs {
 
-    nixos-test = (pkgs.nixos {
-      system.nixos = dummyVersioning;
-      boot.loader.grub.enable = false;
-      fileSystems."/".device = "/dev/null";
-      system.stateVersion = lib.trivial.release;
-    }).toplevel;
+  nixos-test = (pkgs.nixos {
+    system.nixos = dummyVersioning;
+    boot.loader.grub.enable = false;
+    fileSystems."/".device = "/dev/null";
+    system.stateVersion = lib.trivial.release;
+  }).toplevel;
 
-  }
-)
+}

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -66,6 +66,11 @@ let
     '';
     # discourage nix-env from matching this package
     priority = 10;
+    platforms = lib.platforms.all;
+    # These create a large number of jobs, which puts load on Hydra
+    # without any appreciable benefit (as the combined packages already
+    # cause them all to be built and cached anyway).
+    hydraPlatforms = [ ];
   } // lib.optionalAttrs (args ? shortdesc) {
     description = args.shortdesc;
   };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -181,7 +181,7 @@ in {
 
       meta = {
         description = "PHP upstream extension: ${name}";
-        inherit (php.meta) maintainers homepage license;
+        inherit (php.meta) maintainers homepage license platforms;
       } // args.meta or { };
     }));
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -182,7 +182,7 @@ in {
       meta = {
         description = "PHP upstream extension: ${name}";
         inherit (php.meta) maintainers homepage license;
-      };
+      } // args.meta or { };
     }));
 
   php = phpPackage;
@@ -459,13 +459,6 @@ in {
           doCheck = stdenv.hostPlatform.isLinux;
         }
         {
-          name = "imap";
-          buildInputs = [ uwimap openssl pam pcre2 libkrb5 ];
-          configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" "--with-kerberos" ];
-          # Using version from PECL on new PHP versions.
-          enable = lib.versionOlder php.version "8.3";
-        }
-        {
           name = "intl";
           buildInputs = [ icu73 ];
         }
@@ -560,7 +553,7 @@ in {
           internalDeps = [ php.extensions.pdo ];
           configureFlags = [ "--with-pdo-dblib=${freetds}" ];
           # Doesn't seem to work on darwin.
-          enable = (!stdenv.hostPlatform.isDarwin);
+          meta.broken = (!stdenv.hostPlatform.isDarwin);
           doCheck = false;
         }
         {
@@ -655,7 +648,7 @@ in {
           buildInputs = [ net-snmp openssl ];
           configureFlags = [ "--with-snmp" ];
           # net-snmp doesn't build on darwin.
-          enable = (!stdenv.hostPlatform.isDarwin);
+          meta.broken = (!stdenv.hostPlatform.isDarwin);
           doCheck = false;
         }
         {
@@ -810,6 +803,13 @@ in {
             "--with-zlib"
           ];
         }
+      ] ++ lib.optionals (lib.versionOlder php.version "8.3") [
+        # Using version from PECL on new PHP versions.
+        {
+          name = "imap";
+          buildInputs = [ uwimap openssl pam pcre2 libkrb5 ];
+          configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" "--with-kerberos" ];
+        }
       ];
 
       # Convert the list of attrs:
@@ -818,14 +818,12 @@ in {
       # [ { name = <name>; value = <extension drv>; } ... ]
       #
       # which we later use listToAttrs to make all attrs available by name.
-      #
-      # Also filter out extensions based on the enable property.
       namedExtensions = builtins.map
         (drv: {
           name = drv.name;
-          value = mkExtension (builtins.removeAttrs drv [ "enable" ]);
+          value = mkExtension drv;
         })
-        (builtins.filter (i: i.enable or true) extensionData);
+        extensionData;
 
       # Produce the final attribute set of all extensions defined.
     in

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -169,7 +169,7 @@ let
       if isDerivation value then
         value.meta.hydraPlatforms
           or (subtractLists (value.meta.badPlatforms or [])
-               (value.meta.platforms or [ "x86_64-linux" ]))
+               (value.meta.platforms or supportedSystems))
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
       else


### PR DESCRIPTION
This was added in <https://github.com/NixOS/nixpkgs/pull/19990> to ensure that packages that previously weren’t building at all would get at least one platform’s worth of coverage. However, since most `runCommand` calls don’t explicitly set any `meta` information, this meant that things like `tests.makeWrapper` were only being run for `x86_64-linux`. Since most trivial builder calls should work on all platforms, it doesn’t make much sense for them to be restricted in this way, and we shouldn’t unnecessarily penalize other platforms by treating an empty `meta.platforms` inconsistently with `check-meta`’s maximally‐permissive interpretation. Actual packages that only work on a subset of platforms should, of course, set `meta.platforms` explicitly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
