### PR TITLE
qt6.qtModule: support finalAttrs

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -1,4 +1,5 @@
 { stdenv
+, runCommand
 , lib
 , src
 , patches ? [ ]
@@ -88,7 +89,7 @@
 let
   isCrossBuild = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "qtbase";
 
   inherit src version;
@@ -243,6 +244,13 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
+  passthru = {
+    plugins = runCommand "${finalAttrs.finalPackage.name}-only-plugins" { } ''
+      mkdir -p "$out/lib/qt-6/plugins"
+      ln -s "${finalAttrs.finalPackage}/lib/qt-6/plugins" "$out/lib/qt-6/plugins"
+    '';
+  };
+
   setupHook = ../hooks/qtbase-setup-hook.sh;
 
   meta = with lib; {
@@ -252,4 +260,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ milahu nickcao LunNova ];
     platforms = platforms.unix ++ platforms.windows;
   };
-}
+})

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -5,9 +5,10 @@
 , wayland-scanner
 , pkg-config
 , libdrm
+, runCommand
 }:
 
-qtModule {
+qtModule (finalAttrs: {
   pname = "qtwayland";
   # wayland-scanner needs to be propagated as both build
   # (for the wayland-scanner binary) and host (for the
@@ -22,4 +23,11 @@ qtModule {
   postPatch = ''
     cp ${wayland-scanner}/share/wayland/wayland.xml src/3rdparty/protocol/wayland/wayland.xml
   '';
-}
+
+  passthru = {
+    plugins = runCommand "${finalAttrs.finalPackage.name}-only-plugins" { } ''
+      mkdir -p "$out/lib/qt-6/plugins"
+      ln -s "${finalAttrs.finalPackage}/lib/qt-6/plugins" "$out/lib/qt-6/plugins"
+    '';
+  };
+})

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,12 +1,13 @@
-{ lib
-, stdenv
-, apple-sdk_qt
-, cmake
-, ninja
-, perl
-, moveBuildTree
-, srcs
-, patches ? [ ]
+{
+  lib,
+  stdenv,
+  apple-sdk_qt,
+  cmake,
+  ninja,
+  perl,
+  moveBuildTree,
+  srcs,
+  patches ? [ ],
 }:
 
 args:
@@ -16,34 +17,61 @@ let
   version = args.version or srcs.${pname}.version;
   src = args.src or srcs.${pname}.src;
 in
-stdenv.mkDerivation (args // {
-  inherit pname version src;
-  patches = args.patches or patches.${pname} or [ ];
+stdenv.mkDerivation (
+  args
+  // {
+    inherit pname version src;
+    patches = args.patches or patches.${pname} or [ ];
 
-  buildInputs =
-    args.buildInputs or [ ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
-  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cmake ninja perl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
-  propagatedBuildInputs =
-    (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or []) ++
-    (args.propagatedBuildInputs or []);
+    buildInputs =
+      args.buildInputs or [ ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
+    nativeBuildInputs =
+      (args.nativeBuildInputs or [ ])
+      ++ [
+        cmake
+        ninja
+        perl
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
+    propagatedBuildInputs =
+      (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
+      ++ (args.propagatedBuildInputs or [ ]);
 
-  moveToDev = false;
+    moveToDev = false;
 
-  outputs = args.outputs or [ "out" "dev" ];
-  separateDebugInfo = args.separateDebugInfo or true;
+    outputs =
+      args.outputs or [
+        "out"
+        "dev"
+      ];
 
-  dontWrapQtApps = args.dontWrapQtApps or true;
-}) // {
-  meta = with lib; let
-    pos = builtins.unsafeGetAttrPos "pname" args;
-  in {
-    homepage = "https://www.qt.io/";
-    description = "Cross-platform application framework for C++";
-    license = with licenses; [ fdl13Plus gpl2Plus lgpl21Plus lgpl3Plus ];
-    maintainers = with maintainers; [ milahu nickcao ];
-    platforms = platforms.unix;
-    position = "${pos.file}:${toString pos.line}";
-  } // (args.meta or { });
+    separateDebugInfo = args.separateDebugInfo or true;
+
+    dontWrapQtApps = args.dontWrapQtApps or true;
+  }
+)
+// {
+  meta =
+    with lib;
+    let
+      pos = builtins.unsafeGetAttrPos "pname" args;
+    in
+    {
+      homepage = "https://www.qt.io/";
+      description = "Cross-platform application framework for C++";
+      license = with licenses; [
+        fdl13Plus
+        gpl2Plus
+        lgpl21Plus
+        lgpl3Plus
+      ];
+      maintainers = with maintainers; [
+        milahu
+        nickcao
+      ];
+      platforms = platforms.unix;
+      position = "${pos.file}:${toString pos.line}";
+    }
+    // (args.meta or { });
 }

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -10,68 +10,76 @@
   patches ? [ ],
 }:
 
-args:
+fnOrAttrs:
 
 let
-  inherit (args) pname;
-  version = args.version or srcs.${pname}.version;
-  src = args.src or srcs.${pname}.src;
+  transformArgs =
+    finalAttrs: args:
+    args
+    // {
+
+      version = args.version or srcs.${args.pname}.version;
+      src = args.src or srcs.${args.pname}.src;
+
+      patches = args.patches or patches.${args.pname} or [ ];
+
+      buildInputs =
+        args.buildInputs or [ ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
+      nativeBuildInputs =
+        (args.nativeBuildInputs or [ ])
+        ++ [
+          cmake
+          ninja
+          perl
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
+      propagatedBuildInputs =
+        (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
+        ++ (args.propagatedBuildInputs or [ ]);
+
+      moveToDev = false;
+
+      outputs =
+        args.outputs or [
+          "out"
+          "dev"
+        ];
+      separateDebugInfo = args.separateDebugInfo or true;
+
+      dontWrapQtApps = args.dontWrapQtApps or true;
+
+      meta =
+        with lib;
+        let
+          pos = builtins.unsafeGetAttrPos "pname" args;
+        in
+        {
+          homepage = "https://www.qt.io/";
+          description = "Cross-platform application framework for C++";
+          license = with licenses; [
+            fdl13Plus
+            gpl2Plus
+            lgpl21Plus
+            lgpl3Plus
+          ];
+          maintainers = with maintainers; [
+            milahu
+            nickcao
+          ];
+          platforms = platforms.unix;
+          position = "${pos.file}:${toString pos.line}";
+        }
+        // (args.meta or { });
+
+    };
 in
+
 stdenv.mkDerivation (
-  args
-  // {
-    inherit pname version src;
-    patches = args.patches or patches.${pname} or [ ];
-
-    buildInputs =
-      args.buildInputs or [ ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
-    nativeBuildInputs =
-      (args.nativeBuildInputs or [ ])
-      ++ [
-        cmake
-        ninja
-        perl
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
-    propagatedBuildInputs =
-      (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
-      ++ (args.propagatedBuildInputs or [ ]);
-
-    moveToDev = false;
-
-    outputs =
-      args.outputs or [
-        "out"
-        "dev"
-      ];
-
-    separateDebugInfo = args.separateDebugInfo or true;
-
-    dontWrapQtApps = args.dontWrapQtApps or true;
-  }
+  finalAttrs:
+  let
+    args = if lib.isFunction fnOrAttrs then fnOrAttrs (args' // finalAttrs) else fnOrAttrs;
+    args' = transformArgs finalAttrs args;
+  in
+  args'
 )
-// {
-  meta =
-    with lib;
-    let
-      pos = builtins.unsafeGetAttrPos "pname" args;
-    in
-    {
-      homepage = "https://www.qt.io/";
-      description = "Cross-platform application framework for C++";
-      license = with licenses; [
-        fdl13Plus
-        gpl2Plus
-        lgpl21Plus
-        lgpl3Plus
-      ];
-      maintainers = with maintainers; [
-        milahu
-        nickcao
-      ];
-      platforms = platforms.unix;
-      position = "${pos.file}:${toString pos.line}";
-    }
-    // (args.meta or { });
-}


### PR DESCRIPTION
Based on https://www.github.com/NixOS/nixpkgs/pull/331398

Overriding works as it should
```
nix-repl> qt6.qtbase.overrideAttrs (previousAttrs: { nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ pkgs.hello ]; })
«derivation /nix/store/wyh7snh6nf8mnnp9saffc5sjaqid32wp-qtbase-6.8.0.drv»

nix-repl> p = qt6.qtbase.overrideAttrs (previousAttrs: { nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ pkgs.hello ]; })

nix-repl> p.nativeBuildInputs
[
  «derivation /nix/store/yp35rww8ybc71bmgdq9b27a7hz2wca99-bison-3.8.2.drv»
  «derivation /nix/store/4rzliqardkl299845js8xwy4p0l4w0bn-flex-2.6.4.drv»
  «derivation /nix/store/rvam632pb8a7j17w3nmai4mg91abzaw1-gperf-3.1.drv»
  «derivation /nix/store/xxm2ks3fdcqfgfiajsldfrz7vz2rjwr4-lndir-1.0.5.drv»
  «derivation /nix/store/dd75caqmnsk3g269hkgsbnbj5gn1xcd3-perl-5.40.0.drv»
  «derivation /nix/store/6kqfi7ndxaiwy25glcc97fkx6dcp2722-pkg-config-wrapper-0.29.2.drv»
  «derivation /nix/store/7b1d2z8lh6a4hjd57j6rjm155djjzddz-which-2.21.drv»
  «derivation /nix/store/s7wkvim8lplr5k4zf0k083ivhwn0im2l-cmake-3.29.6.drv»
  «derivation /nix/store/rbjl8vphyrn9jwaqm7545qwcvwac4jrv-xmlstarlet-1.6.1.drv»
  «derivation /nix/store/9pv5plcg55hln8ihsh4gchhj284sw9q6-ninja-1.12.1.drv»
  «derivation /nix/store/161hd6k485dvr9cx02ccnc1x4n9fzix6-hello-2.12.1.drv»
]

nix-repl> p = qt6.qtbase.overrideAttrs (previousAttrs: { dontWrapQtApps = false; })

nix-repl> p.dontWrapQtApps
false

nix-repl> qt6.qtbase.dontWrapQtApps
true
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
