### PR TITLE
pgadmin4: fix service start issue

### DIFF
--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -205,6 +205,7 @@ pythonPackages.buildPythonApplication rec {
     rich
     jsonformatter
     libgravatar
+    setuptools
   ];
 
   passthru.tests = {


### PR DESCRIPTION
systemd service unit currently fails with requiring `pkg_resources` to be available:

```
systemd[1]: Starting pgadmin.service...
pgadmin-pre-start[2114]: Traceback (most recent call last):
pgadmin-pre-start[2114]:   File "/nix/store/11clxms2cwnz31wvdfpadmkpqs843q2z-pgadmin-8.12/bin/.pgadmin4-cli-wrapped", line 6, in <module>
pgadmin-pre-start[2114]:     from pgadmin4.setup import app
pgadmin-pre-start[2114]:   File "/nix/store/11clxms2cwnz31wvdfpadmkpqs843q2z-pgadmin-8.12/lib/python3.12/site-packages/pgadmin4/setup.py", line 32, in <module>
pgadmin-pre-start[2114]:     import config
pgadmin-pre-start[2114]:   File "/nix/store/11clxms2cwnz31wvdfpadmkpqs843q2z-pgadmin-8.12/lib/python3.12/site-packages/pgadmin4/config.py", line 33, in <module>
pgadmin-pre-start[2114]:     from pgadmin.utils import env, IS_WIN, fs_short_path
pgadmin-pre-start[2114]:   File "/nix/store/11clxms2cwnz31wvdfpadmkpqs843q2z-pgadmin-8.12/lib/python3.12/site-packages/pgadmin4/pgadmin/__init__.py", line 32, in <module>
pgadmin-pre-start[2114]:     from flask_security import Security, SQLAlchemyUserDatastore, current_user
pgadmin-pre-start[2114]:   File "/nix/store/rpp6k594x68s4w50vngfbg069pyq49lf-python3.12-flask-security-5.5.2/lib/python3.12/site-packages/flask_security/__init__.py", line 16, in <module>
pgadmin-pre-start[2114]:     from .core import (
pgadmin-pre-start[2114]:   File "/nix/store/rpp6k594x68s4w50vngfbg069pyq49lf-python3.12-flask-security-5.5.2/lib/python3.12/site-packages/flask_security/core.py", line 88, in <module>
pgadmin-pre-start[2114]:     from .totp import Totp
pgadmin-pre-start[2114]:   File "/nix/store/rpp6k594x68s4w50vngfbg069pyq49lf-python3.12-flask-security-5.5.2/lib/python3.12/site-packages/flask_security/totp.py", line 18, in <module>
pgadmin-pre-start[2114]:     from passlib.pwd import genword
pgadmin-pre-start[2114]:   File "/nix/store/a920dbsqj9v3qmxlzr8z5qdgaqyfjlk0-python3.12-passlib-1.7.4/lib/python3.12/site-packages/passlib/pwd.py", line 16, in <module>
pgadmin-pre-start[2114]:     import pkg_resources
pgadmin-pre-start[2114]: ModuleNotFoundError: No module named 'pkg_resources'
systemd[1]: pgadmin.service: Control process exited, code=exited, status=1/FAILURE
systemd[1]: pgadmin.service: Failed with result 'exit-code'.
systemd[1]: Failed to start pgadmin.service.
```
Adding `setuptools` to `propagatedBuildInputs` fixes this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
