### PR TITLE
buildbot: fix setting `package` to a drv from a different nixpkgs

### DIFF
--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -5,7 +5,7 @@ let
   opt = options.services.buildbot-master;
 
   package = cfg.package.python.pkgs.toPythonModule cfg.package;
-  python = package.pythonModule;
+  python = cfg.package.python;
 
   escapeStr = lib.escape [ "'" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I'm not quite sure why, but using a buildbot package from a different nixpkgs than the host nixpkgs leads to a error such as following:
```
Unhandled Error
Traceback (most recent call last):
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/application/app.py", line 673, in run
    runApp(config)
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/scripts/twistd.py", line 29, in runApp
    runner.run()
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/application/app.py", line 370, in run
    self.application = self.createOrGetApplication()
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/application/app.py", line 437, in createOrGetApplication
    application = getApplication(self.config, passphrase)
--- <exception caught here> ---
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/application/app.py", line 446, in getApplication
    application = service.loadApplication(filename, style, passphrase)
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/application/service.py", line 404, in loadApplication
    application = sob.loadValueFromFile(filename, "application")
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/twisted/persisted/sob.py", line 175, in loadValueFromFile
    eval(codeObj, d, d)
  File "/var/lib/buildbot/master/buildbot.tac", line 4, in <module>
    from buildbot.master import BuildMaster
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/buildbot/master.py", line 29, in <module>
    from buildbot import config
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/buildbot/config/__init__.py", line 17, in <module>
    from .builder import BuilderConfig  # noqa: F401
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/buildbot/config/builder.py", line 21, in <module>
    from buildbot.db.model import Model
  File "/nix/store/71z9mnp02xncb3z21qn6bgzpasjp7lna-python3-3.12.4-env/lib/python3.12/site-packages/buildbot/db/model.py", line 20, in <module>
    import alembic
builtins.ModuleNotFoundError: No module named 'alembic'
Failed to load application: No module named 'alembic'
```

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
