### PR TITLE
qt6Packages.{qwlroots: 0.1.0 -> 0.3.0, waylib: 0.1.1 -> 0.3.0-alpha}

### DIFF
--- a/pkgs/development/libraries/qwlroots/default.nix
+++ b/pkgs/development/libraries/qwlroots/default.nix
@@ -20,19 +20,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qwlroots";
-  version = "0.1.0";
+  version = "0.3.0-wlroots0.17-0.18";
 
   src = fetchFromGitHub {
     owner = "vioken";
     repo = "qwlroots";
     rev = finalAttrs.version;
-    hash = "sha256-ev4oCKR43XaYNTavj9XI3RAtB6RFprChpBFsrA2nVsM=";
+    hash = "sha256-ObXegiJ4LT8bTUxNVJ9wBKN5oILWPDYTsuCy+OCsh3k=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
     wayland-scanner
   ];
 
@@ -57,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "PREFER_QT_5" (lib.versionOlder qtbase.version "6"))
   ];
+
+  dontWrapQtApps = true;
 
   meta = {
     description = "Qt and QML bindings for wlroots";

--- a/pkgs/development/libraries/waylib/default.nix
+++ b/pkgs/development/libraries/waylib/default.nix
@@ -1,46 +1,31 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , wayland-scanner
 , wrapQtAppsHook
 , qtbase
-, qtquick3d
+, qtdeclarative
 , qwlroots
 , wayland
 , wayland-protocols
 , wlr-protocols
 , pixman
 , libdrm
-, nixos-artwork
+, libinput
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "waylib";
-  version = "0.1.1";
+  version = "0.3.0-alpha";
 
   src = fetchFromGitHub {
     owner = "vioken";
     repo = "waylib";
     rev = finalAttrs.version;
-    hash = "sha256-3IdrChuXQyQGhJ/7kTqmkV0PyuSNP53Y0Po01Fc9Qi0=";
+    hash = "sha256-5IWe8VFpLwDSja4to/ugVS80s5+bcAbM6/fg1HPP52Q=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-build-on-qt-6_7.patch";
-      url = "https://github.com/vioken/waylib/commit/09875ebedb074089ec57e71cbc8d8011f555be70.patch";
-      hash = "sha256-ulXlLxn7TOlXSl4N5mjXCy3PJhxVeyDwbwKeV9J/FSI=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace examples/tinywl/OutputDelegate.qml \
-      --replace "/usr/share/wallpapers/deepin/desktop.jpg" \
-                "${nixos-artwork.wallpapers.simple-blue}/share/backgrounds/nixos/nix-wallpaper-simple-blue.png"
-  '';
 
   depsBuildBuild = [
     # To find wayland-scanner
@@ -51,36 +36,30 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     wayland-scanner
-    wrapQtAppsHook
   ];
 
   buildInputs = [
     qtbase
-    qtquick3d
+    qtdeclarative
+    qwlroots
     wayland
     wayland-protocols
     wlr-protocols
     pixman
     libdrm
-  ];
-
-  propagatedBuildInputs = [
-    qwlroots
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "INSTALL_TINYWL" true)
+    libinput
   ];
 
   strictDeps = true;
 
-  outputs = [ "out" "dev" "bin" ];
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
 
   meta = {
     description = "Wrapper for wlroots based on Qt";
     homepage = "https://github.com/vioken/waylib";
     license = with lib.licenses; [ gpl3Only lgpl3Only asl20 ];
-    outputsToInstall = [ "out" ];
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ rewine ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vioken/waylib/releases/tag/0.3.0-alpha
https://github.com/vioken/qwlroots/releases/tag/0.3.0-wlroots0.17-0.18

Although 0.3 it is a Pre-release tag, it is still more stable than the 0.1 version.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
