### PR TITLE
zookeeper: 3.9.2 -> 3.9.3

### DIFF
--- a/pkgs/development/libraries/zookeeper_mt/default.nix
+++ b/pkgs/development/libraries/zookeeper_mt/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${zookeeper.pname}-${version}/apache-${zookeeper.pname}-${version}.tar.gz";
-    hash = "sha512-G6Yw9HBF43QCw8FTLnJ7boCjUYwaQVQAT4wXqUowSlzox1cUPH5+8ZYMBxToJCbr0ppmz22t0uKsHRUI/IDAPQ==";
+    hash = "sha512-eo/9yeSPbik+5f3g3uc//N0aTx5VS0KCzkA/+wn/FFtAmHwnLex1GZOoOlQwly4KU10Y+pgY1shKab/aigPSFg==";
   };
 
   sourceRoot = "apache-${zookeeper.pname}-${version}/zookeeper-client/zookeeper-client-c";

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -6,11 +6,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "zookeeper";
-  version = "3.9.2";
+  version = "3.9.3";
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${pname}-${version}/apache-${pname}-${version}-bin.tar.gz";
-    hash = "sha512-K1rgLWGKJ8qM1UkkhV1TRCY7fZ3udgGB+dZrr6kjAyTSrTF4aJXwZUyWncONSj0Ad/dMw3a1i1+i+5S+satEXw==";
+    hash = "sha512-1E2HDBaRZi778ai68YWckBuCDcX/Fjs26BvrJ7b7880xtfHwdWl+2q9tPnpMsMyS+STc/2SylO8T1TVYm9rxQw==";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Release notes:

https://zookeeper.apache.org/doc/r3.9.3/releasenotes.html

(No known breaking changes.)

## Things done

- Translated checksums from Apache release using `nix hash to-sri --type sha512` (no TOFU);
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  > Also tested a number of features as part of an Apache vote:
  https://lists.apache.org/thread/rk9466sjzyyrh5m545frdb4q3jybwsfx
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  > (No major changes.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
