### PR TITLE
bitwarden-desktop: 2024.9.0 -> 2024.10.2

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -46,6 +46,7 @@ in buildNpmPackage rec {
 
   patches = [
     ./electron-builder-package-lock.patch
+    ./writable-electron-binary.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -35,13 +35,13 @@ let
 
 in buildNpmPackage rec {
   pname = "bitwarden-desktop";
-  version = "2024.9.0";
+  version = "2024.10.2";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-o5nRG2j73qheDOyeFfSga64D8HbTn1EUrCiN0W+Xn0w=";
+    hash = "sha256-7kjLytLkM9Ta/INsMCYESJIMWNFPMYEASlWkAR134AY=";
   };
 
   patches = [
@@ -58,7 +58,7 @@ in buildNpmPackage rec {
   makeCacheWritable = true;
   npmFlags = [ "--engine-strict" "--legacy-peer-deps" ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-L7/frKCNlq0xr6T+aSqyEQ44yrIXwcpdU/djrhCJNNk=";
+  npmDepsHash = "sha256-2thF3dp1oSlqk6aHfgk8uyWFUifXHbCZ52Ajo9b3bGA=";
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "${pname}-${version}";
@@ -74,7 +74,7 @@ in buildNpmPackage rec {
       patches;
     patchFlags = [ "-p4" ];
     sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-y+6vaESiOeVrFJpZoOJ75onOpldqSsT2kqkMMzTDUmM=";
+    hash = "sha256-tmp2VWxR++v7VKNpXqg+IJx/twnxX23+dM0HTLGZGEg=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 

--- a/pkgs/by-name/bi/bitwarden-desktop/writable-electron-binary.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/writable-electron-binary.patch
@@ -1,0 +1,10 @@
+--- result/apps/desktop/scripts/after-pack.js	1970-01-01 01:00:01.000000000 +0100
++++ source/apps/desktop/scripts/after-pack.js	2024-11-02 21:38:58.691351376 +0100
+@@ -126,6 +126,7 @@
+     : context.packager.appInfo.productFilename; // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
+ 
+   const electronBinaryPath = path.join(context.appOutDir, `${executableName}${ext}`);
++  fse.chmodSync(electronBinaryPath, "755");
+ 
+   console.log("## Adding fuses to the electron binary", electronBinaryPath);
+ 


### PR DESCRIPTION
Changelog:
https://bitwarden.com/help/releasenotes/#2024-10-2

The build failed because of electron-builder copying the electron binary to the build. This happened before this version as well, but now an `after-pack.js` script is introduced that uses `flipFuses` to alter the binary (see https://github.com/bitwarden/clients/blob/5842200084dca0e8653953afb787fa8e703c9edb/apps/desktop/scripts/after-pack.js#L132C9-L132C18 and https://www.electronjs.org/docs/latest/tutorial/fuses).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
