### PR TITLE
apptainer, singularity: deprecate workarounds for vendorHash overriding

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -8,6 +8,10 @@
 
 - `services.rippleDataApi` has been removed, as `ripple-data-api` was broken and had not been updated since 2022.
 
+- `apptainer` and `singularity` deprecate the workaround of overriding `vendorHash` and related attributes via `<pkg>.override`,
+  in favour of the unified overriding of the same group of attributes via `<pkg>.overrideAttrs`.
+  The compatibility layer will be removed in future releases.
+
 - `squid` has been updated to version 7, this release includes multiple breaking changes, like ESI removal.
   For more information, [check the release notes](https://github.com/squid-cache/squid/releases/tag/SQUID_7_0_1).
 

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -16,7 +16,8 @@
 let
   # Backward compatibility layer for the obsolete workaround of
   # the "vendor-related attributes not overridable" issue (#86349),
-  # whose solution is merged and released.
+  # whose solution (#225051) is merged and released.
+  # TODO(@ShamrockLee): Remove after the Nixpkgs 25.05 branch-off.
   _defaultGoVendorArgs = {
     inherit vendorHash deleteVendor proxyVendor;
   };
@@ -96,14 +97,28 @@ in
   #   "path/to/source/file1" = [ "<originalDefaultPath11>" "<originalDefaultPath12>" ... ];
   # }
   sourceFilesWithDefaultPaths ? { },
-  # Workaround #86349
-  # should be removed when the issue is resolved
-  vendorHash ? _defaultGoVendorArgs.vendorHash,
-  deleteVendor ? _defaultGoVendorArgs.deleteVendor,
-  proxyVendor ? _defaultGoVendorArgs.proxyVendor,
+  # Placeholders for the obsolete workaround of #86349
+  # TODO(@ShamrockLee): Remove after the Nixpkgs 25.05 branch-off.
+  vendorHash ? null,
+  deleteVendor ? null,
+  proxyVendor ? null,
 }@args:
 
 let
+  # Backward compatibility layer for the obsolete workaround of #86349
+  # TODO(@ShamrockLee): Convert to simple inheritance after the Nixpkgs 25.05 branch-off.
+  moduleArgsOverridingCompat =
+    argName:
+    if args.${argName} or null == null then
+      _defaultGoVendorArgs.${argName}
+    else
+      lib.warn
+        "${projectName}: Override ${argName} with .override is deprecated. Use .overrideAttrs instead."
+        args.${argName};
+  vendorHash = moduleArgsOverridingCompat "vendorHash";
+  deleteVendor = moduleArgsOverridingCompat "deleteVendor";
+  proxyVendor = moduleArgsOverridingCompat "proxyVendor";
+
   addShellDoubleQuotes = s: lib.escapeShellArg ''"'' + s + lib.escapeShellArg ''"'';
 in
 (buildGoModule {


### PR DESCRIPTION
Remove obsolete overriding workarounds for vendorHash, deleteVendor, and proxyVendor (through the <pkg>.override interface).

The workaround functionality has been fixed by commit eed069a5bc40 ("buildGoModule: fix overrideAttrs overriding"), and these arguments can now be overridden using <pkg>.overrideAttrs. This PR guides users to the now-fixed overriding approaches by warning them against the workaround. The obsolete workaround will be removed entirely after the branch-off of Nixpkgs 25.05.

Cc: @GaetanLepage, @jbedo, @SomeoneSerge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
