### PR TITLE
Immich update -> 1.119.1

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -258,7 +258,7 @@ in
       postgresEnv
       // redisEnv
       // {
-        HOST = cfg.host;
+        IMMICH_HOST = cfg.host;
         IMMICH_PORT = toString cfg.port;
         IMMICH_MEDIA_LOCATION = cfg.mediaLocation;
         IMMICH_MACHINE_LEARNING_URL = "http://localhost:3003";

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -101,8 +101,8 @@ let
 
   web = buildNpmPackage' {
     pname = "immich-web";
-    inherit version;
-    src = "${src}/web";
+    inherit version src;
+    sourceRoot = "${src.name}/web";
     inherit (sources.components.web) npmDepsHash;
 
     preBuild = ''

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.118.2",
-  "hash": "sha256-u2/Xs1SdAzmQ02pyXD9+ncamIKFcq8qMijnx7KFtrmU=",
+  "version": "1.119.0",
+  "hash": "sha256-mflVxz+Pxv7xS4onsjRQ1lMZ43U/rkuqO6vPRon7Gms=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-RwfGq0fDPYo+ZP2xv+sMKmr3Tf8szbB8506c1PqiMM0=",
-      "version": "2.2.26"
+      "npmDepsHash": "sha256-QClG/WQK2MbVKuR0Wk9+TdSTAbemtFeg7GkKjvEjC4c=",
+      "version": "2.2.27"
     },
     "server": {
-      "npmDepsHash": "sha256-4jPvLCsI2gz+maBU3ZtrWZzJ6Zp2PTQwaCuCKr1hK/o=",
-      "version": "1.118.2"
+      "npmDepsHash": "sha256-9mMnOiKsTTO4PJUKYN668yjIELeFUgdqSx6Gf87UYVU=",
+      "version": "1.119.0"
     },
     "web": {
-      "npmDepsHash": "sha256-j6+EkcfwpaCP048v/kZv1xthp0DSylraJTeU4+LcDbw=",
-      "version": "1.118.2"
+      "npmDepsHash": "sha256-ieTGMywR26msYqmQOK/q/l3O6/Vkmu0TLFn956kK/xE=",
+      "version": "1.119.0"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-e+7BEFc46scLZDqCJNRhrczOEydSoiK9m7vSj/2ECaE=",
-      "version": "1.118.2"
+      "npmDepsHash": "sha256-NLvuHTVWuzv5G0ONu3S3K8AgyliTZowYQN0fzYhWtUQ=",
+      "version": "1.119.0"
     }
   }
 }

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.119.0",
-  "hash": "sha256-mflVxz+Pxv7xS4onsjRQ1lMZ43U/rkuqO6vPRon7Gms=",
+  "version": "1.119.1",
+  "hash": "sha256-AH3p9Qzoy9VkniHaGf2Ia4LrtP24SiKqENpdZnWi1QQ=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-QClG/WQK2MbVKuR0Wk9+TdSTAbemtFeg7GkKjvEjC4c=",
-      "version": "2.2.27"
+      "npmDepsHash": "sha256-dvHkRbiXTEf5d+GeuHrCQyH+ATxaI+kp52n4gB4arN4=",
+      "version": "2.2.28"
     },
     "server": {
-      "npmDepsHash": "sha256-9mMnOiKsTTO4PJUKYN668yjIELeFUgdqSx6Gf87UYVU=",
-      "version": "1.119.0"
+      "npmDepsHash": "sha256-HWuFjH1OCJAn1xRXlqxjNFz3wl2iWcVw7K5Jk1gZKao=",
+      "version": "1.119.1"
     },
     "web": {
-      "npmDepsHash": "sha256-ieTGMywR26msYqmQOK/q/l3O6/Vkmu0TLFn956kK/xE=",
-      "version": "1.119.0"
+      "npmDepsHash": "sha256-1ezw1dXrNlA535LQmWfEhoJrmukBls/wqayVVmDeEXM=",
+      "version": "1.119.1"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-NLvuHTVWuzv5G0ONu3S3K8AgyliTZowYQN0fzYhWtUQ=",
-      "version": "1.119.0"
+      "npmDepsHash": "sha256-pWEJIhKx1xlW7ljd4vSZcVpxpMxqKLZzTc9qFKU/S7A=",
+      "version": "1.119.1"
     }
   }
 }


### PR DESCRIPTION
Update immich and related for 1.119.1

Running on my nixos-unstable x86-64 server

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [-] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)  (running now, sorry, my first contribution)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

![CleanShot 2024-10-31 at 16 02 20](https://github.com/user-attachments/assets/b09abceb-20ae-4fe4-a6f8-77f2b76fb845)
