### PR TITLE
llvmPackages_19: 19.1.1 -> 19.1.3

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -947,6 +947,10 @@ let
             url = "https://github.com/llvm/llvm-project/commit/abc2eae68290c453e1899a94eccc4ed5ea3b69c1.patch";
             hash = "sha256-oxCxOjhi5BhNBEraWalEwa1rS3Mx9CuQgRVZ2hrbd7M=";
           })
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/5909979869edca359bcbca74042c2939d900680e.patch";
+            hash = "sha256-l4rQHYbblEADBXaZIdqTG0sZzH4fEQvYiqhLYNZDMa8=";
+          })
         ];
       };
     }

--- a/pkgs/development/compilers/llvm/common/libclc.nix
+++ b/pkgs/development/compilers/llvm/common/libclc.nix
@@ -17,6 +17,14 @@ let
   spirv-llvm-translator = buildPackages.spirv-llvm-translator.override {
     inherit (buildLlvmTools) llvm;
   };
+
+  # The build requires an unwrapped clang but wrapped clang++ thus we need to
+  # split the unwrapped clang out to prevent the build from finding the
+  # unwrapped clang++
+  clang-only = runCommand "clang-only" { } ''
+    mkdir -p "$out"/bin
+    ln -s "${lib.getExe' buildLlvmTools.clang.cc "clang"}" "$out"/bin
+  '';
 in
 stdenv.mkDerivation rec {
   pname = "libclc";
@@ -78,7 +86,7 @@ stdenv.mkDerivation rec {
       python3
     ]
     ++ lib.optional (lib.versionAtLeast release_version "19") [
-      buildLlvmTools.clang.cc
+      clang-only
       buildLlvmTools.llvm
       spirv-llvm-translator
     ];

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -28,7 +28,7 @@ let
     "16.0.6".officialRelease.sha256 = "sha256-fspqSReX+VD+Nl/Cfq+tDcdPtnQPV1IRopNDfd5VtUs=";
     "17.0.6".officialRelease.sha256 = "sha256-8MEDLLhocshmxoEBRSKlJ/GzJ8nfuzQ8qn0X/vLA+ag=";
     "18.1.8".officialRelease.sha256 = "sha256-iiZKMRo/WxJaBXct9GdAcAT3cz9d9pnAcO1mmR6oPNE=";
-    "19.1.1".officialRelease.sha256 = "sha256-xTo44+vH1Bz49fEl4bIpU3eIgQtFuBTGbgU7mzeY33s=";
+    "19.1.3".officialRelease.sha256 = "sha256-NUx01eJNsYMlk+8mtlf10isIqhK8zBmqaOTjuFqMNRQ=";
     "20.0.0-git".gitRelease = {
       rev = "0e8555d4dbfdfeddc01dc2ecf9a9b6e804f7b645";
       rev-version = "20.0.0-unstable-2024-10-07";


### PR DESCRIPTION
https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3

bolt is broken on x86_64-darwin on master  https://hydra.nixos.org/build/276866191 due to trying to write an archive to the llvm package store. applied upstream change https://github.com/llvm/llvm-project/commit/5909979869edca359bcbca74042c2939d900680e to fix.

had to make one tweak to fix the workaround for `libclc` that our wrappers can't accept `-arch`. `libclc` needs a wrapped `c++` to get header access but an unwrapped `clang`.
this fixes  https://hydra.nixos.org/build/276170976/nixlog/1/tail


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
