### PR TITLE
scx.csheds -> scx.cscheds: fix typo in name

### DIFF
--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -69,7 +69,7 @@ let
     { rlfifo = import ./scx_rlfifo; }
     { rustland = import ./scx_rustland; }
     { rusty = import ./scx_rusty; }
-    { csheds = import ./scx_csheds.nix; }
+    { cscheds = import ./scx_cscheds.nix; }
     { full = import ./scx_full.nix; }
   ];
 in

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -54,7 +54,7 @@ let
 
 in
 mkScxScheduler "c" {
-  schedulerName = "scx_csheds";
+  schedulerName = "scx_cscheds";
 
   postPatch = ''
     rm meson-scripts/fetch_bpftool

--- a/pkgs/os-specific/linux/scx/scx_full.nix
+++ b/pkgs/os-specific/linux/scx/scx_full.nix
@@ -4,7 +4,7 @@
   scx,
   mkScxScheduler,
 }:
-scx.csheds.overrideAttrs (oldAttrs: {
+scx.cscheds.overrideAttrs (oldAttrs: {
   pname = "scx_full";
   postInstall =
     (oldAttrs.postInstall or "")


### PR DESCRIPTION
scx.csheds -> scx.cscheds

I don't think we need a alias here, as it has been unstable for a few days.

If anyone thinks otherwise, I am happy to oblige.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
