### PR TITLE
Don't read swap files during evaluation

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1029,8 +1029,26 @@ rec {
         getSubOptions = finalType.getSubOptions;
         getSubModules = finalType.getSubModules;
         substSubModules = m: coercedTo coercedType coerceFunc (finalType.substSubModules m);
-        typeMerge = t: null;
-        functor = (defaultFunctor name) // { wrapped = finalType; };
+        typeMerge = f':
+          let coercedType' = coercedType.typeMerge (f'.coercedType).functor;
+              finalType' = finalType.typeMerge (f'.wrapped).functor;
+              coerceFunc' =
+                if coerceFunc == null
+                then f'.coerceFunc
+                else if f'.coerceFunc == null
+                then coerceFunc
+                else # both are non-null, but only one conversion function can be used
+                  null;
+          in
+             if name == f'.name
+                && coercedType' != null
+                && finalType' != null
+             then functor.type coercedType' coerceFunc' finalType'
+             else null;
+        functor = (defaultFunctor name) // {
+          wrapped = finalType;
+          inherit coercedType coerceFunc;
+        };
         nestedTypes.coercedType = coercedType;
         nestedTypes.finalType = finalType;
       };

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -216,8 +216,12 @@ in
         {command}`mkswap -L`).  Using a label is
         recommended.
       '';
-
-      type = types.listOf (types.submodule swapCfg);
+      type =
+        let
+          t = types.submodule swapCfg;
+          disallow = s: throw "Definitions for swapDevices items must be submodules, normally either { device = \"…\"; } or { label = \"…\"; }, but got a definition that is just ${lib.strings.escapeNixString s}";
+        in
+        types.listOf (types.coercedTo types.str disallow t // { inherit (t) description; });
     };
 
   };

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -74,7 +74,7 @@ in
       type = with lib.types; attrsOf (submodule encryptedFSOptions);
     };
     swapDevices = mkOption {
-      type = with lib.types; listOf (submodule encryptedFSOptions);
+      type = with lib.types; listOf (coercedTo str null (submodule encryptedFSOptions));
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Provide a proper type error in the following situation. Otherwise, `/dev/zero` would be read _during evaluation_; see https://github.com/NixOS/nix/issues/11764.

```nix
nix-repl> (nixos { swapDevices = [ "/dev/zero" ]; boot.loader.grub.enable = false; fileSystems."/".device = "x"; }).config.system.build.toplevel

       error: Definitions for swapDevices items must be submodules, normally either { device = "…"; } or { label = "…"; }, but got a definition that is just "/dev/zero"
```

- A fix for  https://github.com/NixOS/nix/issues/11764

- It seems that to fix #352253 is a prerequisite to this PR's solution

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
