### PR TITLE
treewide: handle *Phases variables __structuredAttrs-agnostically (round 2)

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
@@ -97,5 +97,5 @@ dotnetFixupHook() {
 }
 
 if [[ -z "${dontFixup-}" && -z "${dontDotnetFixup-}" ]]; then
-    preFixupPhases+=" dotnetFixupHook"
+    appendToVar preFixupPhases dotnetFixupHook
 fi

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
@@ -34,7 +34,7 @@ gappsWrapperArgsHook() {
     done
 }
 
-preFixupPhases+=" gappsWrapperArgsHook"
+appendToVar preFixupPhases gappsWrapperArgsHook
 
 wrapGApp() {
     local program="$1"

--- a/pkgs/by-name/de/desktop-file-utils/setup-hook.sh
+++ b/pkgs/by-name/de/desktop-file-utils/setup-hook.sh
@@ -3,4 +3,4 @@ mimeinfoPreFixupPhase() {
     rm -f $out/share/applications/mimeinfo.cache
 }
 
-preFixupPhases="${preFixupPhases-} mimeinfoPreFixupPhase"
+appendToVar preFixupPhases mimeinfoPreFixupPhase

--- a/pkgs/development/ada-modules/gprbuild/gpr-project-darwin-rpath-hook.sh
+++ b/pkgs/development/ada-modules/gprbuild/gpr-project-darwin-rpath-hook.sh
@@ -7,4 +7,4 @@ fixGprProjectDarwinRpath() {
     done
 }
 
-preFixupPhases+=" fixGprProjectDarwinRpath"
+appendToVar preFixupPhases fixGprProjectDarwinRpath

--- a/pkgs/development/libraries/gtk/hooks/drop-icon-theme-cache.sh
+++ b/pkgs/development/libraries/gtk/hooks/drop-icon-theme-cache.sh
@@ -16,4 +16,4 @@ dropIconThemeCache() {
     fi
 }
 
-preFixupPhases="${preFixupPhases-} dropIconThemeCache"
+appendToVar preFixupPhases dropIconThemeCache

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -65,7 +65,7 @@ qtOwnPathsHook() {
     qtHostPathHook "${!outputBin}"
 }
 
-preFixupPhases+=" qtOwnPathsHook"
+appendToVar preFixupPhases qtOwnPathsHook
 
 # Note: $qtWrapperArgs still gets defined even if ${dontWrapQtApps-} is set.
 wrapQtAppsHook() {

--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -63,7 +63,7 @@ if [[ -z "${__nix_wrapQtAppsHook-}" ]]; then
         qtHostPathHook "${!outputBin}"
     }
 
-    preFixupPhases+=" qtOwnPathsHook"
+    appendToVar preFixupPhases qtOwnPathsHook
 
     # Note: $qtWrapperArgs still gets defined even if ${dontWrapQtApps-} is set.
     wrapQtAppsHook() {


### PR DESCRIPTION
This PR clears the remaining non-`__structuredAttrs`-agnostic appending to the `*Phase` list not caught by #339117.

For the "insert the new phase before certain phase" operation, this commit adds a new Bash function `replaceElement` to `setup.sh` to provide a more graceful solution to the string-replacement hack in #339117 and previous implementations. (Previous discussion: https://github.com/NixOS/nixpkgs/pull/339117#issuecomment-2334961783).

Cc: @philiptaron @wolfgangwalther

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
