### PR TITLE
apacheHttpdPackages.mod_python: fix build with python3.12

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -26,12 +26,14 @@ stdenv.mkDerivation rec {
     "BINDIR=$(out)/bin"
   ];
 
-  buildInputs = [
-    apacheHttpd
-    python3
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libintl
-  ];
+  buildInputs =
+    [
+      apacheHttpd
+      python3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libintl
+    ];
 
   passthru = {
     inherit apacheHttpd;

--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -1,5 +1,6 @@
 {
   apacheHttpd,
+  ensureNewerSourcesForZipFilesHook,
   fetchFromGitHub,
   lib,
   libintl,
@@ -8,15 +9,15 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mod_python";
   version = "3.5.0.2";
 
   src = fetchFromGitHub {
     owner = "grisha";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-EH8wrXqUAOFWyPKfysGeiIezgrVc789RYO4AHeSA6t4=";
+    repo = "mod_python";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-++yHNKVe1u3w47DaB0zvYyuTrBcQdmuDm22areAeejs=";
   };
 
   patches = [ ./install.patch ];
@@ -26,10 +27,18 @@ stdenv.mkDerivation rec {
     "BINDIR=$(out)/bin"
   ];
 
+  nativeBuildInputs = [
+    ensureNewerSourcesForZipFilesHook
+  ];
+
   buildInputs =
     [
       apacheHttpd
-      python3
+      (python3.withPackages (ps: with ps; [
+        distutils
+        packaging
+        setuptools
+      ]))
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       libintl
@@ -40,12 +49,12 @@ stdenv.mkDerivation rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://modpython.org/";
-    changelog = "https://github.com/grisha/mod_python/blob/${version}/NEWS";
+    changelog = "https://github.com/grisha/mod_python/blob/master/NEWS";
     description = "Apache module that embeds the Python interpreter within the server";
     mainProgram = "mod_python";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
ZHF: #352882

Build log: https://hydra.nixos.org/build/276557116/nixlog/1

adding distutils, packaging and setuptools to fix:
- ModuleNotFoundError: No module named 'distutils'
- ModuleNotFoundError: No module named 'packaging'
- error: invalid command 'install'
    
and ensureNewerSourcesForZipFilesHook for:
- ValueError: ZIP does not support timestamps before 1980

This fixes the build but `bin/mod_python` seems to be not working for a while at least in `master` and `nixos-24.05`. (grisha/mod_python#139)

@anthonyroussel: I saw you made the last changes, might you have a look?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
