### PR TITLE
python3Packages: don't depend on setup hooks' bash eval

### DIFF
--- a/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
     "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"

--- a/pkgs/development/python-modules/certbot-dns-google/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-google/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
     # https://github.com/certbot/certbot/issues/9988
     "-Wignore::DeprecationWarning"
   ];

--- a/pkgs/development/python-modules/certbot-dns-ovh/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-ovh/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
     "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"

--- a/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
     "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"

--- a/pkgs/development/python-modules/certbot-dns-route53/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-route53/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
     "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "-o cache_dir=$(mktemp -d)"
+    "-p no:cacheprovider"
     "-W"
     "ignore::DeprecationWarning"
   ];

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -58,7 +58,8 @@ buildPythonPackage rec {
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/255262
-  pytestFlagsArray = [ "$out/${python.sitePackages}/numcodecs" ];
+  preCheck = "pushd $out";
+  postCheck = "popd";
 
   meta = {
     homepage = "https://github.com/zarr-developers/numcodecs";

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -211,8 +211,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "-o"
-    "cache_dir=$TMPDIR"
+    "-o cache_dir=.cache"
     "-m"
     "'not refcount and not timing and not flakey'"
     # pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -44,6 +44,7 @@ python3.pkgs.buildPythonApplication rec {
   preBuild = lib.optionalString withDriver ''
     export CHIPSEC_BUILD_LIB=$(mktemp -d)
     mkdir -p $CHIPSEC_BUILD_LIB/chipsec/helper/linux
+    appendToVar setupPyBuildFlags "--build-lib=$CHIPSEC_BUILD_LIB"
   '';
 
   env.NIX_CFLAGS_COMPILE = toString [
@@ -57,9 +58,7 @@ python3.pkgs.buildPythonApplication rec {
       $out/${python3.pkgs.python.sitePackages}/drivers/linux/chipsec.ko
   '';
 
-  setupPyBuildFlags = [
-    "--build-lib=$CHIPSEC_BUILD_LIB"
-  ] ++ lib.optionals (!withDriver) [
+  setupPyBuildFlags = lib.optionals (!withDriver) [
     "--skip-driver"
   ];
 


### PR DESCRIPTION
This came up in #335110 and then in #347194.

The python ecosystem currently uses bash `eval` in some setup hooks - and of course some packages depend on that. Mostly in `pytestFlagsArray`, but also in `setupPyBuildFlags` and `setupPyGlobalFlags`.

This PR deals with all those cases, replacing it with more adequate solutions. This will allow us to replace `pytestFlagsArray` with a structuredAttrs-supporting `pytestFlags` alternative more easily later on.

@ShamrockLee @SomeoneSerge @emilazy @philiptaron 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
