### PR TITLE
stopmotion: 0.8.5 -> 0.8.7

### DIFF
--- a/pkgs/applications/video/linuxstopmotion/default.nix
+++ b/pkgs/applications/video/linuxstopmotion/default.nix
@@ -1,4 +1,16 @@
-{ mkDerivation, lib, fetchgit, pkg-config, qmake, qtbase, qttools, qtmultimedia, libvorbis, libtar, libxml2 }:
+{
+  mkDerivation,
+  lib,
+  fetchgit,
+  pkg-config,
+  qmake,
+  qtbase,
+  qttools,
+  qtmultimedia,
+  libvorbis,
+  libtar,
+  libxml2,
+}:
 
 mkDerivation rec {
   version = "0.8.5";
@@ -10,8 +22,18 @@ mkDerivation rec {
     sha256 = "1612lkwsfzc59wvdj2zbj5cwsyw66bwn31jrzjrxvygxdh4ab069";
   };
 
-  nativeBuildInputs = [ qmake pkg-config ];
-  buildInputs = [ qtbase qttools qtmultimedia libvorbis libtar libxml2 ];
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+  ];
+  buildInputs = [
+    qtbase
+    qttools
+    qtmultimedia
+    libvorbis
+    libtar
+    libxml2
+  ];
 
   postPatch = ''
     substituteInPlace stopmotion.pro --replace '$$[QT_INSTALL_BINS]' '${lib.getDev qttools}/bin'

--- a/pkgs/applications/video/linuxstopmotion/default.nix
+++ b/pkgs/applications/video/linuxstopmotion/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchgit,
   pkg-config,
   qmake,
@@ -10,9 +10,10 @@
   libvorbis,
   libtar,
   libxml2,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "0.8.5";
   pname = "linuxstopmotion";
 
@@ -25,6 +26,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/by-name/st/stopmotion/package.nix
+++ b/pkgs/by-name/st/stopmotion/package.nix
@@ -3,19 +3,15 @@
   stdenv,
   fetchgit,
   pkg-config,
-  qmake,
-  qtbase,
-  qttools,
-  qtmultimedia,
+  qt5,
   libvorbis,
   libtar,
   libxml2,
-  wrapQtAppsHook,
 }:
 
 stdenv.mkDerivation rec {
   version = "0.8.5";
-  pname = "linuxstopmotion";
+  pname = "stopmotion";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/linuxstopmotion/code";
@@ -24,21 +20,21 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
+    qt5.qmake
     pkg-config
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
-    qtbase
-    qttools
-    qtmultimedia
+    qt5.qtbase
+    qt5.qttools
+    qt5.qtmultimedia
     libvorbis
     libtar
     libxml2
   ];
 
   postPatch = ''
-    substituteInPlace stopmotion.pro --replace '$$[QT_INSTALL_BINS]' '${lib.getDev qttools}/bin'
+    substituteInPlace stopmotion.pro --replace '$$[QT_INSTALL_BINS]' '${lib.getDev qt5.qttools}/bin'
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/st/stopmotion/package.nix
+++ b/pkgs/by-name/st/stopmotion/package.nix
@@ -2,25 +2,26 @@
   lib,
   stdenv,
   fetchgit,
+  cmake,
   pkg-config,
   qt5,
   libvorbis,
-  libtar,
+  libarchive,
   libxml2,
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.5";
+  version = "0.8.7";
   pname = "stopmotion";
 
   src = fetchgit {
-    url = "https://git.code.sf.net/p/linuxstopmotion/code";
+    url = "https://invent.kde.org/multimedia/stopmotion";
     rev = version;
-    sha256 = "1612lkwsfzc59wvdj2zbj5cwsyw66bwn31jrzjrxvygxdh4ab069";
+    hash = "sha256-wqrB0mo7sI9ntWF9QlYmGiRiIoLkMzD+mQ6BzhbAKX8=";
   };
 
   nativeBuildInputs = [
-    qt5.qmake
+    cmake
     pkg-config
     qt5.wrapQtAppsHook
   ];
@@ -29,13 +30,9 @@ stdenv.mkDerivation rec {
     qt5.qttools
     qt5.qtmultimedia
     libvorbis
-    libtar
+    libarchive
     libxml2
   ];
-
-  postPatch = ''
-    substituteInPlace stopmotion.pro --replace '$$[QT_INSTALL_BINS]' '${lib.getDev qt5.qttools}/bin'
-  '';
 
   meta = with lib; {
     description = "Create stop-motion animation movies";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -711,6 +711,8 @@ mapAliases {
   linuxPackages_testing_bcachefs = throw "'linuxPackages_testing_bcachefs' has been removed, please use 'linuxPackages_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";
   linux_testing_bcachefs = throw "'linux_testing_bcachefs' has been removed, please use 'linux_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";
 
+  linuxstopmotion = stopmotion; # Added 2024-11-01
+
   llvmPackages_git = (callPackages ../development/compilers/llvm { }).git;
 
   lld_9 = throw "lld_9 has been removed from nixpkgs"; # Added 2024-04-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32277,8 +32277,6 @@ with pkgs;
     curses = ncurses;
   };
 
-  linuxstopmotion = libsForQt5.callPackage ../applications/video/linuxstopmotion { };
-
   sweethome3d = recurseIntoAttrs (
     (callPackage ../applications/misc/sweethome3d { }) //
     (callPackage ../applications/misc/sweethome3d/editors.nix {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **linuxstopmotion: format with nixpkgs-rfc-style**
- **linuxstopmotion: stop using qt5.mkDerivation**
- **stopmotion: rename from linuxstopmotion**
- **stopmotion: 0.8.5 -> 0.8.7**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
