### PR TITLE
python312Packages.scikit-misc: 0.4.0 -> 0.5.1 and fix build

### DIFF
--- a/pkgs/development/python-modules/scikit-misc/default.nix
+++ b/pkgs/development/python-modules/scikit-misc/default.nix
@@ -7,24 +7,21 @@
   git,
   meson-python,
   pkg-config,
-  blas,
-  lapack,
   numpy,
   setuptools,
-  wheel,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "scikit-misc";
-  version = "0.4.0";
+  version = "0.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "has2k1";
     repo = "scikit-misc";
     rev = "refs/tags/v${version}";
-    hash = "sha256-/mX6gRc52rkHKr6GI9XIHbksdhqpksndmSBNMtk3HFs=";
+    hash = "sha256-w6RHmVxJjLx9ov2LxXvicxmY8jixfkIRfbfVnV2yhOU=";
   };
 
   postPatch = ''
@@ -32,8 +29,8 @@ buildPythonPackage rec {
 
     # unbound numpy and disable coverage testing in pytest
     substituteInPlace pyproject.toml \
-      --replace 'numpy==' 'numpy>=' \
-      --replace 'addopts = "' '#addopts = "'
+      --replace-fail 'numpy>=2.0' 'numpy' \
+      --replace-fail 'addopts = "' '#addopts = "'
 
     # provide a version to use when git fails to get the tag
     [[ -f skmisc/_version.py ]] || \
@@ -41,27 +38,19 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    cython
     gfortran
     git
+    pkg-config
+  ];
+
+  build-system = [
+    cython
     meson-python
     numpy
-    pkg-config
     setuptools
-    wheel
   ];
 
-  propagatedBuildInputs = [ numpy ];
-
-  buildInputs = [
-    blas
-    lapack
-  ];
-
-  mesonFlags = [
-    "-Dblas=${blas.pname}"
-    "-Dlapack=${lapack.pname}"
-  ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Diff: https://github.com/has2k1/scikit-misc/compare/refs/tags/v0.4.0...v0.5.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
