### PR TITLE
kotatogram-desktop: minor improvements

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -7,6 +7,9 @@
 , yasm
 }:
 
+let
+  version = "1.4.9";
+in
 (libsForQt5.callPackage ../telegram-desktop/default.nix {
   inherit stdenv;
 
@@ -30,7 +33,7 @@
   withWebKitGTK = false;
 }).overrideAttrs {
   pname = "kotatogram-desktop";
-  version = "1.4.9-unstable-2024-09-27";
+  version = "${version}-unstable-2024-09-27";
 
   src = fetchFromGitHub {
     owner = "kotatogram";
@@ -62,7 +65,7 @@
     license = licenses.gpl3Only;
     platforms = platforms.all;
     homepage = "https://kotatogram.github.io";
-    changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k{version}";
+    changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k${version}";
     maintainers = with maintainers; [ ilya-fedin ];
     mainProgram = if stdenv.hostPlatform.isLinux then "kotatogram-desktop" else "Kotatogram";
   };

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -59,7 +59,7 @@
 
       It contains some useful (or purely cosmetic) features, but they could be unstable. A detailed list is available here: https://kotatogram.github.io/changes
     '';
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.all;
     homepage = "https://kotatogram.github.io";
     changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k{version}";

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, kotatogram-desktop, glib-networking, webkitgtk_4_1, makeWrapper }:
+{ stdenv, lib, kotatogram-desktop, glib-networking, webkitgtk_4_1, makeBinaryWrapper }:
 
 stdenv.mkDerivation {
   pname = "${kotatogram-desktop.pname}-with-webkit";
   version = kotatogram-desktop.version;
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
   dontUnpack = true;
   installPhase = ''
     mkdir -p $out
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   '';
   postFixup = ''
     mkdir -p $out/bin
-    makeWrapper {${kotatogram-desktop},$out}/bin/${kotatogram-desktop.meta.mainProgram} \
+    makeBinaryWrapper {${kotatogram-desktop},$out}/bin/${kotatogram-desktop.meta.mainProgram} \
       --inherit-argv0 \
       --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ webkitgtk_4_1 ]}

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
   postFixup = ''
     mkdir -p $out/bin
     makeWrapper ${kotatogram-desktop}/bin/kotatogram-desktop $out/bin/kotatogram-desktop \
+      --inherit-argv0 \
       --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ webkitgtk_4_1 ]}
   '';

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   '';
   postFixup = ''
     mkdir -p $out/bin
-    makeWrapper ${kotatogram-desktop}/bin/kotatogram-desktop $out/bin/kotatogram-desktop \
+    makeWrapper {${kotatogram-desktop},$out}/bin/${kotatogram-desktop.meta.mainProgram} \
       --inherit-argv0 \
       --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ webkitgtk_4_1 ]}


### PR DESCRIPTION
Just making license consistent with other tdesktop forks (gpl3 -> gpl3Only), fixes changelog link and webkit wrapper to inherit argv0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
