### PR TITLE
shadps4: 0.3.0-unstable-2024-10-14 -> 0.4.0

### DIFF
--- a/pkgs/by-name/sh/shadps4/av_err2str_macro.patch
+++ b/pkgs/by-name/sh/shadps4/av_err2str_macro.patch
@@ -1,0 +1,28 @@
+diff --git a/src/core/libraries/videodec/videodec2_impl.cpp b/src/core/libraries/videodec/videodec2_impl.cpp
+index 021965e..31eb537 100644
+--- a/src/core/libraries/videodec/videodec2_impl.cpp
++++ b/src/core/libraries/videodec/videodec2_impl.cpp
+@@ -8,6 +8,16 @@
+ #include "common/logging/log.h"
+ #include "core/libraries/error_codes.h"
+ 
++#ifdef av_err2str 
++#undef av_err2str 
++#include <string> 
++av_always_inline std::string av_err2string(int errnum) { 
++    char errbuf[AV_ERROR_MAX_STRING_SIZE]; 
++    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum); 
++} 
++#define av_err2str(err) av_err2string(err).c_str() 
++#endif // av_err2str
++
+ namespace Libraries::Vdec2 {
+ 
+ std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
+@@ -225,4 +235,4 @@ AVFrame* VdecDecoder::ConvertNV12Frame(AVFrame& frame) {
+     return nv12_frame;
+ }
+ 
+-} // namespace Libraries::Vdec2
+\ No newline at end of file
++} // namespace Libraries::Vdec2

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -33,15 +33,15 @@
   unstableGitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.3.0-unstable-2024-10-14";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
-    rev = "09725bd921088b73746605e672abf6ff40171880";
-    hash = "sha256-NtIiqmiZ1iCciMjT1cL7ONWxNHRO/0bci/thLrcORjo=";
+    rev = "refs/tags/v.${finalAttrs.version}";
+    hash = "sha256-dAhm9XMFnpNmbgi/TGktNHMdFDYPOWj31pZkBoUfQhA=";
     fetchSubmodules = true;
   };
 
@@ -55,6 +55,9 @@ stdenv.mkDerivation {
     # downloading an AppImage and trying to run it just won't work.
     # https://github.com/shadps4-emu/shadPS4/issues/1368
     ./0001-Disable-update-checking.patch
+
+    # https://github.com/shadps4-emu/shadPS4/issues/1457
+    ./av_err2str_macro.patch
   ];
 
   buildInputs = [
@@ -132,9 +135,10 @@ stdenv.mkDerivation {
   meta = {
     description = "Early in development PS4 emulator";
     homepage = "https://github.com/shadps4-emu/shadPS4";
+    changelog = "https://github.com/shadps4-emu/shadPS4/releases/tag/v.${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ryand56 ];
     mainProgram = "shadps4";
     platforms = lib.intersectLists lib.platforms.linux lib.platforms.x86_64;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
