### PR TITLE
nixos/scx: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -27,6 +27,9 @@
   This also allows configuring runtime settings of AMDVLK and enabling experimental features.
 - The `moonlight-qt` package ([Moonlight game streaming](https://moonlight-stream.org/)) now has HDR support on Linux systems.
 
+- [Sched-ext](https://github.com/sched-ext/scx), a Linux kernel feature to run schedulers in userspace, is now available [`services.scx`](options.html#opt-services.scx.enable).
+  Requires Linux kernel version 6.12 or later.
+
 - PostgreSQL now defaults to major version 16.
 
 - `authelia` has been upgraded to version 4.38. This version brings several features and improvements which are detailed in the [release blog post](https://www.authelia.com/blog/4.38-release-notes/).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1292,6 +1292,7 @@
   ./services/scheduling/atd.nix
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix
+  ./services/scheduling/scx.nix
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix
   ./services/search/hound.nix

--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.scx;
+in
+{
+  options.services.scx = {
+    enable = lib.mkEnableOption null // {
+      description = ''
+        Whether to enable SCX service, a daemon to run schedulers from userspace.
+
+        ::: {.note}
+        This service requires a kernel with the Sched-ext feature.
+        Generally, kernel version 6.12 and later are supported.
+        :::
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.scx.full;
+      defaultText = lib.literalExpression "pkgs.scx.full";
+      example = lib.literalExpression "pkgs.scx.rustland";
+      description = ''
+        `scx` package to use. `scx.full`, which includes all schedulers, is the default.
+        You may choose a minimal package, such as `pkgs.scx.rustland`, if only one specific scheduler is needed.
+
+        ::: {.note}
+        Overriding this does not change the default scheduler; you should set `services.scx.scheduler` for it.
+        :::
+      '';
+    };
+
+    scheduler = lib.mkOption {
+      type = lib.types.enum [
+        "scx_bpfland"
+        "scx_central"
+        "scx_flatcg"
+        "scx_lavd"
+        "scx_layered"
+        "scx_nest"
+        "scx_pair"
+        "scx_qmap"
+        "scx_rlfifo"
+        "scx_rustland"
+        "scx_rusty"
+        "scx_simple"
+        "scx_userland"
+      ];
+      default = "scx_rustland";
+      example = "scx_bpfland";
+      description = ''
+        Which scheduler to use. See [SCX documentation](https://github.com/sched-ext/scx/tree/main/scheds)
+        for details on each scheduler and guidance on selecting the most suitable one.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.singleLineStr;
+      example = [
+        "--slice-us 5000"
+        "--verbose"
+      ];
+      description = ''
+        Parameters passed to the chosen scheduler at runtime.
+
+        ::: {.note}
+        Run `chosen-scx-scheduler --help` to see the available options. Generally,
+        each scheduler has its own set of options, and they are incompatible with each other.
+        :::
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.scx = {
+      description = "SCX scheduler daemon";
+
+      # SCX service should be started only if the kernel supports sched-ext
+      unitConfig.ConditionPathIsDirectory = "/sys/kernel/sched_ext";
+
+      startLimitIntervalSec = 30;
+      startLimitBurst = 2;
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe' cfg.package cfg.scheduler} ${lib.concatStringsSep " " cfg.extraArgs}";
+        Restart = "on-failure";
+        StandardError = "journal";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12";
+        message = "SCX is only supported on kernel version >= 6.12.";
+      }
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+}


### PR DESCRIPTION
This adds a `services.scx.enable` option to enable sched-ext schedulers.

Requires a kernel with sched-ext enabled (6.12+) or a kernel with the patchset. As of this PR, in Nixpkgs only `linuxPackages_testing` is compatible.

Since kernel upgrades are also backported, this can be backported as well.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux

- [x] Tested, as applicable:
  - With my own configuration
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
