### PR TITLE
linuxPackages.librem-ec-acpi: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21234,6 +21234,11 @@
     githubId = 80012;
     name = "Simon Jagoe";
   };
+  sjamaan = {
+    github = "sjamaan";
+    name = "Peter Bex";
+    githubId = 128536;
+  };
   sjau = {
     email = "nixos@sjau.ch";
     github = "sjau";

--- a/pkgs/os-specific/linux/purism/librem-ec-acpi/Makefile.patch
+++ b/pkgs/os-specific/linux/purism/librem-ec-acpi/Makefile.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile b/Makefile
+index d8d3f91..47abc37 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,8 +1,10 @@
+ obj-m := librem_ec_acpi.o
+-KERNEL_DIR = /lib/modules/$(shell uname -r)/build
+ 
+ all:
+ 	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" modules
+ 
++install:
++	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" modules_install
++
+ clean:
+ 	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" clean

--- a/pkgs/os-specific/linux/purism/librem-ec-acpi/default.nix
+++ b/pkgs/os-specific/linux/purism/librem-ec-acpi/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  kernel,
+}:
+
+let
+  version = "0.9.2";
+in
+stdenv.mkDerivation {
+  pname = "librem-ec-acpi";
+  version = "${version}-${kernel.version}";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "nicole.faerber";
+    repo = "librem-ec-acpi-dkms";
+    rev = "v${version}";
+    sha256 = "gPb1/4UPbwjJiqtP27KKjiIKxIYEl2nlQACUAlxVEFU=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  KERNEL_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  installFlags = [ "DEPMOD=true" ];
+  enableParallelBuilding = true;
+
+  patches = [
+    # Required to drop assumption of location of module build directory
+    # and ensure installation of compiled module:
+    ./Makefile.patch
+    # Required to make it work on newer Linux versions, as per
+    # https://source.puri.sm/nicole.faerber/librem-ec-acpi-dkms/-/merge_requests/2
+    ./linux-6.10.3.patch
+  ];
+
+  meta = with lib; {
+    homepage = "https://source.puri.sm/nicole.faerber/librem-ec-acpi-dkms";
+    maintainers = [ maintainers.sjamaan ];
+    license = lib.licenses.gpl2Only;
+    description = "Kernel module for the Purism Librem EC ACPI DKMS";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/os-specific/linux/purism/librem-ec-acpi/linux-6.10.3.patch
+++ b/pkgs/os-specific/linux/purism/librem-ec-acpi/linux-6.10.3.patch
@@ -1,0 +1,26 @@
+From 13fc2a3949c30cfd8624acdbc97c7942aee588f8 Mon Sep 17 00:00:00 2001
+From: primalmotion <primalmotion@pm.me>
+Date: Tue, 6 Aug 2024 18:14:10 +0200
+Subject: [PATCH] fixed: build on linux 6.10.3
+
+---
+ librem_ec_acpi.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/librem_ec_acpi.c b/librem_ec_acpi.c
+index 4e8ebf3..d53f580 100644
+--- a/librem_ec_acpi.c
++++ b/librem_ec_acpi.c
+@@ -779,7 +779,9 @@ static SIMPLE_DEV_PM_OPS(librem_ec_pm, librem_ec_suspend, librem_ec_resume);
+ 
+ static struct acpi_driver librem_ec_driver = {
+ 	.name = "Librem EC ACPI Driver",
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 3)
+ 	.owner = THIS_MODULE,
++#endif
+ 	.class = "hotkey",
+ 	.ids = device_ids,
+ 	// .flags = ACPI_DRIVER_ALL_NOTIFY_EVENTS,
+-- 
+GitLab
+

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -617,6 +617,8 @@ in {
 
     tsme-test = callPackage ../os-specific/linux/tsme-test { };
 
+    librem-ec-acpi = callPackage ../os-specific/linux/purism/librem-ec-acpi { };
+
   } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
     hid-nintendo = throw "hid-nintendo was added in mainline kernel version 5.16"; # Added 2023-07-30


### PR DESCRIPTION
This packages the [librem-ec-acpi-dkms](https://source.puri.sm/nicole.faerber/librem-ec-acpi-dkms) kernel module.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
