### PR TITLE
php84: 8.4.0beta3 -> 8.4.0RC3

### DIFF
--- a/pkgs/development/interpreters/php/8.4.nix
+++ b/pkgs/development/interpreters/php/8.4.nix
@@ -4,10 +4,10 @@ let
   base = callPackage ./generic.nix (
     _args
     // {
-      version = "8.4.0beta3";
+      version = "8.4.0RC3";
       phpSrc = fetchurl {
-        url = "https://downloads.php.net/~calvinb/php-8.4.0beta3.tar.xz";
-        hash = "sha256-aTgUCmS3tdV304Ag05DZObLKTQ8XgpNIfHARbhpZUAw=";
+        url = "https://downloads.php.net/~saki/php-8.4.0RC3.tar.xz";
+        hash = "sha256-6eA5w7NRfH5k+AyoIvuSEY9JgjtQqYwyZXTRSuKHBvY=";
       };
     }
   );

--- a/pkgs/development/interpreters/php/fix-paths-php84.patch
+++ b/pkgs/development/interpreters/php/fix-paths-php84.patch
@@ -13,15 +13,16 @@ index e46acf0928..ee8e5a88f8 100644
  
    AS_VAR_IF([GETTEXT_DIR],,
      [AC_MSG_ERROR([Cannot locate header file libintl.h])])
-diff -ru a/sapi/apache2handler/config.m4 b/sapi/apache2handler/config.m4
---- a/sapi/apache2handler/config.m4	2018-11-07 15:35:23.000000000 +0000
-+++ b/sapi/apache2handler/config.m4	2018-11-27 00:32:28.000000000 +0000
-@@ -66,7 +66,7 @@
-     AC_MSG_ERROR([Please note that Apache version >= 2.0.44 is required])
-   fi
+diff --git a/sapi/apache2handler/config.m4 b/sapi/apache2handler/config.m4
+index e335721f19..a5087e1320 100644
+--- a/sapi/apache2handler/config.m4
++++ b/sapi/apache2handler/config.m4
+@@ -68,7 +68,7 @@ if test "$PHP_APXS2" != "no"; then
+   AS_VERSION_COMPARE([$APACHE_VERSION], [2.4.0],
+     [AC_MSG_ERROR([Please note that Apache version >= 2.4 is required])])
  
--  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'$($APXS -q LIBEXECDIR)
 +  APXS_LIBEXECDIR="$prefix/modules"
-   if test -z `$APXS -q SYSCONFDIR`; then
+   if test -z $($APXS -q SYSCONFDIR); then
      INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
                   $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \


### PR DESCRIPTION
Changes:
https://github.com/php/php-src/blob/php-8.4.0RC3/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 5 packages marked as broken and skipped:</summary>
  <ul>
    <li>php84Extensions.parallel</li>
    <li>php84Extensions.pdo_dblib</li>
    <li>php84Extensions.pdo_dblib.dev</li>
    <li>php84Extensions.snmp</li>
    <li>php84Extensions.snmp.dev</li>
  </ul>
</details>
<details>
  <summary>:x: 30 packages failed to build:</summary>
  <ul>
    <li>php84</li>
    <li>php84Extensions.apcu</li>
    <li>php84Extensions.apcu.dev</li>
    <li>php84Extensions.couchbase</li>
    <li>php84Extensions.datadog_trace</li>
    <li>php84Extensions.openswoole</li>
    <li>php84Extensions.pdo_oci</li>
    <li>php84Extensions.phalcon</li>
    <li>php84Extensions.soap</li>
    <li>php84Extensions.soap.dev</li>
    <li>php84Extensions.swoole</li>
    <li>php84Extensions.vld</li>
    <li>php84Extensions.xdebug</li>
    <li>php84Packages.castor</li>
    <li>php84Packages.composer</li>
    <li>php84Packages.composer-local-repo-plugin</li>
    <li>php84Packages.cyclonedx-php-composer</li>
    <li>php84Packages.deployer</li>
    <li>php84Packages.grumphp</li>
    <li>php84Packages.phan</li>
    <li>php84Packages.phing</li>
    <li>php84Packages.phive</li>
    <li>php84Packages.php-codesniffer</li>
    <li>php84Packages.php-cs-fixer</li>
    <li>php84Packages.php-parallel-lint</li>
    <li>php84Packages.phpinsights</li>
    <li>php84Packages.phpmd</li>
    <li>php84Packages.phpstan</li>
    <li>php84Packages.psalm</li>
    <li>php84Packages.psysh</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 141 packages built:</summary>
  <ul>
    <li>php84Extensions.amqp</li>
    <li>php84Extensions.ast</li>
    <li>php84Extensions.bcmath</li>
    <li>php84Extensions.bcmath.dev</li>
    <li>php84Extensions.bz2</li>
    <li>php84Extensions.bz2.dev</li>
    <li>php84Extensions.calendar</li>
    <li>php84Extensions.calendar.dev</li>
    <li>php84Extensions.ctype</li>
    <li>php84Extensions.ctype.dev</li>
    <li>php84Extensions.curl</li>
    <li>php84Extensions.curl.dev</li>
    <li>php84Extensions.dba</li>
    <li>php84Extensions.dba.dev</li>
    <li>php84Extensions.dom</li>
    <li>php84Extensions.dom.dev</li>
    <li>php84Extensions.ds</li>
    <li>php84Extensions.enchant</li>
    <li>php84Extensions.enchant.dev</li>
    <li>php84Extensions.event</li>
    <li>php84Extensions.exif</li>
    <li>php84Extensions.exif.dev</li>
    <li>php84Extensions.ffi</li>
    <li>php84Extensions.ffi.dev</li>
    <li>php84Extensions.fileinfo</li>
    <li>php84Extensions.fileinfo.dev</li>
    <li>php84Extensions.filter</li>
    <li>php84Extensions.filter.dev</li>
    <li>php84Extensions.ftp</li>
    <li>php84Extensions.ftp.dev</li>
    <li>php84Extensions.gd</li>
    <li>php84Extensions.gd.dev</li>
    <li>php84Extensions.gettext</li>
    <li>php84Extensions.gettext.dev</li>
    <li>php84Extensions.gmp</li>
    <li>php84Extensions.gmp.dev</li>
    <li>php84Extensions.gnupg</li>
    <li>php84Extensions.grpc</li>
    <li>php84Extensions.iconv</li>
    <li>php84Extensions.iconv.dev</li>
    <li>php84Extensions.igbinary</li>
    <li>php84Extensions.igbinary.dev</li>
    <li>php84Extensions.imagick</li>
    <li>php84Extensions.imap</li>
    <li>php84Extensions.inotify</li>
    <li>php84Extensions.intl</li>
    <li>php84Extensions.intl.dev</li>
    <li>php84Extensions.ldap</li>
    <li>php84Extensions.ldap.dev</li>
    <li>php84Extensions.mailparse</li>
    <li>php84Extensions.maxminddb</li>
    <li>php84Extensions.mbstring</li>
    <li>php84Extensions.mbstring.dev</li>
    <li>php84Extensions.memcache</li>
    <li>php84Extensions.memcached</li>
    <li>php84Extensions.meminfo</li>
    <li>php84Extensions.memprof</li>
    <li>php84Extensions.mongodb</li>
    <li>php84Extensions.msgpack</li>
    <li>php84Extensions.mysqli</li>
    <li>php84Extensions.mysqli.dev</li>
    <li>php84Extensions.mysqlnd</li>
    <li>php84Extensions.mysqlnd.dev</li>
    <li>php84Extensions.oci8</li>
    <li>php84Extensions.opcache</li>
    <li>php84Extensions.opcache.dev</li>
    <li>php84Extensions.openssl</li>
    <li>php84Extensions.openssl.dev</li>
    <li>php84Extensions.opentelemetry</li>
    <li>php84Extensions.pcntl</li>
    <li>php84Extensions.pcntl.dev</li>
    <li>php84Extensions.pcov</li>
    <li>php84Extensions.pdlib</li>
    <li>php84Extensions.pdo</li>
    <li>php84Extensions.pdo.dev</li>
    <li>php84Extensions.pdo_mysql</li>
    <li>php84Extensions.pdo_mysql.dev</li>
    <li>php84Extensions.pdo_odbc</li>
    <li>php84Extensions.pdo_odbc.dev</li>
    <li>php84Extensions.pdo_pgsql</li>
    <li>php84Extensions.pdo_pgsql.dev</li>
    <li>php84Extensions.pdo_sqlite</li>
    <li>php84Extensions.pdo_sqlite.dev</li>
    <li>php84Extensions.pdo_sqlsrv</li>
    <li>php84Extensions.pgsql</li>
    <li>php84Extensions.pgsql.dev</li>
    <li>php84Extensions.pinba</li>
    <li>php84Extensions.posix</li>
    <li>php84Extensions.posix.dev</li>
    <li>php84Extensions.protobuf</li>
    <li>php84Extensions.pspell</li>
    <li>php84Extensions.rdkafka</li>
    <li>php84Extensions.readline</li>
    <li>php84Extensions.readline.dev</li>
    <li>php84Extensions.redis</li>
    <li>php84Extensions.rrd</li>
    <li>php84Extensions.session</li>
    <li>php84Extensions.session.dev</li>
    <li>php84Extensions.shmop</li>
    <li>php84Extensions.shmop.dev</li>
    <li>php84Extensions.simplexml</li>
    <li>php84Extensions.simplexml.dev</li>
    <li>php84Extensions.smbclient</li>
    <li>php84Extensions.snuffleupagus</li>
    <li>php84Extensions.sockets</li>
    <li>php84Extensions.sockets.dev</li>
    <li>php84Extensions.sodium</li>
    <li>php84Extensions.sodium.dev</li>
    <li>php84Extensions.spx</li>
    <li>php84Extensions.sqlite3</li>
    <li>php84Extensions.sqlite3.dev</li>
    <li>php84Extensions.sqlsrv</li>
    <li>php84Extensions.ssh2</li>
    <li>php84Extensions.sysvmsg</li>
    <li>php84Extensions.sysvmsg.dev</li>
    <li>php84Extensions.sysvsem</li>
    <li>php84Extensions.sysvsem.dev</li>
    <li>php84Extensions.sysvshm</li>
    <li>php84Extensions.sysvshm.dev</li>
    <li>php84Extensions.tidy</li>
    <li>php84Extensions.tidy.dev</li>
    <li>php84Extensions.tokenizer</li>
    <li>php84Extensions.tokenizer.dev</li>
    <li>php84Extensions.uv</li>
    <li>php84Extensions.xml</li>
    <li>php84Extensions.xml.dev</li>
    <li>php84Extensions.xmlreader</li>
    <li>php84Extensions.xmlreader.dev</li>
    <li>php84Extensions.xmlwriter</li>
    <li>php84Extensions.xmlwriter.dev</li>
    <li>php84Extensions.xsl</li>
    <li>php84Extensions.xsl.dev</li>
    <li>php84Extensions.yaml</li>
    <li>php84Extensions.zend_test</li>
    <li>php84Extensions.zend_test.dev</li>
    <li>php84Extensions.zip</li>
    <li>php84Extensions.zip.dev</li>
    <li>php84Extensions.zlib</li>
    <li>php84Extensions.zlib.dev</li>
    <li>php84Extensions.zstd</li>
    <li>php84Packages.phpspy</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
