### PR TITLE
starsector: refactor, initial modding infrastructure

### DIFF
--- a/pkgs/by-name/st/starsector/mods.nix
+++ b/pkgs/by-name/st/starsector/mods.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  runCommand,
+  dos2unix,
+  jq,
+  p7zip,
+  starsector,
+  unrar,
+}:
+
+let
+  semiOptionalInput =
+    str: bool: "mkStarsectorMod needs an '${str}' attribute, or 'isStandardSrc' set to '${bool}'.";
+  mkStarsectorMod =
+    {
+      pname,
+      version,
+      id,
+      isStandardSrc ? true,
+      src ? if isStandardSrc then "" else throw (semiOptionalInput "src" "true"),
+      url ? if !isStandardSrc then "" else throw (semiOptionalInput "url" "false"),
+      hash ? if !isStandardSrc then "" else throw (semiOptionalInput "hash" "false"),
+      stripRoot ? true,
+      author ? "",
+      prettyName ? "",
+      summary ? "",
+      description ? "",
+      forumURL ? "",
+      ...
+    }@args:
+
+    stdenvNoCC.mkDerivation (
+      finalAttrs:
+      {
+        inherit version pname;
+
+        src =
+          if isStandardSrc then
+            fetchzip {
+              pname = "source-" + pname;
+              inherit
+                version
+                url
+                hash
+                stripRoot
+                ;
+              nativeBuildInputs =
+                lib.optional (lib.hasSuffix ".rar" url) unrar
+                ++ lib.optional (lib.hasSuffix ".7z" url) p7zip;
+              extension =
+                if (!lib.hasSuffix ".zip" url && !lib.hasSuffix ".rar" url && !lib.hasSuffix ".7z" url) then
+                  "zip"
+                else
+                  null;
+            }
+          else
+            src;
+
+        dontConfigure = true;
+        dontBuild = true;
+
+        installPhase = "mkdir $out && cp -prvd * $out";
+
+        passthru = {
+          inherit
+            author
+            prettyName
+            forumURL
+            id
+            ;
+          tests = {
+            gameVersionMatches =
+              runCommand "${finalAttrs.pname}-gameVersionMatchTest"
+                {
+                  nativeBuildInputs = [
+                    jq
+                    dos2unix
+                  ];
+                }
+                ''
+                  dos2unix ${finalAttrs.finalPackage}/mod_info.json
+                  modVersion="$(jq -n -f ${finalAttrs.finalPackage}/mod_info.json | jq -cMj .gameVersion)"
+                  gameVersion="${starsector.version}"
+                  if [ "$gameVersion" = "$modVersion" ]; then
+                    echo "Mod version matches!" && echo "Success: ${finalAttrs.pname}" >> $out
+                  else
+                    echo "Mod version did not match! Tried comparing '$gameVersion' to '$modVersion'."
+                    exit 1
+                  fi
+                '';
+          };
+        };
+
+        meta = {
+          description = "Starsector Mod: ${prettyName}";
+          longDescription =
+            (if (lib.hasPrefix summary description) then description else "${summary}\n${description}")
+            + "\n- by ${author}.";
+          homepage = forumURL;
+          sourceProvenance = lib.optional (lib.pathIsDirectory (
+            finalAttrs.src + "/jars"
+          )) lib.sourceTypes.binaryBytecode;
+          inherit (starsector.meta)
+            license
+            maintainers
+            platforms
+            badPlatforms
+            ;
+        };
+      }
+      // args
+    );
+in
+{
+  inherit mkStarsectorMod;
+}
+
+# TODO: Somehow parse the very non-standard mess that are
+# Starsector mods. There are mod packages that include two mods
+# in a single zip, some mods just straight up use invalid JSON,
+# while others can only be accessed through impermanent source
+# directories and/or lack a versioned URL. Oh, did I mention the
+# lack of consistent line endings?

--- a/pkgs/by-name/st/starsector/package.nix
+++ b/pkgs/by-name/st/starsector/package.nix
@@ -9,20 +9,23 @@
   xorg,
   copyDesktopItems,
   makeDesktopItem,
-  writeScript,
+  writeShellApplication,
+  curl,
+  gnugrep,
+  common-updater-scripts,
 }:
 
 let
   openjdk = openjdk8;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "starsector";
   version = "0.97a-RC11";
 
   src = fetchzip {
-    url = "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-${version}.zip";
-    sha256 = "sha256-KT4n0kBocaljD6dTbpr6xcwy6rBBZTFjov9m+jizDW4=";
+    url = "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-${finalAttrs.version}.zip";
+    hash = "sha256-KT4n0kBocaljD6dTbpr6xcwy6rBBZTFjov9m+jizDW4=";
   };
 
   nativeBuildInputs = [
@@ -42,14 +45,14 @@ stdenv.mkDerivation rec {
       name = "starsector";
       exec = "starsector";
       icon = "starsector";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       genericName = "starsector";
       desktopName = "Starsector";
       categories = [ "Game" ];
     })
   ];
 
-  # need to cd into $out in order for classpath to pick up correct jar files
+  # We need to `cd` into $out in order for `classpath` to pick up correct .jar files.
   installPhase = ''
     runHook preInstall
 
@@ -69,7 +72,7 @@ stdenv.mkDerivation rec {
           xorg.xrandr
         ]
       } \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs} \
       --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
       --chdir "$out/share/starsector"
     ln -s $out/share/starsector/starsector.sh $out/bin/starsector
@@ -77,37 +80,61 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  # it tries to run everything with relative paths, which makes it CWD dependent
-  # also point mod, screenshot, and save directory to $XDG_DATA_HOME
-  # additionally, add some GC options to improve performance of the game,
-  # remove flags "PermSize" and "MaxPermSize" that were removed with Java 8 and
-  # pass-through CLI args ($@) to the JVM.
-  postPatch = ''
-    substituteInPlace starsector.sh \
+  postPatch =
+    # Patch the starsector.sh init script.
+    ''
+      substituteInPlace starsector.sh \
+    ''
+    # Starsector tries to run everything with relative paths, which makes it CWD dependent, so we hardcode the relevant store paths here.
+    + ''
       --replace-fail "./jre_linux/bin/java" "${openjdk}/bin/java" \
       --replace-fail "./native/linux" "$out/share/starsector/native/linux" \
+    ''
+    # We also point the mod, screenshot, and save directories to $XDG_DATA_HOME.
+    + ''
       --replace-fail "=." "=\''${XDG_DATA_HOME:-\$HOME/.local/share}/starsector" \
+    ''
+    # Additionally, we add some GC options to improve performance of the game.
+    + ''
       --replace-fail "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC" \
+    ''
+    # Furthermore, we remove the "PermSize" and "MaxPermSize" flags, as they were removed with Java 8.
+    + ''
       --replace-quiet " -XX:PermSize=192m -XX:MaxPermSize=192m" "" \
+    ''
+    # Finally, we pass-through CLI args ($@) to the JVM.
+    + ''
       --replace-fail "com.fs.starfarer.StarfarerLauncher" "\"\$@\" com.fs.starfarer.StarfarerLauncher"
-  '';
+    '';
 
-  passthru.updateScript = writeScript "starsector-update-script" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl gnugrep common-updater-scripts
-    set -eou pipefail;
-    version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
-    update-source-version ${pname} "$version" --file=./pkgs/by-name/st/starsector/package.nix
-  '';
+  passthru = {
+    updateScript = writeShellApplication {
+      name = "starsector-update-script";
+      runtimeInputs = [
+        curl
+        gnugrep
+        common-updater-scripts
+      ];
+      runtimeEnv = {
+        inherit (finalAttrs) pname;
+      };
+      text = builtins.readFile ./update.sh;
+    };
+  };
 
-  meta = with lib; {
-    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
+  meta = {
+    description = "Open-world, single-player space combat, roleplaying, exploration, and economic game";
     homepage = "https://fractalsoftworks.com";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [
+    downloadPage = finalAttrs.meta.homepage + "/preorder";
+    changelog = finalAttrs.meta.homepage + "/blog";
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    license = lib.licenses.unfree;
+    platforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isUnix lib.systems.inspect.patterns.isx86_64;
+    badPlatforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isDarwin lib.systems.inspect.patterns.isx86_64;
+    maintainers = with lib.maintainers; [
       bbigras
       rafaelrc
+      sigmasquadron
     ];
   };
-}
+})

--- a/pkgs/by-name/st/starsector/package.nix
+++ b/pkgs/by-name/st/starsector/package.nix
@@ -1,14 +1,15 @@
-{ lib
-, fetchzip
-, libGL
-, makeWrapper
-, openal
-, openjdk8
-, stdenv
-, xorg
-, copyDesktopItems
-, makeDesktopItem
-, writeScript
+{
+  lib,
+  fetchzip,
+  libGL,
+  makeWrapper,
+  openal,
+  openjdk8,
+  stdenv,
+  xorg,
+  copyDesktopItems,
+  makeDesktopItem,
+  writeScript,
 }:
 
 let
@@ -24,8 +25,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-KT4n0kBocaljD6dTbpr6xcwy6rBBZTFjov9m+jizDW4=";
   };
 
-  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
-  buildInputs = [ xorg.libXxf86vm openal libGL ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+  buildInputs = [
+    xorg.libXxf86vm
+    openal
+    libGL
+  ];
 
   dontBuild = true;
 
@@ -55,7 +63,12 @@ stdenv.mkDerivation rec {
       $out/share/icons/hicolor/64x64/apps/starsector.png
 
     wrapProgram $out/share/starsector/starsector.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk xorg.xrandr ]} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          openjdk
+          xorg.xrandr
+        ]
+      } \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
       --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
       --chdir "$out/share/starsector"
@@ -92,6 +105,9 @@ stdenv.mkDerivation rec {
     homepage = "https://fractalsoftworks.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ bbigras rafaelrc ];
+    maintainers = with maintainers; [
+      bbigras
+      rafaelrc
+    ];
   };
 }

--- a/pkgs/by-name/st/starsector/package.nix
+++ b/pkgs/by-name/st/starsector/package.nix
@@ -3,13 +3,17 @@
 , libGL
 , makeWrapper
 , openal
-, openjdk
+, openjdk8
 , stdenv
 , xorg
 , copyDesktopItems
 , makeDesktopItem
 , writeScript
 }:
+
+let
+  openjdk = openjdk8;
+in
 
 stdenv.mkDerivation rec {
   pname = "starsector";
@@ -80,7 +84,7 @@ stdenv.mkDerivation rec {
     #!nix-shell -i bash -p curl gnugrep common-updater-scripts
     set -eou pipefail;
     version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
-    update-source-version ${pname} "$version" --file=./pkgs/games/starsector/default.nix
+    update-source-version ${pname} "$version" --file=./pkgs/by-name/st/starsector/package.nix
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/st/starsector/update.sh
+++ b/pkgs/by-name/st/starsector/update.sh
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+
+# Starsector
+version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
+update-source-version "$pname" "$version" --file=./pkgs/by-name/st/starsector/package.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34934,10 +34934,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
-  starsector = callPackage ../games/starsector {
-    openjdk = openjdk8;
-  };
-
   scid = callPackage ../games/scid { };
 
   scid-vs-pc = callPackage ../games/scid-vs-pc { };


### PR DESCRIPTION
This was originally a much larger PR, but as the `TODO` in mods.nix will tell you, I was unable to package the mods themselves in an automated way.

- Does your standard refactor: by-name migration, formatting, and a few other things as detailed in the [commit message](https://github.com/NixOS/nixpkgs/pull/352214/commits/5de106ad7734326131fa8cee8f3cc51737ab542a).
- Adds a new function, `mkStarsectorMod`, available inside the `starsector.passthru` attributes, which is *probably* an abuse of `by-name`, but [I just think it's neat](https://youtu.be/J2eud_tEIj8?t=6)!
  - End users can then produce their own derivations with their own mods.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - Only manual testing is available.
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review pr 352214`.
- [x] Tested basic functionality of all binary files (`./result/bin/starsector`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
