### PR TITLE
ycmd: correct gopls package and link path

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14701,6 +14701,14 @@
     githubId = 8263431;
     name = "Matt Miemiec";
   };
+  mel = {
+    email = "mel@rnrd.eu";
+    github = "melnary";
+    githubId = 10659529;
+    matrix = "@mel:rnrd.eu";
+    name = "Mel G.";
+    keys = [ { fingerprint = "D75A C286 ACA7 00B4 D8EC  377D 2082 F8EC 11CC 009B"; } ];
+  };
   melchips = {
     email = "truphemus.francois@gmail.com";
     github = "melchips";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3822,6 +3822,7 @@ in
       maintainers = with maintainers; [
         marcweber
         jagajaga
+        mel
       ];
       platforms = platforms.unix;
     };

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -6,8 +6,8 @@
 , python
 , withGodef ? true
 , godef
-, withGotools ? true
-, gotools
+, withGopls ? true
+, gopls
 , withRustAnalyzer ? true
 , rust-analyzer
 , withTypescript ? true
@@ -80,10 +80,10 @@ stdenv.mkDerivation {
     TARGET=$out/lib/ycmd/third_party/godef
     mkdir -p $TARGET
     ln -sf ${godef}/bin/godef $TARGET
-  '' + lib.optionalString withGotools ''
-    TARGET=$out/lib/ycmd/third_party/go/src/golang.org/x/tools/cmd/gopls
+  '' + lib.optionalString withGopls ''
+    TARGET=$out/lib/ycmd/third_party/go/bin
     mkdir -p $TARGET
-    ln -sf ${gotools}/bin/gopls $TARGET
+    ln -sf ${gopls}/bin/gopls $TARGET
   '' + lib.optionalString withRustAnalyzer ''
     TARGET=$out/lib/ycmd/third_party/rust-analyzer
     mkdir -p $TARGET

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
     mainProgram = "ycmd";
     homepage = "https://github.com/ycm-core/ycmd";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ rasendubi lnl7 siriobalmelli ];
+    maintainers = with maintainers; [ rasendubi lnl7 mel ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
This fixes built-in Go completion support in `vimPlugins.YouCompleteMe`.

This essentially fixes two problems:
* `ycmd` previously used the package `gotools` to source it's `gopls` binary from, even though the binary has been removed from there in https://github.com/NixOS/nixpkgs/pull/85868 and moved to a separate package. Now we use the correct `gopls` package again.
* Upstream YCM has changed where the server binary is searched for by default. The defaults change is reflected in their install/build script (since https://github.com/ycm-core/ycmd/pull/1427), as well as in the server implementation (since https://github.com/ycm-core/ycmd/commit/f666d38fbbfdc3a5c585cb97596ef954a91763ec). The link path has now been adjusted.

These two problems both contributed to `gopls` ending up a dangling symlink and breaking Go completion in YCM. After this it has been working correctly once again! :3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
