### PR TITLE
opennox{,-hd,-server}: init at 1.9.0-alpha13

### DIFF
--- a/pkgs/by-name/no/nox-assets/package.nix
+++ b/pkgs/by-name/no/nox-assets/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  requireFile,
+  gogUnpackHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nox-assets";
+  version = "2.0.0.20";
+
+  src = requireFile {
+    name = "setup_nox_${finalAttrs.version}.exe";
+    hash = "sha256-TbzPEzDb3cDAE0XbrReFnPy/bBEu0OWll0OFSRQKNwI=";
+    message = ''
+      In order to continue, you must first obtain a valid copy of Nox.
+
+      Please purchase the game on gog.com and download the Windows installer, or obtain it
+      from a physical copy.
+
+      Once you have the installer, please run either of the following commands and re-run the
+      installation:
+
+      Either
+        nix-store --add-fixed sha256 setup_nox_${finalAttrs.version}.exe
+      or
+        nix-prefetch-url --type sha256 file:///path/to/setup_nox_${finalAttrs.version}.exe
+    '';
+  };
+
+  nativeBuildInputs = [ gogUnpackHook ];
+
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -a app/. $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Assets for the game Nox";
+    homepage = "https://gog.com/game/nox";
+    license = with lib.licenses; [ unfree ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+})

--- a/pkgs/by-name/op/opennox-hd/package.nix
+++ b/pkgs/by-name/op/opennox-hd/package.nix
@@ -1,0 +1,9 @@
+{
+  opennox,
+}:
+opennox.override {
+  pname = "opennox-hd";
+  desktopName = "OpenNox HD";
+  extraDescription = "With HD support";
+  tags = [ "highres" ];
+}

--- a/pkgs/by-name/op/opennox-server/package.nix
+++ b/pkgs/by-name/op/opennox-server/package.nix
@@ -1,0 +1,9 @@
+{
+  opennox,
+}:
+opennox.override {
+  pname = "opennox-server";
+  desktopName = "OpenNox Dedicated Server";
+  extraDescription = "Dedicated server";
+  tags = [ "server" ];
+}

--- a/pkgs/by-name/op/opennox/package.nix
+++ b/pkgs/by-name/op/opennox/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  pkgsi686Linux,
+  buildGoModule,
+  SDL2,
+  openal,
+
+  pkg-config,
+  writableDirWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  nox-assets,
+
+  nix-update-script,
+
+  pname ? "opennox",
+  desktopName ? "OpenNox",
+  extraDescription ? "",
+  tags ? [ ],
+}:
+let
+  # OpenNox can't compile under x86_64 :(
+  deps_32bit =
+    if (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86) then
+      { inherit (pkgsi686Linux) buildGoModule SDL2 openal; }
+    else
+      { inherit buildGoModule SDL2 openal; };
+
+  isWindowsClient = (!lib.elem "server" tags) && stdenv.hostPlatform.isWindows;
+
+  fqpn = "io.github.noxworld_dev.OpenNox";
+
+  version = "1.9.0-alpha13";
+
+  src = fetchFromGitHub {
+    owner = "opennox";
+    repo = "opennox";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-EfAYu2ZTBoFbroK5OLPftuSV91QhBNARpDULMayEOjg=";
+  };
+
+  description =
+    "Modern implementation of the Nox game engine"
+    + lib.optionalString (extraDescription != "") " (${extraDescription})";
+
+  dataDir = "\${XDG_DATA_HOME:-$HOME/.local/share}/opennox";
+  logDir = "\${XDG_STATE_HOME:-$HOME/.local/state}/opennox";
+in
+deps_32bit.buildGoModule {
+  inherit pname version src;
+
+  vendorHash = "sha256-kkaC/SrpdXzGLA4KdJT0uWZLk6/Zzmys9rnc/U8py4Q=";
+
+  nativeBuildInputs = [
+    pkg-config
+    writableDirWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    deps_32bit.SDL2
+    deps_32bit.openal
+  ];
+
+  modRoot = "src";
+  subPackages = [ "cmd/opennox" ];
+
+  tags = tags ++ lib.optional isWindowsClient "guiapp";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/noxworld-dev/opennox/v1/internal/version.commit=${src.rev}"
+    "-X github.com/noxworld-dev/opennox/v1/internal/version.version=v${version}"
+  ] ++ lib.optional isWindowsClient "-H windowsgui";
+
+  env = {
+    CGO_CFLAGS_ALLOW = lib.concatMapStringsSep "|" (f: "(-f${f})") [
+      "short-wchar"
+      "no-strict-aliasing"
+      "no-strict-overflow"
+    ];
+    CGO_CFLAGS = "-Wno-format-security";
+  };
+
+  # Requires gamedata.bin
+  doCheck = false;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = fqpn;
+      exec = pname;
+      comment = description;
+      icon = fqpn;
+      inherit desktopName;
+      terminal = false;
+      categories = [
+        "Game"
+        "ActionGame"
+        "RolePlaying"
+      ];
+    })
+  ];
+
+  postInstall = ''
+    install -Dm644 ../app/${fqpn}.metainfo.xml -t $out/share/metainfo
+    install -Dm644 ../res/opennox_256.png $out/share/icons/hicolor/256x256/apps/${fqpn}.png
+    install -Dm644 ../res/opennox_512.png $out/share/icons/hicolor/512x512/apps/${fqpn}.png
+  '';
+
+  postFixup = ''
+    wrapProgramInWritableDir $out/bin/opennox '${dataDir}' \
+      --add-flags '--data ${dataDir} --logs ${logDir}' \
+      --link ${nox-assets} .
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://opennox.github.io/docs/";
+    changelog = "https://opennox.github.io/docs/opennox/releases/index.html";
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = pname;
+    platforms = lib.intersectLists lib.platforms.x86 (lib.platforms.linux ++ lib.platforms.windows);
+  };
+}

--- a/pkgs/by-name/wr/writableDirWrapper/package.nix
+++ b/pkgs/by-name/wr/writableDirWrapper/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  writeShellApplication,
+  xorg,
+  makeSetupHook,
+
+  makeWrapper,
+}:
+makeSetupHook {
+  name = "writable-dir-wrapper";
+
+  propagatedBuildInputs = [
+    makeWrapper
+  ];
+
+  substitutions = {
+    lndir = lib.getExe xorg.lndir;
+  };
+
+} ./wrapper.sh
+
+/**
+  A wrapper for programs that require a writable directory to function, typically
+  games or proprietary software that expect read-only resources to be placed alongside
+  config files and state files (e.g. logs).
+
+  # Inputs
+
+  *`options`* (Attribute set)
+
+  : Set of options for the wrapper.
+
+    `name` (String)
+
+    : File name of the wrapper.
+
+   `version` (String, _optional_)
+
+    : Version of the underlying program. When set, version checks will be enabled and existing links will be recreated if they belong to a different version.
+
+    `path` (String)
+
+    : Path of the directory that would hold the linked data.
+
+    `links` (List of attrsets, _optional_)
+
+    : List of links from a source directory to a directory relative to the output path.
+
+      `src` (String)
+
+      : Source directory of the link, usually from the Nix store.
+
+      `dst` (String, _optional_)
+
+      : Destination directory of the link.
+
+      : _Default:_ the output path.
+
+    `postLink` (String, _optional_)
+
+    : Command to run after (re-)linking. Since links are first created in a temporary directory, `postLink` can be used to remove or add files that will be copied to the output path (for example, when some files need to be excluded from the linked result).
+
+    `exec` (String)
+
+    : Command to run.
+
+    `flags` (List of strings, _optional_)
+
+    : The list of flags given to the command. ***Unescaped and can refer to Bash variables and perform shell substitutions.***
+
+  # Type
+
+  ```
+  writableDirWrapper ::
+    {
+      name :: String;
+      version? :: String;
+      path :: String;
+      links? :: [{ src :: String; dst? :: String }];
+      postLink? :: String;
+      exec :: String
+    } -> Derivation
+  ```
+
+  # Examples
+  :::{.example}
+  ## `pkgs.writableDirWrapper` usage example
+
+  ```nix
+  {
+    writableDirWrapper,
+    hello,
+  }:
+  writableDirWrapper {
+    name = "writable-hello";
+    links = [
+      {
+        src = hello;
+        dst = "hello";
+      }
+    ];
+    postLink = ''
+      echo "Hello world!" | base64 > hello.txt
+    '';
+    exec = ''
+      ./hello/bin/hello --greeting=$(<"hello.txt")
+    '';
+  }
+  ```
+
+  When built and run, this should output:
+  ```console
+  SGVsbG8gd29ybGQhCg==
+  ```
+  :::
+*/

--- a/pkgs/by-name/wr/writableDirWrapper/wrapper.sh
+++ b/pkgs/by-name/wr/writableDirWrapper/wrapper.sh
@@ -1,0 +1,129 @@
+# makeWritableDirWrapper EXECUTABLE OUT_PATH DIR ARGS
+
+# ARGS:
+# --dont-track-version               : don't relink when version mismatches
+#
+# --post-link-run      COMMAND       : run command after linking
+#
+# --link               SRC DST       : link SRC to DST
+
+makeWritableDirWrapper() {
+  local original="$1"; shift
+  local wrapper="$1"; shift
+  local dir="$1"; shift
+  local postLinkRun dontTrackVersion
+  local -A links
+
+  local makeWrapperParams=("$original" "$wrapper")
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --post-link-run)
+        postLinkRun="$2"; shift
+        ;;
+      --dont-track-version)
+        dontTrackVersion=true
+        ;;
+      --link)
+        src="$2"; shift
+        dst="$2"; shift
+        links["$src"]="$dst"
+        ;;
+      *) makeWrapperParams+=("$1") ;;
+    esac
+    shift
+  done
+
+  local fragment=$(mktemp)
+
+  local unlinkCommands=()
+  local linkCommands=()
+  for src in "${!links[@]}"; do
+    dst=${links[$src]}
+    unlinkCommands+=("[[ -d \"$dir/$dst\" ]] && find \"$dir/$dst\" -type l -lname '$src' -delete;")
+    linkCommands+=(
+      "mkdir -p './$dst';"
+      "@lndir@ -silent '$src' './$dst';"
+    )
+  done
+
+
+  {
+    cat <<EOF
+unlink() {
+  echo 'Removing existing file links'
+  ${unlinkCommands[@]}
+}
+
+link() {
+  echo 'Linking files'
+  mkdir -p "$dir"
+EOF
+
+    if [[ -z "$dontTrackVersion" ]]; then
+      echo "  echo '$version' > \"$dir/.$pname.version\""
+    fi
+
+    # In case that postLink needs to remove some links to avoid conflict,
+    # we first link everything into a temporary directory then move over
+    cat <<EOF
+  (
+    cd \$(mktemp -d)
+    ${linkCommands[@]}
+    $postLinkRun
+    cp -a ./. -t "$dir"
+  )
+}
+
+relink() {
+  [[ -d "$dir" ]] && unlink
+  link
+}
+
+declare manuallyRelink
+for arg in "\$@"; do
+  case "\$arg" in
+    --relink-files) manuallyRelink=true ;;
+    *) args+=("\$arg") ;; # Passthrough all other args
+  esac
+done
+set -- "\${args[@]}"
+
+if [[ -n "\$manuallyRelink" ]]; then
+  echo "Manually relinking files"; relink
+elif [[ ! -d "$dir" ]]; then
+  echo "Directory $dir not found. Linking files..."; relink
+EOF
+
+    if [[ -z "$dontTrackVersion" ]]; then
+      cat <<EOF
+elif [[ ! -e "$dir/.$name.version" ]]; then
+  echo "Version file not found. Relinking files just to be safe..."; relink
+elif [[ '$version' != "\$(<"$dir/.$pname.version")" ]]; then
+  echo "Current version is not the same as the newest version ($version). Relinking files"; relink
+EOF
+    fi
+
+    echo "fi"
+  } >> "$fragment"
+
+  makeWrapper "${makeWrapperParams[@]}"
+
+  # Inject after the shebang
+  sed -i "1r $fragment" "$wrapper"
+}
+
+# Syntax: wrapProgramInWritableDir <PROGRAM> <DIRECTORY> <MAKE-WRAPPER FLAGS...>
+wrapProgramInWritableDir() {
+    local prog="$1"
+    local dir="$2"
+    local hidden
+
+    assertExecutable "$prog"
+
+    hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+    while [ -e "$hidden" ]; do
+      hidden="${hidden}_"
+    done
+    mv "$prog" "$hidden"
+    makeWritableDirWrapper "$hidden" "$prog" "$dir" --inherit-argv0 "${@:3}"
+}


### PR DESCRIPTION
This has been pure cross-compilation multilib suffering. Hadn't yet been tested with an actual game since I think I need to buy a copy of Nox to obtain the gamedata.bin, but it's clear that some wrapper script is needed to set the game dir and log dir properly

Fixes #289222

Depends on #361114 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
