### PR TITLE
dosbox-staging: 0.81.1 -> 0.82.0

### DIFF
--- a/pkgs/by-name/do/dosbox-staging/0001-remove-get-version.patch
+++ b/pkgs/by-name/do/dosbox-staging/0001-remove-get-version.patch
@@ -1,0 +1,31 @@
+diff --git a/meson.build b/meson.build
+index 84844242b..98187ad8c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,10 +1,6 @@
+ project(
+     'dosbox-staging', 'c', 'cpp',
+ 
+-    version: run_command(
+-      meson.project_source_root() + '/scripts/get-version.sh',
+-      'version', check: true,
+-    ).stdout().strip(),
+ 
+     license: 'GPL-2.0-or-later',
+     meson_version: '>= 0.59.0',
+@@ -419,14 +415,10 @@ add_project_link_arguments(link_supported_arguments, language: 'cpp')
+ # The actual config.h file will be generated after interpreting
+ # all the build files in all the subdirs.
+ #
+-git_hash = run_command(
+-  './scripts/get-version.sh', 'hash', check: true,
+-).stdout().strip()
+ 
+ conf_data = configuration_data()
+ conf_data.set('version', meson.project_version())
+ conf_data.set('project_name', meson.project_name())
+-conf_data.set('git_hash', git_hash)
+ conf_data.set_quoted(
+     'CUSTOM_DATADIR',
+     get_option('prefix') / get_option('datadir'),
+

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -1,12 +1,10 @@
 {
   lib,
   SDL2,
-  SDL2_image,
   SDL2_net,
   alsa-lib,
   darwin,
   fetchFromGitHub,
-  fetchpatch,
   fluidsynth,
   gitUpdater,
   glib,
@@ -34,21 +32,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dosbox-staging";
-  version = "0.81.1";
+  version = "0.82.0";
 
   src = fetchFromGitHub {
     owner = "dosbox-staging";
     repo = "dosbox-staging";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XGssEyX+AVv7/ixgGTRtPFjsUSX0FT0fhP+TXsFl2fY=";
+    hash = "sha256-raCVhG0GmNhLQviaVbD0hn2N9XaJqj2rbSFV6aMzjOg=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "darwin-allow-bypass-wraps.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/9f0fc1dc762010e5f7471d01c504d817a066cae3.patch";
-      hash = "sha256-IzxRE1Vr+M8I5hdy80UwebjJ5R1IlH9ymaYgs6VwAO4=";
-    })
+    # get-version fails during the build, I don't know why but this works
+    ./0001-remove-get-version.patch
   ];
 
   nativeBuildInputs = [
@@ -62,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       SDL2
-      SDL2_image
       SDL2_net
       fluidsynth
       glib
@@ -90,10 +84,13 @@ stdenv.mkDerivation (finalAttrs: {
       ]
     );
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   postInstall = ''
-    install -Dm644 $src/contrib/linux/dosbox-staging.desktop $out/share/applications/
+    install -Dm644 $src/contrib/linux/org.dosbox-staging.dosbox-staging.desktop $out/share/applications/
   '';
 
   # Rename binary, add a wrapper, and copy manual to avoid conflict with


### PR DESCRIPTION
Update dosbox-staging to 0.82.0

Remove the patch since the code it changes no longer exists in the codebase
fixes #351660
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

both `dosbox` and `dosbox-staging` seem to run correctly, I don't know enough about them to test the full functionality
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
