### PR TITLE
fastfetch: switch to apple-sdk_15

### DIFF
--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -2,9 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  apple-sdk_11,
   chafa,
   cmake,
-  darwin,
+  darwinMinVersionHook,
   dbus,
   dconf,
   ddcutil,
@@ -23,7 +24,6 @@
   nix-update-script,
   ocl-icd,
   opencl-headers,
-  overrideSDK,
   pcre,
   pcre2,
   pkg-config,
@@ -43,10 +43,7 @@
   waylandSupport ? true,
   x11Support ? true,
 }:
-let
-  stdenv' = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
-in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fastfetch";
   version = "2.28.0";
 
@@ -105,24 +102,11 @@ stdenv'.mkDerivation (finalAttrs: {
       xorg.libXext
     ]
     ++ lib.optionals (x11Support && (!stdenv.hostPlatform.isDarwin)) [ xfce.xfconf ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk_11_0.frameworks;
-      [
-        Apple80211
-        AppKit
-        AVFoundation
-        Cocoa
-        CoreDisplay
-        CoreVideo
-        CoreWLAN
-        DisplayServices
-        IOBluetooth
-        MediaRemote
-        OpenCL
-        SystemConfiguration
-        moltenvk
-      ]
-    );
+    ++ lib.optionals stdenv.hostPlatform.isDarwin ([
+      apple-sdk_11
+      moltenvk
+      (darwinMinVersionHook "10.13")
+    ]);
 
   cmakeFlags =
     [

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -29,8 +29,8 @@
   python3,
   rpm,
   sqlite,
-  testers,
   util-linux,
+  versionCheckHook,
   vulkan-loader,
   wayland,
   xfce,
@@ -140,14 +140,11 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}"
   '';
 
-  passthru = {
-    updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "fastfetch -v | cut -d '(' -f 1";
-      version = "fastfetch ${finalAttrs.version}";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "An actively maintained, feature-rich and performance oriented, neofetch like system information tool";

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -2,10 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  apple-sdk_11,
+  apple-sdk_15,
   chafa,
   cmake,
-  darwinMinVersionHook,
   dbus,
   dconf,
   ddcutil,
@@ -103,9 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals (x11Support && (!stdenv.hostPlatform.isDarwin)) [ xfce.xfconf ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin ([
-      apple-sdk_11
+      apple-sdk_15
       moltenvk
-      (darwinMinVersionHook "10.13")
     ]);
 
   cmakeFlags =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Upstream uses `@available` and `#ifdef` checks for SDK features. Bumping to latest SDK and patching so that we don't need to bump minimum.

https://github.com/fastfetch-cli/fastfetch/blob/e0acce9646d7cd0b45506cf618d0401974b57875/src/detection/camera/camera_apple.m#L17-L25
> `if (@available(macOS 14.0, *))`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
