### PR TITLE
python3Packages.accelerate: Bump version 1.0.0 -> 1.1.0 and fix few things

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -115,6 +115,31 @@ buildPythonPackage rec {
       "test_init_trackers"
       "test_log"
       "test_log_with_tensor"
+
+      # After enabling MPS in pytorch, these tests started failing
+      "test_accelerated_optimizer_step_was_skipped"
+      "test_auto_wrap_policy"
+      "test_autocast_kwargs"
+      "test_automatic_loading"
+      "test_backward_prefetch"
+      "test_can_resume_training"
+      "test_can_resume_training_checkpoints_relative_path"
+      "test_can_resume_training_with_folder"
+      "test_can_unwrap_model_fp16"
+      "test_checkpoint_deletion"
+      "test_cpu_offload"
+      "test_cpu_ram_efficient_loading"
+      "test_grad_scaler_kwargs"
+      "test_invalid_registration"
+      "test_map_location"
+      "test_mixed_precision"
+      "test_mixed_precision_buffer_autocast_override"
+      "test_project_dir"
+      "test_project_dir_with_config"
+      "test_sharding_strategy"
+      "test_state_dict_type"
+      "test_with_save_limit"
+      "test_with_scheduler"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
       # RuntimeError: torch_shm_manager: execl failed: Permission denied

--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "accelerate";
-  version = "1.0.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "accelerate";
     rev = "refs/tags/v${version}";
-    hash = "sha256-XVJqyhDSUPQDHdaB6GDxHhuC6EWCSZNArjzyLpvhQHI=";
+    hash = "sha256-GBNe4zomy8dmfvYrk/9Q77Z6r+JJA+2dgAhJx2opqAc=";
   };
 
   buildInputs = [ llvmPackages.openmp ];

--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -12,6 +12,7 @@
   setuptools,
 
   # dependencies
+  huggingface-hub,
   numpy,
   packaging,
   psutil,
@@ -45,6 +46,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    huggingface-hub
     numpy
     packaging
     psutil


### PR DESCRIPTION
python3Packages.accelerate
* Add missing huggingface-hub dependency, it caused package being broken already before version bump
* Bump version 1.0.0 -> 1.1.0
* On Darwin: Disable some tests, which started failing after enabling MPS in pytorch package

Changelog can be found here: https://github.com/huggingface/accelerate/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [X] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)

Tested some of the basic functionality.

I tested that now running binaries don't give straight ImportError about missing huggingface-hub anymore, but didn't test the functionality otherwise than trying to run binaries does print out --help to the terminal. I'm able to use accelerate in my own Python code whch runs StableDiffusion.

- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
