### PR TITLE
{febio, febio-studio}: darwin sdk refactor; fix qt 6.8 build

### DIFF
--- a/pkgs/by-name/fe/febio-studio/package.nix
+++ b/pkgs/by-name/fe/febio-studio/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  overrideSDK,
   fetchFromGitHub,
   cmake,
   ninja,
@@ -10,6 +9,8 @@
   qt6Packages,
   febio,
   glew,
+  apple-sdk_11,
+  darwinMinVersionHook,
   sshSupport ? true,
   openssl,
   libssh,
@@ -23,18 +24,7 @@
   withCadFeatures ? false,
 }:
 
-let
-  stdenv' =
-    if stdenv.hostPlatform.isDarwin then
-      overrideSDK stdenv {
-        darwinSdkVersion = "11.0";
-        darwinMinVersion = "10.15";
-      }
-    else
-      stdenv;
-in
-
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "febio-studio";
   version = "2.7";
 
@@ -76,7 +66,11 @@ stdenv'.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional tetgenSupport tetgen
     ++ lib.optional ffmpegSupport ffmpeg
-    ++ lib.optional dicomSupport dcmtk;
+    ++ lib.optional dicomSupport dcmtk
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_11
+      (darwinMinVersionHook "10.15")
+    ];
 
   meta = {
     description = "FEBio Suite Solver";

--- a/pkgs/by-name/fe/febio-studio/package.nix
+++ b/pkgs/by-name/fe/febio-studio/package.nix
@@ -11,6 +11,7 @@
   glew,
   apple-sdk_11,
   darwinMinVersionHook,
+  fetchpatch,
   sshSupport ? true,
   openssl,
   libssh,
@@ -35,7 +36,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ggIzz6bvNjqlI8s31EVnbM0TOspBSc9/myKpWukS3MU=";
   };
 
-  patches = [ ./cmake-install.patch ];
+  patches = [
+    ./cmake-install.patch
+    # Fix qt 6.8 compile, can be removed after next release
+    (fetchpatch {
+      url = "https://github.com/febiosoftware/FEBioStudio/commit/15524d958a6f5ef81ccee58b4efa1ea25de91543.patch";
+      hash = "sha256-LRToK1/RQC+bLXgroDTQOV6H8pI+IZ38Y0nsl/Fz1WE=";
+    })
+  ];
 
   cmakeFlags =
     [ (lib.cmakeFeature "Qt_Root" "${qt6Packages.qtbase}") ]

--- a/pkgs/by-name/fe/febio/package.nix
+++ b/pkgs/by-name/fe/febio/package.nix
@@ -1,23 +1,19 @@
 {
   lib,
   stdenv,
-  overrideSDK,
   fetchFromGitHub,
   fetchpatch2,
   substituteAll,
+  apple-sdk_11,
   cmake,
+  darwinMinVersionHook,
   ninja,
   zlib,
-  darwin,
   mklSupport ? true,
   mkl,
 }:
 
-let
-  stdenv' = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
-in
-
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "FEBio";
   version = "4.7";
 
@@ -57,9 +53,8 @@ stdenv'.mkDerivation (finalAttrs: {
     [ zlib ]
     ++ lib.optionals mklSupport [ mkl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.CoreGraphics
-      darwin.apple_sdk.frameworks.CoreVideo
-      darwin.apple_sdk.frameworks.Accelerate
+      apple-sdk_11
+      (darwinMinVersionHook "10.15")
     ];
 
   meta = {


### PR DESCRIPTION
## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
