### PR TITLE
bootc: init at 1.1.0

### DIFF
--- a/pkgs/by-name/bo/bootc/package.nix
+++ b/pkgs/by-name/bo/bootc/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  libz,
+  zstd,
+  pkg-config,
+  openssl,
+  glib,
+  ostree,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bootc";
+  version = "1.1.0";
+  cargoHash = "sha256-2Ka3n6sT1RUlReNjtV6tMe4ow/M7DFNvWPZktwcEi/w=";
+  doInstallCheck = true;
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "bootc";
+    rev = "v${version}";
+    hash = "sha256-vsJwJHPE5Puv9xCnDRDtHzNuFj1U7s1HzZ2vQKTavhs=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libz
+    zstd
+    openssl
+    glib
+    ostree
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  meta = {
+    description = "Boot and upgrade via container images";
+    homepage = "https://containers.github.io/bootc";
+    license = lib.licenses.mit;
+    mainProgram = "bootc";
+    maintainers = with lib.maintainers; [ thesola10 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added `bootc` from [containers/bootc](https://github.com/containers/bootc)

This is useful to install or repair a `bootc` system from NixOS, such as from a live USB. Intended as a successor to `rpm-ostree` together with `dnf5`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
