### PR TITLE
nitrokey-udev-rules: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18604,6 +18604,13 @@
     githubId = 521306;
     name = "Rob Glossop";
   };
+  robinkrahl = {
+    email = "nix@ireas.org";
+    github = "robinkrahl";
+    githubId = 165115;
+    keys = [ { fingerprint = "EC7E F0F9 B681 4C24 6236  3842 B755 6972 702A FD45"; } ];
+    name = "Robin Krahl";
+  };
   roblabla = {
     email = "robinlambertz+dev@gmail.com";
     github = "roblabla";

--- a/nixos/modules/hardware/nitrokey.nix
+++ b/nixos/modules/hardware/nitrokey.nix
@@ -19,6 +19,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.udev.packages = [ pkgs.libnitrokey ];
+    services.udev.packages = [ pkgs.nitrokey-udev-rules ];
   };
 }

--- a/nixos/modules/hardware/nitrokey.nix
+++ b/nixos/modules/hardware/nitrokey.nix
@@ -11,9 +11,7 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Enables udev rules for Nitrokey devices. By default grants access
-        to users in the "nitrokey" group. You may want to install the
-        nitrokey-app package, depending on your device and needs.
+        Enables udev rules for Nitrokey devices.
       '';
     };
   };

--- a/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
+++ b/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nitrokey-udev-rules";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-udev-rules";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-uq1+YQg+oe5UFphpy1AdxEYaPFyRle6ffYOPoU6Li28=";
+  };
+
+  installPhase = ''
+    install -D 41-nitrokey.rules -t $out/etc/udev/rules.d
+  '';
+
+  meta = with lib; {
+    description = "udev rules for Nitrokey devices";
+    homepage = "https://github.com/Nitrokey/nitrokey-udev-rules";
+    license = [ licenses.cc0 ];
+    maintainers = with maintainers; [
+      frogamic
+      robinkrahl
+    ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -804,7 +804,6 @@ mapAliases {
   neochat = libsForQt5.kdeGear.neochat; # added 2022-05-10
   newlibCross = newlib; # Added 2024-09-06
   newlib-nanoCross = newlib-nano; # Added 2024-09-06
-  nitrokey-udev-rules = libnitrokey; # Added 2023-03-25
   nix-direnv-flakes = nix-direnv;
   nix-ld-rs = nix-ld; # Added 2024-08-17
   nix-repl = throw (


### PR DESCRIPTION
This PR adds the nitrokey-udev-rules package that contains udev rules for Nitrokey devices (previously included in libnitrokey).  It also updates the hardware.nitrokey module to use the new package.

Fixes: https://github.com/NixOS/nixpkgs/issues/351921

Open questions:
- [ ] Should we also remove the udev rules from libnitrokey?
- [ ] During testing I noticed that the rules for the Nitrokey 3 NFC bootloader do not work.  It seems like the reason is the packaged hidapi Python module.  When installing pynitrokey or nitrokey-sdk-py from PyPI, it works fine.  The problem is also present in the current rules from libnitrokey so I would move on with this PR despite this issue.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
