### PR TITLE
NixOS: clean up toplevel package attrset and add `meta.mainProgram`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -59,6 +59,7 @@
   - The `apply` script reduces the roundtrips required when performing a remote deployment with `nixos-rebuild switch --target-host HOST`.
   - Developers and power users can now update NixOS in a single call.
   - Alternative NixOS deployment methods have feature parity with `nixos-rebuild`, and NixOS can evolve all of its switching logic in one place.
+  - It is now possible to update a NixOS system locally with `nix run -- <config>.config.system.build.toplevel switch`, e.g. `nix run -- ~/config#nixosConfigurations.my-machine.config.system.build.toplevel switch`.
 
 - Support for mounting filesystems from block devices protected with [dm-verity](https://docs.kernel.org/admin-guide/device-mapper/verity.html)
   was added through the `boot.initrd.systemd.dmVerity` option.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -8,6 +8,7 @@ let
     mkOption
     mkRemovedOptionModule
     mkRenamedOptionModule
+    optionalAttrs
     optionalString
     showWarnings
     types
@@ -31,7 +32,7 @@ let
 
       ln -s ${config.system.build.etc}/etc $out/etc
 
-      ${lib.optionalString config.system.etc.overlay.enable ''
+      ${optionalString config.system.etc.overlay.enable ''
         ln -s ${config.system.build.etcMetadataImage} $out/etc-metadata-image
         ln -s ${config.system.build.etcBasedir} $out/etc-basedir
       ''}
@@ -147,7 +148,7 @@ let
       name = topLevelName;
       position = __curPos;
       unsupported = false;
-    } // lib.optionalAttrs config.system.switch.enable {
+    } // optionalAttrs config.system.switch.enable {
       mainProgram = "apply";
     };
   };
@@ -231,7 +232,7 @@ in
       internal = true;
       default = {};
       description = ''
-        `lib.mkDerivation` attributes that will be passed to the top level system builder.
+        `stdenv.mkDerivation` attributes that will be passed to the top level system builder.
       '';
     };
 
@@ -282,7 +283,7 @@ in
     system.replaceDependencies = {
       replacements = mkOption {
         default = [];
-        example = lib.literalExpression "[ ({ oldDependency = pkgs.openssl; newDependency = pkgs.callPackage /path/to/openssl { }; }) ]";
+        example = literalExpression "[ ({ oldDependency = pkgs.openssl; newDependency = pkgs.callPackage /path/to/openssl { }; }) ]";
         type = types.listOf (types.submodule (
           { ... }: {
             imports = [
@@ -380,7 +381,7 @@ in
             "$out/configuration.nix"
         '' +
       optionalString
-        (config.system.forbiddenDependenciesRegexes != []) (lib.concatStringsSep "\n" (map (regex: ''
+        (config.system.forbiddenDependenciesRegexes != []) (concatStringsSep "\n" (map (regex: ''
           if [[ ${regex} != "" && -n $closureInfo ]]; then
             if forbiddenPaths="$(grep -E -- "${regex}" $closureInfo/store-paths)"; then
               echo -e "System closure $out contains the following disallowed paths:\n$forbiddenPaths"
@@ -409,7 +410,7 @@ in
       # option, as opposed to `system.extraDependencies`.
       passedChecks = concatStringsSep " " config.system.checks;
     }
-    // lib.optionalAttrs (config.system.forbiddenDependenciesRegexes != []) {
+    // optionalAttrs (config.system.forbiddenDependenciesRegexes != []) {
       closureInfo = pkgs.closureInfo { rootPaths = [
         # override to avoid  infinite recursion (and to allow using extraDependencies to add forbidden dependencies)
         (config.system.build.toplevel.overrideAttrs (_: { extraDependencies = []; closureInfo = null; }))

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -1,8 +1,18 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    concatStringsSep
+    filter
+    literalExpression
+    mkOption
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    optionalString
+    showWarnings
+    types
+    ;
+
   systemBuilder =
     ''
       mkdir $out

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -137,6 +137,8 @@ let
       name = topLevelName;
       position = __curPos;
       unsupported = false;
+    } // lib.optionalAttrs config.system.switch.enable {
+      mainProgram = "apply";
     };
   };
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -46,13 +46,15 @@ let
       ${config.system.extraSystemBuilderCmds}
     '';
 
+  topLevelName = "nixos-system-${config.system.name}-${config.system.nixos.label}";
+
   # Putting it all together.  This builds a store path containing
   # symlinks to the various parts of the built configuration (the
   # kernel, systemd units, init scripts, etc.) as well as a script
   # `bin/apply` that activates the configuration and
   # makes it bootable. See `activatable-system.nix` and `switchable-system.nix`.
   baseSystem = pkgs.stdenvNoCC.mkDerivation ({
-    name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
+    name = topLevelName;
     preferLocalBuild = true;
     allowSubstitutes = false;
     passAsFile = [ "extraDependencies" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Follow-up to https://github.com/NixOS/nixpkgs/pull/344407

## Things done

- Make `nix run -- <toplevel> switch` work.
- Remove uncontrolled attributes from the toplevel package attrset; see code comment.
  - Without this, I wouldn't know where to put `meta`, so I figured we could just fix this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
