### PR TITLE
dnsdbq: init at 2.6.7

### DIFF
--- a/pkgs/by-name/dn/dnsdbq/package.nix
+++ b/pkgs/by-name/dn/dnsdbq/package.nix
@@ -1,0 +1,60 @@
+{
+  curl,
+  dnsdbq,
+  fetchFromGitHub,
+  jansson,
+  lib,
+  nix-update-script,
+  stdenv,
+  testers,
+}:
+stdenv.mkDerivation rec {
+  pname = "dnsdbq";
+  version = "2.6.7";
+
+  src = fetchFromGitHub {
+    owner = "dnsdb";
+    repo = "dnsdbq";
+    rev = "v${version}";
+    hash = "sha256-VeoLgDLly5bDIzvcf6Xb+tqCaQxIzeSpoW3ij+Hq4O8=";
+  };
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      version = testers.testVersion {
+        package = dnsdbq;
+        command = "dnsdbq -v";
+      };
+    };
+  };
+
+  nativeBuildInputs = [
+    curl # curl-config
+  ];
+
+  buildInputs = [
+    curl
+    jansson
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp dnsdbq $out/bin
+    mkdir -p $out/man/man1
+    cp dnsdbq.man $out/man/man1/dnsdbq.1
+    runHook postInstall
+  '';
+
+  extraOutputsToInstall = [ "man" ];
+
+  meta = {
+    description = "C99 program that accesses passive DNS database systems";
+    homepage = "https://github.com/dnsdb/dnsdbq";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ x123 ];
+    mainProgram = "dnsdbq";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Init dnsdbq at 2.6.7.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
