### PR TITLE
network: Fix cycle dependency causing race of netdev and address configuration

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -260,7 +260,6 @@ let
             bindsTo = optional (!config.boot.isContainer) "dev-net-tun.device";
             after = optional (!config.boot.isContainer) "dev-net-tun.device" ++ [ "network-pre.target" ];
             wantedBy = [ "network-setup.service" (subsystemDevice i.name) ];
-            partOf = [ "network-setup.service" ];
             before = [ "network-setup.service" ];
             path = [ pkgs.iproute2 ];
             serviceConfig = {
@@ -411,7 +410,6 @@ let
           { description = "Bond Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
-            partOf = [ "network-setup.service" ];
             after = [ "network-pre.target" ] ++ deps
               ++ map (i: "network-addresses-${i}.service") v.interfaces;
             before = [ "network-setup.service" ];
@@ -450,7 +448,6 @@ let
           { description = "MACVLAN Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
-            partOf = [ "network-setup.service" ];
             after = [ "network-pre.target" ] ++ deps;
             before = [ "network-setup.service" ];
             serviceConfig.Type = "oneshot";
@@ -485,7 +482,6 @@ let
           { description = "FOU endpoint ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
-            partOf = [ "network-setup.service" ];
             after = [ "network-pre.target" ] ++ deps;
             before = [ "network-setup.service" ];
             serviceConfig.Type = "oneshot";
@@ -508,7 +504,6 @@ let
           { description = "6-to-4 Tunnel Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
-            partOf = [ "network-setup.service" ];
             after = [ "network-pre.target" ] ++ deps;
             before = [ "network-setup.service" ];
             serviceConfig.Type = "oneshot";
@@ -542,7 +537,6 @@ let
           { description = "GRE Tunnel Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
-            partOf = [ "network-setup.service" ];
             after = [ "network-pre.target" ] ++ deps;
             before = [ "network-setup.service" ];
             serviceConfig.Type = "oneshot";


### PR DESCRIPTION
This changes the following chain after `nixos-rebuild switch` with modified tunnel interfaces: stop network-setup -> stop TUN-netdev -> stop network-addresses-TUN -> start network-addresses-TUN (fails since it depends on TUN-netdev which is off).

Chain after this change:
stop TUN-netdev -> stop network-setup -> stop network-addresses-TUN -> start TUN-netdev -> start network-addresses-TUN -> start network-setup

Was found when we investigated https://git.m-labs.hk/M-Labs/it-infra/issues/34 .

## Reproduction steps

1. In `/etc/nixos/configuration.nix`, add any GRE tunnel and a corresponding interface addresses configuration, like here:
    ```
    greTunnels."mytunnel" = {
      dev = myEthDevice;
      remote = "X.X.X.X";
      local = "Y.Y.Y.Y";
      ttl = 255;
      type = "tun";
    };
    interfaces."mytunnel" = {
      ipv4.addresses = [
        {
          address = "Z.Z.Z.Z";
          prefixLength = N;
        }
      ];
      ipv4.routes = [
        {
          address = "0.0.0.0";
          prefixLength = 0;
          via = "R.R.R.R";
          options.table = "1";
        }
      ];
    };
   ```
2. Save and apply configuration in any way
3. Change the addresses in the `/etc/nixos/configuration.nix` again, and use `nixos-rebuild switch`
4. After patch: configuration is applied without any errors
5. Before patch: configuration fails on restarting the services with similar to the following log in journal:
    ```
    Feb 06 17:33:49 nixbld systemd[1]: network-addresses-mytunnel.service: Bound to unit sys-subsystem-net-devices-mytunnel.device, but unit isn't active.
    Feb 06 17:33:49 nixbld systemd[1]: Dependency failed for Address configuration of mytunnel.
    Feb 06 17:33:49 nixbld systemd[1]: network-addresses-alt0.service: Job network-addresses-mytunnel.service/start failed with result 'dependency'.
    Feb 06 17:35:25 nixbld systemd[1]: Dependency failed for Address configuration of mytunnel.
    Feb 06 17:35:25 nixbld systemd[1]: network-addresses-alt0.service: Job network-addresses-mytunnel.service/start failed with result 'dependency'.
    ```

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@bjornfor 
@sinanmohd
@rgrunbla

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
