### PR TITLE
sage: fix gc-related hypellfrob.pyx test failure

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -54,6 +54,13 @@ stdenv.mkDerivation rec {
   # fix those bugs themselves. This is for critical bugfixes, where "critical"
   # == "causes (transient) doctest failures / somebody complained".
   bugfixPatches = [
+    # https://github.com/sagemath/sage/pull/38628, landed in 10.5.beta4
+    (fetchpatch {
+      name = "pari-stack-cysignals-exception.patch";
+      url = "https://github.com/sagemath/sage/commit/4a9c985b769b1209902c970ade1892f18ab48c10.diff";
+      hash = "sha256-S6NdonB7needJlQdx52Huk34Q8/vG3nyGicA5JpsdWc=";
+    })
+
     # https://github.com/sagemath/sage/pull/38851, landed in 10.5.beta8
     (fetchpatch {
       name = "glpk-aarch64-hang-workaround.patch";


### PR DESCRIPTION
The following is supposed to be an intermittent failure depending on when the Python GC runs, but it is happening very often on CI, both [on x86_64-linux](https://cache.nixos.org/log/wq9psx4hc3z670q1jdwvv97j0zm8yp6h-sage-tests-10.4.drv) and on [aarch64-linux](https://cache.nixos.org/log/cy0q9ywqjph3qxc123kq85lcxc2dx6g2-sage-tests-10.4.drv).

```
sage -t --long --random-seed=117549725075878326137444096744237283023 /nix/store/ml7lj6avy06nayljdmykibx331hkqdgd-sage-src-10.4/src/sage/schemes/cyclic_covers/cycliccover_finite_field.py
**********************************************************************
File "/nix/store/ml7lj6avy06nayljdmykibx331hkqdgd-sage-src-10.4/src/sage/schemes/cyclic_covers/cycliccover_finite_field.py", line 1203, in sage.schemes.cyclic_covers.cycliccover_finite_field.CyclicCover_finite_field.frobenius_polynomial
Failed example:
    CyclicCover(5, x^5 + x).frobenius_polynomial()  # long time
[...]
      File "sage/schemes/hyperelliptic_curves/hypellfrob.pyx", line 129, in sage.schemes.hyperelliptic_curves.hypellfrob.interval_products (build/cythonized/sage/schemes/hyperelliptic_curves/hypellfrob.cpp:7112)
        sig_on()
    SystemError: calling remove_from_pari_stack() inside sig_on()
```

I'm not exactly sure why the uptick (cypari2 update?), but let's just patch it by importing https://github.com/sagemath/sage/pull/38628.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
