### PR TITLE
zed-editor: fix license generation

### DIFF
--- a/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
+++ b/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
@@ -1,8 +1,8 @@
 diff --git a/script/generate-licenses b/script/generate-licenses
-index 43b2f5c458..c740a3afa2 100755
+index 9602813f0c..d16d11c203 100755
 --- a/script/generate-licenses
 +++ b/script/generate-licenses
-@@ -15,12 +15,6 @@ cat assets/icons/LICENSES >> $OUTPUT_FILE
+@@ -16,16 +16,9 @@ cat assets/icons/LICENSES >> $OUTPUT_FILE
  
  echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
  
@@ -14,4 +14,8 @@ index 43b2f5c458..c740a3afa2 100755
 -fi
  
  echo "Generating cargo licenses"
- cargo about generate --fail -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md >> $OUTPUT_FILE
+ cargo about generate \
+-    --fail \
+     -c script/licenses/zed-licenses.toml \
+     "${TEMPLATE_FILE}" >> $OUTPUT_FILE
+ 

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -101,6 +101,8 @@ rustPlatform.buildRustPackage rec {
     [
       # Zed uses cargo-install to install cargo-about during the script execution.
       # We provide cargo-about ourselves and can skip this step.
+      # Until https://github.com/zed-industries/zed/issues/19971 is fixed,
+      # we also skip any crate for which the license cannot be determined.
       ./0001-generate-licenses.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -206,10 +208,9 @@ rustPlatform.buildRustPackage rec {
   RUSTFLAGS = if withGLES then "--cfg gles" else "";
   gpu-lib = if withGLES then libglvnd else vulkan-loader;
 
-  # Enable back when https://github.com/zed-industries/zed/issues/19971 is fixed
-  # preBuild = ''
-  #   bash script/generate-licenses
-  # '';
+  preBuild = ''
+    bash script/generate-licenses
+  '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As of #352420, generating license attribution for crates used by zed-editor has been disabled because of https://github.com/zed-industries/zed/issues/19971.
This PR re-enables generating license information for crates where this information is available by removing cargo-about's `--fail` parameter.
Having license information available for almost all dependencies is better than none.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
