### PR TITLE
nixos/hypridle: add hyprctl, hyprlock and pidof to path

### DIFF
--- a/nixos/modules/services/wayland/hypridle.nix
+++ b/nixos/modules/services/wayland/hypridle.nix
@@ -20,6 +20,11 @@ in
     systemd = {
       packages = [ cfg.package ];
       user.services.hypridle.wantedBy = [ "graphical-session.target" ];
+      user.services.hypridle.path = [
+        config.programs.hyprland.package
+        config.programs.hyprlock.package
+        pkgs.procps
+      ];
     };
   };
 


### PR DESCRIPTION
Without this journal error pops up as:

```log
Oct 31 17:51:00 Ainz-NIX hypridle[2720]: [LOG] Process Created with pid 5398
Oct 31 17:51:00 Ainz-NIX hypridle[5399]: /bin/sh: line 1: pidof: command not found
Oct 31 17:51:00 Ainz-NIX hypridle[5398]: /bin/sh: line 1: hyprlock: command not found
Oct 31 17:51:19 Ainz-NIX hypridle[2720]: [LOG] Got PrepareForSleep from dbus with sleep false
Oct 31 17:51:19 Ainz-NIX hypridle[2720]: [LOG] Running: hyprctl dispatch dpms on
Oct 31 17:51:19 Ainz-NIX hypridle[2720]: [LOG] Executing hyprctl dispatch dpms on
Oct 31 17:51:19 Ainz-NIX hypridle[2720]: [LOG] Process Created with pid 5567
Oct 31 17:51:19 Ainz-NIX hypridle[5567]: /bin/sh: line 1: hyprctl: command not found
```

This makes hyprlock properly start on unlock.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - With my own configuration
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
