### PR TITLE
python3Packages.stix2-patterns: fix dependency on incorrect version of antlr4

### DIFF
--- a/pkgs/development/python-modules/stix2-patterns/default.nix
+++ b/pkgs/development/python-modules/stix2-patterns/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  antlr4_9,
   antlr4-python3-runtime,
   buildPythonPackage,
   fetchFromGitHub,
@@ -23,29 +24,16 @@ buildPythonPackage rec {
     hash = "sha256-lFgnvI5a7U7/Qj4Pqjr3mx4TNDnC2/Ru7tVG7VggR7Y=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "antlr4-python3-runtime~=" "antlr4-python3-runtime>="
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [
-    antlr4-python3-runtime
+    (antlr4-python3-runtime.override { antlr4 = antlr4_9; })
     six
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "stix2patterns" ];
-
-  disabledTestPaths = [
-    # Exception: Could not deserialize ATN with version  (expected 4)
-    "stix2patterns/test/v20/test_inspector.py"
-    "stix2patterns/test/v21/test_inspector.py"
-    "stix2patterns/test/v20/test_validator.py"
-    "stix2patterns/test/v21/test_validator.py"
-  ];
 
   meta = with lib; {
     description = "Validate patterns used to express cyber observable content in STIX Indicators";


### PR DESCRIPTION
Address issues with the stix2-patterns package, which was broken due to a dependency on an incorrect version of the antlr4-python3-runtime package.

The tests that were previously disabled were failing because the package was not functioning properly.

All tests should now pass successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
