### PR TITLE
photofield: 0.13.0 -> 0.17.0, fix build

### DIFF
--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -1,23 +1,23 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
-, buildGoModule
+, buildGo122Module
 , buildNpmPackage
 , makeWrapper
 , exiftool
 , ffmpeg
 , testers
 , photofield
+, nix-update-script
 }:
 
 let
-  version = "0.13.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "SmilyOrg";
     repo = "photofield";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6pJvOn3sN6zfjt2dVZ/xH6pSXM0WgbG7au9tSVUGYys=";
+    hash = "sha256-GYU0BR5X3s3SGmZEFMyK7m+zUa2i2E9krAbtk8dwPdg=";
   };
 
   webui = buildNpmPackage {
@@ -26,7 +26,7 @@ let
 
     sourceRoot = "${src.name}/ui";
 
-    npmDepsHash = "sha256-trKcNuhRdiabFKMafOLtPg8x1bQHLOif6Hm4k5bTAYc=";
+    npmDepsHash = "sha256-ULl4wHEo/PP0Y0O5po7eRDd+T/UjkZhQGIj262WFtFU=";
 
     installPhase = ''
       mkdir -p $out/share
@@ -35,20 +35,11 @@ let
   };
 in
 
-buildGoModule {
+buildGo122Module {
   pname = "photofield";
   inherit version src;
 
-  patches = [
-    # Needed for Go 1.22 build support
-    (fetchpatch {
-      name = "upgrade-pyroscope-go.patch";
-      url = "https://github.com/SmilyOrg/photofield/commit/681dcd48ab4113b0e99fe1a0d3638f0dfe985c05.patch";
-      hash = "sha256-JGb5KAI/SmR1kiiaPoSsAF7G4YWDFXj0K3Gjw0zA3Ro=";
-    })
-  ];
-
-  vendorHash = "sha256-BnImE4wK2MDO21N5tT9Q9w+NkDpdBCEqUwzuH/xb6fg=";
+  vendorHash = "sha256-eN9syG9/QUA8yut3LaeIb+xlaNUvRAFspyqcCHv6oSA=";
 
   preBuild = ''
     cp -r ${webui}/share/photofield-ui ui/dist
@@ -72,9 +63,12 @@ buildGoModule {
       --prefix PATH : "${lib.makeBinPath [exiftool ffmpeg]}"
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = photofield;
-    command = "photofield -version";
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = photofield;
+      command = "photofield -version";
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
Needs Go 1.22 for now: https://hydra.nixos.org/build/274261022/nixlog/1/tail

ZHF: #352882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
