### PR TITLE
Fix NixOS tests for various Prometheus exporters

### DIFF
--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -597,6 +597,8 @@ let
             rpcauth=bitcoinrpc:e8fe33f797e698ac258c16c8d7aadfbe$872bdb8f4d787367c26bcfd75e6c23c4f19d44a69f5d1ad329e5adf3f82710f7
             zmqpubrawblock=tcp://127.0.0.1:28332
             zmqpubrawtx=tcp://127.0.0.1:28333
+            # https://github.com/lightningnetwork/lnd/issues/9163
+            deprecatedrpc=warnings
           '';
           extraCmdlineOptions = [ "-regtest" ];
         };

--- a/pkgs/servers/monitoring/prometheus/pgbouncer-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/pgbouncer-exporter.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "pgbouncer-exporter";
-  version = "0.10.0";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "prometheus-community";
     repo = "pgbouncer_exporter";
     rev = "v${version}";
-    hash = "sha256-9Sa9BimyKwYTjh0ELlDlUS3kc5gnkK1i7xiO84vVPYA=";
+    hash = "sha256-8ChYYJIHdzH2vWxqnzS6sz9fDeLe+Y29fzia3/aBkgc=";
   };
 
   vendorHash = "sha256-PjoS56MdYpDOuSTHHo5lGL9KlWlu3ycA08qim8jrnSU=";

--- a/pkgs/servers/monitoring/prometheus/surfboard-exporter/add-go-mod.patch
+++ b/pkgs/servers/monitoring/prometheus/surfboard-exporter/add-go-mod.patch
@@ -1,0 +1,72 @@
+diff --git a/go.mod b/go.mod
+new file mode 100644
+index 0000000..64972bc
+--- /dev/null
++++ b/go.mod
+@@ -0,0 +1,20 @@
++module github.com/ipstatic/surfboard_exporter
++
++go 1.22
++
++require (
++	github.com/prometheus/client_golang v0.8.1-0.20160916180340-5636dc67ae77
++	github.com/prometheus/common v0.0.0-20160928123818-e35a2e33a50a
++	golang.org/x/net v0.0.0-20161019184016-3bafa3320efd
++)
++
++require (
++	github.com/Sirupsen/logrus v0.10.1-0.20160829202321-3ec0642a7fb6 // indirect
++	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
++	github.com/golang/protobuf v0.0.0-20160926185624-87c000235d3d // indirect
++	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
++	github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335 // indirect
++	github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 // indirect
++	github.com/stretchr/testify v1.9.0 // indirect
++	golang.org/x/sys v0.26.0 // indirect
++)
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+new file mode 100644
+index 0000000..d7c6fa3
+--- /dev/null
++++ b/vendor/modules.txt
+@@ -0,0 +1,40 @@
++# github.com/Sirupsen/logrus v0.10.1-0.20160829202321-3ec0642a7fb6
++## explicit
++github.com/Sirupsen/logrus
++# github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
++## explicit
++github.com/beorn7/perks/quantile
++# github.com/golang/protobuf v0.0.0-20160926185624-87c000235d3d
++## explicit
++github.com/golang/protobuf/proto
++# github.com/matttproud/golang_protobuf_extensions v1.0.1
++## explicit
++github.com/matttproud/golang_protobuf_extensions/pbutil
++# github.com/prometheus/client_golang v0.8.1-0.20160916180340-5636dc67ae77
++## explicit
++github.com/prometheus/client_golang/prometheus
++# github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335
++## explicit
++github.com/prometheus/client_model/go
++# github.com/prometheus/common v0.0.0-20160928123818-e35a2e33a50a
++## explicit
++github.com/prometheus/common/expfmt
++github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
++github.com/prometheus/common/log
++github.com/prometheus/common/model
++github.com/prometheus/common/version
++# github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9
++## explicit
++github.com/prometheus/procfs
++# github.com/stretchr/testify v1.9.0
++## explicit; go 1.17
++# golang.org/x/net v0.0.0-20161019184016-3bafa3320efd
++## explicit
++golang.org/x/net/html
++golang.org/x/net/html/atom
++# golang.org/x/sys v0.26.0
++## explicit; go 1.18
++golang.org/x/sys/unix
++golang.org/x/sys/windows
++golang.org/x/sys/windows/registry
++golang.org/x/sys/windows/svc/eventlog

--- a/pkgs/servers/monitoring/prometheus/surfboard-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/surfboard-exporter/default.nix
@@ -11,9 +11,9 @@ buildGoModule rec {
     sha256 = "11qms26648nwlwslnaflinxcr5rnp55s908rm1qpnbz0jnxf5ipw";
   };
 
-  postPatch = ''
-    go mod init github.com/ipstatic/surfboard_exporter
-  '';
+  patches = [
+    ./add-go-mod.patch
+  ];
 
   vendorHash = null;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24919,7 +24919,7 @@ with pkgs;
   prometheus-smokeping-prober = callPackage ../servers/monitoring/prometheus/smokeping-prober.nix { };
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix { };
   prometheus-statsd-exporter = callPackage ../servers/monitoring/prometheus/statsd-exporter.nix { };
-  prometheus-surfboard-exporter = callPackage ../servers/monitoring/prometheus/surfboard-exporter.nix { };
+  prometheus-surfboard-exporter = callPackage ../servers/monitoring/prometheus/surfboard-exporter { };
   prometheus-sql-exporter = callPackage ../servers/monitoring/prometheus/sql-exporter.nix { };
   prometheus-systemd-exporter = callPackage ../servers/monitoring/prometheus/systemd-exporter.nix { };
   prometheus-unbound-exporter = callPackage ../servers/monitoring/prometheus/unbound-exporter.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* [prometheus-pgbouncer-exporter: 0.10.0 -> 0.10.2](https://github.com/NixOS/nixpkgs/commit/bde2af72dda75741d883c66065614f9590cd190d): solves an issue with PostgreSQL compatibility.
* [prometheus-surfboard-exporter: fix module vendoring](https://github.com/NixOS/nixpkgs/commit/1b6b600470842ea582814b468a17d622ed7dadd4): replaces Go module trick that no longer works in Go 1.23.
* [nixos/tests/prometheus-exporters/lnd: fix bitcoind configuration](https://github.com/NixOS/nixpkgs/commit/44b35795df5f6834c6b17fa8fd43600c57620122): fixes the `bitcoind` configuration to avoid a breaking change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
