### PR TITLE
patchance, raysession: fix pipewire compatibility

### DIFF
--- a/pkgs/applications/audio/patchance/default.nix
+++ b/pkgs/applications/audio/patchance/default.nix
@@ -25,7 +25,7 @@ buildPythonApplication rec {
   installFlags = [ "PREFIX=$(out)" ];
 
   makeWrapperArgs = [
-    "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
+    "--suffix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
   ];
 
   preFixup = ''

--- a/pkgs/applications/audio/raysession/default.nix
+++ b/pkgs/applications/audio/raysession/default.nix
@@ -32,7 +32,7 @@ buildPythonApplication rec {
   installFlags = [ "PREFIX=$(out)" ];
 
   makeWrapperArgs = [
-    "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
+    "--suffix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ libjack2 ])
   ];
 
   postFixup = ''


### PR DESCRIPTION
TL;DR: this seems to make these apps work with PipeWire-emulated JACK.

Currently, running patchance or raysession with a setup like the following, where PipeWire emulates JACK,

```nix
{
  services.pipewire = {
    enable = true;
    jack.enable = true;
  }
}
```

these apps are unable function (a "JACK is not started !" message is shown).

This seems to happen because the wrapper in their derivations *prefixes* the `LD_LIBRARY_PATH` environment variable with `${libjack2}/lib`. Since `services.pipewire.jack.enable` also functions by putting a path to its own version of `libjack` into this environment variable:

https://github.com/NixOS/nixpkgs/blob/080166c15633801df010977d9d7474b4a6c549d7/nixos/modules/services/desktops/pipewire/pipewire.nix#L408C34-L409

the wrappers for patchance / raysession end up clobbering them. The apps then load the libraries from `libjack2` and as such try to connect to a (non-existent) "real" JACK server.

Instead, my PR makes the wrapper *suffix* the environment variable with `libjack2`'s path. If the machine is running pipewire-jack, PW libs will be preferred, otherwise, the "traditional" JACK will be used.

My PR seems to fix the issue in a `pipewire.jack` setup. I have not tested with normal JACK, but it should keep working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
