### PR TITLE
mfem: init at 4.7

### DIFF
--- a/pkgs/by-name/mf/mfem/package.nix
+++ b/pkgs/by-name/mf/mfem/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gfortran,
+  mpi,
+  mpiCheckPhaseHook,
+  blas,
+  hypre,
+  metis,
+  suitesparse,
+  mumps_par,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mfem";
+  version = "4.7";
+
+  src = fetchFromGitHub {
+    owner = "mfem";
+    repo = "mfem";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-NJI8ABsfnnzMETfyscpNX8qK72BFF9FfxsY0J48aRtg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs = [
+    mpi
+    blas
+    hypre
+    metis
+    suitesparse
+    mumps_par
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "MFEM_ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "MFEM_USE_MPI" true)
+    (lib.cmakeBool "MFEM_USE_SUITESPARSE" true)
+    (lib.cmakeBool "MFEM_USE_MUMPS" true)
+    (lib.cmakeFeature "MUMPS_REQUIRED_PACKAGES" (
+      lib.concatStringsSep ";" (
+        [
+          "MPI"
+          "MPI_Fortran"
+          "METIS"
+          "ScaLAPACK"
+          "LAPACK"
+          "BLAS"
+        ]
+        ++ lib.optional mumps_par.withParmetis "ParMETIS"
+      )
+    ))
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  meta = {
+    description = "Free, lightweight, scalable C++ library for finite element methods";
+    homepage = "https://mfem.org";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     ${lib.optionalString stdenv.hostPlatform.isDarwin "export DYLD_LIBRARY_PATH=$out/lib\n"}
     ${lib.optionalString mpiSupport "export MPIRUN='mpirun -n 2'\n"}
     cd examples
-    make all
     $MPIRUN ./ssimpletest <input_simpletest_real
     $MPIRUN ./dsimpletest <input_simpletest_real
     $MPIRUN ./csimpletest <input_simpletest_cmplx

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -105,12 +105,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     gfortran
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames ++ lib.optional mpiSupport mpi;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   # Parmetis should be placed before scotch to avoid conflict of header file "parmetis.h"
-  buildInputs =
+  propagatedBuildInputs =
     lib.optional withParmetis parmetis
-    ++ lib.optional mpiSupport scalapack
+    ++ lib.optionals mpiSupport [
+      mpi
+      scalapack
+    ]
     ++ [
       blas
       lapack


### PR DESCRIPTION
# Motivation
MFEM is a free, lightweight, scalable C++ library for finite element methods.

This commit init mfem built with optional dependencies mpi, suitesparse, mumps_par.

These three dependencies are commonly used in mfem examples so they will be set with by default.

Need more careful consideration before merge.

- keep int/float size align with its dependency
- distinguish buildInputs and propagatedBuildInputs
- make sure there is no redundent or missing dependencies for each combination of options
- people who are interested in building mfem prefer to build mumps_par with parmetis which is unfree and thus by default disabled, how can we override mfem built with thoes unfree dependencies easily.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
