### PR TITLE
evremap: init at 0-unstable-2024-06-17, nixos/evremap: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -121,6 +121,8 @@
 
 - [HomeBox](https://github.com/sysadminsmedia/homebox), an inventory and organization system built for the home user. Available as [services.homebox](#opt-services.homebox.enable).
 
+- [evremap](https://github.com/wez/evremap), a keyboard input remapper for Linux/Wayland systems. Available as [services.evremap](options.html#opt-services.evremap).
+
 - [matrix-hookshot](https://matrix-org.github.io/matrix-hookshot), a Matrix bot for connecting to external services. Available as [services.matrix-hookshot](#opt-services.matrix-hookshot.enable).
 
 - [Renovate](https://github.com/renovatebot/renovate), a dependency updating tool for various Git forges and language ecosystems. Available as [services.renovate](#opt-services.renovate.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -752,6 +752,7 @@
   ./services/misc/etebase-server.nix
   ./services/misc/etesync-dav.nix
   ./services/misc/evdevremapkeys.nix
+  ./services/misc/evremap.nix
   ./services/misc/felix.nix
   ./services/misc/flaresolverr.nix
   ./services/misc/forgejo.nix

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -1,0 +1,167 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.evremap;
+  format = pkgs.formats.toml { };
+
+  key = lib.types.strMatching "KEY_[[:upper:]]+" // {
+    description = "key ID prefixed with KEY_";
+  };
+
+  mkKeyOption =
+    description:
+    lib.mkOption {
+      type = key;
+      description = ''
+        ${description}
+
+        You can get a list of keys by running `evremap list-keys`.
+      '';
+    };
+  mkKeySeqOption =
+    description:
+    (mkKeyOption description)
+    // {
+      type = lib.types.listOf key;
+    };
+
+  dualRoleModule = lib.types.submodule {
+    options = {
+      input = mkKeyOption "The key that should be remapped.";
+      hold = mkKeySeqOption "The key sequence that should be output when the input key is held.";
+      tap = mkKeySeqOption "The key sequence that should be output when the input key is tapped.";
+    };
+  };
+
+  remapModule = lib.types.submodule {
+    options = {
+      input = mkKeySeqOption "The key sequence that should be remapped.";
+      output = mkKeySeqOption "The key sequence that should be output when the input sequence is entered.";
+    };
+  };
+in
+{
+  options.services.evremap = {
+    enable = lib.mkEnableOption "evremap, a keyboard input remapper for Linux/Wayland systems";
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+
+        options = {
+          device_name = lib.mkOption {
+            type = lib.types.str;
+            example = "AT Translated Set 2 keyboard";
+            description = ''
+              The name of the device that should be remapped.
+
+              You can get a list of devices by running `evremap list-devices` with elevated permissions.
+            '';
+          };
+
+          dual_role = lib.mkOption {
+            type = lib.types.listOf dualRoleModule;
+            default = [ ];
+            example = [
+              {
+                input = "KEY_CAPSLOCK";
+                hold = [ "KEY_LEFTCTRL" ];
+                tap = [ "KEY_ESC" ];
+              }
+            ];
+            description = ''
+              List of dual-role remappings that output different key sequences based on whether the
+              input key is held or tapped.
+            '';
+          };
+
+          remap = lib.mkOption {
+            type = lib.types.listOf remapModule;
+            default = [ ];
+            example = [
+              {
+                input = [
+                  "KEY_LEFTALT"
+                  "KEY_UP"
+                ];
+                output = [ "KEY_PAGEUP" ];
+              }
+            ];
+            description = ''
+              List of remappings.
+            '';
+          };
+        };
+      };
+
+      description = ''
+        Settings for evremap.
+
+        See the [upstream documentation](https://github.com/wez/evremap/blob/master/README.md#configuration)
+        for how to configure evremap.
+      '';
+      default = { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.evremap ];
+
+    hardware.uinput.enable = true;
+
+    systemd.services.evremap = {
+      description = "evremap - keyboard input remapper";
+      wantedBy = [ "multi-user.target" ];
+
+      script = "${lib.getExe pkgs.evremap} remap ${format.generate "evremap.toml" cfg.settings}";
+
+      serviceConfig = {
+        DynamicUser = true;
+        User = "evremap";
+        SupplementaryGroups = [
+          config.users.groups.input.name
+          config.users.groups.uinput.name
+        ];
+        Restart = "on-failure";
+        RestartSec = 5;
+        TimeoutSec = 20;
+
+        # Hardening
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectHome = true;
+        ProcSubset = "pid";
+
+        PrivateTmp = true;
+        PrivateNetwork = true;
+        PrivateUsers = true;
+
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        RestrictAddressFamilies = "none";
+
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        IPAddressDeny = "any";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@resources"
+          "~@privileged"
+        ];
+        UMask = "0027";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ev/evremap/package.nix
+++ b/pkgs/by-name/ev/evremap/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libevdev,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage {
+  pname = "evremap";
+  version = "0-unstable-2024-06-17";
+
+  src = fetchFromGitHub {
+    owner = "wez";
+    repo = "evremap";
+    rev = "cc618e8b973f5c6f66682d1477b3b868a768c545";
+    hash = "sha256-aAAnlGlSFPOK3h8UuAOlFyrKTEuzbyh613IiPE7xWaA=";
+  };
+
+  cargoHash = "sha256-uFej58+51+JX36K1Rr1ZmBe7rHojOjmTO2VWINS6MvU=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libevdev ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Keyboard input remapper for Linux/Wayland systems";
+    homepage = "https://github.com/wez/evremap";
+    maintainers = with lib.maintainers; [ pluiedev ];
+    license = with lib.licenses; [ mit ];
+    mainProgram = "evremap";
+  };
+}


### PR DESCRIPTION
Fixes #352471
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
