### PR TITLE
telegram-bot-api: 7.10 -> 7.11

### DIFF
--- a/pkgs/by-name/te/telegram-bot-api/package.nix
+++ b/pkgs/by-name/te/telegram-bot-api/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "telegram-bot-api";
-  version = "7.10";
+  version = "7.11";
 
   src = fetchFromGitHub {
     repo = "telegram-bot-api";
     owner = "tdlib";
-    rev = "a186a9ae823d91678ace87ef5b920688c555f5b5";
-    hash = "sha256-1oGDR9WLWC/0QyAmTkMWkbkD+49/gU/nWBZq0mMOl8g=";
+    rev = "6d1b62b51bdc543c10f854aae751e160e5b7b9c5";
+    hash = "sha256-FLHAv9CQ90Jd2DnzQSRl5wHW6hnWUCz0Ap65Vjkgj0s=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/te/telegram-bot-api/package.nix
+++ b/pkgs/by-name/te/telegram-bot-api/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       Anillc
       Forden
+      nartsiss
     ];
     platforms = lib.platforms.all;
     mainProgram = "telegram-bot-api";


### PR DESCRIPTION
Changelog: https://core.telegram.org/bots/api-changelog#october-31-2024

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
