### PR TITLE
nixos/tools: set the default for the enable options

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -217,7 +217,7 @@ in
   imports = let
     mkToolModule = { name, package ? pkgs.${name} }: { config, ... }: {
       options.system.tools.${name}.enable = lib.mkEnableOption "${name} script" // {
-        default = config.nix.enable;
+        default = config.nix.enable && ! config.system.disableInstallerTools;
         internal = true;
       };
 
@@ -235,27 +235,14 @@ in
     (mkToolModule { name = "nixos-version"; package = nixos-version; })
   ];
 
-  config = lib.mkMerge [
-    (lib.mkIf config.system.disableInstallerTools {
-      system.tools = {
-        nixos-build-vms.enable = lib.mkDefault false;
-        nixos-enter.enable = lib.mkDefault false;
-        nixos-generate-config.enable = lib.mkDefault false;
-        nixos-install.enable = lib.mkDefault false;
-        nixos-option.enable = lib.mkDefault false;
-        nixos-rebuild.enable = lib.mkDefault false;
-        nixos-version.enable = lib.mkDefault false;
-      };
-    })
-    {
-      documentation.man.man-db.skipPackages = [ nixos-version ];
+  config = {
+    documentation.man.man-db.skipPackages = [ nixos-version ];
 
-      # These may be used in auxiliary scripts (ie not part of toplevel), so they are defined unconditionally.
-      system.build = {
-        inherit nixos-generate-config nixos-install nixos-rebuild;
-        nixos-option = lib.warn "Accessing nixos-option through `config.system.build` is deprecated, use `pkgs.nixos-option` instead." pkgs.nixos-option;
-        nixos-enter = lib.warn "Accessing nixos-enter through `config.system.build` is deprecated, use `pkgs.nixos-enter` instead." pkgs.nixos-enter;
-      };
-    }
-  ];
+    # These may be used in auxiliary scripts (ie not part of toplevel), so they are defined unconditionally.
+    system.build = {
+      inherit nixos-generate-config nixos-install nixos-rebuild;
+      nixos-option = lib.warn "Accessing nixos-option through `config.system.build` is deprecated, use `pkgs.nixos-option` instead." pkgs.nixos-option;
+      nixos-enter = lib.warn "Accessing nixos-enter through `config.system.build` is deprecated, use `pkgs.nixos-enter` instead." pkgs.nixos-enter;
+    };
+  };
 }

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -238,13 +238,13 @@ in
   config = lib.mkMerge [
     (lib.mkIf config.system.disableInstallerTools {
       system.tools = {
-        nixos-build-vms.enable = false;
-        nixos-enter.enable = false;
-        nixos-generate-config.enable = false;
-        nixos-install.enable = false;
-        nixos-option.enable = false;
-        nixos-rebuild.enable = false;
-        nixos-version.enable = false;
+        nixos-build-vms.enable = lib.mkDefault false;
+        nixos-enter.enable = lib.mkDefault false;
+        nixos-generate-config.enable = lib.mkDefault false;
+        nixos-install.enable = lib.mkDefault false;
+        nixos-option.enable = lib.mkDefault false;
+        nixos-rebuild.enable = lib.mkDefault false;
+        nixos-version.enable = lib.mkDefault false;
       };
     })
     {


### PR DESCRIPTION
This makes it easier to enable some of them again after disabling the installer tools.
Before this change you had to use mkForce. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
