### PR TITLE
artifacts-credprovider: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ar/artifacts-credprovider/package.nix
+++ b/pkgs/by-name/ar/artifacts-credprovider/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchurl,
+  buildDotnetPackage,
+}:
+buildDotnetPackage rec {
+  pname = "artifacts-credprovider";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/microsoft/artifacts-credprovider/releases/download/v${version}/Microsoft.Net8.NuGet.CredentialProvider.tar.gz";
+    hash = "sha256-WEssfdOKMjJ3WD/egD4wA69k+JdB9O/ZWM8RstRJGkA=";
+  };
+
+  dontBuild = true;
+  outputFiles = [ "netcore/*" ];
+
+  meta = {
+    description = "Automates the acquisition of credentials needed to restore NuGet packages as part of your .NET development workflow";
+    changelog = "https://github.com/microsoft/artifacts-credprovider/releases/tag/v${version}";
+    homepage = "https://github.com/microsoft/artifacts-credprovider";
+    license = lib.licenses.mit;
+    longDescription = ''
+      The Azure Artifacts Credential Provider automates the acquisition of credentials needed to restore NuGet packages as part of your .NET development workflow.
+      It integrates with MSBuild, dotnet, and NuGet(.exe) and works on Windows, Mac, and Linux.
+      Any time you want to use packages from an Azure Artifacts feed, the Credential Provider will automatically acquire and securely store a token on behalf of the NuGet client you're using
+    '';
+    maintainers = with lib.maintainers; [ khaneliman ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Things done
https://github.com/microsoft/artifacts-credprovider

Been meaning to upstream this for a while. Wasn't able to successfully build from source due to authenticated devops registry. Might revisit that in the future again. 

Usage: 
```bash
    export NUGET_PLUGIN_PATHS=${pkgs.artifacts-credprovider}/bin/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.dll
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
