### PR TITLE
viddy: 1.1.5 -> 1.2.0

### DIFF
--- a/pkgs/by-name/vi/viddy/package.nix
+++ b/pkgs/by-name/vi/viddy/package.nix
@@ -6,21 +6,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "viddy";
-  version = "1.1.5";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "sachaos";
     repo = "viddy";
     rev = "v${version}";
-    hash = "sha256-RewzToI7vhaH8r6ZWDLgfSJOOCm26Udkzh9+xkJP2jE=";
+    hash = "sha256-r+zgZutBwNRLYNltdSaIB5lS4qHAhI5XL3iFF+FVd64=";
   };
 
-  cargoHash = "sha256-NhgiaUEUTfsbVqFkBgLPc3A8XmtwgQ5tp673zFD4TGI=";
+  cargoHash = "sha256-rEz3GFfqtSzZa0r4Nwbu3gEf7GhsOkfawaFaNplD/tE=";
 
   # requires nightly features
   env.RUSTC_BOOTSTRAP = 1;
 
-  env.VERGEN_BUILD_DATE = "2024-09-30"; # managed via the update script
+  env.VERGEN_BUILD_DATE = "2024-10-13"; # managed via the update script
   env.VERGEN_GIT_DESCRIBE = "Nixpkgs";
 
   passthru.updateScript.command = [ ./update.sh ];

--- a/pkgs/by-name/vi/viddy/update.sh
+++ b/pkgs/by-name/vi/viddy/update.sh
@@ -35,10 +35,10 @@ update-source-version viddy "${latestVersion}"
 
 pushd "$SCRIPT_DIR"
 # Build date
-sed -i 's#env.VERGEN_BUILD_DATE = "[^"]*"#env.VERGEN_BUILD_DATE = "'"${latestBuildDate}"'"#' default.nix
+sed -i 's#env.VERGEN_BUILD_DATE = "[^"]*"#env.VERGEN_BUILD_DATE = "'"${latestBuildDate}"'"#' package.nix
 
 # Hashes
 # https://github.com/msteen/nix-prefetch/issues/51
 cargoHash=$(nix-prefetch --option extra-experimental-features flakes "{ sha256 }: (import $NIXPKGS_DIR {}).viddy.cargoDeps.overrideAttrs (_: { outputHash = sha256; })")
-sed -i -E 's#\bcargoHash = ".*?"#cargoHash = "'"$cargoHash"'"#' default.nix
+sed -i -E 's#\bcargoHash = ".*?"#cargoHash = "'"$cargoHash"'"#' package.nix
 popd


### PR DESCRIPTION
I used `gh pr create --fill` so lost the template.

But it built on
- [x] x86_64-linux
  - /nix/store/pm592n682d0gmagm9vb3xsfi4csn3dx9-viddy-1.2.0
- [x] aarch64-linux (cross compiled and binfmt ran)
  - /nix/store/g97zs1ximpifbpvq4xjys4kd3kmb9xmr-viddy-aarch64-unknown-linux-gnu-1.2.0

nixpkgs-review
```console
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
....
1 package updated:
viddy (1.1.5 → 1.2.0)
```

Also fixes update script. It was default.nix before moving it to `pkgs/by-name/package.nix`