### PR TITLE
peertube: startup script: exec into nodejs

### DIFF
--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -432,7 +432,6 @@ in {
       path = with pkgs; [ nodejs_18 yarn ffmpeg-headless openssl ];
 
       script = ''
-        #!/bin/sh
         umask 077
         cat > /var/lib/peertube/config/local.yaml <<EOF
         ${lib.optionalString (cfg.secrets.secretsFile != null) ''
@@ -457,7 +456,7 @@ in {
         ln -sf ${cfg.package}/config/default.yaml /var/lib/peertube/config/default.yaml
         ln -sf ${cfg.package}/client/dist -T /var/lib/peertube/www/client
         ln -sf ${cfg.settings.storage.client_overrides} -T /var/lib/peertube/www/client-overrides
-        node dist/server
+        exec node dist/server
       '';
       serviceConfig = {
         Type = "simple";


### PR DESCRIPTION
So, there is no big deal in this PR, just a little bit of cleaning for peertube's startup script.
Thanks for this NixOS module which saved me lots of time! 

1. Removed the `#!/bin/sh` shebang at the beginning, because `systemd.services.<name>.script` already adds a `#!/nix/store/.../bin/bash` shebang.

Previously:
```bash
#!/nix/store/516kai7nl5dxr792c0nzq0jp8m4zvxpi-bash-5.2p32/bin/bash
set -e
#!/bin/sh
umask 077
...
```

2. Exec into nodejs, so that the startup script is no longer running but replaces itself by nodejs.
This way, only one processus is running inside peertube.service.

ping maintainers: @immae @Izorkin @stevenroose 