### PR TITLE
gcc: do not allow version skew when cross-building gcc

### DIFF
--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
-, gccStdenv
-, gcc9Stdenv
+, pkgs
 , callPackage
 , isl_0_20
 , libcCross
@@ -15,6 +14,7 @@ let
   versions = import ./versions.nix;
   gccForMajorMinorVersion = majorMinorVersion:
     let
+      majorVersion = lib.versions.major majorMinorVersion;
       atLeast = lib.versionAtLeast majorMinorVersion;
       attrName = "gcc${lib.replaceStrings ["."] [""] majorMinorVersion}";
       pkg = lowPrio (wrapCC (callPackage ./default.nix {
@@ -24,7 +24,25 @@ let
         profiledCompiler = false;
         libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then args.libcCross else null;
         threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else { };
-        isl = if stdenv.hostPlatform.isDarwin then null else isl_0_20;
+        # do not allow version skew when cross-building gcc
+        #
+        # When `gcc` is cross-built (`build` != `target` && `host` == `target`)
+        # `gcc` assumes that it has a compatible cross-compiler in the environment
+        # that can build target libraries. Version of a cross-compiler has to
+        # match the compiler being cross-built as libraries frequently use fresh
+        # compiler features, like `-std=c++26` or target-specific types like
+        # `_Bfloat16`.
+        # Version mismatch causes build failures like:
+        #     https://github.com/NixOS/nixpkgs/issues/351905
+        #
+        # Similar problems (but on a smaller scale) happen when a `gcc`
+        # cross-compiler is built (`build` == `host` && `host` != `target`) built
+        # by a mismatching version of a native compiler (`build` == `host` &&
+        # `host` == `target`).
+        #
+        # Let's fix both problems by requiring the same compiler version for
+        # cross-case.
+        stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform || stdenv.hostPlatform != stdenv.targetPlatform) && stdenv.cc.isGNU then pkgs."gcc${majorVersion}Stdenv" else stdenv;
       }));
     in
       lib.nameValuePair attrName pkg;


### PR DESCRIPTION
When `gcc` is cross-built (`build` != `target` && `host` == `target`) `gcc` assumes that it has a compatible cross-compiler in the environment that can build target libraries. Version of a cross-compiler has to match the compiler being cross-built as libraries frequently use fresh compiler features, like `-std=c++26` or target-specific types like `_Bfloat16`.

Version mismatch causes build failures like:

    https://github.com/NixOS/nixpkgs/issues/351905

Similar problems (but on a smaller scale) happen when a `gcc` cross-compiler is built (`build` == `host` && `host` != `target`) built by a mismatching version of a native compiler (`build` == `host` && `host` == `target`). That was worked around by forcing `gcc9Stdenv` for older compiler versions.

Let's fix both problems by requiring the same compiler version for cross-case.

Closes: https://github.com/NixOS/nixpkgs/issues/351905


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
