### PR TITLE
nixos/lomiri: Better support stand-alone greeter usage

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -1,8 +1,14 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 let
   cfg = config.services.desktopManager.lomiri;
-in {
+in
+{
   options.services.desktopManager.lomiri = {
     enable = lib.mkEnableOption ''
       the Lomiri graphical shell (formerly known as Unity8)
@@ -11,42 +17,46 @@ in {
 
   config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = (with pkgs; [
-        glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
-        libayatana-common
-        ubports-click
-      ]) ++ (with pkgs.lomiri; [
-        hfd-service
-        history-service
-        libusermetrics
-        lomiri
-        lomiri-calculator-app
-        lomiri-camera-app
-        lomiri-clock-app
-        lomiri-content-hub
-        lomiri-docviewer-app
-        lomiri-download-manager
-        lomiri-filemanager-app
-        lomiri-gallery-app
-        lomiri-polkit-agent
-        lomiri-schemas # exposes some required dbus interfaces
-        lomiri-session # wrappers to properly launch the session
-        lomiri-sounds
-        lomiri-system-settings
-        lomiri-terminal-app
-        lomiri-thumbnailer
-        lomiri-url-dispatcher
-        lomiri-wallpapers
-        mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
-        morph-browser
-        qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
-        suru-icon-theme
-        telephony-service
-        teleports
-      ]);
+      systemPackages =
+        (with pkgs; [
+          glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
+          libayatana-common
+          ubports-click
+        ])
+        ++ (with pkgs.lomiri; [
+          hfd-service
+          history-service
+          libusermetrics
+          lomiri
+          lomiri-calculator-app
+          lomiri-camera-app
+          lomiri-clock-app
+          lomiri-content-hub
+          lomiri-docviewer-app
+          lomiri-download-manager
+          lomiri-filemanager-app
+          lomiri-gallery-app
+          lomiri-polkit-agent
+          lomiri-schemas # exposes some required dbus interfaces
+          lomiri-session # wrappers to properly launch the session
+          lomiri-sounds
+          lomiri-system-settings
+          lomiri-terminal-app
+          lomiri-thumbnailer
+          lomiri-url-dispatcher
+          lomiri-wallpapers
+          mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
+          morph-browser
+          qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
+          suru-icon-theme
+          telephony-service
+          teleports
+        ]);
 
       # To override the default keyboard layout in Lomiri
-      etc.${pkgs.lomiri.lomiri.passthru.etcLayoutsFile}.text = lib.strings.replaceStrings [","] ["\n"] config.services.xserver.xkb.layout;
+      etc.${pkgs.lomiri.lomiri.passthru.etcLayoutsFile}.text = lib.strings.replaceStrings [ "," ] [
+        "\n"
+      ] config.services.xserver.xkb.layout;
     };
 
     hardware = {
@@ -84,21 +94,26 @@ in {
 
     services.ayatana-indicators = {
       enable = true;
-      packages = (with pkgs; [
-        ayatana-indicator-datetime
-        ayatana-indicator-display
-        ayatana-indicator-messages
-        ayatana-indicator-power
-        ayatana-indicator-session
-      ] ++ lib.optionals config.hardware.bluetooth.enable [
-        ayatana-indicator-bluetooth
-      ] ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
-        ayatana-indicator-sound
-      ]) ++ (with pkgs.lomiri; [
-        telephony-service
-      ] ++ lib.optionals config.networking.networkmanager.enable [
-        lomiri-indicator-network
-      ]);
+      packages =
+        (
+          with pkgs;
+          [
+            ayatana-indicator-datetime
+            ayatana-indicator-display
+            ayatana-indicator-messages
+            ayatana-indicator-power
+            ayatana-indicator-session
+          ]
+          ++ lib.optionals config.hardware.bluetooth.enable [ ayatana-indicator-bluetooth ]
+          ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+            ayatana-indicator-sound
+          ]
+        )
+        ++ (
+          with pkgs.lomiri;
+          [ telephony-service ]
+          ++ lib.optionals config.networking.networkmanager.enable [ lomiri-indicator-network ]
+        );
     };
 
     services.udisks2.enable = true;
@@ -159,7 +174,13 @@ in {
 
       "lomiri-polkit-agent" = rec {
         description = "Lomiri Polkit agent";
-        wantedBy = [ "lomiri.service" "lomiri-full-greeter.service" "lomiri-full-shell.service" "lomiri-greeter.service" "lomiri-shell.service" ];
+        wantedBy = [
+          "lomiri.service"
+          "lomiri-full-greeter.service"
+          "lomiri-full-shell.service"
+          "lomiri-greeter.service"
+          "lomiri-shell.service"
+        ];
         after = [ "graphical-session.target" ];
         partOf = wantedBy;
         serviceConfig = {
@@ -172,17 +193,19 @@ in {
 
     systemd.services = {
       "dbus-com.lomiri.UserMetrics" = {
-        serviceConfig = {
-          Type = "dbus";
-          BusName = "com.lomiri.UserMetrics";
-          User = "usermetrics";
-          StandardOutput = "syslog";
-          SyslogIdentifier = "com.lomiri.UserMetrics";
-          ExecStart = "${pkgs.lomiri.libusermetrics}/libexec/libusermetrics/usermetricsservice";
-        } // lib.optionalAttrs (!config.security.apparmor.enable) {
-          # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, auth must be disabled when not using AppArmor, lest the next database usage breaks
-          Environment = "USERMETRICS_NO_AUTH=1";
-        };
+        serviceConfig =
+          {
+            Type = "dbus";
+            BusName = "com.lomiri.UserMetrics";
+            User = "usermetrics";
+            StandardOutput = "syslog";
+            SyslogIdentifier = "com.lomiri.UserMetrics";
+            ExecStart = "${pkgs.lomiri.libusermetrics}/libexec/libusermetrics/usermetricsservice";
+          }
+          // lib.optionalAttrs (!config.security.apparmor.enable) {
+            # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, auth must be disabled when not using AppArmor, lest the next database usage breaks
+            Environment = "USERMETRICS_NO_AUTH=1";
+          };
       };
     };
 

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -13,211 +13,246 @@ in
     enable = lib.mkEnableOption ''
       the Lomiri graphical shell (formerly known as Unity8)
     '';
+
+    basics = lib.mkOption {
+      internal = true;
+      description = ''
+        Enable basic things for getting Lomiri working.
+      '';
+      type = lib.types.bool;
+      default = config.services.xserver.displayManager.lightdm.greeters.lomiri.enable || cfg.enable;
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment = {
-      systemPackages =
-        (with pkgs; [
-          glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
-          libayatana-common
-          ubports-click
-        ])
-        ++ (with pkgs.lomiri; [
-          hfd-service
-          history-service
-          libusermetrics
-          lomiri
-          lomiri-calculator-app
-          lomiri-camera-app
-          lomiri-clock-app
-          lomiri-content-hub
-          lomiri-docviewer-app
-          lomiri-download-manager
-          lomiri-filemanager-app
-          lomiri-gallery-app
-          lomiri-polkit-agent
-          lomiri-schemas # exposes some required dbus interfaces
-          lomiri-session # wrappers to properly launch the session
-          lomiri-sounds
-          lomiri-system-settings
-          lomiri-terminal-app
-          lomiri-thumbnailer
-          lomiri-url-dispatcher
-          lomiri-wallpapers
-          mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
-          morph-browser
-          qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
-          suru-icon-theme
-          telephony-service
-          teleports
-        ]);
+  config = lib.mkMerge [
+    # Basics for getting Lomiri to work
+    (lib.mkIf cfg.basics {
+      environment = {
+        # To override the default keyboard layout in Lomiri
+        etc.${pkgs.lomiri.lomiri.passthru.etcLayoutsFile}.text = lib.strings.replaceStrings [ "," ] [
+          "\n"
+        ] config.services.xserver.xkb.layout;
 
-      # To override the default keyboard layout in Lomiri
-      etc.${pkgs.lomiri.lomiri.passthru.etcLayoutsFile}.text = lib.strings.replaceStrings [ "," ] [
-        "\n"
-      ] config.services.xserver.xkb.layout;
-    };
+        pathsToLink = [
+          # Data
+          "/share/locale" # TODO LUITK hardcoded default locale path, fix individual apps to not rely on it
+          "/share/wallpapers"
+        ];
 
-    hardware = {
-      bluetooth.enable = lib.mkDefault true;
-    };
+        systemPackages = with pkgs.lomiri; [
+          lomiri-wallpapers # default + additional wallpaper
+          suru-icon-theme # basic indicator icons
+        ];
+      };
 
-    networking.networkmanager.enable = lib.mkDefault true;
+      fonts.packages = with pkgs; [
+        ubuntu-classic # Ubuntu is default font
+      ];
 
-    systemd.packages = with pkgs.lomiri; [
-      hfd-service
-      lomiri-download-manager
-    ];
+      # Xwayland is partly hardcoded in Mir so it can't really be fully turned off, and it must be on PATH for X11 apps *and Lomiri's web browser* to work.
+      # Until Mir/Lomiri can be properly used without it, force it on so everything behaves as expected.
+      programs.xwayland.enable = lib.mkForce true;
 
-    services.dbus.packages = with pkgs.lomiri; [
-      hfd-service
-      libusermetrics
-      lomiri-download-manager
-    ];
-
-    fonts.packages = with pkgs; [
-      # Applications tend to default to Ubuntu font
-      ubuntu-classic
-    ];
-
-    # Copy-pasted basic stuff
-    hardware.graphics.enable = lib.mkDefault true;
-    fonts.enableDefaultPackages = lib.mkDefault true;
-    programs.dconf.enable = lib.mkDefault true;
-
-    # Xwayland is partly hardcoded in Mir so it can't really be fully turned off, and it must be on PATH for X11 apps *and Lomiri's web browser* to work.
-    # Until Mir/Lomiri can be properly used without it, force it on so everything behaves as expected.
-    programs.xwayland.enable = lib.mkForce true;
-
-    services.accounts-daemon.enable = true;
-
-    services.ayatana-indicators = {
-      enable = true;
-      packages =
-        (
+      services.ayatana-indicators = {
+        enable = true;
+        packages = (
           with pkgs;
           [
-            ayatana-indicator-datetime
-            ayatana-indicator-display
-            ayatana-indicator-messages
-            ayatana-indicator-power
-            ayatana-indicator-session
+            ayatana-indicator-datetime # Clock
+            ayatana-indicator-session # Controls for shutting down etc
           ]
-          ++ lib.optionals config.hardware.bluetooth.enable [ ayatana-indicator-bluetooth ]
-          ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
-            ayatana-indicator-sound
-          ]
-        )
-        ++ (
-          with pkgs.lomiri;
-          [ telephony-service ]
-          ++ lib.optionals config.networking.networkmanager.enable [ lomiri-indicator-network ]
         );
-    };
+      };
+    })
 
-    services.udisks2.enable = true;
-    services.upower.enable = true;
-    services.geoclue2.enable = true;
+    # Full Lomiri DE
+    (lib.mkIf cfg.enable {
+      # We need the basic setup as well
+      services.desktopManager.lomiri.basics = true;
 
-    services.gnome.evolution-data-server = {
-      enable = true;
-      plugins = with pkgs; [
-        # TODO: lomiri.address-book-service
+      environment = {
+        systemPackages =
+          (with pkgs; [
+            glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
+            libayatana-common
+            ubports-click
+          ])
+          ++ (with pkgs.lomiri; [
+            hfd-service
+            history-service
+            libusermetrics
+            lomiri
+            lomiri-calculator-app
+            lomiri-camera-app
+            lomiri-clock-app
+            lomiri-content-hub
+            lomiri-docviewer-app
+            lomiri-download-manager
+            lomiri-filemanager-app
+            lomiri-gallery-app
+            lomiri-polkit-agent
+            lomiri-schemas # exposes some required dbus interfaces
+            lomiri-session # wrappers to properly launch the session
+            lomiri-sounds
+            lomiri-system-settings
+            lomiri-terminal-app
+            lomiri-thumbnailer
+            lomiri-url-dispatcher
+            mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
+            morph-browser
+            qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
+            telephony-service
+            teleports
+          ]);
+      };
+
+      hardware = {
+        bluetooth.enable = lib.mkDefault true;
+      };
+
+      networking.networkmanager.enable = lib.mkDefault true;
+
+      systemd.packages = with pkgs.lomiri; [
+        hfd-service
+        lomiri-download-manager
       ];
-    };
 
-    services.telepathy.enable = true;
+      services.dbus.packages = with pkgs.lomiri; [
+        hfd-service
+        libusermetrics
+        lomiri-download-manager
+      ];
 
-    services.displayManager = {
-      defaultSession = lib.mkDefault "lomiri";
-      sessionPackages = with pkgs.lomiri; [ lomiri-session ];
-    };
+      # Copy-pasted basic stuff
+      hardware.graphics.enable = lib.mkDefault true;
+      fonts.enableDefaultPackages = lib.mkDefault true;
+      programs.dconf.enable = lib.mkDefault true;
 
-    services.xserver = {
-      enable = lib.mkDefault true;
-      displayManager.lightdm = {
-        enable = lib.mkDefault true;
-        greeters.lomiri.enable = lib.mkDefault true;
-      };
-    };
+      services.accounts-daemon.enable = true;
 
-    environment.pathsToLink = [
-      # Configs for inter-app data exchange system
-      "/share/lomiri-content-hub/peers"
-      # Configs for inter-app URL requests
-      "/share/lomiri-url-dispatcher/urls"
-      # Splash screens & other images for desktop apps launched via lomiri-app-launch
-      "/share/lomiri-app-launch"
-      # TODO Try to get maliit stuff working
-      "/share/maliit/plugins"
-      # At least the network indicator is still under the unity name, due to leftover Unity-isms
-      "/share/unity"
-      # Data
-      "/share/locale" # TODO LUITK hardcoded default locale path, fix individual apps to not rely on it
-      "/share/sounds"
-      "/share/wallpapers"
-    ];
-
-    systemd.user.services = {
-      # Unconditionally run service that collects system-installed URL handlers before LUD
-      # TODO also run user-installed one?
-      "lomiri-url-dispatcher-update-system-dir" = {
-        description = "Lomiri URL dispatcher system directory updater";
-        wantedBy = [ "lomiri-url-dispatcher.service" ];
-        before = [ "lomiri-url-dispatcher.service" ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${pkgs.lomiri.lomiri-url-dispatcher}/libexec/lomiri-url-dispatcher/lomiri-update-directory /run/current-system/sw/share/lomiri-url-dispatcher/urls/";
-        };
+      services.ayatana-indicators = {
+        enable = true;
+        packages =
+          (
+            with pkgs;
+            [
+              ayatana-indicator-display
+              ayatana-indicator-messages
+              ayatana-indicator-power
+            ]
+            ++ lib.optionals config.hardware.bluetooth.enable [ ayatana-indicator-bluetooth ]
+            ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+              ayatana-indicator-sound
+            ]
+          )
+          ++ (
+            with pkgs.lomiri;
+            [ telephony-service ]
+            ++ lib.optionals config.networking.networkmanager.enable [ lomiri-indicator-network ]
+          );
       };
 
-      "lomiri-polkit-agent" = rec {
-        description = "Lomiri Polkit agent";
-        wantedBy = [
-          "lomiri.service"
-          "lomiri-full-greeter.service"
-          "lomiri-full-shell.service"
-          "lomiri-greeter.service"
-          "lomiri-shell.service"
+      services.udisks2.enable = true;
+      services.upower.enable = true;
+      services.geoclue2.enable = true;
+
+      services.gnome.evolution-data-server = {
+        enable = true;
+        plugins = with pkgs; [
+          # TODO: lomiri.address-book-service
         ];
-        after = [ "graphical-session.target" ];
-        partOf = wantedBy;
-        serviceConfig = {
-          Type = "simple";
-          Restart = "always";
-          ExecStart = "${pkgs.lomiri.lomiri-polkit-agent}/libexec/lomiri-polkit-agent/policykit-agent";
+      };
+
+      services.telepathy.enable = true;
+
+      services.displayManager = {
+        defaultSession = lib.mkDefault "lomiri";
+        sessionPackages = with pkgs.lomiri; [ lomiri-session ];
+      };
+
+      services.xserver = {
+        enable = lib.mkDefault true;
+        displayManager.lightdm = {
+          enable = lib.mkDefault true;
+          greeters.lomiri.enable = lib.mkDefault true;
         };
       };
-    };
 
-    systemd.services = {
-      "dbus-com.lomiri.UserMetrics" = {
-        serviceConfig =
-          {
-            Type = "dbus";
-            BusName = "com.lomiri.UserMetrics";
-            User = "usermetrics";
-            StandardOutput = "syslog";
-            SyslogIdentifier = "com.lomiri.UserMetrics";
-            ExecStart = "${pkgs.lomiri.libusermetrics}/libexec/libusermetrics/usermetricsservice";
-          }
-          // lib.optionalAttrs (!config.security.apparmor.enable) {
-            # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, auth must be disabled when not using AppArmor, lest the next database usage breaks
-            Environment = "USERMETRICS_NO_AUTH=1";
+      environment.pathsToLink = [
+        # Configs for inter-app data exchange system
+        "/share/lomiri-content-hub/peers"
+        # Configs for inter-app URL requests
+        "/share/lomiri-url-dispatcher/urls"
+        # Splash screens & other images for desktop apps launched via lomiri-app-launch
+        "/share/lomiri-app-launch"
+        # TODO Try to get maliit stuff working
+        "/share/maliit/plugins"
+        # At least the network indicator is still under the unity name, due to leftover Unity-isms
+        "/share/unity"
+        # Data
+        "/share/sounds"
+      ];
+
+      systemd.user.services = {
+        # Unconditionally run service that collects system-installed URL handlers before LUD
+        # TODO also run user-installed one?
+        "lomiri-url-dispatcher-update-system-dir" = {
+          description = "Lomiri URL dispatcher system directory updater";
+          wantedBy = [ "lomiri-url-dispatcher.service" ];
+          before = [ "lomiri-url-dispatcher.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${pkgs.lomiri.lomiri-url-dispatcher}/libexec/lomiri-url-dispatcher/lomiri-update-directory /run/current-system/sw/share/lomiri-url-dispatcher/urls/";
           };
+        };
+
+        "lomiri-polkit-agent" = rec {
+          description = "Lomiri Polkit agent";
+          wantedBy = [
+            "lomiri.service"
+            "lomiri-full-greeter.service"
+            "lomiri-full-shell.service"
+            "lomiri-greeter.service"
+            "lomiri-shell.service"
+          ];
+          after = [ "graphical-session.target" ];
+          partOf = wantedBy;
+          serviceConfig = {
+            Type = "simple";
+            Restart = "always";
+            ExecStart = "${pkgs.lomiri.lomiri-polkit-agent}/libexec/lomiri-polkit-agent/policykit-agent";
+          };
+        };
       };
-    };
 
-    users.users.usermetrics = {
-      group = "usermetrics";
-      home = "/var/lib/usermetrics";
-      createHome = true;
-      isSystemUser = true;
-    };
+      systemd.services = {
+        "dbus-com.lomiri.UserMetrics" = {
+          serviceConfig =
+            {
+              Type = "dbus";
+              BusName = "com.lomiri.UserMetrics";
+              User = "usermetrics";
+              StandardOutput = "syslog";
+              SyslogIdentifier = "com.lomiri.UserMetrics";
+              ExecStart = "${pkgs.lomiri.libusermetrics}/libexec/libusermetrics/usermetricsservice";
+            }
+            // lib.optionalAttrs (!config.security.apparmor.enable) {
+              # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, auth must be disabled when not using AppArmor, lest the next database usage breaks
+              Environment = "USERMETRICS_NO_AUTH=1";
+            };
+        };
+      };
 
-    users.groups.usermetrics = { };
-  };
+      users.users.usermetrics = {
+        group = "usermetrics";
+        home = "/var/lib/usermetrics";
+        createHome = true;
+        isSystemUser = true;
+      };
+
+      users.groups.usermetrics = { };
+    })
+  ];
 
   meta.maintainers = lib.teams.lomiri.members;
 }

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
 

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
@@ -22,6 +22,9 @@ in
   };
 
   config = lib.mkIf (ldmcfg.enable && cfg.enable) {
+    # Lomiri greeter == Lomiri shell in special mode, need some basics setup at least
+    services.desktopManager.lomiri.basics = true;
+
     services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
 
     services.xserver.displayManager.lightdm.greeter = lib.mkDefault {

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -72,11 +72,13 @@ in
             inherit description password;
           };
 
-          services.desktopManager.lomiri.enable = lib.mkForce true;
-          services.displayManager.defaultSession = lib.mkForce "lomiri";
-
-          # Help with OCR
-          fonts.packages = [ pkgs.inconsolata ];
+          services.xserver.enable = true;
+          services.xserver.windowManager.icewm.enable = true;
+          services.xserver.displayManager.lightdm = {
+            enable = true;
+            greeters.lomiri.enable = true;
+          };
+          services.displayManager.defaultSession = lib.mkForce "none+icewm";
         };
 
       enableOCR = true;
@@ -110,13 +112,8 @@ in
 
               # Login
               machine.send_chars("${password}\n")
-              machine.wait_until_succeeds("pgrep -u ${user} -f 'lomiri --mode=full-shell'")
-
-              # Output rendering from Lomiri has started when it starts printing performance diagnostics
-              machine.wait_for_console_text("Last frame took")
-              # Look for datetime's clock, one of the last elements to load
-              wait_for_text(r"(AM|PM)")
-              machine.screenshot("lomiri_launched")
+              machine.wait_for_x()
+              machine.screenshot("session_launched")
         '';
     }
   );


### PR DESCRIPTION
#260859

> #### Follow-up issues/notes
> 
> […]
> 
> - `services.xserver.displayManager.lightdm.greeters.lomiri.enable` likely doesn't work without `services.desktopManager.lomiri.enable`, might need some duplicated settings

- Moves the minimal options required to have just Lomiri-as-a-greeter working into an internal `services.desktopManager.lomiri.basics` option (name open to be changed)
- Hooks up both `services.desktopManager.lomiri.enable` and `services.xserver.displayManager.lightdm.greeters.lomiri.enable` to enable the new option
- Changes `nixosTests.lomiri.greeter` to only enable Lomiri-as-a-greeter, to check the new option on its own

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
