### PR TITLE
qt6.wrapQtAppsHook: add `qtwayland` to `propagatedBuildInputs`

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -29,9 +29,9 @@ Any Qt package should include `wrapQtAppsHook` or `wrapQtAppsNoGuiHook` in `nati
 
 ::: {.note}
 
-`wrapQtAppsHook` propagates plugins and QML components from `qtwayland` to ensure the Wayland platform plugin is available, which is required for graphical applications to run under Wayland on non-Qt based desktops. On platforms that do not support `qtwayland` (e.g. Darwin), only plugins `qtbase` will be propagated.
+`wrapQtAppsHook` propagates plugins and QML components from `qtwayland` on platforms that support it, to allow applications to act as native Wayland clients. It should be used for all graphical applications.
 
-`wrapQtAppsNoGuiHook` does not propagate `qtwayland` reduce closure size for purely command-line applications.
+`wrapQtAppsNoGuiHook` does not propagate `qtwayland` to reduce closure size for purely command-line applications.
 
 :::
 

--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -25,12 +25,14 @@ stdenv.mkDerivation {
 
 The same goes for Qt 5 where libraries and tools are under `libsForQt5`.
 
-Any Qt package should include `wrapQtAppsHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
+Any Qt package should include `wrapQtAppsHook` or `wrapQtAppsNoGuiHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
 
 ::: {.note}
-Qt 6 graphical applications should also include `qtwayland` in `buildInputs` on Linux (but not on platforms e.g. Darwin, where `qtwayland` is not available), to ensure the Wayland platform plugin is available.
 
-This may become default in the future, see [NixOS/nixpkgs#269674](https://github.com/NixOS/nixpkgs/pull/269674).
+`wrapQtAppsHook` propagates plugins and QML components from `qtwayland` to ensure the Wayland platform plugin is available, which is required for graphical applications to run under Wayland on non-Qt based desktops. On platforms that do not support `qtwayland` (e.g. Darwin), only plugins `qtbase` will be propagated.
+
+`wrapQtAppsNoGuiHook` does not propagate `qtwayland` reduce closure size for purely command-line applications.
+
 :::
 
 ## Packages supporting multiple Qt versions {#qt-versions}

--- a/pkgs/applications/graphics/pineapple-pictures/default.nix
+++ b/pkgs/applications/graphics/pineapple-pictures/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , qtsvg
-, qtwayland
 , qttools
 , exiv2
 , wrapQtAppsHook
@@ -28,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     qtsvg
-    qtwayland
     exiv2
   ];
 

--- a/pkgs/desktops/deepin/core/dde-application-manager/default.nix
+++ b/pkgs/desktops/deepin/core/dde-application-manager/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qt6Packages.wrapQtAppsHook
+    qt6Packages.wrapQtAppsNoGuiHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -172,6 +172,14 @@ let
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 
+      wrapQtAppsNoGuiHook = callPackage
+        ({ makeBinaryWrapper }: makeSetupHook
+          {
+            name = "wrap-qt6-apps-no-gui-hook";
+            propagatedBuildInputs = [ makeBinaryWrapper ];
+          } ./hooks/wrap-qt-apps-hook.sh)
+        { };
+
       qmake = callPackage
         ({ qtbase }: makeSetupHook
           {

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -168,7 +168,7 @@ let
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ makeBinaryWrapper ];
-            depsTargetTargetPropagated = lib.optionals stdenv.isLinux [ qtwayland.out ];
+            depsTargetTargetPropagated = lib.optionals (lib.meta.availableOn stdenv.targetPlatform qtwayland) [ qtwayland.out ];
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -164,10 +164,11 @@ let
       qtwebview = callPackage ./modules/qtwebview.nix { };
 
       wrapQtAppsHook = callPackage
-        ({ makeBinaryWrapper }: makeSetupHook
+        ({ makeBinaryWrapper, qtwayland }: makeSetupHook
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ makeBinaryWrapper ];
+            depsTargetTargetPropagated = lib.optionals stdenv.isLinux [ qtwayland.out ];
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -75,9 +75,9 @@ else # Only set up Qt once.
     fi
 
     qtPreHook() {
-        # Check that wrapQtAppsHook is used, or it is explicitly disabled.
+        # Check that wrapQtAppsHook/wrapQtAppsNoGuiHook is used, or it is explicitly disabled.
         if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
-            echo >&2 "Error: wrapQtAppsHook is not used, and dontWrapQtApps is not set."
+            echo >&2 "Error: neither wrapQtAppsHook nor wrapQtAppsNoGuiHook are used, and dontWrapQtApps is not set either."
             exit 1
         fi
     }

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -77,7 +77,10 @@ else # Only set up Qt once.
     qtPreHook() {
         # Check that wrapQtAppsHook/wrapQtAppsNoGuiHook is used, or it is explicitly disabled.
         if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
-            echo >&2 "Error: neither wrapQtAppsHook nor wrapQtAppsNoGuiHook are used, and dontWrapQtApps is not set either."
+            echo >&2 "Error: this derivation depends on qtbase, but no wrapping behavior was specified."
+            echo >&2 "  - If this is a graphical application, add wrapQtAppsHook to nativeBuildInputs"
+            echo >&2 "  - If this is a CLI application, add wrapQtAppsNoGuiHook to nativeBuildInputs"
+            echo >&2 "  - If this is a library or you need custom wrapping logic, set dontWrapQtApps = true"
             exit 1
         fi
     }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -1,4 +1,5 @@
-{ qtModule
+{ lib
+, qtModule
 , qtbase
 , qtdeclarative
 , wayland
@@ -22,4 +23,9 @@ qtModule {
   postPatch = ''
     cp ${wayland-scanner}/share/wayland/wayland.xml src/3rdparty/protocol/wayland/wayland.xml
   '';
+
+  meta = {
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+  };
 }


### PR DESCRIPTION
Cont of https://github.com/NixOS/nixpkgs/pull/333012

- **qt6.wrapQtAppsHook: add `qtwayland` to `propagatedBuildInputs`**
- **qt6.wrapQtAppsNoGuiHook: init**
- **qt6.qtwayland: set meta.{platforms,badPlatforms}**
- **doc/qt: mention wrapQtAppsNoGuiHook**
- **qtbase-setup-hook: add wrapQtAppsNoGuiHook to error message**
- **deepin.dde-application-manager: use wrapQtAppsNoGuiHook to avoid propagating qtwayland**
- **pineapple-pictures: let wrapQtAppsHook propagate qtwayland**
