### PR TITLE
cpu-go: init at 0-unstable-2024-10-17

### DIFF
--- a/pkgs/by-name/cp/cpu-go/package.nix
+++ b/pkgs/by-name/cp/cpu-go/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenv,
+  mdnsSupport ? stdenv.hostPlatform.isLinux,
+  buildCpud ? stdenv.hostPlatform.isLinux,
+}:
+
+buildGoModule {
+  pname = "cpu-go";
+  version = "0-unstable-2024-10-17";
+
+  src = fetchFromGitHub {
+    owner = "u-root";
+    repo = "cpu";
+    rev = "54ca8c104060501ddc02ab5e3fc787d58feba1d8";
+    hash = "sha256-+SQLxq7XKj2F81LrDpzs8c0VzTHdYg/fnVGlB75op3g=";
+  };
+
+  vendorHash = "sha256-0NBuVyyJG71jeghIohTuy9zi/qhDLqJa+jrPjR0C5co=";
+
+  # Requires binding network port
+  checkFlags = [ "-skip=^TestDnsSdStart$" ];
+
+  tags = lib.optionals mdnsSupport [ "mDNS" ];
+
+  # cpud is incomplete on platforms other than linux and cannot build
+  # There is a PR in progress: https://github.com/u-root/cpu/pull/281
+  excludedPackages = lib.optionals (!buildCpud) [ "cmds/cpud" ];
+
+  meta = {
+    description = "Implementation the Plan 9 cpu command in Go";
+    homepage = "https://github.com/u-root/cpu";
+    license = lib.licenses.bsd3;
+    mainProgram = "cpu";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Haven't figured out how this stuff works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
