### PR TITLE
whitesur-kde: 2022-05-01-unstable-2024-09-26 -> 2022-05-01-unstable-2…

### DIFF
--- a/pkgs/data/themes/whitesur-kde/default.nix
+++ b/pkgs/data/themes/whitesur-kde/default.nix
@@ -1,28 +1,40 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
-, plasma-desktop
-, qtsvg
 , unstableGitUpdater
 }:
 
+# NOTE:
+#
+# In order to use the whitesur sddm themes, the packages
+# kdePackages.plasma-desktop and kdePackages.qtsvg should be added to
+# the option services.displayManager.sddm.extraPackages of the sddm
+# module:
+#
+# environment.systemPackages = with pkgs; [
+#   whitesur-kde
+# ];
+#
+# services.displayManager.sddm = {
+#     enable = true;
+#     package = pkgs.kdePackages.sddm;
+#     theme = "WhiteSur-dark";
+#     extraPackages = with pkgs; [
+#       kdePackages.plasma-desktop
+#       kdePackages.qtsvg
+#     ];
+# };
+
 stdenvNoCC.mkDerivation {
   pname = "whitesur-kde";
-  version = "2022-05-01-unstable-2024-09-26";
+  version = "2022-05-01-unstable-2024-11-01";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "whitesur-kde";
-    rev = "8cbb617049ad79ecff63eb62770d360b73fed656";
-    hash = "sha256-uNRO/r8kJByS4BDq0jXth+y0rg3GtGsbXoNLOZHpuNU=";
+    rev = "efba411e11f8f4d3219bffb393d25afae62eacf2";
+    hash = "sha256-052mKpf8e5pSecMzaWB3McOZ/uAqp/XGJjcVWnlKPLE=";
   };
-
-  # Propagate sddm theme dependencies to user env otherwise sddm does
-  # not find them. Putting them in buildInputs is not enough.
-  propagatedUserEnvPkgs = [
-    plasma-desktop
-    qtsvg
-  ];
 
   postPatch = ''
     patchShebangs install.sh sddm/install.sh
@@ -55,11 +67,11 @@ stdenvNoCC.mkDerivation {
 
   passthru.updateScript = unstableGitUpdater { };
 
-  meta = with lib; {
+  meta = {
     description = "MacOS big sur like theme for KDE Plasma desktop";
     homepage = "https://github.com/vinceliuice/WhiteSur-kde";
-    license = licenses.gpl3Only;
-    platforms = platforms.all;
-    maintainers = [ maintainers.romildo ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
…024-11-01

Update [whitesur-kde](https://github.com/vinceliuice/WhiteSur-kde) to version 2022-05-01-unstable-2024-11-01

**NOTE**

In order to use the WhiteSur sddm themes, the packages `kdePackages.plasma-desktop` and `kdePackages.qtsvg` should be added to the option `services.displayManager.sddm.extraPackages` of the `sddm` module:

``` nix
environment.systemPackages = with pkgs; [
  whitesur-kde
];

services.displayManager.sddm = {
    enable = true;
    package = pkgs.kdePackages.sddm;
    theme = "WhiteSur-dark";
    extraPackages = with pkgs; [
      kdePackages.plasma-desktop
      kdePackages.qtsvg
    ];
};
```
![image](https://github.com/user-attachments/assets/db0adee0-03e2-455c-9956-059a82031863)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
