### PR TITLE
nixos/bluetooth: reference bluez doc in descriptions

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -62,7 +62,10 @@ in
             ControllerMode = "bredr";
           };
         };
-        description = "Set configuration for system-wide bluetooth (/etc/bluetooth/main.conf).";
+        description = ''
+          Set configuration for system-wide bluetooth (/etc/bluetooth/main.conf).
+          See <https://github.com/bluez/bluez/blob/master/src/main.conf> for full list of options.
+        '';
       };
 
       input = mkOption {
@@ -74,7 +77,10 @@ in
             ClassicBondedOnly = true;
           };
         };
-        description = "Set configuration for the input service (/etc/bluetooth/input.conf).";
+        description = ''
+          Set configuration for the input service (/etc/bluetooth/input.conf).
+          See <https://github.com/bluez/bluez/blob/master/profiles/input/input.conf> for full list of options.
+        '';
       };
 
       network = mkOption {
@@ -85,7 +91,10 @@ in
             DisableSecurity = true;
           };
         };
-        description = "Set configuration for the network service (/etc/bluetooth/network.conf).";
+        description = ''
+          Set configuration for the network service (/etc/bluetooth/network.conf).
+          See <https://github.com/bluez/bluez/blob/master/profiles/network/network.conf> for full list of options.
+        '';
       };
     };
   };


### PR DESCRIPTION
Include link to the full list of values for:
- hardware.bluetooth.settings
- hardware.bluetooth.input
- hardware.bluetooth.network
