### PR TITLE
qctools: revert ffmpeg version to 6

### DIFF
--- a/pkgs/applications/video/qctools/default.nix
+++ b/pkgs/applications/video/qctools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, qmake, wrapQtAppsHook, ffmpeg, qtmultimedia, qwt }:
+{ lib, stdenv, fetchurl, qmake, wrapQtAppsHook, ffmpeg_6, qtmultimedia, qwt }:
 
 stdenv.mkDerivation rec {
   pname = "qctools";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake wrapQtAppsHook ];
 
-  buildInputs = [ ffmpeg qtmultimedia qwt ];
+  buildInputs = [ ffmpeg_6 qtmultimedia qwt ];
 
   installPhase = ''
     runHook preInstall
@@ -30,11 +30,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Audiovisual analytics and filtering of video files";
     homepage = "https://mediaarea.net/QCTools";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ orivej ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Regression caused by #337855

Fixes #352418

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).