### PR TITLE
python312Packages.monai-label: init at 0.8.4

### DIFF
--- a/pkgs/development/python-modules/girder-client/default.nix
+++ b/pkgs/development/python-modules/girder-client/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  click,
+  diskcache,
+  requests,
+  requests-toolbelt,
+}:
+
+buildPythonPackage rec {
+  pname = "girder-client";
+  version = "3.2.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "girder";
+    repo = "girder";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/lRD01ll4FL6cVOmBDECARLXxeMJggeVx4pHWCqcGwI=";
+  };
+
+  sourceRoot = "${src.name}/clients/python";
+
+  build-system = [
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    diskcache
+    requests
+    requests-toolbelt
+    setuptools # uses `pkg_resources` at runtime
+  ];
+
+  pythonImportsCheck = [ "girder_client" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Client for interacting with the Girder data management platform";
+    homepage = "http://girder.readthedocs.io";
+    changelog = "https://github.com/girder/girder/releases/tag/v${version}";
+    mainProgram = "girder-cli";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/monai-label/default.nix
+++ b/pkgs/development/python-modules/monai-label/default.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  # build:
+  ninja,
+  setuptools,
+
+  # dependencies:
+  torch,
+  bcrypt,
+  cachetools,
+  dicomweb-client,
+  einops,
+  expiring-dict,
+  expiringdict,
+  fastapi,
+  filelock,
+  girder-client,
+  google-auth,
+  httpx,
+  monai,
+  passlib,
+  pydantic,
+  pydantic-settings,
+  pydicom,
+  pydicom-seg,
+  pyjwt,
+  pynetdicom,
+  pynrrd,
+  python-dotenv,
+  python-multipart,
+  pyyaml,
+  requests,
+  requests-toolbelt,
+  schedule,
+  scikit-learn,
+  scipy,
+  shapely,
+  timeloop,
+  urllib3,
+  uvicorn,
+  watchdog,
+
+  # test
+  pytestCheckHook,
+  parameterized,
+}:
+
+buildPythonPackage rec {
+  pname = "monai-label";
+  version = "0.8.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Project-MONAI";
+    repo = "MONAILabel";
+    rev = "refs/tags/${version}";
+    hash = "sha256-4XhL8zdYz33UIyIk9aih8GsFj2ktSt07sCKk0mgpXFw=";
+  };
+
+  postPatch = ''
+    patchShebangs monailabel/scripts/monailabel
+  '';
+
+  build-system = [
+    ninja
+    setuptools
+  ];
+
+  dependencies =
+    [
+      bcrypt
+      cachetools
+      dicomweb-client
+      einops
+      expiring-dict
+      expiringdict
+      fastapi
+      filelock
+      girder-client
+      google-auth
+      httpx
+      monai
+      passlib
+      pydantic
+      pydantic-settings
+      pydicom
+      pydicom-seg
+      pyjwt
+      pynetdicom
+      pynrrd
+      python-dotenv
+      python-multipart
+      pyyaml
+      requests
+      requests-toolbelt
+      schedule
+      scikit-learn
+      scipy
+      shapely
+      timeloop
+      torch
+      urllib3
+      uvicorn
+      watchdog
+    ]
+    ++ (
+      let
+        d = monai.optional-dependencies;
+      in
+      lib.flatten [
+        d.fire
+        d.gdown
+        d.ignite
+        d.itk
+        d.lmdb
+        d.mlflow
+        d.nibabel
+        d.numpymaxflow
+        d.openslide
+        d.pillow
+        d.psutil
+        d.scikit-image
+        d.tensorboard
+        d.torchvision
+        d.tqdm
+      ]
+    );
+
+  pythonRelaxDeps = true;
+
+  pythonImportsCheck = [
+    "monailabel"
+    "monailabel.app"
+    "monailabel.config"
+    "monailabel.main"
+    "monailabel.client"
+    "monailabel.datastore"
+    "monailabel.deepedit"
+    "monailabel.interfaces"
+    "monailabel.scribbles"
+    "monailabel.tasks"
+    "monailabel.transform"
+    "monailabel.utils"
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+    parameterized
+  ];
+
+  preCheck = ''rm -rf monailabel/'';
+
+  disabledTestPaths = [
+    "plugins/cellprofiler/test_runvista2d.py" # needs cellprofiler, not in nixpkgs
+    "tests/integration/monaibundle/detection" # plugin issue
+
+    # try to download data/access nonexistent data:
+    "tests/integration/pathology/test_info.py"
+    "tests/integration/radiology"
+    "tests/unit/datastore"
+    "tests/unit/deepedit/test_planner.py"
+    "tests/unit/endpoints"
+    "tests/unit/test_main.py" # also some sort of plugin issue
+    "tests/unit/utils/test_sessions.py"
+  ];
+
+  meta = {
+    description = "Tool/framework for labeling and deep learning in medical imaging";
+    homepage = "https://docs.monai.io/projects/label";
+    changelog = "https://github.com/Project-MONAI/MONAILabel/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/monai/default.nix
+++ b/pkgs/development/python-modules/monai/default.nix
@@ -10,6 +10,23 @@
   pybind11,
   torch,
   which,
+
+  # optional dependencies (incomplete; for monai-label):
+  fire,
+  gdown,
+  ignite,
+  itk,
+  lmdb,
+  nibabel,
+  numpymaxflow,
+  mlflow,
+  openslide,
+  pillow,
+  psutil,
+  scikit-image,
+  tensorboard,
+  torchvision,
+  tqdm,
 }:
 
 buildPythonPackage rec {
@@ -44,6 +61,24 @@ buildPythonPackage rec {
     packaging
     torch
   ];
+
+  optional-dependencies = {
+    fire = [ fire ];
+    gdown = [ gdown ];
+    ignite = [ ignite ];
+    itk = [ itk ];
+    lmdb = [ lmdb ];
+    mlflow = [ mlflow ];
+    nibabel = [ nibabel ];
+    numpymaxflow = [ numpymaxflow ];
+    openslide = [ openslide ];
+    pillow = [ pillow ];
+    psutil = [ psutil ];
+    scikit-image = [ scikit-image ];
+    tensorboard = [ tensorboard ];
+    torchvision = [ torchvision ];
+    tqdm = [ tqdm ];
+  };
 
   env.BUILD_MONAI = 1;
 

--- a/pkgs/development/python-modules/numpymaxflow/default.nix
+++ b/pkgs/development/python-modules/numpymaxflow/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  python,
+  numpy,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "numpymaxflow";
+  version = "0.0.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "masadcv";
+    repo = "numpymaxflow";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-s1Pbab3vK0Co1KQev+/4+IRqyLzqUXBixz4b0ndq+5k=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail "numpy==1.26.0" "numpy"
+  '';
+
+  build-system = [
+    numpy
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
+
+  pythonImportsCheck = [ "numpymaxflow" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Numpy-based implementation of max-flow/min-cut (graphcut) for 2D/3D data";
+    homepage = "https://github.com/masadcv/numpymaxflow";
+    changelog = "https://github.com/masadcv/numpymaxflow/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/timeloop/default.nix
+++ b/pkgs/development/python-modules/timeloop/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "timeloop";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sankalpjonn";
+    repo = "timeloop";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HHbhqMH+xN6LRWQe48lDP1A0mwbhK8i0EnATXfxcrQ0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "timeloop" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Elegant periodic task executor";
+    homepage = "https://github.com/sankalpjonn/timeloop";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5159,6 +5159,8 @@ self: super: with self; {
 
   gipc = callPackage ../development/python-modules/gipc { };
 
+  girder-client = callPackage ../development/python-modules/girder-client { };
+
   gistyc = callPackage ../development/python-modules/gistyc { };
 
   git-annex-adapter =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15900,6 +15900,8 @@ self: super: with self; {
 
   timelib = callPackage ../development/python-modules/timelib { };
 
+  timeloop = callPackage ../development/python-modules/timeloop { };
+
   time-machine = callPackage ../development/python-modules/time-machine { };
 
   timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9267,6 +9267,8 @@ self: super: with self; {
   numpy_2 = callPackage ../development/python-modules/numpy/2.nix { };
   numpy = if self.pythonOlder "3.13" then numpy_1 else numpy_2;
 
+  numpymaxflow = callPackage ../development/python-modules/numpymaxflow { };
+
   numpy-groupies = callPackage ../development/python-modules/numpy-groupies { };
 
   numpy-stl = callPackage ../development/python-modules/numpy-stl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8283,6 +8283,8 @@ self: super: with self; {
 
   monai-deploy = callPackage ../development/python-modules/monai-deploy { };
 
+  monai-label = callPackage ../development/python-modules/monai-label { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };


### PR DESCRIPTION
Init `python311Packages.monai-label`, a [package for medical image labelling with deep learning](https://docs.monai.io/projects/label), and its dependencies, `python312Packages.{numpymaxflow,girder-client,timeloop}`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
