### PR TITLE
fish: add patch to fix `$PATH` for nix-darwin

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -148,6 +148,20 @@ let
       hash = "sha256-YUyfVkPNB5nfOROV+mu8NklCe7g5cizjsRTTu8GjslA=";
     };
 
+    patches = [
+      # We don’t want to run `/usr/libexec/path_helper` on nix-darwin,
+      # as it pulls in paths not tracked in the system configuration
+      # and messes up the order of `$PATH`. Upstream are unfortunately
+      # unwilling to accept a change for this and have recommended that
+      # it should be a distro‐specific patch instead.
+      #
+      # See:
+      #
+      # * <https://github.com/LnL7/nix-darwin/issues/122>
+      # * <https://github.com/fish-shell/fish-shell/issues/7142>
+      ./nix-darwin-path.patch
+    ];
+
     # Fix FHS paths in tests
     postPatch = ''
       # src/fish_tests.cpp

--- a/pkgs/shells/fish/nix-darwin-path.patch
+++ b/pkgs/shells/fish/nix-darwin-path.patch
@@ -1,0 +1,12 @@
+diff --git a/share/config.fish b/share/config.fish
+index d85fd1e185..c564e45b27 100644
+--- a/share/config.fish
++++ b/share/config.fish
+@@ -158,6 +158,7 @@
+ #
+ if status --is-login
+     if command -sq /usr/libexec/path_helper
++        and not set -q __NIX_DARWIN_SET_ENVIRONMENT_DONE
+         # Adapt construct_path from the macOS /usr/libexec/path_helper
+         # executable for fish; see
+         # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .


### PR DESCRIPTION
See the comment for details. This is adapted from my nix-darwin configuration.

cc @Enzime

cc @RossComputerGuy – this is technically a breaking change, but only when a variable is set that is only set by nix-darwin, and as a nix-darwin maintainer I affirm that it is the kind of bug‐fixing breaking change that we really want; this has been [a very long‐standing issue](https://github.com/LnL7/nix-darwin/issues/122) with nix-darwin and it would be sad to tell users of stable branches they have to wait 6 months for a fix.

cc @lilyball who I think uses an alternative workaround
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
