### PR TITLE
geoclue2: 2.7.0 -> 2.7.2

### DIFF
--- a/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
@@ -1,7 +1,7 @@
-diff --git i/data/meson.build w/data/meson.build
-index 6ac2a11..73f433b 100644
---- i/data/meson.build
-+++ w/data/meson.build
+diff --git a/data/meson.build b/data/meson.build
+index b22ff55..01c5910 100644
+--- a/data/meson.build
++++ b/data/meson.build
 @@ -1,6 +1,6 @@
  if get_option('enable-backend')
      conf = configuration_data()
@@ -10,8 +10,8 @@ index 6ac2a11..73f433b 100644
  
      if get_option('demo-agent')
          conf.set('demo_agent', 'geoclue-demo-agent;')
-@@ -8,7 +8,7 @@ if get_option('enable-backend')
-         conf.set('demo_agent', '')
+@@ -14,7 +14,7 @@ if get_option('enable-backend')
+         conf.set('default_wifi_enable', 'false')
      endif
  
 -    conf_dir = join_paths(sysconfdir, 'geoclue')
@@ -19,7 +19,7 @@ index 6ac2a11..73f433b 100644
      configure_file(output: 'geoclue.conf',
                     input: 'geoclue.conf.in',
                     configuration: conf,
-@@ -17,7 +17,7 @@ if get_option('enable-backend')
+@@ -23,7 +23,7 @@ if get_option('enable-backend')
      conf = configuration_data()
      conf.set('libexecdir', libexecdir)
      conf.set('dbus_srv_user', get_option('dbus-srv-user'))
@@ -28,19 +28,10 @@ index 6ac2a11..73f433b 100644
  
      confd_dir = join_paths(conf_dir, 'conf.d')
      install_emptydir(confd_dir)
-@@ -37,7 +37,7 @@ if get_option('enable-backend')
-     # DBus Service policy file
-     dbus_service_dir = get_option('dbus-sys-dir')
-     if dbus_service_dir == ''
--        dbus_service_dir = join_paths(sysconfdir, 'dbus-1', 'system.d')
-+        dbus_service_dir = join_paths(sysconfdir_install, 'dbus-1', 'system.d')
-     endif
-     configure_file(output: 'org.freedesktop.GeoClue2.conf',
-                    input: 'org.freedesktop.GeoClue2.conf.in',
-diff --git i/demo/meson.build w/demo/meson.build
+diff --git a/demo/meson.build b/demo/meson.build
 index 1427fbe..2623f16 100644
---- i/demo/meson.build
-+++ w/demo/meson.build
+--- a/demo/meson.build
++++ b/demo/meson.build
 @@ -54,7 +54,7 @@ if get_option('demo-agent')
                                     install_dir: desktop_dir)
  
@@ -50,43 +41,33 @@ index 1427fbe..2623f16 100644
      meson.add_install_script('install-file.py',
                               desktop_file.full_path(),
                               autostart_dir)
-diff --git i/meson.build w/meson.build
-index 220ae2b..dbf6458 100644
---- i/meson.build
-+++ w/meson.build
-@@ -12,7 +12,11 @@ gclue_api_version='2.0'
- datadir = join_paths(get_option('prefix'), get_option('datadir'))
+diff --git a/meson.build b/meson.build
+index c561572..bca0cb3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -13,6 +13,11 @@ datadir = join_paths(get_option('prefix'), get_option('datadir'))
  includedir = join_paths(get_option('prefix'), get_option('includedir'))
  libexecdir = join_paths(get_option('prefix'), get_option('libexecdir'))
--sysconfdir = join_paths(get_option('prefix'), get_option('sysconfdir'))
+ sysconfdir = join_paths(get_option('prefix'), get_option('sysconfdir'))
 +if get_option('sysconfdir_install') != ''
 +  sysconfdir_install = join_paths(get_option('prefix'), get_option('sysconfdir_install'))
 +else
-+  sysconfdir_install = get_option('sysconfdir')
++  sysconfdir_install = sysconfdir
 +endif
  localedir = join_paths(datadir, 'locale')
  
  header_dir = 'libgeoclue-' + gclue_api_version
-@@ -29,7 +33,7 @@ conf.set_quoted('PACKAGE_URL', 'https://gitlab.freedesktop.org/geoclue/geoclue/w
- conf.set_quoted('PACKAGE_BUGREPORT', 'https://gitlab.freedesktop.org/geoclue/geoclue/issues/new')
- conf.set_quoted('TEST_SRCDIR', meson.project_source_root() + '/data/')
- conf.set_quoted('LOCALEDIR', localedir)
--conf.set_quoted('SYSCONFDIR', sysconfdir)
-+conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
- conf.set_quoted('MOZILLA_API_KEY', get_option('mozilla-api-key'))
- conf.set10('GCLUE_USE_3G_SOURCE', get_option('3g-source'))
- conf.set10('GCLUE_USE_CDMA_SOURCE', get_option('cdma-source'))
-diff --git i/meson_options.txt w/meson_options.txt
-index 5b8c42d..945dfd5 100644
---- i/meson_options.txt
-+++ w/meson_options.txt
-@@ -40,6 +40,9 @@ option('systemd-system-unit-dir',
- option('dbus-srv-user',
-        type: 'string', value: 'root',
-        description: 'The user (existing) as which the service will run')
+diff --git a/meson_options.txt b/meson_options.txt
+index 4d55a63..682b39c 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -31,6 +31,9 @@ option('enable-backend',
+ option('demo-agent',
+        type: 'boolean', value: true,
+        description: 'Build demo agent')
 +option('sysconfdir_install',
 +       type: 'string', value: '',
 +       description: 'sysconfdir to use during installation')
- option('mozilla-api-key',
-        type: 'string', value: 'geoclue',
-        description: 'Your API key for Mozilla Location Service')
+ option('dbus-sys-dir',
+        type: 'string',
+        description: 'where D-BUS system.d directory is')

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -22,11 +22,12 @@
 , gobject-introspection
 , vala
 , withDemoAgent ? false
+, nix-update-script
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "geoclue";
-  version = "2.7.0";
+  version = "2.7.2";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -34,8 +35,8 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "geoclue";
     repo = "geoclue";
-    rev = version;
-    hash = "sha256-vzarUg4lBEXYkH+n9SY8SYr0gHUX94PSTDmKd957gyc=";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-LwL1WtCdHb/NwPr3/OLISwaAwplhJwiZT9vUdX29Bbs=";
   };
 
   patches = [
@@ -76,13 +77,11 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dsystemd-system-unit-dir=${placeholder "out"}/etc/systemd/system"
+    "-Dsystemd-system-unit-dir=${placeholder "out"}/lib/systemd/system"
     "-Ddemo-agent=${lib.boolToString withDemoAgent}"
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
-    "-Dmozilla-api-key=5c28d1f4-9511-47ff-b11a-2bef80fc177c"
     "-Ddbus-srv-user=geoclue"
-    "-Ddbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-D3g-source=false"
     "-Dcdma-source=false"
@@ -95,12 +94,15 @@ stdenv.mkDerivation rec {
     patchShebangs demo/install-file.py
   '';
 
+  updateScript = nix-update-script {};
+
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin && withDemoAgent;
     description = "Geolocation framework and some data providers";
     homepage = "https://gitlab.freedesktop.org/geoclue/geoclue/wikis/home";
+    changelog = "https://gitlab.freedesktop.org/geoclue/geoclue/-/blob/${finalAttrs.version}/NEWS";
     maintainers = with maintainers; [ raskin mimame ];
     platforms = with platforms; linux ++ darwin;
     license = licenses.lgpl2Plus;
   };
-}
+})


### PR DESCRIPTION
https://gitlab.freedesktop.org/geoclue/geoclue/-/blob/2.7.2/NEWS

The Mozilla API key option was removed since the Mozilla location service is now defunct, see #321121

Fixes #327464

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
