### PR TITLE
summoning-pixel-dungeon: use default gradle

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/summoning-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/summoning-pixel-dungeon/default.nix
@@ -1,6 +1,6 @@
 { callPackage
 , fetchFromGitHub
-, gradle_6
+, fetchpatch
 , substitute
 }:
 
@@ -16,10 +16,26 @@ callPackage ../generic.nix rec {
     hash = "sha256-VQcWkbGe/0qyt3M5WWgTxczwC5mE3lRHbYidOwRoukI=";
   };
 
-  patches = [(substitute {
-    src = ./disable-git-version.patch;
-    substitutions = [ "--subst-var-by" "version" version ];
-  })];
+  patches = [
+    (substitute {
+      src = ./disable-git-version.patch;
+      substitutions = [ "--subst-var-by" "version" version ];
+    })
+    # FIXME: Remove after next release
+    (fetchpatch {
+      name = "Update-desktop-build-script-for-Gradle-7.0+";
+      url = "https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/commit/5610142126e161cbdc78a07c5d5abfbcd6eaf8a6.patch";
+      hash = "sha256-zAiOz/Cu89Y+VmAyLCf7fzq0Mr0sYFZu14sqBZ/XvZU=";
+    })
+  ];
+
+  postPatch = ''
+    # Upstream patched this in https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/commit/c8a6fdd57c49fd91bf65be48679ae6a77578ef9f,
+    # but the patch fails to apply cleanly. Manually replace the deprecated option instead.
+    # FIXME: Remove after next release
+    substituteInPlace gradle.properties \
+      --replace-fail "-XX:MaxPermSize" "-XX:MaxMetaspaceSize"
+  '';
 
   desktopName = "Summoning Pixel Dungeon";
 
@@ -28,7 +44,4 @@ callPackage ../generic.nix rec {
     downloadPage = "https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/releases";
     description = "A fork of the Shattered Pixel Dungeon roguelike with added summoning mechanics";
   };
-
-  # Probably due to https://github.com/gradle/gradle/issues/17236
-  gradle = gradle_6;
 }


### PR DESCRIPTION
Upstream has made it possible to use a recent version of Gradle,
thanks to some patches:
* "1.2.6: changed JVM args to be compatible with Java 17"
    -> This is not directly applied, as it fails to apply cleanly; we use substituteInPlace instead
    -> https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/commit/c8a6fdd57c49fd91bf65be48679ae6a77578ef9f

* "1.2.6: updated desktop build script for Gradle 7.0+"
    -> https://github.com/TrashboxBobylev/Summoning-Pixel-Dungeon/commit/5610142126e161cbdc78a07c5d5abfbcd6eaf8a6

Tastes best warm and with ~~grandma's cookies~~ #352236

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
