### PR TITLE
neovim-require-check-hook: auto discover modules to require

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -234,14 +234,46 @@ Finally, there are some plugins that are also packaged in nodePackages because t
 
 ### Testing Neovim plugins {#testing-neovim-plugins}
 
-`nvimRequireCheck=MODULE` is a simple test which checks if Neovim can requires the lua module `MODULE` without errors. This is often enough to catch missing dependencies.
+#### neovimRequireCheck {#testing-neovim-plugins-neovim-require-check}
+`neovimRequireCheck` is a simple test which checks if Neovim can requires lua modules without errors. This is often enough to catch missing dependencies.
 
-This can be manually added through plugin definition overrides in the [overrides.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/overrides.nix).
+It accepts a single string for a module, or a list of module strings to test.
+- `nvimRequireCheck = MODULE;`
+- `nvimRequireCheck = [ MODULE1 MODULE2 ];`
+
+When `neovimRequireCheck` is not specified, we will search the plugin's directory for lua modules to attempt loading. This quick smoke test can catch obvious dependency errors that might be missed.
+The check hook will fail the build if any failures are detected to encourage inspecting the logs to identify potential issues.
+
+If you would like to only check a specific module, this can be manually added through plugin definition overrides in the [overrides.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/overrides.nix).
 
 ```nix
   gitsigns-nvim = super.gitsigns-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "gitsigns";
+  };
+```
+Some plugins will have lua modules that require a user configuration to function properly or can contain optional lua modules that we dont want to test requiring.
+We can skip specific modules using `nvimSkipModule`. Similar to `nvimRequireCheck`, it accepts a single string or a list of strings.
+- `nvimSkipModule = MODULE;`
+- `nvimSkipModule = [ MODULE1 MODULE2 ];`
+
+```nix
+  asyncrun-vim = super.asyncrun-vim.overrideAttrs {
+    nvimSkipModule = [
+      # vim plugin with optional toggleterm integration
+      "asyncrun.toggleterm"
+      "asyncrun.toggleterm2"
+    ];
+  };
+```
+
+In rare cases, we might not want to actually test loading lua modules for a plugin. In those cases, we can disable `neovimRequireCheck` with `doCheck = false;`.
+
+This can be manually added through plugin definition overrides in the [overrides.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/overrides.nix).
+```nix
+  vim-test = super.vim-test.overrideAttrs {
+    # Vim plugin with a test lua file
+    doCheck = false;
   };
 ```
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3760,6 +3760,9 @@
   "testing-neovim-plugins": [
     "index.html#testing-neovim-plugins"
   ],
+  "testing-neovim-plugins-neovim-require-check": [
+    "index.html#testing-neovim-plugins-neovim-require-check"
+  ],
   "vim-plugin-required-snippet": [
     "index.html#vim-plugin-required-snippet"
   ],

--- a/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
@@ -1,24 +1,136 @@
 #shellcheck shell=bash
-# Setup hook for checking whether Python imports succeed
+# Setup hook for checking whether Lua imports succeed
 echo "Sourcing neovim-require-check-hook.sh"
 
-neovimRequireCheckHook () {
+# Discover modules automatically if nvimRequireCheck is not set
+discover_modules() {
+    echo "Running module discovery in source directory..."
+
+    # Create unique lists so we can organize later
+    modules=()
+
+    while IFS= read -r lua_file; do
+        # Ignore certain infra directories
+        if [[ "$lua_file" =~ debug/|scripts?/|tests?/|spec/ || "$lua_file" =~ .*\meta.lua ]]; then
+            continue
+        # Ignore optional telescope and lualine modules
+        elif [[ "$lua_file" =~ ^lua/telescope/_extensions/(.+)\.lua || "$lua_file" =~ ^lua/lualine/(.+)\.lua ]]; then
+            continue
+        # Grab main module names
+        elif [[ "$lua_file" =~ ^lua/([^/]+)/init.lua$ ]]; then
+            echo "$lua_file"
+            modules+=("${BASH_REMATCH[1]}")
+        # Check other lua files
+        elif [[ "$lua_file" =~ ^lua/(.*)\.lua$ ]]; then
+            echo "$lua_file"
+            # Replace slashes with dots to form the module name
+            module_name="${BASH_REMATCH[1]//\//.}"
+            modules+=("$module_name")
+        elif [[ "$lua_file" =~ ^([^/.][^/]*)\.lua$ ]]; then
+            echo "$lua_file"
+            modules+=("${BASH_REMATCH[1]}")
+        fi
+    done < <(find "$src" -name '*.lua' | xargs -n 1 realpath --relative-to="$src")
+
+    nvimRequireCheck=("${modules[@]}")
+    echo "Discovered modules: ${nvimRequireCheck[*]}"
+
+    if [ "${#nvimRequireCheck[@]}" -eq 0 ]; then
+        echo "No valid Lua modules found; skipping check"
+        return 1
+    fi
+    return 0
+}
+
+# Run require checks on each module in nvimRequireCheck
+run_require_checks() {
+    echo "Starting require checks"
+    check_passed=false
+    failed_modules=()
+    successful_modules=()
+
+    export HOME="$TMPDIR"
+    local deps="${dependencies[*]}"
+    local checks="${nativeBuildInputs[*]}"
+    set +e
+    for name in "${nvimRequireCheck[@]}"; do
+        local skip=false
+        for module in "${nvimSkipModule[@]}"; do
+            if [[ "$module" == "$name" ]]; then
+                echo "$name is in list of modules to not check. Skipping..."
+                skip=true
+                break
+            fi
+        done
+
+        if [ "$skip" = false ]; then
+            echo "Attempting to require module: $name"
+            if @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
+                --cmd "set rtp+=$out,${deps// /,}" \
+                --cmd "set rtp+=$out,${checks// /,}" \
+                --cmd "lua require('$name')"; then
+                check_passed=true
+                successful_modules+=("$name")
+                echo "Successfully required module: $name"
+            else
+                echo "Failed to require module: $name"
+                failed_modules+=("$name")
+            fi
+        fi
+    done
+    set -e
+}
+
+# Define color codes
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
+# Print summary of the require checks
+print_summary() {
+    echo -e "\n======================================================"
+    if [[ "$check_passed" == "true" ]]; then
+        echo -e "${GREEN}Require check succeeded for the following modules:${NC}"
+        for module in "${successful_modules[@]}"; do
+            echo -e "  ${GREEN}- $module${NC}"
+        done
+        echo "All lua modules were checked."
+    else
+        echo -e "${RED}No successful require checks.${NC}"
+    fi
+
+    # Print any modules that failed with improved formatting and color
+    if [ "${#failed_modules[@]}" -gt 0 ]; then
+        echo -e "\n${RED}Require check failed for the following modules:${NC}"
+        for module in "${failed_modules[@]}"; do
+            echo -e "  ${RED}- $module${NC}"
+        done
+    fi
+    echo "======================================================"
+
+    if [ "${#failed_modules[@]}" -gt 0 ]; then
+        return 1
+    fi
+}
+
+# Main entry point: orchestrates discovery, require checks, and summary
+neovimRequireCheckHook() {
     echo "Executing neovimRequireCheckHook"
 
-    if [ -n "$nvimRequireCheck" ]; then
-        echo "Check whether the following module can be imported: $nvimRequireCheck"
-
-		# editorconfig-checker-disable
-        export HOME="$TMPDIR"
-
-        local deps="${dependencies[*]}"
-        @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
-            --cmd "set rtp+=$out,${deps// /,}" \
-            --cmd "lua require('$nvimRequireCheck')"
+    if [ "${nvimRequireCheck[*]}" = "" ]; then
+        echo "nvimRequireCheck is empty; entering discovery mode"
+        # Auto-discovery mode
+        if ! discover_modules; then
+            echo "No modules found during discovery; exiting hook"
+            return
+        fi
+    else
+        echo "nvimRequireCheck is pre-populated; entering manual check mode"
     fi
+
+    run_require_checks
+    print_summary
 }
 
 echo "Using neovimRequireCheckHook"
 appendToVar preDistPhases neovimRequireCheckHook
-
-

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -466,6 +466,13 @@ in
 
   cmp-dictionary = super.cmp-dictionary.overrideAttrs (oa: {
     nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+    nvimSkipModule = [
+      # Test files
+      "cmp_dictionary.dict.external_spec"
+      "cmp_dictionary.dict.trie_spec"
+      "cmp_dictionary.lib.trie_spec"
+      "cmp_dictionary.lib.unknown_spec"
+    ];
   });
 
   cmp-digraphs = super.cmp-digraphs.overrideAttrs (oa: {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2897,6 +2897,10 @@ in
       "snacks.terminal"
       "snacks.win"
       "snacks.words"
+      "snacks.debug"
+      "snacks.scratch"
+      # Optional trouble integration
+      "trouble.sources.profiler"
     ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -499,8 +499,15 @@ rec {
       nativeBuildInputs =
         oldAttrs.nativeBuildInputs or [ ]
         ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-          vimCommandCheckHook
           vimGenDocHook
+        ];
+
+      doCheck = oldAttrs.doCheck or true;
+
+      nativeCheckInputs =
+        oldAttrs.nativeCheckInputs or [ ]
+        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+          vimCommandCheckHook
           # many neovim plugins keep using buildVimPlugin
           neovimRequireCheckHook
         ];


### PR DESCRIPTION
This PR introduces automatic Lua module discovery and enhances the existing Lua module checking mechanism by enabling support for multi-module checks within Vim plugins. These changes improve the flexibility and usability of the module validation process for plugin maintainers, helping catch errors and confirm module integrity more effectively.

TODO:
- [x] Parse failures to identify real issues / broken plugins
- [X] Skip plugins with lua modules that can't be required
~- [ ] Cleanup redundant setting in overrides.nix~

### Key Changes

-    #### Automatic Module Discovery:
        If no specific modules are defined in nvimRequireCheck, the script now automatically searches the plugin source for conventional Lua module paths (e.g., lua/name/init.lua or standalone name.lua files).
        This ensures that module checking can occur even if a module list isn’t pre-populated, reducing the need for manual configuration.

```nix
  telescope-nvim = super.telescope-nvim.overrideAttrs {
    dependencies = with self; [ plenary-nvim ];
  };
```

```bash
vimplugin-lua5.1-telescope.nvim-scm> ======================================================
vimplugin-lua5.1-telescope.nvim-scm> Require check succeeded for the following modules:
vimplugin-lua5.1-telescope.nvim-scm>   - telescope/_extensions
vimplugin-lua5.1-telescope.nvim-scm> Stopped after first success in auto-discovery mode.
vimplugin-lua5.1-telescope.nvim-scm> Require check failed for the following modules:
vimplugin-lua5.1-telescope.nvim-scm>   - finders
vimplugin-lua5.1-telescope.nvim-scm>   - entry_manager
vimplugin-lua5.1-telescope.nvim-scm>   - __diagnostics
vimplugin-lua5.1-telescope.nvim-scm>   - linked_list_spec
vimplugin-lua5.1-telescope.nvim-scm>   - __git
vimplugin-lua5.1-telescope.nvim-scm>   - find_files_spec
vimplugin-lua5.1-telescope.nvim-scm> ======================================================
```
-    #### Multi-Module Checking with Configurable Success Logic:
        When nvimRequireCheck is pre-populated, the script now runs checks on all listed modules, providing comprehensive feedback on each module's status.
        In the discovery mode (when nvimRequireCheck starts empty), the script will stop after the first successful check, streamlining the process by stopping early when at least one valid module is confirmed.

```nix
    nvimRequireCheck = [
      "advanced_git_search.utils"
      "advanced_git_search.fzf"
    ];
```

```bash
vimplugin-advanced-git-search.nvim> ======================================================
vimplugin-advanced-git-search.nvim> Require check succeeded for the following modules:
vimplugin-advanced-git-search.nvim>   - advanced_git_search.utils
vimplugin-advanced-git-search.nvim>   - advanced_git_search.fzf
vimplugin-advanced-git-search.nvim> All manually provided modules were checked.
vimplugin-advanced-git-search.nvim> ======================================================
```
-    #### Improved Output Formatting:
        Summaries now use structured, indented bullet points, making the output more organized and easy to interpret.

### Drawbacks

-    #### Potential for Slower Execution:
        If nvimRequireCheck is populated with many modules or if the automatic discovery mode finds a large number of potential modules, this can increase script execution time. The additional checks may slow down validation slightly, especially if running in a CI environment with many modules.

-    #### Overhead in Failure Cases:
        If a plugin has many invalid or incomplete module paths, the script will attempt to check each one, potentially resulting in a lengthy list of failures before finding a valid module. This might require further optimization or fallback handling in future updates.

-    #### Edge Cases with Non-Standard File Structures:
        The automatic discovery relies on conventional file structures (lua/name/init.lua or name.lua). Plugins that don’t follow these conventions may not have all relevant modules discovered, and maintainers might need to still specify nvimRequireCheck manually for non-standard cases.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->






----------------------------
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
