### PR TITLE
dependabot-cli: 1.41.0 -> 1.57.0, pin image dependencies

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -1,9 +1,10 @@
-{ buildGoModule
-, dependabot-cli
-, fetchFromGitHub
-, installShellFiles
-, lib
-, testers
+{
+  buildGoModule,
+  dependabot-cli,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  testers,
 }:
 let
   pname = "dependabot-cli";

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -5,10 +5,37 @@
   installShellFiles,
   lib,
   testers,
+  dockerTools,
+  makeWrapper,
 }:
 let
   pname = "dependabot-cli";
   version = "1.57.0";
+
+  # vv Also update this vv
+  tag = "nixpkgs-dependabot-cli-${version}";
+  updateJobProxy = dockerTools.pullImage {
+    imageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy";
+    # Get these hashes from
+    # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
+    imageDigest = "sha256:cc4a9b7db8ddf3924b6c25cc8a74d9937bf803e64733035809862a1c0a6df984";
+    sha256 = "0wkr0rac7dp1080s4zik5yzi5967gkfylly2148ipgw50sp0sq8s";
+
+    # Don't update this, it's used to refer to the imported image later
+    finalImageName = "dependabot-update-job-proxy";
+    finalImageTag = tag;
+  };
+  updaterGitHubActions = dockerTools.pullImage {
+    imageName = "ghcr.io/dependabot/dependabot-updater-github-actions";
+    # Get these hashes from
+    # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/dependabot-updater-github-actions --image-tag latest --final-image-name dependabot-updater-github-actions --final-image-tag ${tag}
+    imageDigest = "sha256:6665b3e26ef97577e83f2dfd0007a73c02b003126e72c0b4b196fe570088ed93";
+    sha256 = "0q7w3yp49wb70gkjjl2syvs75hm1jkva2qslzckwxh73z0kq2z0q";
+
+    # Don't update this, it's used to refer to the imported image later
+    finalImageName = "dependabot-updater-github-actions";
+    finalImageTag = tag;
+  };
 in
 buildGoModule {
   inherit pname version;
@@ -28,13 +55,23 @@ buildGoModule {
     "-X github.com/dependabot/cli/cmd/dependabot/internal/cmd.version=v${version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   postInstall = ''
     installShellCompletion --cmd dependabot \
       --bash <($out/bin/dependabot completion bash) \
       --fish <($out/bin/dependabot completion fish) \
       --zsh <($out/bin/dependabot completion zsh)
+
+    # Create a wrapper that pins the docker images that are depended upon
+    makeWrapper $out/bin/dependabot $out/bin/dependabot-pinned \
+      --run "docker load --input ${updateJobProxy}" \
+      --add-flags "--proxy-image=dependabot-update-job-proxy:${tag}" \
+      --run "docker load --input ${updaterGitHubActions}" \
+      --add-flags "--updater-image=dependabot-updater-github-actions:${tag}"
   '';
 
   checkFlags = [

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   pname = "dependabot-cli";
-  version = "1.41.0";
+  version = "1.57.0";
 in
 buildGoModule {
   inherit pname version;
@@ -16,10 +16,10 @@ buildGoModule {
     owner = "dependabot";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-CnSDvLcLupWKBp1Wr6E9BScA8VsBlfmmfPwh8cyERZg=";
+    hash = "sha256-ZT1fwDT19uUjp5iG0NLSrc/6PLW/sukAd0w66mLdFVg=";
   };
 
-  vendorHash = "sha256-vN5r1OtHT16LeJ6iPmHmXTx9Oo+WALhV4PWqzMiUwSA=";
+  vendorHash = "sha256-jSINiETadd0ixzFBilgphi1vJNsRYeDkbaVNk5stTp4=";
 
   ldflags = [
     "-s"
@@ -37,7 +37,7 @@ buildGoModule {
   '';
 
   checkFlags = [
-    "-skip=TestIntegration|TestNewProxy_customCert|TestRun"
+    "-skip=TestDependabot"
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -95,6 +95,9 @@ buildGoModule {
     mainProgram = "dependabot";
     homepage = "https://github.com/dependabot/cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ l0b0 ];
+    maintainers = with maintainers; [
+      l0b0
+      infinisil
+    ];
   };
 }


### PR DESCRIPTION
Noticed that the dependabot updates for https://github.com/NixOS/nixpkgs-vet aren't working anymore. Tracked it down to it needing a dependabot CLI update, but to prevent future breakage, this PR also introduces a `dependabot-pinned` wrapper that pins the docker images.

Ping @NixOS/nixpkgs-vet 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Successfully ran the nixpkgs-vet update script making use of dependabot

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
