### PR TITLE
nixos/networkmanager: add options to supply secrets to connection profiles based on secret files

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12338,6 +12338,13 @@
     githubId = 101508537;
     name = "Yuchen He";
   };
+  lilioid = {
+    name = "Lilly";
+    email = "li@lly.sh";
+    matrix = "@17sell:mafiasi.de";
+    github = "lilioid";
+    githubId = 12398140;
+  };
   LilleAila = {
     name = "Olai";
     email = "olai@olai.dev";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1146,6 +1146,7 @@
   ./services/networking/nixops-dns.nix
   ./services/networking/nncp.nix
   ./services/networking/nntp-proxy.nix
+  ./services/networking/nm-file-secret-agent.nix
   ./services/networking/nomad.nix
   ./services/networking/nsd.nix
   ./services/networking/ntopng.nix

--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -1,0 +1,131 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.networking.networkmanager;
+  toml = pkgs.formats.toml { };
+
+  enabled = (lib.length cfg.ensureProfiles.secrets.entries) > 0;
+
+  nmFileSecretAgentConfig = {
+    entry = builtins.map (
+      i:
+      {
+        key = i.key;
+        file = i.file;
+      }
+      // lib.optionalAttrs (i.matchId != null) { match_id = i.matchId; }
+      // lib.optionalAttrs (i.matchUuid != null) { match_uuid = i.matchUuid; }
+      // lib.optionalAttrs (i.matchType != null) { match_type = i.matchType; }
+      // lib.optionalAttrs (i.matchIface != null) { match_iface = i.matchIface; }
+      // lib.optionalAttrs (i.matchSetting != null) {
+        match_setting = i.matchSetting;
+      }
+    ) cfg.ensureProfiles.secrets.entries;
+  };
+  nmFileSecretAgentConfigFile = toml.generate "config.toml" nmFileSecretAgentConfig;
+in
+{
+  meta = {
+    maintainers = [ lib.maintainers.lilioid ];
+  };
+
+  ####### interface
+  options = {
+    networking.networkmanager.ensureProfiles.secrets = {
+      package = lib.mkPackageOption pkgs "nm-file-secret-agent" { };
+      entries = lib.mkOption {
+        description = ''
+          A list of secrets to provide to NetworkManager by reading their values from configured files.
+
+          Note that NetworkManager should be configured to read secrets from a secret agent.
+          This can be done for example through the `networking.networkmanager.ensureProfiles.profiles` options.
+        '';
+        default = [ ];
+        example = [
+          {
+            matchId = "My WireGuard VPN";
+            matchType = "wireguard";
+            matchSetting = "wireguard";
+            key = "private-key";
+            file = "/root/wireguard_key";
+          }
+        ];
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              matchId = lib.mkOption {
+                description = ''
+                  connection id used by NetworkManager. Often displayed as name in GUIs.
+
+                  NetworkManager describes this as a human readable unique identifier for the connection, like "Work Wi-Fi" or "T-Mobile 3G".
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "wifi1";
+              };
+              matchUuid = lib.mkOption {
+                description = ''
+                  UUID of the connection profile
+
+                  UUIDs are assigned once on connection creation and should never change as long as the connection still applies to the same network.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "669ea4c9-4cb3-4901-ab52-f9606590976e";
+              };
+              matchType = lib.mkOption {
+                description = ''
+                  NetworkManager connection type
+
+                  The NetworkManager configuration settings reference roughly corresponds to connection types.
+                  More might be available on your system depending on the installed plugins.
+
+                  https://networkmanager.dev/docs/api/latest/ch01.html
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "wireguard";
+              };
+              matchIface = lib.mkOption {
+                description = "interface name of the NetworkManager connection";
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+              matchSetting = lib.mkOption {
+                description = "name of the setting section for which secrets are requested";
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+              key = lib.mkOption {
+                description = "key in the setting section for which this entry provides a value";
+                type = lib.types.str;
+              };
+              file = lib.mkOption {
+                description = "file from which the secret value is read";
+                type = lib.types.str;
+              };
+            };
+          }
+        );
+      };
+    };
+  };
+
+  ####### implementation
+  config = lib.mkIf enabled {
+    # start nm-file-secret-agent if required
+    systemd.services."nm-file-secret-agent" = {
+      description = "NetworkManager secret agent that responds with the content of preconfigured files";
+      documentation = [ "https://github.com/lilioid/nm-file-secret-agent/" ];
+      requires = [ "NetworkManager.service" ];
+      after = [ "NetworkManager.service" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ nmFileSecretAgentConfigFile ];
+      script = "${lib.getExe cfg.ensureProfiles.secrets.package} --conf ${nmFileSecretAgentConfigFile}";
+    };
+  };
+}

--- a/pkgs/by-name/nm/nm-file-secret-agent/package.nix
+++ b/pkgs/by-name/nm/nm-file-secret-agent/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  dbus,
+  networkmanager,
+  pkg-config,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  name = "nm-file-secret-agent";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "lilioid";
+    repo = "nm-file-secret-agent";
+    rev = "v${version}";
+    hash = "sha256-5L4bhf6nsINZD+oINC1f71P2cebPG7bzDYtlsU8UMMk=";
+  };
+  cargoHash = "sha256-SlYz55hc9HEueN7AYVpqadxQjI0hERcdQSJ7rEPnbVE=";
+  buildInputs = [ dbus ];
+  nativeBuildInputs = [ pkg-config ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "NetworkManager secret agent that responds with the content of preconfigured files";
+    mainProgram = "nm-file-secret-agent";
+    homepage = "https://github.com/lilioid/nm-file-secret-agent/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lilioid ];
+    platforms = lib.lists.intersectLists dbus.meta.platforms networkmanager.meta.platforms;
+  };
+}


### PR DESCRIPTION
This PR adds nm-file-secret-agent ([homepage/repository](https://github.com/lilioid/nm-file-secret-agent/)) as a package as well as corresponding nixos options.
The program is a small agent that can supply secrets of connection profiles to NetworkManager by reading the contents of preconfigured files.

It is intended to work alongside the existing `networking.networkmanager.ensureProfiles.profiles` options but in contrast to `networking.networkmanager.ensureProfiles.environmentFiles`, which requires an environment file in `KEY=value` format, the options introduced here enable using files that contain just the values.

## Development, Testing

The package and module definitions were developed in the packages repository ([link](https://github.com/lilioid/nm-file-secret-agent/blob/main/nix/module.nix)) and I am using them on my systems daily. 
The module code was then copied to nixpkgs and tested by evaluating the configuration and checking that all generated files were the same. I, however, did not switch to the instantiated configuration as I prefer my systems to be based on a stable release channel instead of the current master branch.

## Examples

An example of the introduced options looks like the following code.
This will generate a `nm-file-secret-agent.service` systemd unit with a corresponding config file to supply a secret named *private-key* whenever NetworkManager asks for wireguard secrets of the *wgVpn* connection profile.

```nix
networking.networkmanager.ensureProfiles.secrets.entries = [
  {
    matchId = "wgVpn";
    matchType = "wireguard";
    matchSetting = "wireguard";
    key = "private-key";
    file = "/run/secrets/wg_vpn/privkey";
  }
];
```

## Implementation Description

The package is implemented as a small Rust system service which uses NetworkManagers [AgentManager](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.AgentManager.html) & [SecretAgent](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.SecretAgent.html) D-Bus APIs to respond to `getSecrets()` requests by NetworkManager with the content of certain files.
Which files exactly is determined by a config file given to the agent on startup.
In the case of nixos, the config file is of course generated through the introduced options.

## Compatibility Note

This PR only adds additional options as well as one package that does not affect running systems in any way. Neither by default option choices nor by any incompatible changes.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
