### PR TITLE
sgx-psw+aesmd: 2.24 -> 2.25

### DIFF
--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -1,10 +1,12 @@
 { config, options, pkgs, lib, ... }:
-with lib;
 let
+  inherit (lib) concatStringsSep literalExpression makeLibraryPath mkEnableOption
+    mkForce mkIf mkOption mkPackageOption mkRemovedOptionModule optional types;
+
   cfg = config.services.aesmd;
   opt = options.services.aesmd;
 
-  sgx-psw = pkgs.sgx-psw.override { inherit (cfg) debug; };
+  sgx-psw = cfg.package;
 
   configFile = with cfg.settings; pkgs.writeText "aesmd.conf" (
     concatStringsSep "\n" (
@@ -18,13 +20,17 @@ let
   );
 in
 {
+  imports = [
+    (mkRemovedOptionModule [ "debug" ] ''
+      Enable debug mode by overriding the aesmd package directly:
+
+          services.aesmd.package = pkgs.sgx-psw.override { debug = true; };
+    '')
+  ];
+
   options.services.aesmd = {
     enable = mkEnableOption "Intel's Architectural Enclave Service Manager (AESM) for Intel SGX";
-    debug = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to build the PSW package in debug mode.";
-    };
+    package = mkPackageOption pkgs "sgx-psw" { };
     environment = mkOption {
       type = with types; attrsOf str;
       default = { };
@@ -126,7 +132,7 @@ in
           "|/dev/sgx_enclave"
         ];
 
-        serviceConfig = rec {
+        serviceConfig = {
           ExecStartPre = pkgs.writeShellScript "copy-aesmd-data-files.sh" ''
             set -euo pipefail
             whiteListFile="${aesmDataFolder}/white_list_cert_to_be_verify.bin"

--- a/pkgs/os-specific/linux/sgx/psw/cppmicroservices-no-mtime.patch
+++ b/pkgs/os-specific/linux/sgx/psw/cppmicroservices-no-mtime.patch
@@ -1,0 +1,26 @@
+diff --git a/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp b/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
+index aee499e9..13fa89d4 100644
+--- a/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
++++ b/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
+@@ -105,7 +105,7 @@ bool BundleResourceContainer::GetStat(int index,
+                    const_cast<mz_zip_archive*>(&m_ZipArchive), index)
+                    ? true
+                    : false;
+-    stat.modifiedTime = zipStat.m_time;
++    stat.modifiedTime = 0;
+     stat.crc32 = zipStat.m_crc32;
+     // This will limit the size info from uint64 to uint32 on 32-bit
+     // architectures. We don't care because we assume resources > 2GB
+diff --git a/external/CppMicroServices/third_party/miniz.c b/external/CppMicroServices/third_party/miniz.c
+index 6b0ebd7a..fa2aebca 100644
+--- a/external/CppMicroServices/third_party/miniz.c
++++ b/external/CppMicroServices/third_party/miniz.c
+@@ -170,7 +170,7 @@
+ // If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or
+ // get/set file times, and the C run-time funcs that get/set times won't be called.
+ // The current downside is the times written to your archives will be from 1979.
+-//#define MINIZ_NO_TIME
++#define MINIZ_NO_TIME
+
+ // Define MINIZ_NO_ARCHIVE_APIS to disable all ZIP archive API's.
+ //#define MINIZ_NO_ARCHIVE_APIS

--- a/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
+++ b/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 19bc05a..6b1acd4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -50,13 +50,13 @@ tips:
+ preparation:
+ # As SDK build needs to clone and patch openmp, we cannot support the mode that download the source from github as zip.
+ # Only enable the download from git
+-	git submodule update --init --recursive
++	# git submodule update --init --recursive
+ 	cd external/dcap_source/external/jwt-cpp && git apply ../0001-Add-a-macro-to-disable-time-support-in-jwt-for-SGX.patch >/dev/null 2>&1 || \
+ 	git apply ../0001-Add-a-macro-to-disable-time-support-in-jwt-for-SGX.patch -R --check
+-	./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
++	# ./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
+ 	cd external/openmp/openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 ||  git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
+ 	cd external/protobuf/protobuf_code && git apply ../sgx_protobuf.patch >/dev/null 2>&1 ||  git apply ../sgx_protobuf.patch --check -R
+-	cd external/protobuf/protobuf_code && git submodule update --init --recursive && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
++	cd external/protobuf/protobuf_code && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
+ 	./external/sgx-emm/create_symlink.sh
+ 	cd external/mbedtls/mbedtls_code && git apply ../sgx_mbedtls.patch >/dev/null 2>&1 || git apply ../sgx_mbedtls.patch --check -R
+ 	cd external/cbor && cp -r libcbor sgx_libcbor
+@@ -64,8 +64,8 @@ preparation:
+ 	cd external/cbor/sgx_libcbor && git apply ../sgx_cbor.patch >/dev/null 2>&1 || git apply ../sgx_cbor.patch --check -R
+ 	cd external/ippcp_internal/ipp-crypto && git apply ../0001-IPP-crypto-for-SGX.patch > /dev/null 2>&1 || git apply ../0001-IPP-crypto-for-SGX.patch --check -R
+ 	cd external/ippcp_internal/ipp-crypto && mkdir -p build
+-	./download_prebuilt.sh
+-	./external/dcap_source/QuoteGeneration/download_prebuilt.sh
++	# ./download_prebuilt.sh
++	# ./external/dcap_source/QuoteGeneration/download_prebuilt.sh
+ 
+ psw:
+ 	$(MAKE) -C psw/ USE_OPT_LIBS=$(USE_OPT_LIBS)


### PR DESCRIPTION
## Changes

Update the `sgx-psw` package to the [latest 2.25 release](https://github.com/intel/linux-sgx/releases/tag/sgx_2.25).

+ Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.24...sgx_2.25>

+ Changelog: <https://github.com/intel/linux-sgx/releases/tag/sgx_2.25>

This diff also decouples the `sgx-psw` and `sgx-sdk` builds so that `sgx-psw` no longer depends on `sgx-sdk`. I discovered that we only require some headers and a single build tool (`sgx_edger8r`) from the base sdk to build `sgx-psw`. The biggest benefit here is that I can quickly iterate on `sgx-psw`, which takes just 3 min to build, vs. waiting 1+ hour to build both `sgx-sdk` and `sgx-psw`.

I [attempted to update `sgx-sdk` and `ipp-crypto` to 2.25](https://github.com/phlip9/nixpkgs/tree/phlip9/sgx-2.25), but the SDK appears broken in some inscrutable ways. It builds successfully, but most of the sample enclaves segfault or return [error 0x1007 (SGX_ERROR_ECALL_NOT_ALLOWED)](https://github.com/intel/linux-sgx/blob/7385e10ce1106215d15f874a024ca224c7417eea/common/inc/sgx_error.h#L53) at runtime. I don't really have the patience to waste more time on the SDK. With this diff I can now focus updates on the single, useful artifact: the `aesmd` service.


**Quick Glossary:**

- **Intel SGX** is a Confidential Computing technology for running hardware-isolated enclaves and confidential VMs (Intel TDX) on Intel server CPUs alongside an untrusted hypervisor/Linux/userspace software stack.
- `sgx-psw` (Platform SoftWare) provides the `aesmd` service (Architecture Enclave Service Manager Daemon), which simplifies running enclaves and getting remote attestation quotes.


**Testing:**

These changes were tested on an SGX-enabled Azure gen2 VM (DCSv3) running NixOS.


## Run against real SGX hardware

Make sure you're running on a recent x86-64 Intel CPU, against a somewhat recent kernel with the in-tree kernel SGX driver (any NixOS config in the last few years should cover this).

Check the hardware and kernel setup:

```bash
$ journalctl --boot --dmesg --grep=sgx
kernel: sgx: EPC section 0x2c0000000-0x3bfffffff
```

In your NixOS `configuration.nix`, add something like:

```nix
  services.aesmd = {
    enable = true;
    # Include this if you're running on Azure
    quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
  };
```

After a `nixos-rebuild switch`, check that the devices are configured and the `aesmd` service is running:

```bash
$ find /dev -name "*sgx*" -ls
 83      0 crw-rw----   1 root     sgx_prv   10, 126 May  8 17:21 /dev/sgx_provision
 84      0 crw-rw----   1 root     sgx       10, 125 May  8 17:21 /dev/sgx_enclave
400      0 drwxr-xr-x   2 root     root           80 May  8 17:21 /dev/sgx

$ systemctl status aesmd.service
● aesmd.service - Intel Architectural Enclave Service Manager
     Loaded: loaded (/etc/systemd/system/aesmd.service; enabled; preset: ignored)
     Active: active (running) since Sat 2024-11-02 01:56:46 UTC; 30min ago
 Invocation: 708bd878f2e7439b8717e5bbba02d307
    Process: 1464 ExecStartPre=/nix/store/vrafi5h28rnfbdxjn5lf19kk9jqxy2jj-copy-aesmd-data-files.sh (code=exited, status=0/SUCCESS)
   Main PID: 1502 (aesm_service)
         IP: 51.2K in, 9.6K out
         IO: 2.2M read, 48K written
      Tasks: 4 (limit: 9514)
     Memory: 5.2M (peak: 5.4M)
        CPU: 373ms
     CGroup: /system.slice/aesmd.service
             └─1502 /nix/store/1mq9p17qkh74fs1yk7hnrisikzmhp3y3-sgx-psw-2.25.100.3/aesm/aesm_service --no-daemon

Nov 02 01:56:46 lexe-dev-sgx systemd[1]: Started Intel Architectural Enclave Service Manager.
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: The path of system bundle: System Bundle
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: ecdsa_quote_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: epid_quote_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: le_launch_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: linux_network_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: pce_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: quote_ex_service_bundle_name:2.0.0
Nov 02 01:56:46 lexe-dev-sgx aesm_service[1502]: system_bundle:4.0.0
Nov 02 01:58:19 lexe-dev-sgx aesm_service[1502]: Azure Quote Provider: libdcap_quoteprov.so [INFO]: Debug Logging Enabled
```

Run a test enclave that exercises remote attestation:

```bash
$ nix run -L github:lexe-app/lexe-public#run-sgx-test
```