### PR TITLE
python3Packages.rtmixer: convert to pyproject, fix cross

### DIFF
--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   isPy27,
+  setuptools,
   cython,
   portaudio,
   cffi,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "rtmixer";
   version = "0.1.7";
-  format = "setuptools";
+  pyproject = true;
   disabled = isPy27;
 
   src = fetchFromGitHub {
@@ -24,10 +25,13 @@ buildPythonPackage rec {
     fetchSubmodules = true;
   };
 
+  build-system = [ setuptools ];
+
   buildInputs = [ portaudio ];
+
   nativeBuildInputs = [ cython ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     cffi
     pa-ringbuffer
     sounddevice

--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -29,7 +29,10 @@ buildPythonPackage rec {
 
   buildInputs = [ portaudio ];
 
-  nativeBuildInputs = [ cython ];
+  nativeBuildInputs = [
+    cython
+    cffi
+  ];
 
   dependencies = [
     cffi


### PR DESCRIPTION
Before this change the build process fails for `nix build .#pkgsCross.aarch64-multiplatform.python3Packages.rtmixer`, but adding `cffi` to `nativeBuildInputs` fixes it.

I've tested this change at runtime as well by cross-compiling a Python env with this package, copying the closure to a Raspberry Pi, and importing the module on the Raspberry Pi. The build machine is `x86_64` and binfmt is disabled (checked by trying to run the cross-compiled environment, and I correctly got "cannot execute binary file: Exec format error"). `nix path-info -r ./result | grep -v aarch` returns no results so it looks clean to me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
