### PR TITLE
calibre-bin: adds binary release for `darwin`, `arch64-linux` and `x86_64-linux`

### DIFF
--- a/pkgs/by-name/ca/calibre-bin/package.nix
+++ b/pkgs/by-name/ca/calibre-bin/package.nix
@@ -1,0 +1,87 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  xz,
+  _7zz,
+}:
+
+let
+  pname = "calibre-bin";
+  version = "7.20.0";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/kovidgoyal/calibre/releases/download/v${version}/calibre-${version}-x86_64.txz";
+      hash = "sha256-yw+Uly6uI+eiWZjFHdXJr4bP41EnW8JOY11CLc9Yb78=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/kovidgoyal/calibre/releases/download/v${version}/calibre-${version}-arm64.txz";
+      hash = "sha256-hyW8BIy23nRxckTdw8x+Piqy3/aU/lI9/k/3BsLgAKk=";
+    };
+    universal-darwin = {
+      url = "https://github.com/kovidgoyal/calibre/releases/download/v${version}/calibre-${version}.dmg";
+      hash = "sha256-kEbxO2K9Fo7CplxBn0IxPIwh88xKTY/udiLjC1Z4JVw=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl (
+    sources.${if stdenv.hostPlatform.isDarwin then "universal-darwin" else stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}")
+  );
+
+  sourceRoot = ".";
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ xz ] ++ lib.optionals stdenv.isDarwin [ _7zz ];
+  # the extra flag is required for the 7zz binary to extract properly
+  unpackCmd = lib.strings.optionalString stdenv.isDarwin ''
+    7zz x -snld $curSrc
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase =
+    lib.strings.optionalString stdenv.isDarwin ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r Calibre.app $out/Applications
+
+      runHook postInstall
+    ''
+    + lib.strings.optionalString stdenv.isLinux ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r . $out/
+
+      runHook postInstall
+    '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "E-book manager";
+    longDescription = ''
+      Calibre is a free and open source e-book library management application
+      developed by users of e-books for users of e-books.
+    '';
+    homepage = "https://calibre-ebook.com";
+    downloadPage = "https://calibre-ebook.com/download";
+    changelog = "https://calibre-ebook.com/whats-new";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ fbettag ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ca/calibre-bin/update.sh
+++ b/pkgs/by-name/ca/calibre-bin/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    https://api.github.com/repos/kovidgoyal/calibre/releases/latest | jq -e -r .tag_name | sed 's/^v//')
+old_version=$(nix-instantiate --eval -A calibre-bin.version | jq -e -r)
+
+if [[ $version == "$old_version" ]]; then
+    echo "New version same as old version, nothing to do." >&2
+    exit 0
+fi
+
+update-source-version calibre-bin "$version"


### PR DESCRIPTION
Building on macOS seems to be [broken](https://github.com/NixOS/nixpkgs/blob/52a00c7e970a3a07237ac4c075ea74fb9cd01a06/pkgs/by-name/ca/calibre/package.nix#L233), so i made a binary package for it.

Since i didn't just want to commit a package soley for darwin, i've added linux as well.

Testing for both linux architectures would be highly appreciated as i currently don't run any nixos with GUI.

## Things done

- tested on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (since it's a universal binary, i presume this works too)
  - [x] aarch64-darwin

I ran this against my existing calibre library and it started up nicely and loaded everything.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
