### PR TITLE
execline: add `withDocs` flag, `execline-minimal` variant; lib/systems: use `execline-minimal` for emulator

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -283,7 +283,7 @@ let
           # to an emulator program. That is, if an emulator requires additional
           # arguments, a wrapper should be used.
           if pkgs.stdenv.hostPlatform.canExecute final
-          then "${pkgs.execline}/bin/exec"
+          then "${pkgs.execline-minimal}/bin/exec"
           else if final.isWindows
           then "${wine}/bin/wine${optionalString (final.parsed.cpu.bits == 64) "64"}"
           else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux && final.qemuArch != null

--- a/pkgs/development/skaware-packages/default.nix
+++ b/pkgs/development/skaware-packages/default.nix
@@ -10,6 +10,7 @@ lib.makeScope pkgs.newScope (self:
 
   # execline
   execline = callPackage ./execline { };
+  execline-minimal = callPackage ./execline { withDocs = false; };
 
   # servers & tools
   mdevd = callPackage ./mdevd { };

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -1,4 +1,4 @@
-{ lib, skawarePackages, skalibs }:
+{ lib, skawarePackages, skalibs, withDocs ? true }:
 
 let
   version = "2.9.6.1";
@@ -14,13 +14,17 @@ in skawarePackages.buildPackage {
   # upstream $version he tags manpages release as ${version}.1, and,
   # in case of extra fixes to manpages, new tags in form ${version}.2,
   # ${version}.3 and so on are created.
-  manpages = skawarePackages.buildManPages {
-    pname = "execline-man-pages";
-    version = "2.9.6.0.1";
-    sha256 = "sha256-0lyX3rIUZ2JqWioRSm22uDS+q9ONkwIZxfR5E2pSDC4=";
-    description = "Port of the documentation for the execline suite to mdoc";
-    maintainers = [ lib.maintainers.sternenseemann ];
-  };
+  manpages =
+    if withDocs then
+      skawarePackages.buildManPages {
+        pname = "execline-man-pages";
+        version = "2.9.6.0.1";
+        sha256 = "sha256-0lyX3rIUZ2JqWioRSm22uDS+q9ONkwIZxfR5E2pSDC4=";
+        description = "Port of the documentation for the execline suite to mdoc";
+        maintainers = [ lib.maintainers.sternenseemann ];
+      }
+    else
+      null;
 
   description = "Small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -8,7 +8,7 @@ let
     || (stdenv.cc.isGNU && stdenv.hostPlatform.isLinux)
   );
   staticLibc = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
-  emulator = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) (stdenv.hostPlatform.emulator buildPackages);
+  emulator = stdenv.hostPlatform.emulator buildPackages;
   isCxx = stdenv.cc.libcxx != null;
   libcxxStdenvSuffix = lib.optionalString isCxx "-libcxx";
   CC = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}cc"}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22862,6 +22862,7 @@ with pkgs;
 
   inherit (skawarePackages)
     execline
+    execline-minimal
     execline-man-pages
     mdevd
     nsss


### PR DESCRIPTION
Considerably reduces the closure size of things that use emulators for non‐cross.

(Can’t be merged until the periodic merge goes through.)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
