### PR TITLE
music-player: 0.2.0-alpha.14-unstable-2024-08-24 -> 0.2.0-alpha.14-unstable-2024-10-02

### DIFF
--- a/pkgs/by-name/mu/music-player/package.nix
+++ b/pkgs/by-name/mu/music-player/package.nix
@@ -40,11 +40,11 @@ rustPlatform.buildRustPackage rec {
       darwin.apple_sdk.frameworks.AudioUnit
     ];
 
-  meta = with lib; {
+  meta = {
     description = "Extensible music player daemon written in Rust";
     homepage = "https://github.com/tsirysndr/music-player";
     changelog = "https://github.com/tsirysndr/music-player/releases/tag/v${version}";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "music-player";
   };

--- a/pkgs/by-name/mu/music-player/package.nix
+++ b/pkgs/by-name/mu/music-player/package.nix
@@ -11,17 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "music-player";
-  version = "0.2.0-alpha.14-unstable-2024-08-24";
+  version = "0.2.0-alpha.14-unstable-2024-10-02";
 
   src = fetchFromGitHub {
     owner = "tsirysndr";
     repo = "music-player";
-    # No patch for 0.2.0, diff patch has a big size, temporarily until the next release
-    rev = "cf01ae4d2dcf5c804559250f2c7f922d870ae26d";
-    hash = "sha256-8C8uFnXSBalLD2MUgzzfg4ylvTVecyPJOSUri5jbvkM=";
+    rev = "cbf03c3f2f0f9baca831b08ec27d9b31438faa3d";
+    hash = "sha256-BG0MU6IdFQX+C4BxTZlq5I7a4BQmUTvwAQALw5/UPBE=";
   };
 
-  cargoHash = "sha256-JmyuA5p6/7jtNuOMWuAuspYYid+dGOeollIlS0DRCIE=";
+  cargoHash = "sha256-t/jdVTdmaJk8Sb43XEuVCKa4kSR+ZrIEmMQKWeVpB70=";
 
   nativeBuildInputs =
     [


### PR DESCRIPTION
Fixes build of unmaintained package for ZHF.

ZHF: #352882

closes #348649
closes #340548

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 353170"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
