### PR TITLE
nixos/meta: add wikiPages attribute

### DIFF
--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -165,5 +165,8 @@ in
     })
   ]);
 
-  meta.maintainers = with lib.maintainers; [ primeos colemickens ];
+  meta = {
+    maintainers = with lib.maintainers; [ primeos colemickens ];
+    wikiPages = ["https://wiki.nixos.org/wiki/Sway"];
+  };
 }

--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -98,5 +98,10 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+  meta = {
+    maintainers = with lib.maintainers; [ Scrumplex ];
+    wikiPages = [
+      "https://wiki.nixos.org/wiki/VR"
+    ];
+  };
 }


### PR DESCRIPTION
During NixOS Wiki Meetup at NixCon 2024, we discussed ways to link NixOS modules (and perhaps packages) to the NixOS Wiki.

This PR proposes a new meta attribute for NixOS modules to link to one or more wiki page for the purposes of documentation.

## Design Decisions

- Allow multiple wiki pages, as some modules might have multiple related pages.
  - For example `hardware.graphics` might have links to https://wiki.nixos.org/wiki/OpenGL, https://wiki.nixos.org/wiki/Mesa and https://wiki.nixos.org/wiki/Graphics
- We use full URLs instead of wiki paths, to allow for easy "greppability" and hyperlinking in the GitHub UI


## Future work

- The same attribute should be added to package meta attributes
- NixOS search should parse this information and link to wiki pages
- Write a bot/workflow that ensures that links exist and/or creates stub pages for missing pages
- Add wiki pages to module sections in manual


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
