### PR TITLE
neovim: Fix withRuby regression

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -29,7 +29,7 @@ let
 
     , withNodeJs ? false
     , withPerl ? false
-    , rubyEnv ? null
+    , withRuby ? true
 
     # wether to create symlinks in $out/bin/vi(m) -> $out/bin/nvim
     , vimAlias ? false
@@ -127,8 +127,7 @@ let
           ;
 
     providerLuaRc = neovimUtils.generateProviderRc {
-      inherit (finalAttrs) withPython3 withNodeJs withPerl;
-      withRuby = rubyEnv != null;
+      inherit (finalAttrs) withPython3 withNodeJs withPerl withRuby;
     };
 
     # If configure != {}, we can't generate the rplugin.vim file with e.g
@@ -155,10 +154,9 @@ let
 
       __structuredAttrs = true;
       dontUnpack = true;
-      inherit viAlias vimAlias withNodeJs withPython3 withPerl;
+      inherit viAlias vimAlias withNodeJs withPython3 withPerl withRuby;
       inherit wrapRc providerLuaRc packpathDirs;
       inherit python3Env rubyEnv;
-      withRuby = rubyEnv != null;
       inherit wrapperArgs generatedWrapperArgs;
       luaRcContent = rcContent;
       # Remove the symlinks created by symlinkJoin which we need to perform
@@ -171,7 +169,7 @@ let
       + lib.optionalString finalAttrs.withPython3 ''
         makeWrapper ${python3Env.interpreter} $out/bin/nvim-python3 --unset PYTHONPATH --unset PYTHONSAFEPATH
       ''
-      + lib.optionalString (finalAttrs.rubyEnv != null) ''
+      + lib.optionalString (finalAttrs.withRuby) ''
         ln -s ${finalAttrs.rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
       ''
       + lib.optionalString finalAttrs.withNodeJs ''


### PR DESCRIPTION
The wrapper refactor https://github.com/NixOS/nixpkgs/pull/344541 effectively make withRuby always enabled.

Fix https://github.com/NixOS/nixpkgs/issues/351839.

After this, with `programs.neovim.withRuby = false;`, nvd shows nixos system:

```
Version changes:
[U.]  #1  nixos-system-nuc       24.11.20241028.09f31f9 -> 24.11.20241029.4e68a0e
Removed packages:
[R.]  #1  bundler               2.5.16
[R.]  #2  gemfile-and-lockfile  <none>
[R.]  #3  neovim-ruby-env       <none>
[R.]  #4  ruby                  3.3.5
[R.]  #5  ruby3.3-msgpack       1.7.2
[R.]  #6  ruby3.3-multi_json    1.15.0
[R.]  #7  ruby3.3-neovim        0.10.0
Closure size: 2176 -> 2169 (37 paths added, 44 paths removed, delta -7, disk usage -36.5MiB).
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
