### PR TITLE
tesseract: ensure fixupPhase is run, e.g. ensuring library codesigning on darwin

### DIFF
--- a/pkgs/applications/graphics/tesseract/wrapper.nix
+++ b/pkgs/applications/graphics/tesseract/wrapper.nix
@@ -18,7 +18,9 @@ let
 
     nativeBuildInputs = [ makeWrapper ];
 
-    buildCommand = ''
+    phases = [ "buildPhase" "fixupPhase" ];
+
+    buildPhase = ''
       makeWrapper {$tesseractBase,$out}/bin/tesseract --set-default TESSDATA_PREFIX $out/share/tessdata
 
       # Recursively link include, share


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since the tesseract wrapper replaces the phases in tesseractBase with it's buildCommand, this prevents running e.g. the fixupPhase which would codesign the modified library for darwin.
This change ensures the fixupPhase is executed, ensuring a valid code signature for `libtesseract.5.dylib`.

Before the change:
```
$ nix-build -A tesseract5.tesseractBase
/nix/store/5f9hf5d2lgdkb44x60khx5b2cm50xyv5-tesseract-5.3.4
$ codesign -vvv result/lib/libtesseract.5.dylib
result/lib/libtesseract.5.dylib: valid on disk
result/lib/libtesseract.5.dylib: satisfies its Designated Requirement

$ nix-build -A tesseract5
/nix/store/zxmnplp54g4iks4h9hrllfrd2rlbbj20-tesseract-5.3.4
$ codesign -vvv result/lib/libtesseract.5.dylib
result/lib/libtesseract.5.dylib: invalid signature (code or signature have been modified)
In architecture: arm64
```

After the change:
```
$ nix-build -A tesseract5.tesseractBase
/nix/store/5f9hf5d2lgdkb44x60khx5b2cm50xyv5-tesseract-5.3.4
$ codesign -vvv result/lib/libtesseract.5.dylib
result/lib/libtesseract.5.dylib: valid on disk
result/lib/libtesseract.5.dylib: satisfies its Designated Requirement

$ nix-build -A tesseract5
/nix/store/zxmnplp54g4iks4h9hrllfrd2rlbbj20-tesseract-5.3.4
$ codesign -vvv result/lib/libtesseract.5.dylib
result/lib/libtesseract.5.dylib: valid on disk
result/lib/libtesseract.5.dylib: satisfies its Designated Requirement
```

Fixes #350072.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
