### PR TITLE
python312Packages.pytest-django: 4.8.0 -> 4.9.0, drop pytest-xdist du…

### DIFF
--- a/pkgs/development/python-modules/pytest-django/default.nix
+++ b/pkgs/development/python-modules/pytest-django/default.nix
@@ -7,17 +7,17 @@
   setuptools-scm,
   django-configurations,
   pytest,
-  pytest-xdist,
   pytestCheckHook,
 }:
 buildPythonPackage rec {
   pname = "pytest-django";
-  version = "4.8.0";
+  version = "4.9.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-XQVP4BHFbzsQ+Xj0Go77Llrfx+aA7zb7VxraHyR3nZA=";
+    pname = "pytest_django";
+    inherit version;
+    hash = "sha256-i/e8NYya5vb8UbbOuxkP4gISGW5oBxIfEb1qOwNCgxQ=";
   };
 
   build-system = [
@@ -31,22 +31,17 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     django-configurations
-    pytest-xdist
+    # pytest-xidst causes random errors in the form of: django.db.utils.OperationalError: no such table: app_item
     pytestCheckHook
   ];
 
   preCheck = ''
     # bring pytest_django_test module into PYTHONPATH
-    export PYTHONPATH="$(pwd):$PYTHONPATH"
+    export PYTHONPATH="$PWD:$PYTHONPATH"
 
     # test the lightweight sqlite flavor
     export DJANGO_SETTINGS_MODULE="pytest_django_test.settings_sqlite"
   '';
-
-  disabledTests = [
-    # AttributeError: type object 'TestLiveServer' has no attribute '_test_settings_before_run'
-    "test_settings_restored"
-  ];
 
   __darwinAllowLocalNetworking = true;
 
@@ -55,5 +50,6 @@ buildPythonPackage rec {
     description = "Pytest plugin for testing of Django applications";
     homepage = "https://pytest-django.readthedocs.org/en/latest/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
…e causing instability

Changelog: https://github.com/pytest-dev/pytest-django/blob/main/docs/changelog.rst#v490-2024-09-02


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
