### PR TITLE
bao: fix tests

### DIFF
--- a/pkgs/tools/security/bao/default.nix
+++ b/pkgs/tools/security/bao/default.nix
@@ -13,7 +13,12 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-+MjfqIg/aKPWhzxbPJ0dnS4egCj50Ib7ob3zXUSBXRg=";
   };
 
-  cargoHash = "sha256-SNsRN5XgchZq6/BZnMeahIqnkP4Jq6bZxbE5cDVpsQA=";
+  cargoPatches = [
+    # https://github.com/oconnor663/bao/pull/55
+    ./test-exe.patch
+  ];
+
+  cargoHash = "sha256-mmhTG3WXVjIKtaz2xP9aYI9GQNTbx4l3c6UgKSMgQJU=";
 
   meta = {
     description = "Implementation of BLAKE3 verified streaming";

--- a/pkgs/tools/security/bao/test-exe.patch
+++ b/pkgs/tools/security/bao/test-exe.patch
@@ -1,0 +1,40 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 2f66e42..34240e8 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -26,6 +26,9 @@ path = "src/main.rs"
+ [dependencies.arrayref]
+ version = "0.3.5"
+ 
++[dependencies.assert_cmd]
++version = "2.0.16"
++
+ [dependencies.bao]
+ version = "0.12"
+ 
+diff --git a/tests/test.rs b/tests/test.rs
+index f9427bd..48aabca 100644
+--- a/tests/test.rs
++++ b/tests/test.rs
+@@ -1,8 +1,7 @@
+ use duct::cmd;
+ use rand::prelude::*;
+-use std::env::consts::EXE_EXTENSION;
+ use std::fs;
+-use std::path::{Path, PathBuf};
++use std::path::PathBuf;
+ use std::sync::Once;
+ use tempfile::tempdir;
+ 
+@@ -15,10 +14,7 @@ pub fn bao_exe() -> PathBuf {
+             .expect("build failed");
+     });
+ 
+-    Path::new("target")
+-        .join("debug")
+-        .join("bao")
+-        .with_extension(EXE_EXTENSION)
++    assert_cmd::cargo::cargo_bin("bao")
+ }
+ 
+ #[test]


### PR DESCRIPTION
Fixes the test failure https://hydra.nixos.org/build/276546807 by patching the logic for determining the executable path in the tests. The previous hardcoded default of `target/debug/bao` no longer works since #298108.

Also submitted upstream https://github.com/oconnor663/bao/pull/55, but vendored here as the part of the patch to `Cargo.toml` does not apply (because it has been normalized before uploading to crates.io).

ZHF: #352882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
