### PR TITLE
manga-tui: 0.3.1 -> 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24010,6 +24010,13 @@
     github = "youhaveme9";
     githubId = 58213083;
   };
+  youwen5 = {
+    name = "Youwen Wu";
+    email = "youwenw@gmail.com";
+    github = "youwen5";
+    githubId = 38934577;
+    keys = [ { fingerprint = "8F5E 6C1A F909 76CA 7102 917A 8656 58ED 1FE6 1EC3"; } ];
+  };
   yrashk = {
     email = "yrashk@gmail.com";
     github = "yrashk";

--- a/pkgs/by-name/ma/manga-tui/0001-fix-remove-flaky-test.patch
+++ b/pkgs/by-name/ma/manga-tui/0001-fix-remove-flaky-test.patch
@@ -1,0 +1,42 @@
+From e84ddb20ca6b99ec2bf84bb3c3cfc3cdbbfd5ff2 Mon Sep 17 00:00:00 2001
+From: Youwen Wu <youwenw@gmail.com>
+Date: Wed, 6 Nov 2024 02:11:30 -0800
+Subject: [PATCH] fix: remove flaky test
+
+---
+ src/view/pages/manga.rs | 21 ---------------------
+ 1 file changed, 21 deletions(-)
+
+diff --git a/src/view/pages/manga.rs b/src/view/pages/manga.rs
+index 119d9ea..7179a22 100644
+--- a/src/view/pages/manga.rs
++++ b/src/view/pages/manga.rs
+@@ -1853,25 +1853,4 @@ mod test {
+         assert_eq!(manga_page.bookmark_state.phase, BookmarkPhase::SearchingFromApi);
+         assert_eq!(expected, result)
+     }
+-
+-    #[tokio::test]
+-    async fn it_sends_event_chapter_bookmarked_failed_to_fetch() {
+-        let (tx, _) = unbounded_channel();
+-        let mut manga_page = MangaPage::new(Manga::default(), None).with_global_sender(tx);
+-
+-        flush_events(&mut manga_page);
+-
+-        let api_client = TestApiClient::with_failing_response();
+-
+-        manga_page.fetch_chapter_bookmarked(ChapterBookmarked::default(), api_client);
+-
+-        let expected = MangaPageEvents::FetchBookmarkFailed;
+-
+-        let result = timeout(Duration::from_millis(250), manga_page.local_event_rx.recv())
+-            .await
+-            .unwrap()
+-            .unwrap();
+-
+-        assert_eq!(expected, result);
+-    }
+ }
+-- 
+2.46.1
+

--- a/pkgs/by-name/ma/manga-tui/package.nix
+++ b/pkgs/by-name/ma/manga-tui/package.nix
@@ -8,6 +8,7 @@
   sqlite,
   stdenv,
   darwin,
+  nix-update-script,
 }:
 let
   version = "0.4.0";
@@ -60,4 +61,6 @@ rustPlatform.buildRustPackage {
     ];
     mainProgram = "manga-tui";
   };
+
+  passthru.updateScript = nix-update-script { };
 }

--- a/pkgs/by-name/ma/manga-tui/package.nix
+++ b/pkgs/by-name/ma/manga-tui/package.nix
@@ -44,7 +44,10 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/josueBarretogit/manga-tui";
     changelog = "https://github.com/josueBarretogit/manga-tui/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ isabelroses ];
+    maintainers = with lib.maintainers; [
+      isabelroses
+      youwen5
+    ];
     mainProgram = "manga-tui";
   };
 }

--- a/pkgs/by-name/ma/manga-tui/package.nix
+++ b/pkgs/by-name/ma/manga-tui/package.nix
@@ -3,13 +3,14 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
+  fetchpatch,
   openssl,
   sqlite,
   stdenv,
   darwin,
 }:
 let
-  version = "0.3.1";
+  version = "0.4.0";
 in
 rustPlatform.buildRustPackage {
   pname = "manga-tui";
@@ -19,10 +20,19 @@ rustPlatform.buildRustPackage {
     owner = "josueBarretogit";
     repo = "manga-tui";
     rev = "v${version}";
-    hash = "sha256-672AuQWviwihnUS3G0xSn4IAMHy0fPE1VLDfu8wrPGg=";
+    hash = "sha256-Se0f5jfYBmvemrYRKduDr1yT3fB2wfQP1fDpa/qrYlI=";
   };
 
-  cargoHash = "sha256-yf0hISz/jHtrO1clTSIKfxFiwI+W0Mu3mY+XW6+ynJU=";
+  patches = [
+    # apply patches to fix failing tests <https://github.com/josueBarretogit/manga-tui/pull/56>
+    (fetchpatch {
+      url = "https://github.com/josueBarretogit/manga-tui/commit/131a5208e6a3d74a9ad852baab75334e4a1ebf34.patch";
+      hash = "sha256-RIliZcaRVUOb33Cl+uBkMH4b34S1JpvnPGv+QCFQZ58=";
+    })
+    ./0001-fix-remove-flaky-test.patch
+  ];
+
+  cargoHash = "sha256-IufJPCvUEWR5p4PrFlaiQPW9wyIFj/Pd/JHki69L6Es=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

There are issues with upstream when building in Nix (specifically, there's 2 tests that don't pass). I submitted a PR upstream to fix one of them but am not sure how to fix the other, so I just added a patch to delete it for the time being.