### PR TITLE
kcl: 0.10.0 -> 0.10.9

### DIFF
--- a/pkgs/by-name/kc/kcl/package.nix
+++ b/pkgs/by-name/kc/kcl/package.nix
@@ -1,69 +1,89 @@
-{ lib
-, stdenv
-, buildGo123Module
-, fetchFromGitHub
-, kclvm_cli
-, kclvm
-, makeWrapper
-, installShellFiles
-, darwin
-,
+{
+  buildGoModule,
+  darwin,
+  fetchFromGitHub,
+  installShellFiles,
+  kclvm_cli,
+  kclvm,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  stdenv,
 }:
-buildGo123Module rec {
+
+buildGoModule rec {
   pname = "kcl";
-  version = "0.10.0";
+  version = "0.10.9";
 
   src = fetchFromGitHub {
     owner = "kcl-lang";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-0KxT4t77EDB7Vr/cb+P20ARRR+7g5uZiF5QYOArUhgI=";
+    hash = "sha256-V9HLUv018gCkzrt1mGNENZVjXCSvqEneQIgIwxawxKM=";
   };
 
-  vendorHash = "sha256-9APQDYCBvG38y0ZYuacfyUmjoEV9jGqRg7OZ7mArzIU=";
+  vendorHash = "sha256-y8KWiy6onZmYdpanXcSQDmYv51pLfo1NTdg+EaR6p0E=";
 
-  # By default, libs and bins are stripped. KCL will crash on darwin if they are.
-  dontStrip = stdenv.hostPlatform.isDarwin;
+  subPackages = [ "cmd/kcl" ];
 
   ldflags = [
     "-w -s"
     "-X=kcl-lang.io/cli/pkg/version.version=v${version}"
   ];
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
-  buildInputs = [ kclvm kclvm_cli ] ++ (
-    lib.optional stdenv.hostPlatform.isDarwin [
+  buildInputs =
+    [
+      kclvm
+      kclvm_cli
+    ]
+    ++ (lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.CoreServices
       darwin.apple_sdk.frameworks.SystemConfiguration
-    ]
-  );
+    ]);
 
-  subPackages = [ "cmd/kcl" ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export HOME=$(mktemp -d)
+    for shell in bash fish zsh; do
+      installShellCompletion --cmd kcl \
+        --$shell <($out/bin/kcl completion $shell)
+    done
+  '';
+
+  # By default, libs and bins are stripped. KCL will crash on darwin if they are.
+  dontStrip = stdenv.hostPlatform.isDarwin;
 
   # env vars https://github.com/kcl-lang/kcl-go/blob/main/pkg/env/env.go#L29
   postFixup = ''
-     wrapProgram $out/bin/kcl \
-    --prefix PATH : "${lib.makeBinPath [kclvm kclvm_cli]}" \
-    --prefix KCL_LIB_HOME : "${lib.makeLibraryPath [kclvm]}" \
-    --prefix KCL_GO_DISABLE_INSTALL_ARTIFACT : false
+    wrapProgram $out/bin/kcl \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          kclvm
+          kclvm_cli
+        ]
+      }" \
+      --prefix KCL_LIB_HOME : "${lib.makeLibraryPath [ kclvm ]}" \
+      --prefix KCL_GO_DISABLE_INSTALL_ARTIFACT : false
   '';
 
-  postInstall = ''
-    export HOME=$(mktemp -d)
-    installShellCompletion --cmd kcl \
-      --bash <($out/bin/kcl completion bash) \
-      --fish <($out/bin/kcl completion fish) \
-      --zsh <($out/bin/kcl completion zsh)
-  '';
+  updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "A command line interface for KCL programming language";
+    changelog = "https://github.com/kcl-lang/cli/releases/tag/v${version}";
     homepage = "https://github.com/kcl-lang/cli";
-    license = licenses.asl20;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ selfuryon peefy ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      peefy
+      selfuryon
+    ];
     mainProgram = "kcl";
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
kcl: 0.10.0 -> 0.10.7

Release: https://github.com/kcl-lang/cli/releases/tag/v0.10.7

- unpin go version
- order by phases/alphabetical order
- add `meta.changelog`
- remove nested `with` in meta
- add partial fix for cross-compiling
- mark cross-compiling as broken
- replace `lib.optional` (single item) with `lib.optionals` (multiple items)
- add nix update script
- refactor install shell completion
- nixfmt

Note: Tried to add a version test but had issues, will consider another time.

CC @selfuryon @peefy

## Status

This PR is ready for review/merge.