### PR TITLE
kanidm: update provisioning patches to 1.4.0

### DIFF
--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
     ''
       cp ${format profile} libs/profiles/${KANIDM_BUILD_PROFILE}.toml
       substituteInPlace libs/profiles/${KANIDM_BUILD_PROFILE}.toml \
-        --replace-fail '@htmx_ui_pkg_path@' "$out/ui/hpkg" \
+        --replace-fail '@htmx_ui_pkg_path@' "$out/ui/hpkg"
     '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ka/kanidm/patches/oauth2-basic-secret-modify.patch
+++ b/pkgs/by-name/ka/kanidm/patches/oauth2-basic-secret-modify.patch
@@ -1,6 +1,6 @@
-From 44dfbc2b9dccce86c7d7e7b54db4c989344b8c56 Mon Sep 17 00:00:00 2001
+From e9dfca73e6fb80faf6fc106e7aee6b93c0908525 Mon Sep 17 00:00:00 2001
 From: oddlama <oddlama@oddlama.org>
-Date: Mon, 12 Aug 2024 23:17:25 +0200
+Date: Fri, 1 Nov 2024 12:26:17 +0100
 Subject: [PATCH 1/2] oauth2 basic secret modify
 
 ---
@@ -11,10 +11,10 @@ Subject: [PATCH 1/2] oauth2 basic secret modify
  4 files changed, 82 insertions(+), 1 deletion(-)
 
 diff --git a/server/core/src/actors/v1_write.rs b/server/core/src/actors/v1_write.rs
-index e00a969fb..1cacc67b8 100644
+index 732e826c8..0fe66503f 100644
 --- a/server/core/src/actors/v1_write.rs
 +++ b/server/core/src/actors/v1_write.rs
-@@ -315,20 +315,62 @@ impl QueryServerWriteV1 {
+@@ -317,20 +317,62 @@ impl QueryServerWriteV1 {
          };
  
          trace!(?del, "Begin delete event");
@@ -39,7 +39,7 @@ index e00a969fb..1cacc67b8 100644
 +    ) -> Result<(), OperationError> {
 +        // Given a protoEntry, turn this into a modification set.
 +        let ct = duration_from_epoch_now();
-+        let mut idms_prox_write = self.idms.proxy_write(ct).await;
++        let mut idms_prox_write = self.idms.proxy_write(ct).await?;
 +        let ident = idms_prox_write
 +            .validate_client_auth_info_to_ident(client_auth_info, ct)
 +            .map_err(|e| {
@@ -78,7 +78,7 @@ index e00a969fb..1cacc67b8 100644
          filter: Filter<FilterInvalid>,
          eventid: Uuid,
 diff --git a/server/core/src/https/v1.rs b/server/core/src/https/v1.rs
-index 8aba83bb2..f1f815026 100644
+index c410a4b5d..cc67cac6c 100644
 --- a/server/core/src/https/v1.rs
 +++ b/server/core/src/https/v1.rs
 @@ -1,17 +1,17 @@
@@ -100,7 +100,7 @@ index 8aba83bb2..f1f815026 100644
  use kanidm_proto::internal::{
      ApiToken, AppLink, CUIntentToken, CURequest, CUSessionToken, CUStatus, CreateRequest,
      CredentialStatus, DeleteRequest, IdentifyUserRequest, IdentifyUserResponse, ModifyRequest,
-@@ -3119,20 +3119,24 @@ pub(crate) fn route_setup(state: ServerState) -> Router<ServerState> {
+@@ -3120,20 +3120,24 @@ pub(crate) fn route_setup(state: ServerState) -> Router<ServerState> {
          )
          .route(
              "/v1/oauth2/:rs_name/_image",
@@ -126,7 +126,7 @@ index 8aba83bb2..f1f815026 100644
                  .delete(super::v1_oauth2::oauth2_id_sup_scopemap_delete),
          )
 diff --git a/server/core/src/https/v1_oauth2.rs b/server/core/src/https/v1_oauth2.rs
-index 5e481afab..a771aed04 100644
+index d3966a7ad..f89c02c69 100644
 --- a/server/core/src/https/v1_oauth2.rs
 +++ b/server/core/src/https/v1_oauth2.rs
 @@ -144,20 +144,49 @@ pub(crate) async fn oauth2_id_get_basic_secret(
@@ -180,47 +180,10 @@ index 5e481afab..a771aed04 100644
      tag = "v1/oauth2",
      operation_id = "oauth2_id_patch"
 diff --git a/server/lib/src/constants/acp.rs b/server/lib/src/constants/acp.rs
-index f3409649d..42e407b7d 100644
+index be1836345..ebf4445be 100644
 --- a/server/lib/src/constants/acp.rs
 +++ b/server/lib/src/constants/acp.rs
-@@ -645,34 +645,36 @@ lazy_static! {
-             Attribute::Image,
-         ],
-         modify_present_attrs: vec![
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
-             Attribute::OAuth2RsOriginLanding,
-             Attribute::OAuth2RsSupScopeMap,
-             Attribute::OAuth2RsScopeMap,
-+            Attribute::OAuth2RsBasicSecret,
-             Attribute::OAuth2AllowInsecureClientDisablePkce,
-             Attribute::OAuth2JwtLegacyCryptoEnable,
-             Attribute::OAuth2PreferShortUsername,
-             Attribute::Image,
-         ],
-         create_attrs: vec![
-             Attribute::Class,
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
-             Attribute::OAuth2RsOriginLanding,
-             Attribute::OAuth2RsSupScopeMap,
-             Attribute::OAuth2RsScopeMap,
-+            Attribute::OAuth2RsBasicSecret,
-             Attribute::OAuth2AllowInsecureClientDisablePkce,
-             Attribute::OAuth2JwtLegacyCryptoEnable,
-             Attribute::OAuth2PreferShortUsername,
-             Attribute::Image,
-         ],
-         create_classes: vec![
-             EntryClass::Object,
-             EntryClass::OAuth2ResourceServer,
-             EntryClass::OAuth2ResourceServerBasic,
-             EntryClass::OAuth2ResourceServerPublic,
-@@ -739,36 +741,38 @@ lazy_static! {
+@@ -658,36 +658,38 @@ lazy_static! {
              Attribute::Image,
          ],
          modify_present_attrs: vec![
@@ -259,7 +222,7 @@ index f3409649d..42e407b7d 100644
          create_classes: vec![
              EntryClass::Object,
              EntryClass::OAuth2ResourceServer,
-@@ -840,36 +844,38 @@ lazy_static! {
+@@ -759,37 +761,39 @@ lazy_static! {
              Attribute::Image,
          ],
          modify_present_attrs: vec![
@@ -282,6 +245,7 @@ index f3409649d..42e407b7d 100644
              Attribute::Class,
              Attribute::Description,
              Attribute::Name,
+             Attribute::DisplayName,
              Attribute::OAuth2RsName,
              Attribute::OAuth2RsOrigin,
              Attribute::OAuth2RsOriginLanding,
@@ -298,6 +262,47 @@ index f3409649d..42e407b7d 100644
          create_classes: vec![
              EntryClass::Object,
              EntryClass::Account,
+@@ -864,38 +868,40 @@ lazy_static! {
+             Attribute::OAuth2StrictRedirectUri,
+         ],
+         modify_present_attrs: vec![
+             Attribute::Description,
+             Attribute::DisplayName,
+             Attribute::Name,
+             Attribute::OAuth2RsOrigin,
+             Attribute::OAuth2RsOriginLanding,
+             Attribute::OAuth2RsSupScopeMap,
+             Attribute::OAuth2RsScopeMap,
++            Attribute::OAuth2RsBasicSecret,
+             Attribute::OAuth2AllowInsecureClientDisablePkce,
+             Attribute::OAuth2JwtLegacyCryptoEnable,
+             Attribute::OAuth2PreferShortUsername,
+             Attribute::OAuth2AllowLocalhostRedirect,
+             Attribute::OAuth2RsClaimMap,
+             Attribute::Image,
+             Attribute::OAuth2StrictRedirectUri,
+         ],
+         create_attrs: vec![
+             Attribute::Class,
+             Attribute::Description,
+             Attribute::Name,
+             Attribute::DisplayName,
+             Attribute::OAuth2RsName,
+             Attribute::OAuth2RsOrigin,
+             Attribute::OAuth2RsOriginLanding,
+             Attribute::OAuth2RsSupScopeMap,
+             Attribute::OAuth2RsScopeMap,
++            Attribute::OAuth2RsBasicSecret,
+             Attribute::OAuth2AllowInsecureClientDisablePkce,
+             Attribute::OAuth2JwtLegacyCryptoEnable,
+             Attribute::OAuth2PreferShortUsername,
+             Attribute::OAuth2AllowLocalhostRedirect,
+             Attribute::OAuth2RsClaimMap,
+             Attribute::Image,
+             Attribute::OAuth2StrictRedirectUri,
+         ],
+         create_classes: vec![
+             EntryClass::Object,
 -- 
-2.45.2
+2.46.1
 

--- a/pkgs/by-name/ka/kanidm/patches/recover-account.patch
+++ b/pkgs/by-name/ka/kanidm/patches/recover-account.patch
@@ -1,6 +1,6 @@
-From cc8269489b56755714f07eee4671f8aa2659c014 Mon Sep 17 00:00:00 2001
+From c8ed69efe3f702b19834c2659be1dd3ec2d41c17 Mon Sep 17 00:00:00 2001
 From: oddlama <oddlama@oddlama.org>
-Date: Mon, 12 Aug 2024 23:17:42 +0200
+Date: Fri, 1 Nov 2024 12:27:43 +0100
 Subject: [PATCH 2/2] recover account
 
 ---
@@ -11,10 +11,10 @@ Subject: [PATCH 2/2] recover account
  4 files changed, 22 insertions(+), 5 deletions(-)
 
 diff --git a/server/core/src/actors/internal.rs b/server/core/src/actors/internal.rs
-index 40c18777f..40d553b40 100644
+index 420e72c6c..5c4353116 100644
 --- a/server/core/src/actors/internal.rs
 +++ b/server/core/src/actors/internal.rs
-@@ -153,25 +153,26 @@ impl QueryServerWriteV1 {
+@@ -171,25 +171,26 @@ impl QueryServerWriteV1 {
      }
  
      #[instrument(
@@ -29,7 +29,7 @@ index 40c18777f..40d553b40 100644
          eventid: Uuid,
      ) -> Result<String, OperationError> {
          let ct = duration_from_epoch_now();
-         let mut idms_prox_write = self.idms.proxy_write(ct).await;
+         let mut idms_prox_write = self.idms.proxy_write(ct).await?;
 -        let pw = idms_prox_write.recover_account(name.as_str(), None)?;
 +        let pw = idms_prox_write.recover_account(name.as_str(), password.as_deref())?;
  
@@ -95,10 +95,10 @@ index 90ccb1927..85e31ddef 100644
                      Some(ctrl_tx) => show_replication_certificate(ctrl_tx).await,
                      None => {
 diff --git a/server/daemon/src/main.rs b/server/daemon/src/main.rs
-index 577995615..a967928c9 100644
+index 7486d34a8..784106352 100644
 --- a/server/daemon/src/main.rs
 +++ b/server/daemon/src/main.rs
-@@ -894,27 +894,39 @@ async fn kanidm_main(
+@@ -903,27 +903,39 @@ async fn kanidm_main(
              } else {
                  let output_mode: ConsoleOutputMode = commonopts.output_mode.to_owned().into();
                  submit_admin_req(
@@ -169,5 +169,5 @@ index f1b45a5b3..9c013e32e 100644
      /// Renew this server's replication certificate
      RenewReplicationCertificate {
 -- 
-2.45.2
+2.46.1
 


### PR DESCRIPTION
This updates the kanidm provisioning patches to 1.4.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
