### PR TITLE
blackmagic: 1.8.2 -> 1.10.2

### DIFF
--- a/pkgs/by-name/gc/gcc-arm-embedded-12-2-rel1/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-12-2-rel1/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses5,
+  python39,
+  libxcrypt-legacy,
+  runtimeShell,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-arm-embedded";
+  version = "12.2.rel1";
+
+  platform =
+    {
+      aarch64-darwin = "darwin-arm64";
+      aarch64-linux = "aarch64";
+      x86_64-darwin = "darwin-x86_64";
+      x86_64-linux = "x86_64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
+    sha256 =
+      {
+        aarch64-darwin = "0j12n631bmbfvnfbmv4q7cfhmh4l7ka3vcjcvyw0vjqb4msyia91";
+        aarch64-linux = "131ydgndff7dyhkivfchbk43lv3cv2p172knkqilx64aapvk5qvy";
+        x86_64-darwin = "00i9gd1ny00681pwinh6ng9x45xsyrnwc6hm2vr348z9gasyxh00";
+        x86_64-linux = "0rv8r5zh0a5621v0xygxi8f6932qgwinw2s9vnniasp9z7897gl4";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${
+        lib.makeLibraryPath [
+          "$out"
+          stdenv.cc.cc
+          ncurses5
+          python39
+          libxcrypt-legacy
+        ]
+      } "$f" || true
+    done
+  '';
+
+  postFixup = ''
+    mv $out/bin/arm-none-eabi-gdb $out/bin/arm-none-eabi-gdb-unwrapped
+    cat <<EOF > $out/bin/arm-none-eabi-gdb
+    #!${runtimeShell}
+    export PYTHONPATH=${python39}/lib/python3.9
+    export PYTHONHOME=${python39.interpreter}
+    exec $out/bin/arm-none-eabi-gdb-unwrapped "\$@"
+    EOF
+    chmod +x $out/bin/arm-none-eabi-gdb
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";
+    homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
+    license = with lib.licenses; [
+      bsd2
+      gpl2
+      gpl3
+      lgpl21
+      lgpl3
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      prusnak
+      prtzl
+      carlossless
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/development/embedded/blackmagic/helper.sh
+++ b/pkgs/development/embedded/blackmagic/helper.sh
@@ -17,6 +17,10 @@ PRODUCTS="blackmagic.bin blackmagic.hex blackmagic_dfu.bin blackmagic_dfu.hex"
 
 ################################################################################
 make_platform() {
+  if [ "$1" = "common" ]; then
+    return;
+  fi
+
   echo "Building for hardware platform $1"
 
   make clean
@@ -32,7 +36,6 @@ make_platform() {
       install -m 0444 "$f" "$out/firmware/$1"
     fi
   done
-
 }
 
 ################################################################################


### PR DESCRIPTION
**DISCLAIMER**: I am aware that due to this PR reincluding an older version of gcc-arm-embedded (12.2.rel1) it won't be merged. I thought it still might be worthwhile to open it up as a reference for others and/or a place where to discuss possible workarounds.

blackmagic v2.0 should come out in a few months and it should build successfully with more recent versions of gcc-arm-embedded thanks to [this](https://github.com/blackmagic-debug/blackmagic/pull/1876).

---

Changes for v1.10.2 - https://github.com/blackmagic-debug/blackmagic/releases/tag/v1.10.2
Changes between v1.8.2 and v1.10.2 - https://github.com/blackmagic-debug/blackmagic/compare/v1.8.2...v1.10.2

`gcc-arm-embedded` v12.2.rel1 is repackaged and included because it's the most recent version where v1.10.2 still builds - https://github.com/blackmagic-debug/blackmagic/issues/1978

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
