### PR TITLE
pulumi: 3.122.0 -> 3.137.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/base.nix
+++ b/pkgs/tools/admin/pulumi-packages/base.nix
@@ -92,6 +92,7 @@ in
 , env ? { }
 , meta
 , fetchSubmodules ? false
+, cmdGenPostConfigure ? ""
 , ...
 }@args:
 let
@@ -105,6 +106,7 @@ let
 
     cmd = cmdGen;
     pname = cmdGen;
+    postConfigure = cmdGenPostConfigure;
   };
 in
 mkBasePackage ({

--- a/pkgs/tools/admin/pulumi-packages/pulumi-aws-native.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-aws-native.nix
@@ -4,10 +4,10 @@
 mkPulumiPackage rec {
   owner = "pulumi";
   repo = "pulumi-aws-native";
-  version = "0.38.0";
+  version = "1.4.0";
   rev = "v${version}";
-  hash = "sha256-v7jNPCrjtfi9KYD4RhiphMIpV23g/CBV/sKPBkMulu0=";
-  vendorHash = "sha256-Yu9tNakwXWYdrjzI6/MFRzVBhJAEOjsmq9iBAQlR0AI=";
+  hash = "sha256-MSsWK9eae1WEo/inNQ52T+B9c6XlJg2ycoFUOJhLJag=";
+  vendorHash = "sha256-1IGahpX7hORFm8tZpoJGwdZWyihtnqR7QqVB5dYamxE=";
   cmdGen = "pulumi-gen-aws-native";
   cmdRes = "pulumi-resource-aws-native";
   extraLdflags = [
@@ -18,7 +18,11 @@ mkPulumiPackage rec {
   postConfigure = ''
     pushd ..
 
-    ${cmdGen} schema aws-cloudformation-schema ${version}
+    chmod +w .
+    chmod -R +w reports/
+
+    ${cmdGen} --docs-url https://github.com/cdklabs/awscdk-service-spec/raw/main/sources/CloudFormationDocumentation/CloudFormationDocumentation.json docs ${version}
+    ${cmdGen} --schema-folder aws-cloudformation-schema --metadata-folder meta schema ${version}
 
     popd
   '';

--- a/pkgs/tools/admin/pulumi-packages/pulumi-azure-native.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-azure-native.nix
@@ -4,15 +4,20 @@
 mkPulumiPackage rec {
   owner = "pulumi";
   repo = "pulumi-azure-native";
-  version = "2.13.0";
+  version = "2.69.0";
   rev = "v${version}";
-  hash = "sha256-YyJxACeXyY7hZkTbLXT/ASNWa1uv9h3cvPoItR183fU=";
-  vendorHash = "sha256-20wHbNE/fenxP9wgTSzAnx6b1UYlw4i1fi6SesTs0sc=";
+  hash = "sha256-4kzLCBPHsSJHX7R4LOFYWoyQLdomihC6ppEnQQcdINE=";
+  vendorHash = "sha256-JZNaez9jWQc2jMXTZywClb2/LAL1FuHLCJprV8MaFTk=";
   cmdGen = "pulumi-gen-azure-native";
   cmdRes = "pulumi-resource-azure-native";
   extraLdflags = [
     "-X github.com/pulumi/${repo}/v2/provider/pkg/version.Version=${version}"
   ];
+  cmdGenPostConfigure = ''
+    pushd ..
+    cp versions/v2-lock.json provider/pkg/versionLookup/
+    popd
+  '';
   postConfigure = ''
     pushd ..
 
@@ -23,6 +28,7 @@ mkPulumiPackage rec {
 
     cp bin/schema-full.json provider/cmd/${cmdRes}
     cp bin/metadata-compact.json provider/cmd/${cmdRes}
+    cp versions/v2-lock.json provider/pkg/versionLookup/
 
     popd
 

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-eHsTEb4Vff2bfADScLSkZiotSSnT1q0bexlUMaWgqbg=";
+  vendorHash = "sha256-Bk/JxFYBnd+bOlExJKGMIl2oUHPg3ViIVBqKBojoEm4=";
 
   ldflags = [
     "-s"

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -9,13 +9,16 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-L91qIud8dWx7dWWEcknKUSTJe+f4OBL8wBg6dKUWgkQ=";
+  vendorHash = "sha256-vs4M0JOVbNKLFNrlyeRp85EWCVGrPIhZs/KbwrQCqk4=";
 
   postPatch = ''
     # Gives github.com/pulumi/pulumi/pkg/v3: is replaced in go.mod, but not marked as replaced in vendor/modules.txt etc
     substituteInPlace language_test.go \
-      --replace "TestLanguage" \
-                "SkipTestLanguage"
+      --replace-quiet "TestLanguage" "SkipTestLanguage"
+    substituteInPlace main_test.go \
+      --replace-quiet "TestNonblockingStdout" "SkipTestNonblockingStdout"
+    substituteInPlace main_test.go \
+      --replace-quiet "TestGetProgramDependencies" "SkipTestGetProgramDependencies"
   '';
 
   ldflags = [

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -9,12 +9,13 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-Q8nnYJJN5+W2luY8JQJj1X9KIk9ad511FBywr+0wBNg=";
+  vendorHash = "sha256-h7X53Tbh5CCkBU0NtlVvAcow9OOGFHxi3LAhz8NKVEQ=";
 
   postPatch = ''
+    substituteInPlace language_test.go \
+      --replace-quiet "TestLanguage" "SkipTestLanguage"
     substituteInPlace main_test.go \
-      --replace "TestDeterminePulumiPackages" \
-                "SkipTestDeterminePulumiPackages"
+      --replace-quiet "TestDeterminePulumiPackages" "SkipTestDeterminePulumiPackages"
   '';
 
   ldflags = [

--- a/pkgs/tools/admin/pulumi-packages/pulumi-random.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-random.nix
@@ -4,10 +4,10 @@
 mkPulumiPackage rec {
   owner = "pulumi";
   repo = "pulumi-random";
-  version = "4.14.0";
+  version = "4.16.7";
   rev = "v${version}";
-  hash = "sha256-1MR7zWNBDbAUoRed7IU80PQxeH18x95MKJKejW5m2Rs=";
-  vendorHash = "sha256-YDuF89F9+pxVq4TNe5l3JlbcqpnJwSTPAP4TwWTriWA=";
+  hash = "sha256-Ef4GRbbGHe+Ni8ksHnV3oCqOw94n5XxHgvfefNpmAm0=";
+  vendorHash = "sha256-O0Edcdw+Auxs+DO9ktESgA4MAnoRrsUDNW6S5QIRilc=";
   cmdGen = "pulumi-tfgen-random";
   cmdRes = "pulumi-resource-random";
   extraLdflags = [

--- a/pkgs/tools/admin/pulumi-packages/pulumi-yandex-unofficial.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-yandex-unofficial.nix
@@ -6,10 +6,10 @@
 mkPulumiPackage rec {
   owner = "Regrau";
   repo = "pulumi-yandex";
-  version = "0.98.0";
+  version = "0.99.1";
   rev = "v${version}";
-  hash = "sha256-Olwl4JNrJUiJaGha7ZT0Qb0+6hRKxOOy06eKMJfYf0I=";
-  vendorHash = "sha256-8mu0msSq59f5GZNo7YIGuNTYealGyEL9kwk0jCcSO68=";
+  hash = "sha256-LCWrt5TIvzXssLjV523K27LWzd+za88WLzgbLLnK+sw=";
+  vendorHash = "sha256-z9UAGX3PRInlO8v/1zgPYR8SlTnDuZfgEruBWJfVNiU=";
   cmdGen = "pulumi-tfgen-yandex";
   cmdRes = "pulumi-resource-yandex";
   extraLdflags = [

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -67,6 +67,7 @@ buildGoModule rec {
     rm -R codegen/{dotnet,go,nodejs,python}/gen_program_test
 
     unset PULUMI_ACCESS_TOKEN
+    export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     export PULUMI_HOME=$(mktemp -d)
   '';
@@ -99,7 +100,7 @@ buildGoModule rec {
         "TestProgressEvents"
         # This test depends on having a PULUMI_ACCESS_TOKEN but is not skipped when one is not provided.
         # Other tests are skipped when the env var is missing. I guess they forgot about this one.
-        "TestPulumiNewSetsTemplateTag/python"
+        "TestPulumiNewSetsTemplateTag"
         # Both tests require having a "pulumi-language-yaml" plugin installed since pulumi/pulumi#17285,
         # which I'm not sure how to add.
         "TestProjectNameDefaults"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This change upgrades pulumi through [multiple versions](https://github.com/pulumi/pulumi/releases/tag/v3.137.0) and its relevante packages in `pulumi-packages`.

Packages in `pulumi-packages` were considerably outdated, some tweaks were necessary to make them work again:
* `pulumi-aws-native` now requires docs to be generated before generating the schema,
* `pulumi-azure-native` requires a new `v2-lock.json` file to be copied to the correct path before building the gen command and resource,
* `pulumi-language-{nodejs,python}` fails to pass some tests that require special setup done through Pulumi's makefile, which I deem irrelevante here.

`pulumi` itself also requires disabling and tweaking some tests. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
