### PR TITLE
kimai, nixos/kimai: init at 2.24.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16881,6 +16881,12 @@
     githubId = 943430;
     name = "David Hagege";
   };
+  peat-psuwit = {
+    name = "Ratchanan Srirattanamet";
+    email = "peat@peat-network.xyz";
+    github = "peat-psuwit";
+    githubId = 6771175;
+  };
   pedohorse = {
     github = "pedohorse";
     githubId = 13556996;

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -12,7 +12,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- [Kimai](https://www.kimai.org/), a web-based multi-user time-tracking application. Available as [services.kimai](option.html#opt-services.kimai).
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1459,6 +1459,7 @@
   ./services/web-apps/kasmweb/default.nix
   ./services/web-apps/kavita.nix
   ./services/web-apps/keycloak.nix
+  ./services/web-apps/kimai.nix
   ./services/web-apps/komga.nix
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lemmy.nix

--- a/nixos/modules/services/web-apps/kimai.nix
+++ b/nixos/modules/services/web-apps/kimai.nix
@@ -1,0 +1,403 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.kimai;
+  eachSite = cfg.sites;
+  user = "kimai";
+  webserver = config.services.${cfg.webserver};
+  stateDir = hostName: "/var/lib/kimai/${hostName}";
+
+  pkg =
+    hostName: cfg:
+    pkgs.stdenv.mkDerivation rec {
+      pname = "kimai-${hostName}";
+      src = cfg.package;
+      version = src.version;
+
+      installPhase = ''
+        mkdir -p $out
+        cp -r * $out/
+
+        # Symlink .env file. This will be dynamically created at the service
+        # startup.
+        ln -sf ${stateDir hostName}/.env $out/share/php/kimai/.env
+
+        # Symlink the var/ folder
+        # TODO: we may have to symlink individual folders if we want to also
+        # manage plugins from Nix.
+        rm -rf $out/share/php/kimai/var
+        ln -s ${stateDir hostName} $out/share/php/kimai/var
+
+        # Symlink local.yaml.
+        ln -s ${kimaiConfig hostName cfg} $out/share/php/kimai/config/packages/local.yaml
+      '';
+    };
+
+  kimaiConfig =
+    hostName: cfg:
+    pkgs.writeTextFile {
+      name = "kimai-config-${hostName}.yaml";
+      text = generators.toYAML { } cfg.settings;
+    };
+
+  siteOpts =
+    {
+      lib,
+      name,
+      config,
+      ...
+    }:
+    {
+      options = {
+        package = mkPackageOption pkgs "kimai" { };
+
+        database = {
+          host = mkOption {
+            type = types.str;
+            default = "localhost";
+            description = "Database host address.";
+          };
+
+          port = mkOption {
+            type = types.port;
+            default = 3306;
+            description = "Database host port.";
+          };
+
+          name = mkOption {
+            type = types.str;
+            default = "kimai";
+            description = "Database name.";
+          };
+
+          user = mkOption {
+            type = types.str;
+            default = "kimai";
+            description = "Database user.";
+          };
+
+          passwordFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            example = "/run/keys/kimai-dbpassword";
+            description = ''
+              A file containing the password corresponding to
+              {option}`database.user`.
+            '';
+          };
+
+          socket = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            defaultText = literalExpression "/run/mysqld/mysqld.sock";
+            description = "Path to the unix socket file to use for authentication.";
+          };
+
+          charset = mkOption {
+            type = types.str;
+            default = "utf8mb4";
+            description = "Database charset.";
+          };
+
+          serverVersion = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              MySQL *exact* version string. Not used if `createdLocally` is set,
+              but must be set otherwise. See
+              https://www.kimai.org/documentation/installation.html#column-table_name-in-where-clause-is-ambiguous
+              for how to set this value, especially if you're using MariaDB.
+            '';
+          };
+
+          createLocally = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Create the database and database user locally.";
+          };
+        };
+
+        poolConfig = mkOption {
+          type =
+            with types;
+            attrsOf (oneOf [
+              str
+              int
+              bool
+            ]);
+          default = {
+            "pm" = "dynamic";
+            "pm.max_children" = 32;
+            "pm.start_servers" = 2;
+            "pm.min_spare_servers" = 2;
+            "pm.max_spare_servers" = 4;
+            "pm.max_requests" = 500;
+          };
+          description = ''
+            Options for the Kimai PHP pool. See the documentation on `php-fpm.conf`
+            for details on configuration directives.
+          '';
+        };
+
+        settings = mkOption {
+          type = types.attrsOf types.anything;
+          default = { };
+          description = ''
+            Structural Kimai's local.yaml configuration.
+            Refer to <https://www.kimai.org/documentation/local-yaml.html#localyaml>
+            for details.
+          '';
+          example = literalExpression ''
+            {
+              kimai = {
+                timesheet = {
+                  rounding = {
+                    default = {
+                      begin = 15;
+                      end = 15;
+                    };
+                  };
+                };
+              };
+            }
+          '';
+        };
+
+        environmentFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/secrets/kimai.env";
+          description = ''
+            Securely pass environment variabels to Kimai. This can be used to
+            set other environement variables such as MAILER_URL.
+          '';
+        };
+      };
+    };
+in
+{
+  # interface
+  options = {
+    services.kimai = {
+      sites = mkOption {
+        type = types.attrsOf (types.submodule siteOpts);
+        default = { };
+        description = "Specification of one or more Kimai sites to serve";
+      };
+
+      webserver = mkOption {
+        type = types.enum [ "nginx" ];
+        default = "nginx";
+        description = ''
+          The webserver to configure for the PHP frontend.
+
+          At the moment, only `nginx` is supported. PRs are welcome for support
+          for other web servers.
+        '';
+      };
+    };
+  };
+
+  # implementation
+  config = mkIf (eachSite != { }) (mkMerge [
+    {
+
+      assertions =
+        (mapAttrsToList (hostName: cfg: {
+          assertion = cfg.database.createLocally -> cfg.database.user == user;
+          message = ''services.kimai.sites."${hostName}".database.user must be ${user} if the database is to be automatically provisioned'';
+        }) eachSite)
+        ++ (mapAttrsToList (hostName: cfg: {
+          assertion = cfg.database.createLocally -> cfg.database.passwordFile == null;
+          message = ''services.kimai.sites."${hostName}".database.passwordFile cannot be specified if services.kimai.sites."${hostName}".database.createLocally is set to true.'';
+        }) eachSite)
+        ++ (mapAttrsToList (hostName: cfg: {
+          assertion = !cfg.database.createLocally -> cfg.database.serverVersion != null;
+          message = ''services.kimai.sites."${hostName}".database.serverVersion must be specified if services.kimai.sites."${hostName}".database.createLocally is set to false.'';
+        }) eachSite);
+
+      services.mysql = mkIf (any (v: v.database.createLocally) (attrValues eachSite)) {
+        enable = true;
+        package = mkDefault pkgs.mariadb;
+        ensureDatabases = mapAttrsToList (hostName: cfg: cfg.database.name) eachSite;
+        ensureUsers = mapAttrsToList (hostName: cfg: {
+          name = cfg.database.user;
+          ensurePermissions = {
+            "${cfg.database.name}.*" = "ALL PRIVILEGES";
+          };
+        }) eachSite;
+      };
+
+      services.phpfpm.pools = mapAttrs' (
+        hostName: cfg:
+        (nameValuePair "kimai-${hostName}" {
+          inherit user;
+          group = webserver.group;
+          settings = {
+            "listen.owner" = webserver.user;
+            "listen.group" = webserver.group;
+          } // cfg.poolConfig;
+        })
+      ) eachSite;
+
+    }
+
+    {
+      systemd.tmpfiles.rules = flatten (
+        mapAttrsToList (hostName: cfg: [
+          "d '${stateDir hostName}' 0770 ${user} ${webserver.group} - -"
+        ]) eachSite
+      );
+
+      systemd.services = mkMerge [
+        (mapAttrs' (
+          hostName: cfg:
+          (nameValuePair "kimai-init-${hostName}" {
+            wantedBy = [ "multi-user.target" ];
+            before = [ "phpfpm-kimai-${hostName}.service" ];
+            after = optional cfg.database.createLocally "mysql.service";
+            script =
+              let
+                envFile = "${stateDir hostName}/.env";
+                appSecretFile = "${stateDir hostName}/.app_secret";
+                mysql = "${config.services.mysql.package}/bin/mysql";
+
+                dbUser = cfg.database.user;
+                dbPwd = if cfg.database.passwordFile != null then ":$(cat ${cfg.database.passwordFile})" else "";
+                dbHost = cfg.database.host;
+                dbPort = toString cfg.database.port;
+                dbName = cfg.database.name;
+                dbCharset = cfg.database.charset;
+                dbUnixSocket = if cfg.database.socket != null then "&unixSocket=${cfg.database.socket}" else "";
+                # Note: serverVersion is a shell variable. See below.
+                dbUri =
+                  "mysql://${dbUser}${dbPwd}@${dbHost}:${dbPort}"
+                  + "/${dbName}?charset=${dbCharset}"
+                  + "&serverVersion=$serverVersion${dbUnixSocket}";
+              in
+              ''
+                set -eu
+
+                serverVersion=${
+                  if !cfg.database.createLocally then
+                    cfg.database.serverVersion
+                  else
+                    # Obtain MySQL version string dynamically from the running
+                    # instance. Doctrine ORM's doc said it should be possible to
+                    # autodetect this, however Kimai's doc insists that it has to
+                    # be set.
+                    # https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#mysql
+                    # https://stackoverflow.com/q/9558867
+                    "$(${mysql} --silent --skip-column-names --execute 'SELECT VERSION();')"
+                }
+
+                # Create .env file containing DATABASE_URL and other default
+                # variables. Set umask to make sure .env is not readable by
+                # unrelated users.
+                oldUmask=$(umask)
+                umask 177
+
+                if ! [ -e ${appSecretFile} ]; then
+                  tr -dc A-Za-z0-9 </dev/urandom | head -c 20 >${appSecretFile}
+                fi
+
+                cat >${envFile} <<EOF
+                DATABASE_URL=${dbUri}
+                MAILER_FROM=kimai@example.com
+                MAILER_URL=null://null
+                APP_ENV=prod
+                APP_SECRET=$(cat ${appSecretFile})
+                CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?\$
+                EOF
+
+                umask $oldUmask
+
+                # Run kimai:install to ensure database is created or updated.
+                # Note that kimai:update is an alias to kimai:install.
+                ${pkg hostName cfg}/bin/console kimai:install
+              '';
+
+            serviceConfig = {
+              Type = "oneshot";
+              User = user;
+              Group = webserver.group;
+              EnvironmentFile = [ cfg.environmentFile ];
+            };
+          })
+        ) eachSite)
+
+        (mapAttrs' (
+          hostName: cfg:
+          (nameValuePair "phpfpm-kimai-${hostName}.service" {
+            serviceConfig = {
+              EnvironmentFile = [ cfg.environmentFile ];
+            };
+          })
+        ) eachSite)
+
+        (optionalAttrs (any (v: v.database.createLocally) (attrValues eachSite)) {
+          "${cfg.webserver}".after = [ "mysql.service" ];
+        })
+      ];
+
+      users.users.${user} = {
+        group = webserver.group;
+        isSystemUser = true;
+      };
+    }
+
+    (mkIf (cfg.webserver == "nginx") {
+      services.nginx = {
+        enable = true;
+        virtualHosts = mapAttrs (hostName: cfg: {
+          serverName = mkDefault hostName;
+          root = "${pkg hostName cfg}/share/php/kimai/public";
+          extraConfig = ''
+            index index.php;
+          '';
+          locations = {
+            "/" = {
+              priority = 200;
+              extraConfig = ''
+                try_files $uri /index.php$is_args$args;
+              '';
+            };
+            "~ ^/index\\.php(/|$)" = {
+              priority = 500;
+              extraConfig = ''
+                fastcgi_split_path_info ^(.+\.php)(/.+)$;
+                fastcgi_pass unix:${config.services.phpfpm.pools."kimai-${hostName}".socket};
+                fastcgi_index index.php;
+                include "${config.services.nginx.package}/conf/fastcgi.conf";
+                fastcgi_param PATH_INFO $fastcgi_path_info;
+                fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+                # Mitigate https://httpoxy.org/ vulnerabilities
+                fastcgi_param HTTP_PROXY "";
+                fastcgi_intercept_errors off;
+                fastcgi_buffer_size 16k;
+                fastcgi_buffers 4 16k;
+                fastcgi_connect_timeout 300;
+                fastcgi_send_timeout 300;
+                fastcgi_read_timeout 300;
+              '';
+            };
+            "~ \\.php$" = {
+              priority = 800;
+              extraConfig = ''
+                return 404;
+              '';
+            };
+          };
+        }) eachSite;
+      };
+    })
+
+  ]);
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -514,6 +514,7 @@ in {
   keycloak = discoverTests (import ./keycloak.nix);
   keyd = handleTest ./keyd.nix {};
   keymap = handleTest ./keymap.nix {};
+  kimai = handleTest ./kimai.nix {};
   knot = handleTest ./knot.nix {};
   komga = handleTest ./komga.nix {};
   krb5 = discoverTests (import ./krb5);

--- a/nixos/tests/kimai.nix
+++ b/nixos/tests/kimai.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "kimai";
+    meta.maintainers = with lib.maintainers; [ peat-psuwit ];
+
+    nodes.machine =
+      { ... }:
+      {
+        services.kimai.sites."localhost" = {
+          database.createLocally = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("phpfpm-kimai-localhost.service")
+      machine.wait_for_unit("nginx.service")
+      machine.wait_for_open_port(80)
+      machine.succeed("curl -v --location --fail http://localhost/")
+    '';
+  }
+)

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -1,0 +1,65 @@
+{
+  php,
+  fetchFromGitHub,
+  lib,
+}:
+
+php.buildComposerProject (finalAttrs: {
+  pname = "kimai";
+  version = "2.24.0";
+
+  src = fetchFromGitHub {
+    owner = "kimai";
+    repo = "kimai";
+    rev = finalAttrs.version;
+    hash = "sha256-C6i263sAfZwZELUIcZh/OmXZqgCKifjPYBafnH0wMC4=";
+  };
+
+  php = php.buildEnv {
+    extensions = (
+      { enabled, all }:
+      enabled
+      ++ (with all; [
+        gd
+        intl
+        mbstring
+        pdo
+        tokenizer
+        xml
+        xsl
+        zip
+      ])
+    );
+
+    # Asset building and (later) cache building process requires a little bit
+    # more memory.
+    extraConfig = ''
+      memory_limit=384M
+    '';
+  };
+
+  vendorHash = "sha256-3y3FfSUuDyBGP1dsuzDORDqFNj3jYix5ArM+2FS4gn4=";
+
+  composerNoPlugins = false;
+  composerNoScripts = false;
+
+  postInstall = ''
+    # Make available the console utility, as Kimai doesn't list this in
+    # composer.json.
+    mkdir -p "$out"/share/php/kimai "$out"/bin
+    ln -s "$out"/share/php/kimai/bin/console "$out"/bin/console
+  '';
+
+  meta = {
+    description = "Web-based multi-user time-tracking application";
+    homepage = "https://www.kimai.org/";
+    license = lib.licenses.agpl3Plus;
+    longDescription = "
+      Kimai is a web-based multi-user time-tracking application. Works great for
+      everyone: freelancers, companies, organizations - everyone can track their
+      times, generate reports, create invoices and do so much more.
+    ";
+    maintainers = with lib.maintainers; [ peat-psuwit ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -2,6 +2,7 @@
   php,
   fetchFromGitHub,
   lib,
+  nixosTests,
 }:
 
 php.buildComposerProject (finalAttrs: {
@@ -49,6 +50,10 @@ php.buildComposerProject (finalAttrs: {
     mkdir -p "$out"/share/php/kimai "$out"/bin
     ln -s "$out"/share/php/kimai/bin/console "$out"/bin/console
   '';
+
+  passthru.tests = {
+    kimai = nixosTests.kimai;
+  };
 
   meta = {
     description = "Web-based multi-user time-tracking application";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Kimai is a web-based multi-user time-tracking application. Works great for
everyone: freelancers, companies, organizations - everyone can track their
times, generate reports, create invoices and do so much more.

https://www.kimai.org/

The project is built using `buildComposerProject` helper. The module and the test are written following (primarily) Wordpress and Zoneminder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
