### PR TITLE
nixos/sway: add wlr portal back with mkDefault

### DIFF
--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -147,9 +147,8 @@ in
       # https://github.com/emersion/xdg-desktop-portal-wlr/blob/master/contrib/wlroots-portals.conf
       # https://github.com/emersion/xdg-desktop-portal-wlr/pull/315
       xdg.portal.config.sway = {
-        # Use xdg-desktop-portal-gtk for every portal interface...
-        default = "gtk";
-        # ... except for the ScreenCast, Screenshot and Secret
+        default = lib.mkDefault [ "wlr" "gtk" ];
+        # use wlr explicitly for screen sharing
         "org.freedesktop.impl.portal.ScreenCast" = "wlr";
         "org.freedesktop.impl.portal.Screenshot" = "wlr";
         # ignore inhibit bc gtk portal always returns as success,


### PR DESCRIPTION
Regression from #348792
Fixes #352188.

@teutat3s please confirm that idle inhibit issues do not reoccur with this.
Pinging @midirhee12 for testing.