### PR TITLE
treewide: update own packages to the new apple-sdk pattern

### DIFF
--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv,
-  darwin,
+  apple-sdk_11,
   lib,
   fetchFromGitHub,
   cmake,
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib
     ++ lib.optional enableWayland wayland
     ++ lib.optional enableVncRenderer libvncserver
-    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk_11_0.libs.xpc;
+    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
   cmakeFlags =
     lib.optional stdenv.hostPlatform.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"

--- a/pkgs/games/augustus/default.nix
+++ b/pkgs/games/augustus/default.nix
@@ -7,6 +7,7 @@
   SDL2_mixer,
   libpng,
   darwin,
+  apple-sdk_11,
   libicns,
   imagemagick,
 }:
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
     SDL2
     SDL2_mixer
     libpng
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_11 ];
 
   installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
     runHook preInstall

--- a/pkgs/games/corsix-th/default.nix
+++ b/pkgs/games/corsix-th/default.nix
@@ -13,10 +13,7 @@
 , timidity
 # Darwin dependencies
 , libiconv
-, Cocoa
-, CoreVideo
-, CoreMedia
-, VideoToolbox
+, apple-sdk_11
 # Update
 , nix-update-script
 }:
@@ -49,13 +46,7 @@ stdenv.mkDerivation(finalAttrs: {
     SDL2
     SDL2_mixer
     timidity
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
-    Cocoa
-    CoreVideo
-    CoreMedia
-    VideoToolbox
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
   cmakeFlags = [ "-Wno-dev" ];
 

--- a/pkgs/games/julius/default.nix
+++ b/pkgs/games/julius/default.nix
@@ -6,6 +6,7 @@
 , cmake
 , libpng
 , darwin
+, apple-sdk_11
 , libicns
 , imagemagick
 }:
@@ -38,9 +39,7 @@ stdenv.mkDerivation rec {
     SDL2
     SDL2_mixer
     libpng
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Cocoa
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
   installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
     runHook preInstall

--- a/pkgs/games/shipwright/default.nix
+++ b/pkgs/games/shipwright/default.nix
@@ -25,12 +25,9 @@
 , zenity
 , makeWrapper
 , darwin
+, apple-sdk_11
 , libicns
 }:
-let
-  inherit (darwin.apple_sdk_11_0.frameworks)
-    IOSurface Metal QuartzCore Cocoa AVFoundation;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shipwright";
   version = "8.0.6";
@@ -85,14 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     libXext
     libpulseaudio
     zenity
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    IOSurface
-    Metal
-    QuartzCore
-    Cocoa
-    AVFoundation
-    darwin.apple_sdk_11_0.libs.simd
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
   cmakeFlags = [
     (lib.cmakeBool "NON_PORTABLE" true)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34050,9 +34050,7 @@ with pkgs;
 
   colobot = callPackage ../games/colobot { };
 
-  corsix-th = callPackage ../games/corsix-th {
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreVideo CoreMedia VideoToolbox;
-  };
+  corsix-th = callPackage ../games/corsix-th { };
 
   enigma = callPackage ../games/enigma { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34088,9 +34088,7 @@ with pkgs;
 
   keeperrl = callPackage ../games/keeperrl { };
 
-  shipwright = callPackage ../games/shipwright {
-    stdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
-  };
+  shipwright = callPackage ../games/shipwright { };
 
   wipeout-rewrite = callPackage ../games/wipeout-rewrite {
     inherit (darwin.apple_sdk.frameworks) Foundation;


### PR DESCRIPTION
Adopted[ the new SDK pattern](https://discourse.nixos.org/t/the-darwin-sdks-have-been-updated/55295) for  the packages I maintain / co-maintain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
