### PR TITLE
ndppd: 0.2.5 -> 0.2.5.43

### DIFF
--- a/nixos/modules/services/networking/ndppd.nix
+++ b/nixos/modules/services/networking/ndppd.nix
@@ -91,7 +91,7 @@ let
           auto: Same as iface, but instead of manually specifying the outgoing
             interface, check for a matching route in /proc/net/ipv6_route.
         '';
-        default = "auto";
+        default = "static";
       };
       interface = mkOption {
         type = types.nullOr types.str;

--- a/pkgs/by-name/nd/ndppd/package.nix
+++ b/pkgs/by-name/nd/ndppd/package.nix
@@ -1,24 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, gzip, nixosTests }:
+{ lib, stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "ndppd";
-  version = "0.2.5";
+  version = "0.2.5.43";
 
-  src = fetchFromGitHub {
-    owner = "DanielAdolfsson";
-    repo = "ndppd";
-    rev = version;
-    sha256 = "0niri5q9qyyyw5lmjpxk19pv3v4srjvmvyd5k6ks99mvqczjx9c0";
+  src = fetchurl {
+    url = "https://api.opensuse.org/public/source/network/ndppd/ndppd-${version}.tar.xz";
+    hash = "sha256-KhU5WefVaWfHM62zY3m7VryLeN9g2u8vCqyqkVM5jRs";
   };
-
-  nativeBuildInputs = [ gzip ];
 
   makeFlags = [
     "PREFIX=$(out)"
   ];
 
   preConfigure = ''
-    substituteInPlace Makefile --replace /bin/gzip gzip
+    substituteInPlace Makefile --replace-fail /bin/gzip gzip
+    substituteInPlace src/ndppd.h --replace-fail "0.2.4" "${version}"
   '';
 
   postInstall = ''


### PR DESCRIPTION
ndppd 0.2.5 is too old and lacks many features.
ndppd 0.2.5.43 means commit eb81b8f, 43 commits after 0.2.5.
https://github.com/DanielAdolfsson/ndppd/compare/0.2.5...eb81b8f

This is what SUSE has done for SLE (SUSE Linux Enterprise), and this version has been tested for many years, so stability should not be a problem.
https://packagehub.suse.com/packages/ndppd/
https://build.opensuse.org/package/show/network/ndppd
https://src.opensuse.org/pool/ndppd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
