### PR TITLE
hardened-chromium: init at 130.0.6723.69

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -1,6 +1,6 @@
 { lib, mkChromiumDerivation
 , channel, chromiumVersionAtLeast
-, enableWideVine, ungoogled
+, enableWideVine, ungoogled, hardened
 }:
 
 mkChromiumDerivation (base: rec {

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -52,6 +52,7 @@
 , proprietaryCodecs ? true
 , pulseSupport ? false, libpulseaudio ? null
 , ungoogled ? false, ungoogled-chromium
+, hardened ? false, hardened-chromium
 # Optional dependencies:
 , libgcrypt ? null # cupsSupport
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
@@ -116,6 +117,9 @@ let
 
   ungoogler = ungoogled-chromium {
     inherit (upstream-info.deps.ungoogled-patches) rev hash;
+  };
+  hardener = hardened-chromium {
+    inherit (upstream-info.deps.hardened-patches) rev hash;
   };
 
   # There currently isn't a (much) more concise way to get a stdenv
@@ -416,6 +420,11 @@ let
     '' + lib.optionalString ungoogled ''
       ${ungoogler}/utils/patches.py . ${ungoogler}/patches
       ${ungoogler}/utils/domain_substitution.py apply -r ${ungoogler}/domain_regex.list -f ${ungoogler}/domain_substitution.list -c ./ungoogled-domsubcache.tar.gz .
+    '' + lib.optionalString hardened ''
+      for f in ${hardener}/fedora_patches/* ${hardener}/vanadium_patches/* ${hardener}/patches/*; do
+        echo "patching!!" "$f"
+        patch -p1 --ignore-whitespace -i "$f" -d . --no-backup-if-mismatch || true
+      done
     '';
 
     llvmCcAndBintools = symlinkJoin {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -15,6 +15,7 @@
 , proprietaryCodecs ? true
 , enableWideVine ? false
 , ungoogled ? false # Whether to build chromium or ungoogled-chromium
+, hardened ? false
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
 , commandLineArgs ? ""
@@ -48,7 +49,7 @@ let
     mkChromiumDerivation = callPackage ./common.nix ({
       inherit channel chromiumVersionAtLeast versionRange;
       inherit proprietaryCodecs
-              cupsSupport pulseSupport ungoogled;
+              cupsSupport pulseSupport ungoogled hardened;
       gnChromium = buildPackages.gn.overrideAttrs (oldAttrs: {
         inherit (upstream-info.deps.gn) version;
         src = fetchgit {
@@ -69,7 +70,7 @@ let
     });
 
     browser = callPackage ./browser.nix {
-      inherit channel chromiumVersionAtLeast enableWideVine ungoogled;
+      inherit channel chromiumVersionAtLeast enableWideVine ungoogled hardened;
     };
 
     # ungoogled-chromium is, contrary to its name, not a build of
@@ -78,6 +79,8 @@ let
     # contains python scripts which get /nix/store/.../bin/python3
     # patched into their shebangs.
     ungoogled-chromium = pkgsBuildBuild.callPackage ./ungoogled.nix {};
+    # hardened-chromium is also a collection of patches
+    hardened-chromium = pkgsBuildBuild.callPackage ./hardened.nix {};
   };
 
   suffix = lib.optionalString (channel != "stable" && channel != "ungoogled-chromium") ("-" + channel);

--- a/pkgs/applications/networking/browsers/chromium/hardened.nix
+++ b/pkgs/applications/networking/browsers/chromium/hardened.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  makeWrapper,
+  patch,
+}:
+
+{
+  rev,
+  hash,
+}:
+
+stdenv.mkDerivation {
+  pname = "hardened-chromium";
+
+  version = rev;
+
+  src = fetchFromGitHub {
+    owner = "secureblue";
+    repo = "hardened-chromium";
+    inherit rev hash;
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    mkdir $out
+    cp -R *patches $out/
+  '';
+}

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,4 +1,20 @@
 {
+  hardened-chromium = {
+    deps = {
+      gn = {
+        hash = "sha256-iNXRq3Mr8+wmY1SR4sV7yd2fDiIZ94eReelwFI0UhGU=";
+        rev = "20806f79c6b4ba295274e3a589d85db41a02fdaa";
+        url = "https://gn.googlesource.com/gn";
+        version = "2024-09-09";
+      };
+      hardened-patches = {
+        hash = "sha256-+IBvTK03ZxX+5p3EG/Y94hi0oCOUMzYu1EjpVDJD+8M=";
+        rev = "2d63d210fa0e95c214bc05b91cef38a9015ffb7c";
+      };
+    };
+    hash = "sha256-k0epbUw9D3Vx7ELNDXIFEnsML+cYvDnHZFOW0kz4Kq8=";
+    version = "130.0.6723.69";
+  };
   stable = {
     chromedriver = {
       hash_darwin = "sha256-SZfl93TcaD9j59zGflPFmHgIP5NaS8bgDi3l3SRRFiI=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20057,6 +20057,11 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  hardened-chromium = callPackage ../applications/networking/browsers/chromium ((config.chromium or {}) // {
+    hardened = true;
+    channel = "hardened-chromium";
+  });
+
   harfbuzz = callPackage ../development/libraries/harfbuzz {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices CoreText;
   };


### PR DESCRIPTION
Closes #352131

Two patches fail to apply:
```
patch fedora_patches/chromium-115-initial_prefs-etc-path.patch
patching file chrome/browser/first_run/first_run_internal_linux.cc
Hunk #1 FAILED at 20.
1 out of 1 hunk FAILED -- saving rejects to file chrome/browser/first_run/first_run_internal_linux.cc.rej

patch fedora_patches/chromium-130-hardware_destructive_interference_size.patch
patching file components/media_router/common/providers/cast/channel/enum_table.h
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
2 out of 2 hunks ignored -- saving rejects to file components/media_router/common/providers/cast/channel/enum_table.h.rej
```
If we ignore the failures, it continues to build (I stopped it after some minutes).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc