### PR TITLE
python312Packages.numcodecs: 0.12.1 -> 0.13.1

### DIFF
--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -84,6 +84,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zarr-developers/numcodecs";
     license = lib.licenses.mit;
     description = "Buffer compression and transformation codecs for use in data storage and communication applications";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -11,6 +11,7 @@
   setuptools-scm,
   cython,
   py-cpuinfo,
+  pkgconfig,
 
   # dependencies
   numpy,
@@ -19,6 +20,11 @@
   msgpack,
   pytestCheckHook,
   importlib-metadata,
+
+  # buildInputs
+  c-blosc,
+  libzstd,
+  liblz4,
 }:
 
 buildPythonPackage rec {
@@ -33,12 +39,21 @@ buildPythonPackage rec {
     hash = "sha256-o883iB3wiY86nA1Ed9+IEz/oUYW//le6MbzC+iB3Cbw=";
   };
 
+  patches = [
+    # A rebased version of:
+    # https://github.com/zarr-developers/numcodecs/pull/569
+    #
+    # From some reason it fails to apply, even when the PR doesn't merge
+    # conflict:
+    ./system-libs.patch
+  ];
 
   nativeBuildInputs = [
     setuptools
     setuptools-scm
     cython
     py-cpuinfo
+    pkgconfig
   ];
 
   propagatedBuildInputs = [ numpy ];
@@ -48,6 +63,13 @@ buildPythonPackage rec {
     # zfpy = [ zfpy ];
   };
 
+  buildInputs = [
+    c-blosc
+    libzstd
+    liblz4
+  ];
+
+  NUMCODECS_USE_SYSTEM_LIBS = 1;
   preBuild = lib.optionalString (stdenv.hostPlatform.isx86 && !stdenv.hostPlatform.avx2Support) ''
     export DISABLE_NUMCODECS_AVX2=1
   '';

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -56,13 +56,9 @@ buildPythonPackage rec {
     # zfpy = [ zfpy ];
   };
 
-  preBuild =
-    if (stdenv.hostPlatform.isx86 && !stdenv.hostPlatform.avx2Support) then
-      ''
-        export DISABLE_NUMCODECS_AVX2=
-      ''
-    else
-      null;
+  preBuild = lib.optionalString (stdenv.hostPlatform.isx86 && !stdenv.hostPlatform.avx2Support) ''
+    export DISABLE_NUMCODECS_AVX2=1
+  '';
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
   python,
   pythonOlder,
 
@@ -19,28 +18,21 @@
   # tests
   msgpack,
   pytestCheckHook,
+  importlib-metadata,
 }:
 
 buildPythonPackage rec {
   pname = "numcodecs";
-  version = "0.12.1";
+  version = "0.13.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-BdkaQzcz5+7yaNfoDsImoCMtokQolhSo84JpAa7BCY4=";
+    hash = "sha256-o883iB3wiY86nA1Ed9+IEz/oUYW//le6MbzC+iB3Cbw=";
   };
 
-  patches = [
-    # https://github.com/zarr-developers/numcodecs/pull/487
-    (fetchpatch {
-      name = "fix-tests.patch";
-      url = "https://github.com/zarr-developers/numcodecs/commit/4896680087d3ff1f959401c51cf5aea0fd56554e.patch";
-      hash = "sha256-+lMWK5IsNzJ7H2SmLckgxbSSRIIcC7FtGYSBKQtuo+Y=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools
@@ -63,22 +55,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     msgpack
+    importlib-metadata
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/255262
   pytestFlagsArray = [ "$out/${python.sitePackages}/numcodecs" ];
-
-  disabledTests = [
-    "test_backwards_compatibility"
-
-    "test_encode_decode"
-    "test_legacy_codec_broken"
-    "test_bytes"
-
-    # ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
-    # with numpy 1.24
-    "test_non_numpy_inputs"
-  ];
 
   meta = {
     homepage = "https://github.com/zarr-developers/numcodecs";

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -2,17 +2,23 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchpatch,
   fetchPypi,
+  fetchpatch,
+  python,
+  pythonOlder,
+
+  # build-system
   setuptools,
   setuptools-scm,
   cython,
-  numpy,
-  msgpack,
   py-cpuinfo,
+
+  # dependencies
+  numpy,
+
+  # tests
+  msgpack,
   pytestCheckHook,
-  python,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -63,6 +69,7 @@ buildPythonPackage rec {
     msgpack
   ];
 
+  # https://github.com/NixOS/nixpkgs/issues/255262
   pytestFlagsArray = [ "$out/${python.sitePackages}/numcodecs" ];
 
   disabledTests = [
@@ -77,9 +84,9 @@ buildPythonPackage rec {
     "test_non_numpy_inputs"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/zarr-developers/numcodecs";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     description = "Buffer compression and transformation codecs for use in data storage and communication applications";
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/numcodecs/system-libs.patch
+++ b/pkgs/development/python-modules/numcodecs/system-libs.patch
@@ -1,0 +1,197 @@
+diff --git c/setup.py w/setup.py
+index b6db079..d468b10 100644
+--- c/setup.py
++++ w/setup.py
+@@ -9,6 +9,7 @@ import cpuinfo
+ from Cython.Distutils.build_ext import new_build_ext as build_ext
+ from setuptools import Extension, setup
+ from setuptools.errors import CCompilerError, ExecError, PlatformError
++import pkgconfig
+ 
+ # determine CPU support for SSE2 and AVX2
+ cpu_info = cpuinfo.get_cpu_info()
+@@ -17,6 +18,7 @@ have_sse2 = 'sse2' in flags
+ have_avx2 = 'avx2' in flags
+ disable_sse2 = 'DISABLE_NUMCODECS_SSE2' in os.environ
+ disable_avx2 = 'DISABLE_NUMCODECS_AVX2' in os.environ
++use_system_libraries = 'NUMCODECS_USE_SYSTEM_LIBS' in os.environ
+ 
+ # setup common compile arguments
+ have_cflags = 'CFLAGS' in os.environ
+@@ -49,8 +51,8 @@ def error(*msg):
+     print('[numcodecs]', *msg, **kwargs)
+ 
+ 
+-def blosc_extension():
+-    info('setting up Blosc extension')
++def _blosc_extension_with_vendored_libs():
++    info('setting up Blosc extension from vendored sources')
+ 
+     extra_compile_args = base_compile_args.copy()
+     define_macros = []
+@@ -125,8 +127,68 @@ def blosc_extension():
+     return extensions
+ 
+ 
+-def zstd_extension():
+-    info('setting up Zstandard extension')
++def _blosc_extension_with_system_libs():
++    info('setting up Blosc extension with system libraries')
++
++    extra_compile_args = base_compile_args.copy()
++
++    blosc_package_configuration = pkgconfig.parse("blosc")
++
++    define_macros = blosc_package_configuration["define_macros"]
++    include_dirs = blosc_package_configuration["include_dirs"]
++    libraries = blosc_package_configuration["libraries"]
++    library_dirs = blosc_package_configuration["library_dirs"]
++
++    # remove minizip because Python.h 3.8 tries to include crypt.h
++    include_dirs = [d for d in include_dirs if 'minizip' not in d]
++
++    # define_macros += [('CYTHON_TRACE', '1')]
++
++    # SSE2
++    if have_sse2 and not disable_sse2:
++        info('compiling Blosc extension with SSE2 support')
++        extra_compile_args.append('-DSHUFFLE_SSE2_ENABLED')
++        if os.name == 'nt':
++            define_macros += [('__SSE2__', 1)]
++    else:
++        info('compiling Blosc extension without SSE2 support')
++
++    # AVX2
++    if have_avx2 and not disable_avx2:
++        info('compiling Blosc extension with AVX2 support')
++        extra_compile_args.append('-DSHUFFLE_AVX2_ENABLED')
++        if os.name == 'nt':
++            define_macros += [('__AVX2__', 1)]
++    else:
++        info('compiling Blosc extension without AVX2 support')
++
++    sources = ['numcodecs/blosc.pyx']
++
++    # define extension module
++    extensions = [
++        Extension(
++            'numcodecs.blosc',
++            sources=sources,
++            include_dirs=include_dirs,
++            define_macros=define_macros,
++            extra_compile_args=extra_compile_args,
++            libraries=libraries,
++            library_dirs=library_dirs,
++        ),
++    ]
++
++    return extensions
++
++
++def blosc_extension():
++    if use_system_libraries:
++        return _blosc_extension_with_system_libs()
++    else:
++        return _blosc_extension_with_vendored_libs()
++
++
++def _zstd_extension_with_vendored_sources():
++    info('setting up Zstandard extension from vendored sources')
+ 
+     zstd_sources = []
+     extra_compile_args = base_compile_args.copy()
+@@ -167,8 +229,46 @@ def zstd_extension():
+     return extensions
+ 
+ 
+-def lz4_extension():
+-    info('setting up LZ4 extension')
++def _zstd_extension_with_system_libs():
++    info('setting up Zstandard extension with system libraries')
++
++    extra_compile_args = base_compile_args.copy()
++
++    zstd_package_configuration = pkgconfig.parse("libzstd")
++    include_dirs = zstd_package_configuration["include_dirs"]
++    define_macros = zstd_package_configuration["define_macros"]
++    libraries = zstd_package_configuration["libraries"]
++    library_dirs = zstd_package_configuration["library_dirs"]
++
++    # define_macros += [('CYTHON_TRACE', '1')]
++
++    sources = ['numcodecs/zstd.pyx']
++
++    # define extension module
++    extensions = [
++        Extension(
++            'numcodecs.zstd',
++            sources=sources,
++            include_dirs=include_dirs,
++            define_macros=define_macros,
++            extra_compile_args=extra_compile_args,
++            libraries=libraries,
++            library_dirs=library_dirs,
++        ),
++    ]
++
++    return extensions
++
++
++def zstd_extension():
++    if use_system_libraries:
++        return _zstd_extension_with_system_libs()
++    else:
++        return _zstd_extension_with_vendored_sources()
++
++
++def _lz4_extension_with_vendored_sources():
++    info('setting up LZ4 extension from vendored sources')
+ 
+     extra_compile_args = base_compile_args.copy()
+     define_macros = []
+@@ -195,6 +295,45 @@ def lz4_extension():
+     return extensions
+ 
+ 
++def _lz4_extension_with_system_libs():
++    info('setting up LZ4 extension with system libraries')
++
++    extra_compile_args = base_compile_args.copy()
++
++    lz4_package_configuration = pkgconfig.parse("liblz4")
++    include_dirs = lz4_package_configuration["include_dirs"]
++    define_macros = lz4_package_configuration["define_macros"]
++    libraries = lz4_package_configuration["libraries"]
++    library_dirs = lz4_package_configuration["library_dirs"]
++
++    include_dirs += ['numcodecs']
++    # define_macros += [('CYTHON_TRACE', '1')]
++
++    sources = ['numcodecs/lz4.pyx']
++
++    # define extension module
++    extensions = [
++        Extension(
++            'numcodecs.lz4',
++            sources=sources,
++            include_dirs=include_dirs,
++            define_macros=define_macros,
++            extra_compile_args=extra_compile_args,
++            libraries=libraries,
++            library_dirs=library_dirs,
++        ),
++    ]
++
++    return extensions
++
++
++def lz4_extension():
++    if use_system_libraries:
++        return _lz4_extension_with_system_libs()
++    else:
++        return _lz4_extension_with_vendored_sources()
++
++
+ def vlen_extension():
+     info('setting up vlen extension')
+     import numpy

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -1,15 +1,20 @@
 {
   lib,
-  asciitree,
   buildPythonPackage,
-  fasteners,
   fetchPypi,
-  numcodecs,
-  msgpack,
-  numpy,
-  pytestCheckHook,
   pythonOlder,
+
+  # build-system
   setuptools-scm,
+
+  # dependencies
+  asciitree,
+  numpy,
+  fasteners,
+  numcodecs,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -24,24 +29,28 @@ buildPythonPackage rec {
     hash = "sha256-m7OTuKCjj7Eh27kTsEfXXbKN6YkPbWRKIXpzz0rnT0c=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [
+    setuptools-scm
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     asciitree
     numpy
     fasteners
     numcodecs
   ] ++ numcodecs.optional-dependencies.msgpack;
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "zarr" ];
 
-  meta = with lib; {
+  meta = {
     description = "Implementation of chunked, compressed, N-dimensional arrays for Python";
     homepage = "https://github.com/zarr-developers/zarr";
     changelog = "https://github.com/zarr-developers/zarr-python/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "zarr";
-  version = "2.18.2";
+  version = "2.18.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-m7OTuKCjj7Eh27kTsEfXXbKN6YkPbWRKIXpzz0rnT0c=";
+    hash = "sha256-JYDYy23YRiF3GhDTHE13fcqKJ3BqGomyn0LS034t9c4=";
   };
 
   build-system = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9127,7 +9127,10 @@ self: super: with self; {
 
   numba-scipy = callPackage ../development/python-modules/numba-scipy { };
 
-  numcodecs = callPackage ../development/python-modules/numcodecs { };
+  numcodecs = callPackage ../development/python-modules/numcodecs {
+    libzstd = pkgs.zstd;
+    liblz4 = pkgs.lz4;
+  };
 
   numdifftools = callPackage ../development/python-modules/numdifftools { };
 


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
