### PR TITLE
signal-desktop: 7.29.0 -> 7.31.0; signal-desktop-beta: 7.30.0-beta.2-> 7.32.0-beta.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
@@ -2,7 +2,7 @@
 callPackage ./generic.nix { } rec {
   pname = "signal-desktop-beta";
   dir = "Signal Beta";
-  version = "7.30.0-beta.2";
+  version = "7.32.0-beta.1";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_amd64.deb";
-  hash = "sha256-mIdbaS4XNDh3wPTUHAyBqMQ67usp312e1McuFAGPrq0=";
+  hash = "sha256-WrHF7Y8OcEOr+W/Jhc+Hj5jCtOjKigZ02N9N/hE+XLA=";
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
@@ -2,7 +2,7 @@
 callPackage ./generic.nix { } rec {
   pname = "signal-desktop";
   dir = "Signal";
-  version = "7.29.0";
+  version = "7.31.0";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-TftTt9pN4EjgZs3N94TlCzXK64g1g+oGPx1ZLVX02VA=";
+  hash = "sha256-7UumNusnexW3ujA65SzxKAdRrWxmKrgZFzK0GMlURaM=";
 }


### PR DESCRIPTION
https://github.com/signalapp/Signal-Desktop/compare/v7.29.0...v7.31.0
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.30.0
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.31.0

https://github.com/signalapp/Signal-Desktop/compare/v7.30.0-beta.2...v7.32.0-beta.1
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.31.0-beta.1
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.32.0-beta.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
