### PR TITLE
whitesur-gtk-theme: 2024-05-01 -> 2024.09.02

### DIFF
--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -2,8 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , gitUpdater
+, dialog
 , glib
-, gnome-shell
 , gnome-themes-extra
 , jdupes
 , libxml2
@@ -32,7 +32,7 @@ lib.checkListOfEnum "${pname}: alt variants" [ "normal" "alt" "all" ] altVariant
 lib.checkListOfEnum "${pname}: color variants" [ "Light" "Dark" ] colorVariants
 lib.checkListOfEnum "${pname}: opacity variants" [ "normal" "solid" ] opacityVariants
 lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
-lib.checkListOfEnum "${pname}: Activities icon variants" [ "standard" "simple" "gnome" "ubuntu" "tux" "arch" "manjaro" "fedora" "debian" "void" "opensuse" "popos" "mxlinux" "zorin" "budgie" "gentoo" ] (single iconVariant)
+lib.checkListOfEnum "${pname}: activities icon variants" [ "standard" "apple" "simple" "gnome" "ubuntu" "tux" "arch" "manjaro" "fedora" "debian" "void" "opensuse" "popos" "mxlinux" "zorin" "budgie" "gentoo" ] (single iconVariant)
 lib.checkListOfEnum "${pname}: nautilus style" [ "stable" "normal" "mojave" "glassy" ] (single nautilusStyle)
 lib.checkListOfEnum "${pname}: nautilus sidebar minimum width" [ "default" "180" "220" "240" "260" "280" ] (single nautilusSize)
 lib.checkListOfEnum "${pname}: panel opacity" [ "default" "30" "45" "60" "75" ] (single panelOpacity)
@@ -40,18 +40,18 @@ lib.checkListOfEnum "${pname}: panel size" [ "default" "smaller" "bigger" ] (sin
 
 stdenv.mkDerivation rec {
   pname = "whitesur-gtk-theme";
-  version = "2024-05-01";
+  version = "2024.09.02";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "sha256-NgmFQtgVJvVXJjZUXt/BIx1hdzjHfVmmwXUCDZZD7+g=";
+    hash = "sha256-a32iHPcbMYuBy65FWm/fkjwJQE3aVScR3WJJzKTVx9k=";
   };
 
   nativeBuildInputs = [
+    dialog
     glib
-    gnome-shell
     jdupes
     libxml2
     sassc
@@ -68,10 +68,10 @@ stdenv.mkDerivation rec {
     done
 
     # Do not provide `sudo`, as it is not needed in our use case of the install script
-    substituteInPlace shell/lib-core.sh --replace '$(which sudo)' false
+    substituteInPlace shell/lib-core.sh --replace-fail '$(which sudo)' false
 
     # Provides a dummy home directory
-    substituteInPlace shell/lib-core.sh --replace 'MY_HOME=$(getent passwd "''${MY_USERNAME}" | cut -d: -f6)' 'MY_HOME=/tmp'
+    substituteInPlace shell/lib-core.sh --replace-fail 'MY_HOME=$(getent passwd "''${MY_USERNAME}" | cut -d: -f6)' 'MY_HOME=/tmp'
   '';
 
   dontBuild = true;
@@ -81,19 +81,19 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/themes
 
-    ./install.sh  \
+    ./install.sh \
       ${toString (map (x: "--alt " + x) altVariants)} \
       ${toString (map (x: "--color " + x) colorVariants)} \
       ${toString (map (x: "--opacity " + x) opacityVariants)} \
       ${toString (map (x: "--theme " + x) themeVariants)} \
-      ${lib.optionalString (iconVariant != null) ("--icon " + iconVariant)} \
-      ${lib.optionalString (nautilusStyle != null) ("--nautilus-style " + nautilusStyle)} \
+      ${lib.optionalString (nautilusStyle != null) ("--nautilus " + nautilusStyle)} \
       ${lib.optionalString (nautilusSize != null) ("--size " + nautilusSize)} \
-      ${lib.optionalString (panelOpacity != null) ("--panel-opacity " + panelOpacity)} \
-      ${lib.optionalString (panelSize != null) ("--panel-size " + panelSize)} \
       ${lib.optionalString roundedMaxWindow "--roundedmaxwindow"} \
       ${lib.optionalString nordColor "--nordcolor"} \
       ${lib.optionalString darkerColor "--darkercolor"} \
+      ${lib.optionalString (iconVariant != null) ("--gnome-shell -i " + iconVariant)} \
+      ${lib.optionalString (panelSize != null) ("--gnome-shell -height " + panelSize)} \
+      ${lib.optionalString (panelOpacity != null) ("--gnome-shell -panelopacity " + panelOpacity)} \
       --dest $out/share/themes
 
     jdupes --quiet --link-soft --recurse $out/share


### PR DESCRIPTION
Update to version [2024.09.02](https://github.com/vinceliuice/WhiteSur-gtk-theme/releases/tag/2024.09.02)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
