### PR TITLE
xar: fix Linux build on staging-next

### DIFF
--- a/pkgs/by-name/xa/xar/package.nix
+++ b/pkgs/by-name/xa/xar/package.nix
@@ -48,7 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
   #   # …
   #   rm -r ../pkgs/by-name/xa/xar/patches
   #   git format-patch --zero-commit --output-directory ../pkgs/by-name/xa/xar/patches main
-  patches = lib.filesystem.listFilesRecursive ./patches;
+  patches =
+    # Avoid Darwin rebuilds on staging-next
+    lib.filter (
+      p: stdenv.hostPlatform.isDarwin -> baseNameOf p != "0020-Fall-back-to-readlink-on-Linux.patch"
+    ) (lib.filesystem.listFilesRecursive ./patches);
 
   # We do not use or modify files outside of the xar subdirectory.
   patchFlags = [ "-p2" ];

--- a/pkgs/by-name/xa/xar/patches/0020-Fall-back-to-readlink-on-Linux.patch
+++ b/pkgs/by-name/xa/xar/patches/0020-Fall-back-to-readlink-on-Linux.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Wed, 30 Oct 2024 20:19:20 -0400
+Subject: [PATCH 20/20] Fall back to readlink on Linux
+
+---
+ xar/lib/archive.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/xar/lib/archive.c b/xar/lib/archive.c
+index b7f9cbf..3a79c74 100644
+--- a/xar/lib/archive.c
++++ b/xar/lib/archive.c
+@@ -507,10 +507,31 @@ xar_t xar_fdopen_digest_verify(int fd, int32_t flags, void *expected_toc_digest,
+ 	// If there are hardlinks, the path we pick is the most recently opened by
+ 	// the filesystem; which is effectively random.
+ 	char path_buff[PATH_MAX];
++#if defined(__APPLE__)
+ 	if (fcntl(fd, F_GETPATH, path_buff) < 0) {
+ 		close(fd);
+ 		return NULL;
+ 	}
++#elif defined(__linux__)
++	// Linux has to get the path to the file via `/proc`.
++	char proc_buff[PATH_MAX];
++	if (snprintf(proc_buff, PATH_MAX, "/proc/self/fd/%i", fd) < 0) {
++		close(fd);
++		return NULL;
++	}
++	if (readlink(proc_buff, &path_buff, PATH_MAX) < 0) {
++		close(fd);
++		return NULL;
++	}
++	// The filename is the file’s when the fd was created. Check to make sure it still exists.
++	struct stat stat_buff;
++	if (stat(path_buff, &stat_buff) < 0) {
++		close(fd);
++		return NULL;
++	}
++#else
++#error "Unknown platform. Please update with an implementation of `F_GETPATH`."
++#endif
+ 	
+ 	// Don't trust the position of the descriptor we were given, reset it back to 0
+ 	if (lseek(fd, 0, SEEK_SET) != 0) {
+-- 
+2.47.0
+


### PR DESCRIPTION
Adds an alternate implementation of `F_GETPATH` for Linux. Avoids rebuilds on Darwin. Fixes failure on staging-next https://github.com/NixOS/nixpkgs/pull/348827. I tested that it builds. It would be good if a Linux user could confirm this is the right approach.

- https://hydra.nixos.org/build/275380931

Closes #352453.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
