### PR TITLE
arouteserver: init at 1.23.1

### DIFF
--- a/pkgs/by-name/ag/aggregate6/package.nix
+++ b/pkgs/by-name/ag/aggregate6/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication aggregate6

--- a/pkgs/by-name/ar/arouteserver/package.nix
+++ b/pkgs/by-name/ar/arouteserver/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  bgpq4,
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "arouteserver";
+  version = "1.23.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pierky";
+    repo = "arouteserver";
+    rev = "v${version}";
+    hash = "sha256-EZOBMDBsxbuVzzjQWU8V4n3gcLkRQxCq2eVK/Tyko4E=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/static/test_irr_queries_failover.py --replace-fail 'bgpq4 -h' '${lib.getExe bgpq4} -h'
+
+    substituteInPlace pierky/arouteserver/builder.py pierky/arouteserver/config/program.py tests/static/test_cfg_program.py \
+      --replace-fail '"bgpq4"' '"${lib.getExe bgpq4}"'
+  '';
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    aggregate6
+    jinja2
+    pyyaml
+    requests
+    packaging
+    urllib3
+    setuptools
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "pierky"
+    "pierky.arouteserver"
+  ];
+
+  pytestFlagsArray = [ "tests/static" ];
+
+  meta = {
+    description = "Automatically build (and test) feature-rich configurations for BGP route servers";
+    mainProgram = "arouteserver";
+    homepage = "https://github.com/pierky/arouteserver";
+    changelog = "https://github.com/pierky/arouteserver/blob/v${version}/CHANGES.rst";
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = lib.teams.wdz.members ++ (with lib.maintainers; [ marcel ]);
+  };
+}

--- a/pkgs/development/python-modules/aggregate6/0001-setup-remove-nose-coverage.patch
+++ b/pkgs/development/python-modules/aggregate6/0001-setup-remove-nose-coverage.patch
@@ -1,0 +1,31 @@
+From d20c7039316ea7c76da86963b266d3c34001b9f7 Mon Sep 17 00:00:00 2001
+From: Marcel <me@m4rc3l.de>
+Date: Sat, 2 Nov 2024 21:13:37 +0100
+Subject: [PATCH] setup: remove nose, coverage
+
+---
+ setup.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index b880f27..7a47360 100644
+--- a/setup.py
++++ b/setup.py
+@@ -70,7 +70,7 @@ setup(
+         'Programming Language :: Python :: 3',
+         'Programming Language :: Python :: 3.6'
+     ],
+-    setup_requires=["nose", "coverage", "mock"],
++    setup_requires=["mock"],
+     install_requires=["py-radix==0.10.0"] + (
+         ["future", "ipaddress"] if sys.version_info.major == 2 else []
+     ),
+@@ -78,5 +78,4 @@ setup(
+     entry_points={'console_scripts':
+                   ['aggregate6 = aggregate6.aggregate6:main']},
+     data_files = [('man/man7', ['aggregate6.7'])],
+-    test_suite='nose.collector'
+ )
+-- 
+2.44.1
+

--- a/pkgs/development/python-modules/aggregate6/default.nix
+++ b/pkgs/development/python-modules/aggregate6/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  py-radix-sr,
+  pytestCheckHook,
+  mock,
+}:
+
+buildPythonPackage rec {
+  pname = "aggregate6";
+  version = "1.0.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "job";
+    repo = "aggregate6";
+    rev = version;
+    hash = "sha256-tBo9LSmEu/0KPSeg17dlh7ngUvP9GyW6b01qqpr5Bx0=";
+  };
+
+  patches = [ ./0001-setup-remove-nose-coverage.patch ];
+
+  # py-radix-sr is a fork, with fixes
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail 'py-radix==0.10.0' 'py-radix-sr'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ py-radix-sr ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    mock
+  ];
+
+  pythonImportsCheck = [ "aggregate6" ];
+
+  meta = {
+    description = "IPv4 and IPv6 prefix aggregation tool";
+    mainProgram = "aggregate6";
+    homepage = "https://github.com/job/aggregate6";
+    license = with lib.licenses; [ bsd2 ];
+    maintainers = lib.teams.wdz.members ++ (with lib.maintainers; [ marcel ]);
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -123,6 +123,8 @@ self: super: with self; {
 
   agent-py = callPackage ../development/python-modules/agent-py { };
 
+  aggregate6 = callPackage ../development/python-modules/aggregate6 { };
+
   ago = callPackage ../development/python-modules/ago { };
 
   aggdraw = callPackage ../development/python-modules/aggdraw { };


### PR DESCRIPTION
## Things done

This PR is already productive deployed at DD-IX.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
