### PR TITLE
open-watcom-bin: do an unattended instead of a scripted install

### DIFF
--- a/pkgs/development/compilers/open-watcom/bin.nix
+++ b/pkgs/development/compilers/open-watcom/bin.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchurl, qemu, expect, writeScript, writeScriptBin, ncurses, bash, coreutils }:
+{ lib, stdenvNoCC, fetchurl, qemu, writeScript, writeScriptBin, ncurses, bash, coreutils, unixtools }:
 
 let
 
@@ -48,41 +48,6 @@ let
     exec ${wrapLegacyBinary} "$TARGET-unwrapped" "$TARGET"
   '';
 
-  # Do a scripted installation of OpenWatcom with its original installer.
-  #
-  # If maintaining this expect script turns out to be too much of a
-  # hassle, we can switch to just using `unzip' on the installer and
-  # the correct file permissions manually.
-  performInstall = writeScriptBin "performInstall" ''
-    #!${expect}/bin/expect -f
-
-    spawn [lindex $argv 0]
-
-    # Wait for button saying "I agree" with escape sequences.
-    expect "gree"
-
-    # Navigate to "I Agree!" and hit enter.
-    send "\t\t\n"
-
-    expect "Install Open Watcom"
-
-    # Where do we want to install to.
-    send "$env(out)\n"
-
-    expect "will be installed"
-
-    # Select Full Installation, Next
-    send "fn"
-
-    expect "Setup will now copy"
-
-    # Next
-    send "n"
-
-    expect "completed successfully"
-    send "\n"
-  '';
-
 in
 stdenvNoCC.mkDerivation rec {
   pname = "${passthru.prettyName}-unwrapped";
@@ -93,7 +58,7 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "1wzkvc6ija0cjj5mcyjng5b7hnnc5axidz030c0jh05pgvi4nj7p";
   };
 
-  nativeBuildInputs = [ wrapInPlace performInstall ];
+  nativeBuildInputs = [ wrapInPlace unixtools.script ];
 
   dontUnpack = true;
   dontConfigure = true;
@@ -104,7 +69,9 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   installPhase = ''
-    performInstall ./install-bin-unwrapped
+    # Command line options to do an unattended install are documented in
+    # https://github.com/open-watcom/open-watcom-v2/blob/master/bld/setupgui/setup.txt
+    script -c "./install-bin-unwrapped -dDstDir=$out -dFullInstall=1 -i"
 
     for e in $(find $out/binl -type f -executable); do
       echo "Wrapping $e"


### PR DESCRIPTION
The `open-watcom-bin` package is installed via the original command line installer. So far an `expect` script interacts with the installer to make the appropriate choices. This PR replaces this with an unattended install that provides the settings on the command line instead.

Fixes https://github.com/NixOS/nixpkgs/issues/351413. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
