### PR TITLE
localstack: meta.mainProgram name

### DIFF
--- a/pkgs/development/python-modules/localstack/default.nix
+++ b/pkgs/development/python-modules/localstack/default.nix
@@ -77,5 +77,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/localstack/localstack";
     license = licenses.asl20;
     maintainers = [ ];
+    mainProgram = "localstack";
   };
 }


### PR DESCRIPTION
minor: set meta.mainProgram for localstack

Demonstration:

Current nixpkgs-unstable:
```
$ nix-instantiate  --eval -E 'let p = builtins.fetchTree "github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53" ; pkgs = import p {} ; in pkgs.lib.getExe pkgs.localstack'
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
trace: evaluation warning: getExe: Package "python3.12-localstack-3.6.0" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
"/nix/store/wb90p0h91xv0aplzmq9sw1l96zh4nwhb-python3.12-localstack-3.6.0/bin/localstack"
```
This PR:
```
$ nix-instantiate  --eval -E 'let p = builtins.fetchTree "github:nixos/nixpkgs/pull/353055/head" ; pkgs = import p {} ; in pkgs.lib.getExe pkgs.localstack'
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
"/nix/store/wb90p0h91xv0aplzmq9sw1l96zh4nwhb-python3.12-localstack-3.6.0/bin/localstack"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
