### PR TITLE
bencodetools,uade: Fix build, update, modernise

### DIFF
--- a/pkgs/by-name/be/bencodetools/package.nix
+++ b/pkgs/by-name/be/bencodetools/package.nix
@@ -12,13 +12,11 @@ stdenv.mkDerivation {
     owner = "heikkiorsila";
     repo = "bencodetools";
     rev = "384d78d297a561dddbbd0f4632f0c74c0db41577";
-    sha256 = "1d699q9r33hkmmqkbh92ax54mcdf9smscmc0dza2gp4srkhr83qm";
+    hash = "sha256-FQ+U4cya3CfUb4BVpqtOrrFKSlciwTVxrROOkRNOybQ=";
   };
 
   postPatch = ''
     patchShebangs configure
-    substituteInPlace configure \
-      --replace 'python_install_option=""' 'python_install_option="--prefix=$out"'
   '';
 
   enableParallelBuilding = true;
@@ -36,12 +34,12 @@ stdenv.mkDerivation {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Collection of tools for manipulating bencoded data";
     homepage = "https://gitlab.com/heikkiorsila/bencodetools";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ OPNA2608 ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
     mainProgram = "bencat";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/be/bencodetools/package.nix
+++ b/pkgs/by-name/be/bencodetools/package.nix
@@ -2,17 +2,18 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  gitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bencodetools";
-  version = "unstable-2022-05-11";
+  version = "1.0.1";
 
   src = fetchFromGitLab {
     owner = "heikkiorsila";
     repo = "bencodetools";
-    rev = "384d78d297a561dddbbd0f4632f0c74c0db41577";
-    hash = "sha256-FQ+U4cya3CfUb4BVpqtOrrFKSlciwTVxrROOkRNOybQ=";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-5Y1r6+aVtK22lYr2N+YUPPdUts9PIF9I/Pq/mI+WqQs=";
   };
 
   postPatch = ''
@@ -34,6 +35,8 @@ stdenv.mkDerivation {
     runHook postInstallCheck
   '';
 
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
   meta = {
     description = "Collection of tools for manipulating bencoded data";
     homepage = "https://gitlab.com/heikkiorsila/bencodetools";
@@ -42,4 +45,4 @@ stdenv.mkDerivation {
     mainProgram = "bencat";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/be/bencodetools/package.nix
+++ b/pkgs/by-name/be/bencodetools/package.nix
@@ -23,9 +23,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  configureFlags = [
-    (lib.strings.withFeature false "python")
-  ];
+  configureFlags = [ (lib.strings.withFeature false "python") ];
 
   # installCheck instead of check due to -install_name'd library on Darwin
   doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/by-name/be/bencodetools/package.nix
+++ b/pkgs/by-name/be/bencodetools/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitLab,
   gitUpdater,
+  python3Packages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,7 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru = {
+    tests.python-module = python3Packages.bencodetools;
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
 
   meta = {
     description = "Collection of tools for manipulating bencoded data";

--- a/pkgs/by-name/be/bencodetools/package.nix
+++ b/pkgs/by-name/be/bencodetools/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  python3,
 }:
 
 stdenv.mkDerivation {
@@ -24,13 +23,20 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [
-    (python3.withPackages (ps: with ps; [ distutils ]))
+  configureFlags = [
+    (lib.strings.withFeature false "python")
   ];
 
   # installCheck instead of check due to -install_name'd library on Darwin
   doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-  installCheckTarget = "check";
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    ./bencodetest
+
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     description = "Collection of tools for manipulating bencoded data";

--- a/pkgs/by-name/li/libzakalwe/package.nix
+++ b/pkgs/by-name/li/libzakalwe/package.nix
@@ -1,0 +1,58 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libzakalwe";
+  version = "1.0.0-unstable-2024-02-26";
+
+  src = fetchFromGitLab {
+    owner = "hors";
+    repo = "libzakalwe";
+    rev = "c7eba014ba14dc6fa145f6e71e75cca2b65bbc8a";
+    hash = "sha256-2a30ztFnemCgGW/I5S6Dz4eC1Y6K2aV9dPvysvQtBxo=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postPatch =
+    ''
+      substituteInPlace Makefile.in \
+        --replace-fail 'libzakalwe.so' "libzakalwe${stdenv.hostPlatform.extensions.sharedLibrary}"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace Makefile.in \
+        --replace-fail '-soname' '-install_name'
+    '';
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-D_DARWIN_C_SOURCE";
+
+  # Darwin: Assertion failed at thread_util_test_0:52: tr != NULL
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && (!stdenv.hostPlatform.isDarwin);
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  preInstall = ''
+    mkdir -p $out/lib
+  '';
+
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+
+  meta = {
+    description = "Library for functions shared across zakalwe projects";
+    homepage = "https://gitlab.com/hors/libzakalwe";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ua/uade/package.nix
+++ b/pkgs/by-name/ua/uade/package.nix
@@ -11,8 +11,6 @@
 , lame
 , flac
 , vorbis-tools
-# https://gitlab.com/uade-music-player/uade/-/issues/38
-, withWriteAudio ? !stdenv.hostPlatform.isDarwin
 }:
 
 stdenv.mkDerivation rec {
@@ -44,8 +42,6 @@ stdenv.mkDerivation rec {
     pkg-config
     which
     makeWrapper
-  ] ++ lib.optionals withWriteAudio [
-    python3
   ];
 
   buildInputs = [
@@ -55,18 +51,11 @@ stdenv.mkDerivation rec {
     lame
     flac
     vorbis-tools
-  ] ++ lib.optionals withWriteAudio [
-    (python3.withPackages (p: with p; [
-      pillow
-      tqdm
-      more-itertools
-    ]))
   ];
 
   configureFlags = [
     "--bencode-tools-prefix=${bencodetools}"
     "--with-text-scope"
-  ] ++ lib.optionals (!withWriteAudio) [
     "--without-write-audio"
   ];
 
@@ -79,9 +68,6 @@ stdenv.mkDerivation rec {
       --prefix PATH : $out/bin:${lib.makeBinPath [ sox lame flac vorbis-tools ]}
     # This is an old script, don't break expectations by renaming it
     ln -s $out/bin/mod2ogg2{.sh,}
-  '' + lib.optionalString withWriteAudio ''
-    wrapProgram $out/bin/generate_amiga_oscilloscope_view \
-      --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ua/uade/package.nix
+++ b/pkgs/by-name/ua/uade/package.nix
@@ -2,62 +2,63 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  bencodetools,
+  flac,
+  lame,
+  libao,
+  makeWrapper,
   python3,
   pkg-config,
-  which,
-  makeWrapper,
-  libao,
-  bencodetools,
   sox,
-  lame,
-  flac,
   vorbis-tools,
+  which,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "uade";
   version = "3.02";
 
   src = fetchFromGitLab {
     owner = "uade-music-player";
     repo = "uade";
-    rev = "uade-${version}";
+    rev = "uade-${finalAttrs.version}";
     hash = "sha256-skPEXBQwyr326zCmZ2jwGxcBoTt3Y/h2hagDeeqbMpw=";
   };
 
   postPatch = ''
     patchShebangs configure
-    substituteInPlace configure \
-      --replace 'PYTHON_SETUP_ARGS=""' 'PYTHON_SETUP_ARGS="--prefix=$out"'
+
     substituteInPlace src/frontends/mod2ogg/mod2ogg2.sh.in \
-      --replace '-e stat' '-n stat' \
-      --replace '/usr/local' "$out"
+      --replace-fail '-e stat' '-n stat' \
+      --replace-fail '/usr/local' "$out"
+
     substituteInPlace python/uade/generate_oscilloscope_view.py \
-      --replace "default='uade123'" "default='$out/bin/uade123'"
+      --replace-fail "default='uade123'" "default='$out/bin/uade123'"
+
     # https://gitlab.com/uade-music-player/uade/-/issues/37
     substituteInPlace write_audio/Makefile.in \
-      --replace 'g++' '${stdenv.cc.targetPrefix}c++'
+      --replace-fail 'g++' '${stdenv.cc.targetPrefix}c++'
   '';
 
   nativeBuildInputs = [
+    makeWrapper
     pkg-config
     which
-    makeWrapper
   ];
 
   buildInputs = [
-    libao
     bencodetools
-    sox
-    lame
     flac
+    lame
+    libao
+    sox
     vorbis-tools
   ];
 
   configureFlags = [
     "--bencode-tools-prefix=${bencodetools}"
-    "--with-text-scope"
-    "--without-write-audio"
+    (lib.strings.withFeature true "text-scope")
+    (lib.strings.withFeature false "write-audio")
   ];
 
   enableParallelBuilding = true;
@@ -68,26 +69,27 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/mod2ogg2.sh \
       --prefix PATH : $out/bin:${
         lib.makeBinPath [
-          sox
-          lame
           flac
+          lame
+          sox
           vorbis-tools
         ]
       }
+
     # This is an old script, don't break expectations by renaming it
     ln -s $out/bin/mod2ogg2{.sh,}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Plays old Amiga tunes through UAE emulation and cloned m68k-assembler Eagleplayer API";
     homepage = "https://zakalwe.fi/uade/";
     # It's a mix of licenses. "GPL", Public Domain, "LGPL", GPL2+, BSD, LGPL21+ and source code with unknown licenses. E.g.
     # - hippel-coso player is "[not] under any Open Source certified license"
     # - infogrames player is disassembled from Andi Silvas player, unknown license
     # Let's make it easy and flag the whole package as unfree.
-    license = licenses.unfree;
-    maintainers = with maintainers; [ OPNA2608 ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
     mainProgram = "uade123";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ua/uade/package.nix
+++ b/pkgs/by-name/ua/uade/package.nix
@@ -1,16 +1,17 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, python3
-, pkg-config
-, which
-, makeWrapper
-, libao
-, bencodetools
-, sox
-, lame
-, flac
-, vorbis-tools
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  python3,
+  pkg-config,
+  which,
+  makeWrapper,
+  libao,
+  bencodetools,
+  sox,
+  lame,
+  flac,
+  vorbis-tools,
 }:
 
 stdenv.mkDerivation rec {
@@ -65,7 +66,14 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/mod2ogg2.sh \
-      --prefix PATH : $out/bin:${lib.makeBinPath [ sox lame flac vorbis-tools ]}
+      --prefix PATH : $out/bin:${
+        lib.makeBinPath [
+          sox
+          lame
+          flac
+          vorbis-tools
+        ]
+      }
     # This is an old script, don't break expectations by renaming it
     ln -s $out/bin/mod2ogg2{.sh,}
   '';

--- a/pkgs/by-name/ua/uade/package.nix
+++ b/pkgs/by-name/ua/uade/package.nix
@@ -2,10 +2,12 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  gitUpdater,
   bencodetools,
   flac,
   lame,
   libao,
+  libzakalwe,
   makeWrapper,
   python3,
   pkg-config,
@@ -16,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uade";
-  version = "3.02";
+  version = "3.05";
 
   src = fetchFromGitLab {
     owner = "uade-music-player";
     repo = "uade";
     rev = "uade-${finalAttrs.version}";
-    hash = "sha256-skPEXBQwyr326zCmZ2jwGxcBoTt3Y/h2hagDeeqbMpw=";
+    hash = "sha256-k6t8EQ/G8PbfRrBMXubn1XfBPvw1qDoMGh5xJKrcX+E=";
   };
 
   postPatch = ''
@@ -34,10 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace python/uade/generate_oscilloscope_view.py \
       --replace-fail "default='uade123'" "default='$out/bin/uade123'"
-
-    # https://gitlab.com/uade-music-player/uade/-/issues/37
-    substituteInPlace write_audio/Makefile.in \
-      --replace-fail 'g++' '${stdenv.cc.targetPrefix}c++'
   '';
 
   nativeBuildInputs = [
@@ -51,12 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
     flac
     lame
     libao
+    libzakalwe
     sox
     vorbis-tools
   ];
 
   configureFlags = [
     "--bencode-tools-prefix=${bencodetools}"
+    "--libzakalwe-prefix=${libzakalwe}"
     (lib.strings.withFeature true "text-scope")
     (lib.strings.withFeature false "write-audio")
   ];
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
     # This is an old script, don't break expectations by renaming it
     ln -s $out/bin/mod2ogg2{.sh,}
   '';
+
+  passthru.updateScript = gitUpdater { rev-prefix = "uade-"; };
 
   meta = {
     description = "Plays old Amiga tunes through UAE emulation and cloned m68k-assembler Eagleplayer API";

--- a/pkgs/development/python-modules/bencodetools/default.nix
+++ b/pkgs/development/python-modules/bencodetools/default.nix
@@ -1,0 +1,30 @@
+{
+  buildPythonPackage,
+  bencodetools,
+  pytestCheckHook,
+  setuptools,
+}:
+buildPythonPackage {
+  inherit (bencodetools) pname version src;
+  format = "pyproject";
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  dontConfigure = true;
+
+  pythonImportsCheck = [
+    "bencode"
+    "typevalidator"
+  ];
+
+  meta = {
+    inherit (bencodetools.meta)
+      description
+      homepage
+      license
+      maintainers
+      ;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1575,6 +1575,10 @@ self: super: with self; {
 
   bencoder = callPackage ../development/python-modules/bencoder { };
 
+  bencodetools = callPackage ../development/python-modules/bencodetools {
+    bencodetools = pkgs.bencodetools;
+  };
+
   beniget = callPackage ../development/python-modules/beniget { };
 
   bentoml = callPackage ../development/python-modules/bentoml { };


### PR DESCRIPTION
Addresses the `bencodetools` build failure on Hydra, which started after Python got bumped to 3.11 (https://hydra.nixos.org/build/275774889) + general maintenance & update stuff.

- `bencodetools`
  - Drop the python module building from the main package, which gets rid of the error
  - `nixfmt` it
  - Update `src.hash` format, get rid of `meta`-wide `with lib`
  - Update to latest stable version, add `passthru.updateScript`
  - Migrate it to `pkgs/by-name`
  - Re-init the python module as a separate `python3Packages` entry, inheriting lots of details from the main `bencodetools` package but only building the python module
- `libzakalwe`
  - init (needed for newer `uade`)
- `uade`
  - Drop the python tools building. It was already disabled on Darwin due to them not working there, but now that python doesn't like `python setup.py install` anymore, it just doesn't install anymore.
  - `nixfmt` it
  - Modernise
    - `rec` -> `finalAttrs`
    - `--replace` -> `--replace-fail`
    - Use `lib.strings.withFeature`
    - Get rid of `meta`-wide `with lib`
  - Update to latest stable version, add `passthru.updateScript`
  - Migrate it to `pkgs/by-name`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
