### PR TITLE
libsForQt5.accounts-qml-module,lomiri.*: Enable qdoc docs

### DIFF
--- a/pkgs/desktops/lomiri/development/u1db-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/u1db-qt/default.nix
@@ -103,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Qt5 binding and QtQuick2 plugin for U1DB";
     homepage = "https://gitlab.com/ubports/development/core/u1db-qt";
+    changelog = "https://gitlab.com/ubports/development/core/u1db-qt/-/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.lgpl3Only;
     maintainers = lib.teams.lomiri.members;
     platforms = lib.platforms.linux;

--- a/pkgs/desktops/lomiri/development/u1db-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/u1db-qt/default.nix
@@ -10,6 +10,7 @@
   pkg-config,
   qtbase,
   qtdeclarative,
+  qttools,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "doc"
     "examples"
   ];
 
@@ -56,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     qtdeclarative # qmlplugindump
+    qttools # qdoc
   ];
 
   buildInputs = [
@@ -66,8 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [ dbus-test-runner ];
 
   cmakeFlags = [
-    # Needs qdoc, see https://github.com/NixOS/nixpkgs/pull/245379
-    (lib.cmakeBool "BUILD_DOCS" false)
+    (lib.cmakeBool "BUILD_DOCS" true)
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
@@ -1,17 +1,18 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, gitUpdater
-, testers
-, cmake
-, dbus
-, dbus-test-runner
-, doxygen
-, pkg-config
-, qtbase
-, qtdeclarative
-, qttools
-, validatePkgConfig
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  testers,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  doxygen,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  validatePkgConfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Queries QMake for broken Qt variable: '/build/qtbase-<commit>/$(out)/$(qtQmlPrefix)'
     substituteInPlace qml/Lomiri/Action/CMakeLists.txt \
-      --replace 'exec_program(''${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_QML" OUTPUT_VARIABLE QT_IMPORTS_DIR)' 'set(QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
+      --replace-fail 'exec_program(''${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_QML" OUTPUT_VARIABLE QT_IMPORTS_DIR)' 'set(QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
 
     # Fix section labels
     substituteInPlace documentation/qml/pages/* \
@@ -64,9 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "GENERATE_DOCUMENTATION" true)
     # Use vendored libhud2, TODO package libhud2 separately?
     (lib.cmakeBool "use_libhud2" false)
-    (lib.cmakeBool "GENERATE_DOCUMENTATION" true)
   ];
 
   dontWrapQtApps = true;
@@ -90,8 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.lgpl3Only;
     maintainers = teams.lomiri.members;
     platforms = platforms.linux;
-    pkgConfigModules = [
-      "lomiri-action-qt-1"
-    ];
+    pkgConfigModules = [ "lomiri-action-qt-1" ];
   };
 })

--- a/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
@@ -6,9 +6,11 @@
 , cmake
 , dbus
 , dbus-test-runner
+, doxygen
 , pkg-config
 , qtbase
 , qtdeclarative
+, qttools
 , validatePkgConfig
 }:
 
@@ -26,20 +28,27 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "doc"
   ];
 
   postPatch = ''
     # Queries QMake for broken Qt variable: '/build/qtbase-<commit>/$(out)/$(qtQmlPrefix)'
     substituteInPlace qml/Lomiri/Action/CMakeLists.txt \
       --replace 'exec_program(''${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_QML" OUTPUT_VARIABLE QT_IMPORTS_DIR)' 'set(QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
+
+    # Fix section labels
+    substituteInPlace documentation/qml/pages/* \
+      --replace-warn '\part' '\section1'
   '';
 
   strictDeps = true;
 
   nativeBuildInputs = [
     cmake
+    doxygen
     pkg-config
     qtdeclarative
+    qttools # qdoc
     validatePkgConfig
   ];
 
@@ -57,8 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
     # Use vendored libhud2, TODO package libhud2 separately?
     (lib.cmakeBool "use_libhud2" false)
-    # QML docs need qdoc, https://github.com/NixOS/nixpkgs/pull/245379
-    (lib.cmakeBool "GENERATE_DOCUMENTATION" false)
+    (lib.cmakeBool "GENERATE_DOCUMENTATION" true)
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -21,6 +21,7 @@
 , qtquickcontrols2
 , qtsvg
 , qtsystems
+, qttools
 , suru-icon-theme
 , validatePkgConfig
 , wrapQtAppsHook
@@ -43,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-r+wUCl+ywFcgFYo7BjBoXiulQptd1Zd3LJchXiMtx4I=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "doc" ];
 
   patches = [
     ./2001-Mark-problematic-tests.patch
@@ -66,6 +67,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Install apicheck tool into bin
     substituteInPlace apicheck/apicheck.pro \
       --replace-fail "\''$\''$[QT_INSTALL_LIBS]/lomiri-ui-toolkit" "$out/bin"
+
+    substituteInPlace documentation/documentation.pro \
+      --replace-fail '/usr/share/doc' '$$PREFIX/share/doc' \
+      --replace-fail '$$[QT_INSTALL_DOCS]' '$$PREFIX/share/doc/lomiri-ui-toolkit'
 
     # Causes redefinition error with our own fortify hardening
     sed -i '/DEFINES += _FORTIFY_SOURCE/d' features/lomiri_common.prf
@@ -105,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     qmake
+    qttools # qdoc, qhelpgenerator
     validatePkgConfig
     wrapQtAppsHook
   ];
@@ -133,8 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   qmakeFlags = [
-    # docs require Qt5's qdoc, which we don't have before https://github.com/NixOS/nixpkgs/pull/245379
-    "CONFIG+=no_docs"
     # Ubuntu UITK compatibility, for older / not-yet-migrated applications
     "CONFIG+=ubuntu-uitk-compat"
     "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -1,37 +1,46 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, gitUpdater
-, substituteAll
-, testers
-, dbus-test-runner
-, dpkg
-, gdb
-, glib
-, lttng-ust
-, perl
-, pkg-config
-, python3
-, qmake
-, qtbase
-, qtdeclarative
-, qtfeedback
-, qtgraphicaleffects
-, qtpim
-, qtquickcontrols2
-, qtsvg
-, qtsystems
-, qttools
-, suru-icon-theme
-, validatePkgConfig
-, wrapQtAppsHook
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  substituteAll,
+  testers,
+  dbus-test-runner,
+  dpkg,
+  gdb,
+  glib,
+  lttng-ust,
+  perl,
+  pkg-config,
+  python3,
+  qmake,
+  qtbase,
+  qtdeclarative,
+  qtfeedback,
+  qtgraphicaleffects,
+  qtpim,
+  qtquickcontrols2,
+  qtsvg,
+  qtsystems,
+  qttools,
+  suru-icon-theme,
+  validatePkgConfig,
+  wrapQtAppsHook,
+  xvfb-run,
 }:
 
 let
   listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
-  qtPluginPaths = listToQtVar qtbase.qtPluginPrefix [ qtbase qtpim qtsvg ];
-  qtQmlPaths = listToQtVar qtbase.qtQmlPrefix [ qtdeclarative qtfeedback qtgraphicaleffects ];
+  qtPluginPaths = listToQtVar qtbase.qtPluginPrefix [
+    qtbase
+    qtpim
+    qtsvg
+  ];
+  qtQmlPaths = listToQtVar qtbase.qtQmlPrefix [
+    qtdeclarative
+    qtfeedback
+    qtgraphicaleffects
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-ui-toolkit";
@@ -44,10 +53,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-r+wUCl+ywFcgFYo7BjBoXiulQptd1Zd3LJchXiMtx4I=";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
 
   patches = [
     ./2001-Mark-problematic-tests.patch
+
     (substituteAll {
       src = ./2002-Nixpkgs-versioned-QML-path.patch.in;
       name = "2002-Nixpkgs-versioned-QML-path.patch";
@@ -205,7 +219,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "QML components to ease the creation of beautiful applications in QML";
     longDescription = ''
       This project consists of a set of QML components to ease the creation of beautiful applications in QML for Lomiri.
@@ -223,9 +237,12 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gitlab.com/ubports/development/core/lomiri-ui-toolkit";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/blob/${finalAttrs.version}/ChangeLog";
-    license = with licenses; [ gpl3Only cc-by-sa-30 ];
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    license = with lib.licenses; [
+      gpl3Only
+      cc-by-sa-30
+    ];
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "LomiriGestures"
       "LomiriMetrics"

--- a/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
@@ -22,6 +22,7 @@
 , qtdeclarative
 , qtfeedback
 , qtgraphicaleffects
+, qttools
 , validatePkgConfig
 , wrapGAppsHook3
 , xvfb-run
@@ -41,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "doc"
     "examples"
   ];
 
@@ -64,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     pkg-config
     qtdeclarative # qmlplugindump
+    qttools # qdoc
     validatePkgConfig
     wrapGAppsHook3
   ];
@@ -100,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "ENABLE_DOC" false) # needs Qt5 qdoc: https://github.com/NixOS/nixpkgs/pull/245379
+    (lib.cmakeBool "ENABLE_DOC" true)
     (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # in case something still depends on it
   ];
 

--- a/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
@@ -1,31 +1,32 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, gitUpdater
-, testers
-, cmake
-, cmake-extras
-, dbus-test-runner
-, gettext
-, glib
-, gsettings-qt
-, gtest
-, libapparmor
-, libnotify
-, lomiri-api
-, lomiri-app-launch
-, lomiri-download-manager
-, lomiri-ui-toolkit
-, pkg-config
-, properties-cpp
-, qtbase
-, qtdeclarative
-, qtfeedback
-, qtgraphicaleffects
-, qttools
-, validatePkgConfig
-, wrapGAppsHook3
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  testers,
+  cmake,
+  cmake-extras,
+  dbus-test-runner,
+  gettext,
+  glib,
+  gsettings-qt,
+  gtest,
+  libapparmor,
+  libnotify,
+  lomiri-api,
+  lomiri-app-launch,
+  lomiri-download-manager,
+  lomiri-ui-toolkit,
+  pkg-config,
+  properties-cpp,
+  qtbase,
+  qtdeclarative,
+  qtfeedback,
+  qtgraphicaleffects,
+  qttools,
+  validatePkgConfig,
+  wrapGAppsHook3,
+  xvfb-run,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -93,9 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
   ];
 
-  checkInputs = [
-    gtest
-  ];
+  checkInputs = [ gtest ];
 
   dontWrapQtApps = true;
 
@@ -107,13 +106,23 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # in case something still depends on it
   ];
 
-  preBuild = let
-    listToQtVar = list: suffix: lib.strings.concatMapStringsSep ":" (drv: "${lib.getBin drv}/${suffix}") list;
-  in ''
-    # Executes qmlplugindump
-    export QT_PLUGIN_PATH=${listToQtVar [ qtbase ] qtbase.qtPluginPrefix}
-    export QML2_IMPORT_PATH=${listToQtVar [ qtdeclarative lomiri-ui-toolkit qtfeedback qtgraphicaleffects ] qtbase.qtQmlPrefix}
-  '';
+  preBuild =
+    let
+      listToQtVar =
+        list: suffix: lib.strings.concatMapStringsSep ":" (drv: "${lib.getBin drv}/${suffix}") list;
+    in
+    ''
+      # Executes qmlplugindump
+      export QT_PLUGIN_PATH=${listToQtVar [ qtbase ] qtbase.qtPluginPrefix}
+      export QML2_IMPORT_PATH=${
+        listToQtVar [
+          qtdeclarative
+          lomiri-ui-toolkit
+          qtfeedback
+          qtgraphicaleffects
+        ] qtbase.qtQmlPrefix
+      }
+    '';
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
@@ -148,7 +157,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gitlab.com/ubports/development/core/lomiri-content-hub";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-content-hub/-/blob/${finalAttrs.version}/ChangeLog";
-    license = with lib.licenses; [ gpl3Only lgpl3Only ];
+    license = with lib.licenses; [
+      gpl3Only
+      lgpl3Only
+    ];
     mainProgram = "lomiri-content-hub-service";
     maintainers = lib.teams.lomiri.members;
     platforms = lib.platforms.linux;

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -9,8 +9,7 @@
 , cmake-extras
 , dbus
 , dbus-test-runner
-# Needs qdoc, https://github.com/NixOS/nixpkgs/pull/245379
-, withDocumentation ? false
+, withDocumentation ? true
 , doxygen
 , glog
 , graphviz
@@ -20,6 +19,7 @@
 , python3
 , qtbase
 , qtdeclarative
+, qttools
 , validatePkgConfig
 , wrapQtAppsHook
 , xvfb-run
@@ -77,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals withDocumentation [
     doxygen
     graphviz
+    qttools # qdoc
   ];
 
   buildInputs = [

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -1,28 +1,29 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, fetchpatch
-, gitUpdater
-, testers
-, boost
-, cmake
-, cmake-extras
-, dbus
-, dbus-test-runner
-, withDocumentation ? true
-, doxygen
-, glog
-, graphviz
-, gtest
-, lomiri-api
-, pkg-config
-, python3
-, qtbase
-, qtdeclarative
-, qttools
-, validatePkgConfig
-, wrapQtAppsHook
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  testers,
+  boost,
+  cmake,
+  cmake-extras,
+  dbus,
+  dbus-test-runner,
+  withDocumentation ? true,
+  doxygen,
+  glog,
+  graphviz,
+  gtest,
+  lomiri-api,
+  pkg-config,
+  python3,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  validatePkgConfig,
+  wrapQtAppsHook,
+  xvfb-run,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,9 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals withDocumentation [
-    "doc"
-  ];
+  ] ++ lib.optionals withDocumentation [ "doc" ];
 
   patches = [
     # This change seems incomplete, potentially breaks things on systems that don't use AppArmor mediation
@@ -69,16 +68,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    validatePkgConfig
-    wrapQtAppsHook
-  ] ++ lib.optionals withDocumentation [
-    doxygen
-    graphviz
-    qttools # qdoc
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      validatePkgConfig
+      wrapQtAppsHook
+    ]
+    ++ lib.optionals withDocumentation [
+      doxygen
+      graphviz
+      qttools # qdoc
+    ];
 
   buildInputs = [
     boost
@@ -96,9 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
   ];
 
-  checkInputs = [
-    gtest
-  ];
+  checkInputs = [ gtest ];
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_DOC" withDocumentation)
@@ -107,11 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_WERROR" false)
   ];
 
-  makeTargets = [
-    "all"
-  ] ++ lib.optionals withDocumentation [
-    "doc"
-  ];
+  makeTargets = [ "all" ] ++ lib.optionals withDocumentation [ "doc" ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
@@ -128,13 +123,13 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Performs uploads and downloads from a centralized location";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-download-manager";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.lgpl3Only;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "ldm-common"
       "lomiri-download-manager-client"

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -28,6 +28,7 @@
   python3,
   qtdeclarative,
   qtbase,
+  qttools,
   validatePkgConfig,
 }:
 
@@ -74,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     intltool
     pkg-config
     qtdeclarative
+    qttools # qdoc
     validatePkgConfig
   ];
 
@@ -106,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # just in case something needs it
-    (lib.cmakeBool "BUILD_DOC" true) # lacks QML docs, needs qdoc: https://github.com/NixOS/nixpkgs/pull/245379
+    (lib.cmakeBool "BUILD_DOC" true)
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "accounts-qml-module";
-  version = "0.7-unstable-2022-10-28";
+  version = "0.7-unstable-2023-10-28";
 
   src = fetchFromGitLab {
     owner = "accounts-sso";

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -1,15 +1,17 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, accounts-qt
-, dbus-test-runner
-, pkg-config
-, qmake
-, qtbase
-, qtdeclarative
-, qttools
-, signond
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  unstableGitUpdater,
+  accounts-qt,
+  dbus-test-runner,
+  pkg-config,
+  qmake,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  signond,
+  xvfb-run,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,21 +30,23 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  postPatch = ''
-    substituteInPlace src/src.pro \
-      --replace '$$[QT_INSTALL_BINS]/qmlplugindump' 'qmlplugindump' \
-      --replace '$$[QT_INSTALL_QML]' '${placeholder "out"}/${qtbase.qtQmlPrefix}'
+  postPatch =
+    ''
+      substituteInPlace src/src.pro \
+        --replace '$$[QT_INSTALL_BINS]/qmlplugindump' 'qmlplugindump' \
+        --replace '$$[QT_INSTALL_QML]' '${placeholder "out"}/${qtbase.qtQmlPrefix}'
 
-    # Find qdoc
-    substituteInPlace doc/doc.pri \
-      --replace-fail 'QDOC = $$[QT_INSTALL_BINS]/qdoc' 'QDOC = qdoc'
+      # Find qdoc
+      substituteInPlace doc/doc.pri \
+        --replace-fail 'QDOC = $$[QT_INSTALL_BINS]/qdoc' 'QDOC = qdoc'
 
-    # Don't install test binary
-    sed -i tests/tst_plugin.pro \
-      -e '/TARGET = tst_plugin/a INSTALLS -= target'
-  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
-    sed -i accounts-qml-module.pro -e '/tests/d'
-  '';
+      # Don't install test binary
+      sed -i tests/tst_plugin.pro \
+        -e '/TARGET = tst_plugin/a INSTALLS -= target'
+    ''
+    + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+      sed -i accounts-qml-module.pro -e '/tests/d'
+    '';
 
   # QMake can't find Qt modules in buildInputs
   strictDeps = false;
@@ -88,11 +92,15 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput share/accounts-qml-module/doc $doc
   '';
 
-  meta = with lib; {
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "VERSION_";
+  };
+
+  meta = {
     description = "QML bindings for libaccounts-qt + libsignon-qt";
     homepage = "https://gitlab.com/accounts-sso/accounts-qml-module";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
With #245379 merged & [in master/unstable](https://nixpk.gs/pr-tracker.html?pr=245379), we can now enable the QML documentation in abunch of stuff.

And as usual, doing nixfmt & other maintenance stuff where possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
