### PR TITLE
jellyfin-ffmpeg: fix build

### DIFF
--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,7 +1,7 @@
 {
   ffmpeg_7-full,
   fetchFromGitHub,
-  fetchpatch,
+  fetchpatch2,
   lib,
 }:
 
@@ -26,6 +26,14 @@ in
       "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
     ];
 
+    patches = [
+      # xeve got an update that broke builds of ffmpeg 7.0.2, is fixed upstream from 7.1 onwards.
+      (fetchpatch2 {
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/3e6c7948626f19c46c1a630c788ea6bbd9e7fbcb";
+        hash = "sha256-HmijTDNqKaNpIMe3re4rIMKEo2udd7VFZdryV/+xiYM=";
+        excludes = [ "libavcodec/version.h" ];
+      })
+    ];
 
     postPatch = ''
       for file in $(cat debian/patches/series); do

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,7 +1,8 @@
-{ ffmpeg_7-full
-, fetchFromGitHub
-, fetchpatch
-, lib
+{
+  ffmpeg_7-full,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
 }:
 
 let
@@ -16,28 +17,30 @@ in
     rev = "v${version}";
     hash = "sha256-cqyXQNx65eLEumOoSCucNpAqShMhiPqzsKc/GjKKQOA=";
   };
-}).overrideAttrs (old: {
-  pname = "jellyfin-ffmpeg";
+}).overrideAttrs
+  (old: {
+    pname = "jellyfin-ffmpeg";
 
-  configureFlags = old.configureFlags ++ [
-    "--extra-version=Jellyfin"
-    "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
-  ];
+    configureFlags = old.configureFlags ++ [
+      "--extra-version=Jellyfin"
+      "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
+    ];
 
-  postPatch = ''
-    for file in $(cat debian/patches/series); do
-      patch -p1 < debian/patches/$file
-    done
 
-    ${old.postPatch or ""}
-  '';
+    postPatch = ''
+      for file in $(cat debian/patches/series); do
+        patch -p1 < debian/patches/$file
+      done
 
-  meta = {
-    inherit (old.meta) license mainProgram;
-    changelog = "https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v${version}";
-    description = "${old.meta.description} (Jellyfin fork)";
-    homepage = "https://github.com/jellyfin/jellyfin-ffmpeg";
-    maintainers = with lib.maintainers; [ justinas ];
-    pkgConfigModules = [ "libavutil" ];
-  };
-})
+      ${old.postPatch or ""}
+    '';
+
+    meta = {
+      inherit (old.meta) license mainProgram;
+      changelog = "https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v${version}";
+      description = "${old.meta.description} (Jellyfin fork)";
+      homepage = "https://github.com/jellyfin/jellyfin-ffmpeg";
+      maintainers = with lib.maintainers; [ justinas ];
+      pkgConfigModules = [ "libavutil" ];
+    };
+  })


### PR DESCRIPTION
Add a patch that fixes the compile errors from `libavcodec/libxeve.c` by changing the offending lines to those in upstream
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
