### PR TITLE
iwd: update settings documentation

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -36,7 +36,7 @@ in
 
       description = ''
         Options passed to iwd.
-        See [here](https://iwd.wiki.kernel.org/networkconfigurationsettings) for supported options.
+        See {manpage}`iwd.config(5)` for supported options.
       '';
     };
   };


### PR DESCRIPTION
The link https://iwd.wiki.kernel.org/networkconfigurationsettings is currently broken, as it redirect to the 404
https://archive.kernel.org/oldwiki/iwd.wiki.kernel.org/networkconfigurationsettings ; the correct link is https://archive.kernel.org/oldwiki/iwd.wiki.kernel.org/networkconfigurationsettings.html but it is marked as obsolete, and tell the user to read the iwd.network(5) man.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
