### PR TITLE
python312Packages.tokenize-rt: 5.2.0 -> 6.1.0; python312Packages.pyupgrade: 3.15.0 -> 3.19.0

### DIFF
--- a/pkgs/development/python-modules/pyupgrade/default.nix
+++ b/pkgs/development/python-modules/pyupgrade/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  setuptools,
   pytestCheckHook,
   tokenize-rt,
 }:
@@ -10,18 +11,20 @@
 buildPythonPackage rec {
   pname = "pyupgrade";
   version = "3.19.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "pyupgrade";
     rev = "v${version}";
     hash = "sha256-uArlT6g7kV94HzCRsiGKZP6/1v8OYUN8OZfZPERzE60=";
   };
 
-  propagatedBuildInputs = [ tokenize-rt ];
+  build-system = [ setuptools ];
+
+  dependencies = [ tokenize-rt ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pyupgrade/default.nix
+++ b/pkgs/development/python-modules/pyupgrade/default.nix
@@ -9,16 +9,16 @@
 
 buildPythonPackage rec {
   pname = "pyupgrade";
-  version = "3.15.0";
+  version = "3.19.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "asottile";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-n6WlJc7Hh7SArJ8Z0fikxidtpXaPQvKTDGn6HukL2q8=";
+    hash = "sha256-uArlT6g7kV94HzCRsiGKZP6/1v8OYUN8OZfZPERzE60=";
   };
 
   propagatedBuildInputs = [ tokenize-rt ];

--- a/pkgs/development/python-modules/tokenize-rt/default.nix
+++ b/pkgs/development/python-modules/tokenize-rt/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "tokenize-rt";
-  version = "5.2.0";
+  version = "6.1.0";
   pyproject = true;
 
   disabled = isPy27;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "asottile";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-G4Dn6iZLVOovzfEt9eMzp93mTX+bo0tHI5cCbaJLxBQ=";
+    hash = "sha256-7ykczY73KkqR99tYLL/5bgr9bqU444qHs2ONz+ldVyg=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/tokenize-rt/default.nix
+++ b/pkgs/development/python-modules/tokenize-rt/default.nix
@@ -2,7 +2,6 @@
   buildPythonPackage,
   lib,
   fetchFromGitHub,
-  isPy27,
   setuptools,
   pytestCheckHook,
 }:
@@ -12,16 +11,16 @@ buildPythonPackage rec {
   version = "6.1.0";
   pyproject = true;
 
-  disabled = isPy27;
-
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "tokenize-rt";
     rev = "v${version}";
     hash = "sha256-7ykczY73KkqR99tYLL/5bgr9bqU444qHs2ONz+ldVyg=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "tokenize_rt" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Diff: https://github.com/asottile/tokenize-rt/compare/v5.2.0...v6.1.0

Diff: https://github.com/asottile/pyupgrade/compare/v3.15.0...v3.19.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
