### PR TITLE
Update surrealdb options for v2

### DIFF
--- a/nixos/modules/services/databases/surrealdb.nix
+++ b/nixos/modules/services/databases/surrealdb.nix
@@ -14,9 +14,9 @@ in {
         type = lib.types.str;
         description = ''
           The path that surrealdb will write data to. Use null for in-memory.
-          Can be one of "memory", "file://:path", "tikv://:addr".
+          Can be one of "memory", "rocksdb://:path", "surrealkv://:path", "tikv://:addr", "fdb://:addr".
         '';
-        default = "file:///var/lib/surrealdb/";
+        default = "rocksdb:///var/lib/surrealdb/";
         example = "memory";
       };
 
@@ -41,10 +41,9 @@ in {
       extraFlags = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [];
-        example = [ "--allow-all" "--auth" "--user root" "--pass root" ];
+        example = [ "--allow-all" "--user" "root" "--pass" "root" ];
         description = ''
-          Specify a list of additional command line flags,
-          which get escaped and are then passed to surrealdb.
+          Specify a list of additional command line flags.
         '';
       };
     };
@@ -61,7 +60,7 @@ in {
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/surreal start --bind ${cfg.host}:${toString cfg.port} ${lib.escapeShellArgs cfg.extraFlags} -- ${cfg.dbPath}";
+        ExecStart = "${cfg.package}/bin/surreal start --bind ${cfg.host}:${toString cfg.port} ${lib.strings.concatStringsSep " " cfg.extraFlags} -- ${cfg.dbPath}";
         DynamicUser = true;
         Restart = "on-failure";
         StateDirectory = "surrealdb";


### PR DESCRIPTION
I went to enable the surrealdb service on a machine of mine and encountered issues because the docs seem to use surrealdb v1 options and things have changed a bit with v2.

[Page to docs on the start command](https://surrealdb.com/docs/surrealdb/cli/start)
[Page to docs on storage options](https://surrealdb.com/docs/surrealdb/introduction/architecture)

* Namely the --auth flag was used in v1 to enable authentication where it has been replaced with --unauthenticated in v2 where you must explicitly disable authentication (--auth is on by default)
* file:// is deprecated; surrealkv:// or rocksdb:// are suggested replacements and surrealkv is in beta, so I switched the default to rocksdb.
* The docs suggest suggest indxdb and fdb are also available, but indxdb is for web browsers, so I only added fdb to the docs
* I could be oversteping here, but I cannot understand why shell args were escaped so I removed it. The reason why is I tried reading in a sops secret but it failed because the $ was removed: `["--user" "root" "--pass" "$(cat ${config.sops.secrets.surreal_pass})"]` and surreal didn't know what to do with `(cat /run/secrets/surreal_pass)` as a password.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
