### PR TITLE
sketchybar: switch to apple-sdk_15

### DIFF
--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -2,10 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  testers,
   nix-update-script,
   apple-sdk_11,
   darwinMinVersionHook,
+  versionCheckHook,
 }:
 
 let
@@ -45,14 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "sketchybar-v${finalAttrs.version}";
-    };
+  passthru.updateScript = nix-update-script { };
 
-    updateScript = nix-update-script { };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Highly customizable macOS status bar replacement";

--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -3,8 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  apple-sdk_11,
-  darwinMinVersionHook,
+  apple-sdk_15,
   versionCheckHook,
 }:
 
@@ -30,8 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    apple-sdk_11
-    (darwinMinVersionHook "10.13")
+    apple-sdk_15
   ];
 
   makeFlags = [ target ];

--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -1,26 +1,15 @@
 {
   lib,
-  overrideSDK,
   stdenv,
-  darwin,
   fetchFromGitHub,
   testers,
   nix-update-script,
+  apple-sdk_11,
+  darwinMinVersionHook,
 }:
 
 let
   inherit (stdenv.hostPlatform) system;
-  inherit (darwin.apple_sdk_11_0.frameworks)
-    AppKit
-    Carbon
-    CoreAudio
-    CoreWLAN
-    CoreVideo
-    DisplayServices
-    IOKit
-    MediaRemote
-    SkyLight
-    ;
 
   target =
     {
@@ -28,10 +17,8 @@ let
       "x86_64-darwin" = "x86";
     }
     .${system} or (throw "Unsupported system: ${system}");
-
-  stdenv' = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
 in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sketchybar";
   version = "2.21.0";
 
@@ -43,15 +30,8 @@ stdenv'.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    AppKit
-    Carbon
-    CoreAudio
-    CoreWLAN
-    CoreVideo
-    DisplayServices
-    IOKit
-    MediaRemote
-    SkyLight
+    apple-sdk_11
+    (darwinMinVersionHook "10.13")
   ];
 
   makeFlags = [ target ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Bump SDK to 15, upstream uses available checks to determine functionality based on available SDK. 
ie: https://github.com/FelixKratz/SketchyBar/blob/ed1684d348fc4d4319c7f9835141524c524bacb3/src/window.c#L240-L250
>if (__builtin_available(macOS 14.0, *)) {

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
