### PR TITLE
mediamtx: 1.9.2 -> 1.9.3

### DIFF
--- a/pkgs/by-name/me/mediamtx/package.nix
+++ b/pkgs/by-name/me/mediamtx/package.nix
@@ -8,27 +8,37 @@
 
 let
   hlsJs = fetchurl {
-    url = "https://cdn.jsdelivr.net/npm/hls.js@v1.5.15/dist/hls.min.js";
-    hash = "sha256-qRwhj9krOcLJKbGghAC8joXfNKXUdN7OkgEDosUWdd8=";
+    url = "https://cdn.jsdelivr.net/npm/hls.js@v1.5.17/dist/hls.min.js";
+    hash = "sha256-SEBU6M0D0/bReB+39AK9wxjYpMUn+TOpXGJOJ8yalHA=";
   };
 in
 buildGoModule rec {
   pname = "mediamtx";
   # check for hls.js version updates in internal/servers/hls/hlsjsdownloader/VERSION
-  version = "1.9.2";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "bluenviron";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-aHVSGyrLuLX/RYf1I1dDackmOeU3m24QcwBus4Uly0I=";
+    hash = "sha256-2qFJujfnlpmiOAmDBPl3hrbbHDOZOWFy8Yh2VOU0FEI=";
   };
 
-  vendorHash = "sha256-YpwbFCfI2kfmX3nI1G9OGUv5qpZ/JMis5VyUkqsESZA=";
+  vendorHash = "sha256-6MHtYrHZF3Oo53MV1Di0wGw9Xk+2CMei2XeoI0OcKsQ=";
 
   postPatch = ''
     cp ${hlsJs} internal/servers/hls/hls.min.js
     echo "v${version}" > internal/core/VERSION
+
+    # disable binary-only rpi camera support
+    substituteInPlace internal/staticsources/rpicamera/camera_disabled.go \
+      --replace-fail '!linux || (!arm && !arm64)' 'linux'
+    substituteInPlace internal/staticsources/rpicamera/{component,camera,params_serialize,pipe}.go \
+      --replace-fail '(linux && arm) || (linux && arm64)' 'linux && !linux'
+    substituteInPlace internal/staticsources/rpicamera/component_32.go \
+      --replace-fail 'linux && arm' 'linux && !linux'
+    substituteInPlace internal/staticsources/rpicamera/component_64.go \
+      --replace-fail 'linux && arm64' 'linux && !linux'
   '';
 
   subPackages = [ "." ];
@@ -41,7 +51,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "Ready-to-use RTSP server and RTSP proxy that allows to read and publish video and audio streams";
+    description = "SRT, WebRTC, RTSP, RTMP, LL-HLS media server and media proxy";
     inherit (src.meta) homepage;
     license = licenses.mit;
     mainProgram = "mediamtx";


### PR DESCRIPTION
https://github.com/bluenviron/mediamtx/releases/tag/v1.9.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
