### PR TITLE
Ledger-Live-Desktop: adds `darwin` package

### DIFF
--- a/pkgs/applications/blockchains/ledger-live-desktop/ledger-live-desktop-darwin.nix
+++ b/pkgs/applications/blockchains/ledger-live-desktop/ledger-live-desktop-darwin.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  _7zz,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ledger-live-desktop";
+  version = "2.89.1";
+
+  src = fetchurl {
+    url = "https://download.live.ledger.com/ledger-live-desktop-${finalAttrs.version}-mac.dmg";
+    hash = "sha256-Q9cevGZy67YkCR6rkvqZiuPl/h+HyhXDyJnpn1OFfb0=";
+  };
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ _7zz ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r "Ledger Live.app" $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "App for Ledger hardware wallets";
+    homepage = "https://www.ledger.com/ledger-live/";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      andresilva
+      thedavidmeister
+      nyanloutre
+      RaghavSood
+      th0rgal
+    ];
+    platforms = platforms.darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/applications/blockchains/ledger-live-desktop/ledger-live-desktop-linux.nix
+++ b/pkgs/applications/blockchains/ledger-live-desktop/ledger-live-desktop-linux.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+  imagemagick,
+}:
+
+let
+  pname = "ledger-live-desktop";
+  version = "2.89.1";
+
+  src = fetchurl {
+    url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
+    hash = "sha256-PPoQnXDVf6Q6QPVE41guJL1vu7rW7mZdpRZjRME3Ue8=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/ledger-live-desktop.desktop $out/share/applications/ledger-live-desktop.desktop
+    install -m 444 -D ${appimageContents}/ledger-live-desktop.png $out/share/icons/hicolor/1024x1024/apps/ledger-live-desktop.png
+    ${imagemagick}/bin/convert ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png
+    install -m 444 -D ledger-live-desktop_512.png $out/share/icons/hicolor/512x512/apps/ledger-live-desktop.png
+
+    wrapProgram "$out/bin/${pname}" \
+       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
+
+    substituteInPlace $out/share/applications/ledger-live-desktop.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "App for Ledger hardware wallets";
+    homepage = "https://www.ledger.com/ledger-live/";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      andresilva
+      thedavidmeister
+      nyanloutre
+      RaghavSood
+      th0rgal
+    ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "ledger-live-desktop";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -1,43 +1,10 @@
-{ lib, fetchurl, appimageTools, makeWrapper, imagemagick }:
+{ stdenv, callPackage }:
 
 let
-  pname = "ledger-live-desktop";
-  version = "2.89.1";
-
-  src = fetchurl {
-    url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-PPoQnXDVf6Q6QPVE41guJL1vu7rW7mZdpRZjRME3Ue8=";
+  self = rec {
+    ledger-live-desktop = if stdenv.hostPlatform.isDarwin then
+      callPackage ./ledger-live-desktop-darwin.nix { }
+    else
+      callPackage ./ledger-live-desktop-linux.nix { };
   };
-
-  appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
-  };
-in
-appimageTools.wrapType2 rec {
-  inherit pname version src;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/ledger-live-desktop.desktop $out/share/applications/ledger-live-desktop.desktop
-    install -m 444 -D ${appimageContents}/ledger-live-desktop.png $out/share/icons/hicolor/1024x1024/apps/ledger-live-desktop.png
-    ${imagemagick}/bin/convert ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png
-    install -m 444 -D ledger-live-desktop_512.png $out/share/icons/hicolor/512x512/apps/ledger-live-desktop.png
-
-    wrapProgram "$out/bin/${pname}" \
-       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
-
-    substituteInPlace $out/share/applications/ledger-live-desktop.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
-  '';
-
-  meta = with lib; {
-    description = "App for Ledger hardware wallets";
-    homepage = "https://www.ledger.com/ledger-live/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ andresilva thedavidmeister nyanloutre RaghavSood th0rgal ];
-    platforms = [ "x86_64-linux" ];
-    mainProgram = "ledger-live-desktop";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-  };
-}
+in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9373,6 +9373,8 @@ with pkgs;
     };
   };
 
+  inherit (callPackage ../applications/blockchains/ledger-live-desktop { }) ledger-live-desktop;
+
   muslCross = musl.override {
     stdenv = stdenvNoLibc;
   };


### PR DESCRIPTION
Adds the macos dmg and app for Ledger-Live-Desktop.

Copied the style from signal-desktop.

Tested on macOS Seqoia (aarch64).

Someone should please verify i didn't break anything linux related.

thank you <3