### PR TITLE
bump signal export to 3.2.2

### DIFF
--- a/pkgs/by-name/si/signal-export/package.nix
+++ b/pkgs/by-name/si/signal-export/package.nix
@@ -6,25 +6,26 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "signal-export";
-  version = "1.8.2";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Hm0BVF2RUsxDacsAB3MJtk1t9FYmBPjeb5JzwaLkZ14=";
+    inherit version;
+    pname = "signal_export";
+    hash = "sha256-b0oJXUbJ9545oVMXBcM4MFjK3U3RiAT1lv9NUu6gF04=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
-    setuptools-scm
+    pdm-backend
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    setuptools
     typer
     beautifulsoup4
     emoji
     markdown
-    pysqlcipher3
+    pycryptodome
+    sqlcipher3-wheels
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/si/signal-export/package.nix
+++ b/pkgs/by-name/si/signal-export/package.nix
@@ -6,13 +6,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "signal-export";
-  version = "3.2.0";
+  version = "3.2.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "signal_export";
-    hash = "sha256-b0oJXUbJ9545oVMXBcM4MFjK3U3RiAT1lv9NUu6gF04=";
+    hash = "sha256-QHTix56hdujxWr+pjCg6zu15tCB7YoDSzmNpWwWOHN0=";
   };
 
   nativeBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/si/signal-export/package.nix
+++ b/pkgs/by-name/si/signal-export/package.nix
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-QHTix56hdujxWr+pjCg6zu15tCB7YoDSzmNpWwWOHN0=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     pdm-backend
   ];
 

--- a/pkgs/development/python-modules/sqlcipher3-binary/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3-binary/default.nix
@@ -1,0 +1,13 @@
+{
+  mkPythonMetaPackage,
+  sqlcipher3,
+}:
+mkPythonMetaPackage {
+  pname = "sqlcipher3-binary";
+  inherit (sqlcipher3) version;
+  dependencies = [ sqlcipher3 ];
+  optional-dependencies = sqlcipher3.optional-dependencies or { };
+  meta = {
+    inherit (sqlcipher3.meta) description homepage license;
+  };
+}

--- a/pkgs/development/python-modules/sqlcipher3-wheels/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3-wheels/default.nix
@@ -1,0 +1,13 @@
+{
+  mkPythonMetaPackage,
+  sqlcipher3,
+}:
+mkPythonMetaPackage {
+  pname = "sqlcipher3-wheels";
+  inherit (sqlcipher3) version;
+  dependencies = [ sqlcipher3 ];
+  optional-dependencies = sqlcipher3.optional-dependencies or { };
+  meta = {
+    inherit (sqlcipher3.meta) description homepage license;
+  };
+}

--- a/pkgs/development/python-modules/sqlcipher3/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage {
     hash = "sha256-4w/1jWTdQ+Gezt3RARahonrR2YiMxCRcdfK9qbA4Tnc=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 

--- a/pkgs/development/python-modules/sqlcipher3/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  sqlcipher,
+  openssl,
+}:
+let
+  pname = "sqlcipher3";
+  version = "0.5.4";
+in
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4w/1jWTdQ+Gezt3RARahonrR2YiMxCRcdfK9qbA4Tnc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  buildInputs = [
+    sqlcipher
+    openssl
+  ];
+
+  pythonImportChecks = [
+    "sqlcipher3"
+  ];
+
+  meta = with lib; {
+    mainProgram = "sqlcipher3";
+    homepage = "https://github.com/coleifer/sqlcipher3";
+    description = "Python 3 bindings for SQLCipher";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ phaer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15013,6 +15013,10 @@ self: super: with self; {
 
   sqlbag = callPackage ../development/python-modules/sqlbag { };
 
+  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 {};
+  sqlcipher3-binary = callPackage ../development/python-modules/sqlcipher3-binary {};
+  sqlcipher3-wheels = callPackage ../development/python-modules/sqlcipher3-wheels {};
+
   sqlfmt = callPackage ../development/python-modules/sqlfmt { };
 
   sqlglot = callPackage ../development/python-modules/sqlglot { };


### PR DESCRIPTION
Update signal-export to version 3.2.0

## Why
signal-desktop has changed a lot since signal-export 1.8.2 and therefore signal-export changed as well.

## Things done

- update version to 3.2.0
- change pypi package name (`signal_export` instead of `signal-export` since otherwise the tarball is not found)
- add dependencies that where missing (see [pyproject.toml](https://github.com/carderne/signal-export/blob/main/pyproject.toml#L36))
- switch build-backend to pdm-backend (see [pyproject.toml](https://github.com/carderne/signal-export/blob/main/pyproject.toml#L58)

### Fixes missing
- dependency for sqlcipher is [sqlcipher3-wheels](https://github.com/carderne/signal-export/blob/main/pyproject.toml#L37) which is basically the same code as pysqlcipher3 but the nix build fails with 
```
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for signal_export-3.2.0-py3-none-any.whl
  - sqlcipher3-wheels not installed
```
I am not proficiant enough to package sqlcipher3**-wheels** and I am also unsure if it is a good idea since maybe the "wheels"-wrapping this provides should rather be done in nixpkgs at python312Packages.sqlcipher3 or in signal-export?
## Checks

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (not applicable, no usages)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [-] (Package updates) Added a release notes entry if the change is major or breaking (not major)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
