### PR TITLE
u3-tool: 0.3 -> 1.0

### DIFF
--- a/pkgs/by-name/u3/u3-tool/package.nix
+++ b/pkgs/by-name/u3/u3-tool/package.nix
@@ -1,15 +1,16 @@
 { lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "u3-tool";
-  version = "0.3";
+  version = "1.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1p9c9kibd1pdbdfa0nd0i3n7bvzi3xg0chm38jg3xfl8gsn0390f";
   };
+
 
   meta = with lib; {
     description = "Tool for controlling the special features of a 'U3 smart drive' USB Flash disk";
@@ -19,4 +20,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ makefu ];
     mainProgram = "u3-tool";
   };
-}
+})

--- a/pkgs/by-name/u3/u3-tool/package.nix
+++ b/pkgs/by-name/u3/u3-tool/package.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "u3-tool";
@@ -6,10 +10,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-    sha256 = "1p9c9kibd1pdbdfa0nd0i3n7bvzi3xg0chm38jg3xfl8gsn0390f";
+  src = fetchFromGitHub {
+    # original sourceforge mirror does not provide direct access to tag 1.0
+    owner = "marcusrugger";
+    repo = "u3-tool";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
+    hash = "sha256-c3cfWUUT5lwy8OedAtwvhuNEa5hgfwrKGJPY/zAlALw=";
   };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
 
   meta = with lib; {

--- a/pkgs/by-name/u3/u3-tool/package.nix
+++ b/pkgs/by-name/u3/u3-tool/package.nix
@@ -1,7 +1,9 @@
-{ lib, stdenv
-, fetchFromGitHub
-, autoreconfHook
-, pkg-config
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,13 +25,12 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
   ];
 
-
-  meta = with lib; {
+  meta = {
     description = "Tool for controlling the special features of a 'U3 smart drive' USB Flash disk";
     homepage = "https://sourceforge.net/projects/u3-tool/";
-    license = licenses.gpl2Plus;
-    platforms = with platforms; linux;
-    maintainers = with maintainers; [ makefu ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ makefu ];
     mainProgram = "u3-tool";
   };
 })


### PR DESCRIPTION
Update u3-tool to latest version (2009 -> 2012).
Also move tool to by-name package structure.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
