### PR TITLE
gnome-maps: fix broken .desktop file

### DIFF
--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -5,7 +5,6 @@
   meson,
   ninja,
   gettext,
-  python3,
   pkg-config,
   gnome,
   glib,
@@ -75,8 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
     # entry point to the wrapped binary we get back to a wrapped
     # binary.
     substituteInPlace "data/org.gnome.Maps.service.in" \
-        --replace "Exec=@pkgdatadir@/@app-id@" \
-                  "Exec=$out/bin/gnome-maps"
+      --replace-fail "Exec=@pkgdatadir@/@app-id@" \
+                     "Exec=$out/bin/gnome-maps"
   '';
 
   preCheck = ''
@@ -95,6 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   postCheck = ''
     rm $out/lib/gnome-maps/libgnome-maps.so.0
+  '';
+
+  preFixup = ''
+    substituteInPlace "$out/share/applications/org.gnome.Maps.desktop" \
+      --replace-fail "Exec=gapplication launch org.gnome.Maps" \
+                     "Exec=gnome-maps"
   '';
 
   passthru = {


### PR DESCRIPTION
## Things done
Fixed impure gnome-maps .desktop file not working in non-gnome environments. Related to #53111

I did some digging and found [this](https://www.mankier.com/1/gapplication), I am not sure if I understood correctly but it seems that apps using `gapplication launch` in their .desktop files is a backwards compatibility measure that is not needed if you already have `DBusActivatable=true` in your .desktop file and gnome-maps does have it, so
```nix
"Exec=${lib.getExe' glib "gapplication"} launch org.gnome.Maps"
```
probably can be replaced by
```nix
"Exec=$out/bin/gnome-maps"
```
with no functionality loss. Correct me if I am wrong.

To be safe and not break anything I went with the `gapplication launch` route for this PR.

@NixOS/gnome


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
