### PR TITLE
fex: init at 2412

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1351,6 +1351,13 @@
     githubId = 638836;
     name = "Andreas Rammhold";
   };
+  andre4ik3 = {
+    name = "andre4ik3";
+    email = "andre4ik3@fastmail.com";
+    matrix = "@andre4ik3:matrix.org";
+    github = "andre4ik3";
+    githubId = 62390580;
+  };
   andreasfelix = {
     email = "fandreas@physik.hu-berlin.de";
     github = "andreasfelix";

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -1,0 +1,80 @@
+{
+  fetchFromGitHub,
+  lib,
+  llvmPackages,
+  cmake,
+  ninja,
+  pkg-config,
+  gitMinimal,
+  qt5,
+  python3,
+}:
+
+llvmPackages.stdenv.mkDerivation (finalAttrs: rec {
+  pname = "fex";
+  version = "2412";
+
+  src = fetchFromGitHub {
+    owner = "FEX-Emu";
+    repo = "FEX";
+    tag = "FEX-${version}";
+    hash = "sha256-VwcfxdRMjE/yoe5q0p3j4FdEMOJdtq17moxiGWO+CN0=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # This is a workaround to get FEX working with NixOS's slightly weird binfmt
+    # infrastructure.
+    ./realpath.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    gitMinimal
+    qt5.wrapQtAppsHook
+    llvmPackages.bintools
+
+    (python3.withPackages (
+      pythonPackages: with pythonPackages; [
+        setuptools
+        libclang
+      ]
+    ))
+  ];
+
+  buildInputs = with qt5; [
+    qtbase
+    qtdeclarative
+    qtquickcontrols
+    qtquickcontrols2
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DUSE_LINKER=lld"
+    "-DENABLE_LTO=True"
+    "-DENABLE_ASSERTIONS=False"
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  strictDeps = true;
+  doCheck = false; # broken on Apple silicon computers
+
+  # Avoid wrapping anything other than FEXConfig, since the wrapped executables
+  # don't seem to work when registered as binfmts.
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp $out/bin/FEXConfig
+  '';
+
+  meta = {
+    description = "Fast usermode x86 and x86-64 emulator for Arm64 Linux";
+    homepage = "https://fex-emu.com/";
+    platforms = [ "aarch64-linux" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    mainProgram = "FEXBash";
+  };
+})

--- a/pkgs/by-name/fe/fex/realpath.patch
+++ b/pkgs/by-name/fe/fex/realpath.patch
@@ -1,0 +1,19 @@
+diff --git a/Source/Common/FEXServerClient.cpp b/Source/Common/FEXServerClient.cpp
+index 424ecf0a0..501bcbac1 100644
+--- a/Source/Common/FEXServerClient.cpp
++++ b/Source/Common/FEXServerClient.cpp
+@@ -209,7 +209,13 @@ int ConnectToAndStartServer(char* InterpreterPath) {
+       return -1;
+     }
+ 
+-    fextl::string FEXServerPath = FHU::Filesystem::ParentPath(InterpreterPath) + "/FEXServer";
++    char RealInterpreterPathBuf[PATH_MAX];
++    char *RealInterpreterPath = realpath(InterpreterPath, RealInterpreterPathBuf);
++    if (!RealInterpreterPath) {
++      LogMan::Msg::EFmt("realpath failed");
++      return -1;
++    }
++    fextl::string FEXServerPath = FHU::Filesystem::ParentPath(RealInterpreterPath) + "/FEXServer";
+     // Check if a local FEXServer next to FEXInterpreter exists
+     // If it does then it takes priority over the installed one
+     if (!FHU::Filesystem::Exists(FEXServerPath)) {


### PR DESCRIPTION
Adds [FEX](https://github.com/FEX-Emu/FEX), a fast usermode x86 and x86-64 emulator for Arm64 Linux.

NOTE: When compiling with tests (`doCheck = true`), FEX requires a kernel with 4k page size. So this means, e.g. running it directly on something like the 16k page size Asahi kernel won't work (it will cause a `<jemalloc>: Unsupported system page size` error when compiling). So for testing I used an aarch64 virtual machine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
