### PR TITLE
nixos/slurm: generate mpi.conf and add config options

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -32,6 +32,12 @@ let
      ${cfg.extraCgroupConfig}
    '';
 
+  mpiConf =  pkgs.writeTextDir "mpi.conf"
+   ''
+     PMIxCliTmpDirBase=${cfg.mpi.PmixCliTmpDirBase}
+     ${cfg.mpi.extraMpiConfig}
+   '';
+
   slurmdbdConf = pkgs.writeText "slurmdbd.conf"
    ''
      DbdHost=${cfg.dbdserver.dbdHost}
@@ -45,7 +51,7 @@ let
   # in the same directory as slurm.conf
   etcSlurm = pkgs.symlinkJoin {
     name = "etc-slurm";
-    paths = [ configFile cgroupConfig plugStackConfig ] ++ cfg.extraConfigPaths;
+    paths = [ configFile cgroupConfig plugStackConfig mpiConf ] ++ cfg.extraConfigPaths;
   };
 in
 
@@ -242,6 +248,24 @@ in
         '';
       };
 
+      mpi = {
+        PmixCliTmpDirBase = lib.mkOption {
+          default = "/tmp/pmix";
+          type = lib.types.str;
+          description = ''
+            Base path for PMIx temporary files.
+          '';
+        };
+
+        extraMpiConfig = lib.mkOption {
+          default = "";
+          type = lib.types.lines;
+          description = ''
+            Extra configuration for that will be added to `mpi.conf`.
+          '';
+        };
+      };
+
       extraPlugstackConfig = lib.mkOption {
         default = "";
         type = lib.types.lines;
@@ -372,8 +396,9 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = lib.mkIf cfg.client.enable [
+    systemd.tmpfiles.rules = lib.optionals cfg.client.enable [
       "d /var/spool/slurmd 755 root root -"
+      "d ${cfg.mpi.PmixCliTmpDirBase} 755 root root -"
     ];
 
     services.openssh.settings.X11Forwarding = lib.mkIf cfg.client.enable (lib.mkDefault true);


### PR DESCRIPTION
mpi.conf is required for PMIx configuration.
Setting the PMIxCliTmpDirBase in mpi.conf per default avoids PMIx errors complaining about a missing temporary directory.




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
