### PR TITLE
composefs: 1.0.6 -> 1.0.7

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "composefs";
-  version = "1.0.6";
+  version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "composefs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9YEY7oTjWwVT2KbzTOOc6sJIGEAkdLSKDf1noF1cYuA=";
+    hash = "sha256-kbXmDdyRrtsERkUomjZUWP3QC2q27AWUTc/J2jCSXg4=";
   };
 
   strictDeps = true;
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "File system for mounting container images";
     homepage = "https://github.com/containers/composefs";
     changelog = "https://github.com/containers/composefs/releases/tag/v${finalAttrs.version}";
-    license = with lib.licenses; [ gpl3Plus lgpl21Plus ];
+    license = with lib.licenses; [ gpl2Only asl20 ];
     maintainers = with lib.maintainers; [ kiskae ];
     mainProgram = "mkcomposefs";
     pkgConfigModules = [ "composefs" ];

--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -35,10 +35,18 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   outputs = [ "out" "lib" "dev" ];
 
-  postPatch = lib.optionalString installExperimentalTools ''
-    substituteInPlace tools/meson.build \
-      --replace-fail "install : false" "install : true"
-  '';
+  postPatch =
+    # 'both_libraries' as an install target always builds both versions.
+    #  This results in double disk usage for normal builds and broken static builds,
+    #  so we replace it with the regular library target.
+    ''
+      substituteInPlace libcomposefs/meson.build \
+        --replace-fail "both_libraries" "library"
+    ''
+    + lib.optionalString installExperimentalTools ''
+      substituteInPlace tools/meson.build \
+        --replace-fail "install : false" "install : true"
+    '';
 
   nativeBuildInputs = [ meson ninja go-md2man pkg-config ];
   buildInputs = [ openssl ]


### PR DESCRIPTION
https://github.com/containers/composefs/releases/tag/v1.0.7

License changed as per COPYING:
> In practice, the intersection here means that the codebase
> as a whole should be treated as if it's under `GPL-2.0-only OR Apache-2.0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
