### PR TITLE
_7zz: use `asmc` on x86 Linux

### DIFF
--- a/pkgs/by-name/as/asmc/package.nix
+++ b/pkgs/by-name/as/asmc/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "asmc";
+  version = "2.36.02-unstable-2024-11-01";
+
+  src = fetchFromGitHub {
+    owner = "nidud";
+    repo = "asmc";
+    rev = "7dda9a180031c3723e270e0b6f51f4d8b73004a9";
+    hash = "sha256-Uk9K8m8r9stetIlUoVfBlayeDZSDvt1EmTI68W8dwso=";
+  };
+
+  makeFlags = [
+    "-C"
+    "source/asmc"
+    # Fails to build with the PIE default, sadly.
+    "pic-default=no"
+  ];
+
+  hardeningDisable = [ "pie" ];
+
+  # Lots of undeclared dependencies.
+  enableParallelBuilding = false;
+
+  postPatch = ''
+    # Unconditionally passes `-Wl,-pie` even when PIC is disabled, and
+    # then fails to build with it.
+    substituteInPlace source/asmc/makefile \
+      --replace-fail 'gcc -Wl,-pie' gcc
+  '';
+
+  # `make install` hard‐codes `/usr` and `sudo`; not worth it.
+  #
+  # This doesn’t handle the include or library directories because we
+  # just use this for `_7zz` and don’t install any of the libraries.
+  # Better to fail fast if anyone needs them so they know they’ll need
+  # to adjust this derivation.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp source/asmc/{asmc,asmc64} $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "MASM‐compatible assembler";
+    homepage = "https://github.com/nidud/asmc";
+    changelog = "https://github.com/nidud/asmc/blob/${finalAttrs.src.rev}/source/asmc/history.txt";
+    license = lib.licenses.gpl2Only;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [ lib.maintainers.jk ];
+    platforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isx86 lib.systems.inspect.patterns.isLinux;
+  };
+})

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -2,9 +2,8 @@
 , lib
 , fetchzip
 
-  # Only useful on Linux x86/x86_64, and brings in non‐free Open Watcom
-, uasm
-, useUasm ? false
+  # Only used on x86/x86_64 Linux
+, asmc
 
   # RAR code is under non-free unRAR license
   # see the meta.license section below for more details
@@ -76,7 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
       "CC=${stdenv.cc.targetPrefix}cc"
       "CXX=${stdenv.cc.targetPrefix}c++"
     ]
-    ++ lib.optionals useUasm [ "MY_ASM=uasm" ]
     # We need at minimum 10.13 here because of utimensat, however since
     # we need a bump anyway, let's set the same minimum version as the one in
     # aarch64-darwin so we don't need additional changes for it
@@ -85,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals (!enableUnfree) [ "DISABLE_RAR_COMPRESS=true" ]
     ++ lib.optionals (stdenv.hostPlatform.isMinGW) [ "IS_MINGW=1" "MSYSTEM=1" ];
 
-  nativeBuildInputs = lib.optionals useUasm [ uasm ];
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86) [ asmc ];
 
   setupHook = ./setup-hook.sh;
 


### PR DESCRIPTION
It turns out that this isn’t actually optional, so there’s no point in having it behind a flag, and that upstream recommend using the GPLv2 Asmc rather than the previous Watcom‐licensed UASM.                                      

Closes: #353119

cc @surfaceflinger @Ma27 @06kellyjac – I have built this, but not tested the resulting `_7zz`. Also `asmc` will definitely not build properly on cross. Also please don’t make me maintain it 🫠
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
