### PR TITLE
armitage: patch for Gradle 8

### DIFF
--- a/pkgs/by-name/ar/armitage/gradle-8.patch
+++ b/pkgs/by-name/ar/armitage/gradle-8.patch
@@ -1,0 +1,28 @@
+Upstream PR: https://github.com/r00t0v3rr1d3/armitage/pull/1
+diff --git a/armitage/build.gradle b/armitage/build.gradle
+index 43a5d08..50ae084 100644
+--- a/armitage/build.gradle
++++ b/armitage/build.gradle
+@@ -19,7 +19,7 @@ jar {
+     from {
+         configurations.compileClasspath.filter { it.exists() }.collect { it.isDirectory() ? it : zipTree(it) }
+     }
+-    archiveName 'armitage.jar'
++    archiveFileName.set 'armitage.jar'
+ }
+ 
+ dependencies {
+diff --git a/cortana/build.gradle b/cortana/build.gradle
+index c7d08bb..aa54635 100644
+--- a/cortana/build.gradle
++++ b/cortana/build.gradle
+@@ -19,7 +19,8 @@ jar {
+     from {
+         configurations.compileClasspath.filter { it.exists() }.collect { it.isDirectory() ? it : zipTree(it) }
+     }
+-    archiveName 'cortana.jar'
++    duplicatesStrategy DuplicatesStrategy.INCLUDE
++    archiveFileName.set 'cortana.jar'
+ }
+ 
+ dependencies {

--- a/pkgs/by-name/ar/armitage/package.nix
+++ b/pkgs/by-name/ar/armitage/package.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , fetchFromGitHub
 , jdk11
-, gradle_6
+, gradle
 , metasploit
 , makeWrapper
 , makeDesktopItem
@@ -14,8 +14,6 @@
 let
   pname = "armitage";
   version = "unstable-2022-12-05";
-
-  gradle = gradle_6;
 
   src = fetchFromGitHub {
     owner = "r00t0v3rr1d3";
@@ -45,6 +43,8 @@ let
       url = "https://gitlab.com/kalilinux/packages/armitage/-/raw/042beb7494a10227761ecb3ddabf4019bbb78681/debian/patches/fix-meterpreter.patch";
       hash = "sha256-p4fs5xFdC2apW0U8x8u9S4p5gq3Eiv+0E4CGccQZYKY=";
     })
+    # Update for Gradle 8 (https://github.com/r00t0v3rr1d3/armitage/pull/1)
+    ./gradle-8.patch
   ];
 
 in


### PR DESCRIPTION
Only one more Gradle 6 usage left to go!

Upstream PR (which includes updating the bundled wrapper scripts and JAR, which we don't need in Nixpkgs): https://github.com/r00t0v3rr1d3/armitage/pull/1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
