### PR TITLE
neovim: add a checkPhase in the wrapper

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -55,9 +55,15 @@ let
   nvim-with-luasnip = wrapNeovim2 "-with-luasnip" (makeNeovimConfig {
     plugins = [ {
         plugin = vimPlugins.luasnip;
-
       }
     ];
+  });
+
+  # build should fail with a wrong
+  nvim-run-failing-check = (wrapNeovimUnstable neovim-unwrapped {
+    luaRcContent = "this is an invalid lua statement to break the build";
+  }).overrideAttrs({
+    doCheck = true;
   });
 
   nvimAutoDisableWrap = makeNeovimConfig { };
@@ -95,6 +101,9 @@ in
   pkgs.recurseIntoAttrs (rec {
 
   inherit nmt;
+
+  # Disabled because of https://github.com/NixOS/nixpkgs/pull/352727
+  # failed_check = pkgs.testers.testBuildFailure nvim-run-failing-check;
 
   vim_empty_config = vimUtils.vimrcFile { beforePlugins = ""; customRC = ""; };
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -61,7 +61,7 @@ let
 
   stdenv.mkDerivation (finalAttrs:
   let
-    pluginsNormalized = neovimUtils.normalizePlugins plugins;
+    pluginsNormalized = neovimUtils.normalizePlugins finalAttrs.plugins;
 
     myVimPackage = neovimUtils.normalizedPluginsToVimPackage pluginsNormalized;
 
@@ -249,6 +249,13 @@ let
 
     # A Vim "package", see ':h packages'
     vimPackage = myVimPackage;
+
+    checkPhase = ''
+      runHook preCheck
+
+      $out/bin/nvim -i NONE -e +quitall!
+      runHook postCheck
+      '';
 
     passthru = {
       inherit providerLuaRc packpathDirs;


### PR DESCRIPTION
add a checkPhase (if doCheck == true, disabled by default) that tries to start neovim and fails in case of errors. It allows to catch small misconfiugurations before switching to a new config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
