### PR TITLE
sccmhunter: Init at 1.0.6-unstable-2024-10-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17673,6 +17673,12 @@
     githubId = 5636;
     name = "Steve Purcell";
   };
+  purpole = {
+    email = "mail@purpole.io";
+    github = "purpole";
+    githubId = 101905225;
+    name = "David Schneider";
+  };
   purrpurrn = {
     email = "scrcpynovideoaudiocodecraw+nixpkgs@gmail.com";
     github = "purrpurrn";

--- a/pkgs/by-name/sc/sccmhunter/package.nix
+++ b/pkgs/by-name/sc/sccmhunter/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "sccmhunter";
+  version = "1.0.6-unstable-2024-11-07";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "garrettfoster13";
+    repo = "sccmhunter";
+    rev = "33c23f0d71e48127a0b03b06a019148df71049ef";
+    hash = "sha256-mU3GKgX8gcuJ+YT3xL0/dDds34uhFD+Rc3m15W7zoKc=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    cmd2
+    cryptography
+    impacket
+    ldap3
+    pandas
+    pyasn1
+    pyasn1-modules
+    requests
+    requests-ntlm
+    requests-toolbelt
+    rich
+    tabulate
+    typer
+    urllib3
+    pyopenssl
+    pycryptodome
+  ];
+
+  meta = {
+    description = "Post exploitation tool to identify and attack SCCM related assets in an Active Directory domain";
+    homepage = "https://github.com/garrettfoster13/sccmhunter";
+    changelog = "https://github.com/garrettfoster13/sccmhunter/blob/${src.rev}/changelog.md";
+    license = lib.licenses.mit;
+    mainProgram = "sccmhunter.py";
+    maintainers = with lib.maintainers; [ purpole ];
+  };
+}


### PR DESCRIPTION
Hello!

I added `sccmhunter` (https://github.com/garrettfoster13/sccmhunter) and added `purpole` to the maintainers list.

`sccmhunter` is a python post-exploitation tool that can be used by pentesters and administrators to identify, profile and attack SCCM related assets in an Active Directory environment. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
