### PR TITLE
team-list: establish java team

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -206,6 +206,12 @@ pkgs/data/misc/cacert/ @ajs124 @lukegb @mweinelt
 pkgs/development/libraries/nss/ @ajs124 @lukegb @mweinelt
 pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
+# Java
+/doc/languages-frameworks/java.section.md @NixOS/java
+/doc/languages-frameworks/gradle.section.md @NixOS/java
+/doc/languages-frameworks/maven.section.md @NixOS/java
+/pkgs/top-level/java-packages.nix @NixOS/java
+
 # Jetbrains
 /pkgs/applications/editors/jetbrains @edwtjo
 

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -497,6 +497,19 @@ with lib.maintainers;
     shortName = "Input-Output Global employees";
   };
 
+  java = {
+    githubTeams = [ "java" ];
+    members = [
+      chayleaf
+      fliegendewurst
+      infinidoge
+      tomodachi94
+    ];
+    shortName = "Java";
+    scope = "Maintainers of the Nixpkgs Java ecosystem (JDK, JVM, Java, Gradle, Maven, Ant, and adjacent projects)";
+    enableFeatureFreezePing = true;
+  };
+
   jitsi = {
     members = [
       cleeyv

--- a/pkgs/by-name/ap/apacheAnt/package.nix
+++ b/pkgs/by-name/ap/apacheAnt/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
 
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ ] ++ lib.teams.java.members;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/gr/gradle-completion/package.nix
+++ b/pkgs/by-name/gr/gradle-completion/package.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "Gradle tab completion for bash and zsh";
     homepage = "https://github.com/gradle/gradle-completion";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ ] ++ teams.java.members;
   };
 }

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.asl20;
     mainProgram = "mvn";
-    maintainers = [ ];
+    maintainers = [ ] ++ lib.teams.java.members;
     inherit (jdk_headless.meta) platforms;
   };
 })

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -636,10 +636,13 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source Java Development Kit";
     homepage = "https://openjdk.java.net/";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [
-      edwtjo
-      infinidoge
-    ];
+    maintainers =
+      with lib.maintainers;
+      [
+        edwtjo
+        infinidoge
+      ]
+      ++ lib.teams.java.members;
     mainProgram = "java";
     platforms =
       [

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -69,7 +69,7 @@ let
       sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
       description = "${brand-name}, prebuilt OpenJDK binary";
       platforms = builtins.map (arch: arch + "-darwin") providedCpuTypes; # some inherit jre.meta.platforms
-      maintainers = with maintainers; [ taku0 ];
+      maintainers = with maintainers; [ taku0 ] ++ lib.teams.java.members;
       inherit knownVulnerabilities;
       mainProgram = "java";
     };

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -127,7 +127,7 @@ let
       sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
       description = "${brand-name}, prebuilt OpenJDK binary";
       platforms = builtins.map (arch: arch + "-linux") providedCpuTypes; # some inherit jre.meta.platforms
-      maintainers = with maintainers; [ taku0 ];
+      maintainers = with maintainers; [ taku0 ] ++ lib.teams.java.members;
       inherit knownVulnerabilities;
       mainProgram = "java";
     };

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -164,7 +164,7 @@ let
       homepage = "https://www.azul.com/products/zulu/";
       license = lib.licenses.gpl2Only;
       mainProgram = "java";
-      maintainers = [ ];
+      maintainers = [ ] ++ lib.teams.java.members;
       platforms = builtins.attrNames dists;
       sourceProvenance = with lib.sourceTypes; [ binaryBytecode binaryNativeCode ];
     };

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -174,7 +174,7 @@ rec {
           binaryNativeCode
         ];
         license = licenses.asl20;
-        maintainers = with maintainers; [ lorenzleutgeb liff ];
+        maintainers = with maintainers; [ lorenzleutgeb liff ] ++ lib.teams.java.members;
         mainProgram = "gradle";
       } // meta;
     });


### PR DESCRIPTION
As discussed in #jvm:nixos.org on Matrix, the maintainers of the Java ecosystem in Nixpkgs feel that a team for Java would be helpful.


## Blockers
- [x] Waiting on responses from the following contributors to the Java Nixpkgs ecosystem (non-blocking after 2024-11-08):
    - [x] @chayleaf (said yes)
    - [x] @Infinidoge (said yes)
    - [x] @\\\\thiagokokada (said no)
    - [x] @\\\\emilazy (said no *for now*)
    - [x] @FliegendeWurst (said yes)
    - [x] @NeQuissimus (said no)
    - [ ] @shlevy (no GitHub activity in the entire month of October, probably won't respond)
    - [ ] @edwtjo  (no GitHub activity since 2024-09-27, not likely to respond)
    - [ ] @taku0 (active on GitHub)
- [x] Waiting on organization owners to add @NixOS\\\/java to the Nixpkgs repository (done by lassulus)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
