### PR TITLE
nushellPlugins.port-scan: init at 1.0.1-unstable-2024-12-23

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -4,6 +4,7 @@ lib.makeScope newScope (self: with self; {
   gstat = callPackage ./gstat.nix { inherit Security; };
   formats = callPackage ./formats.nix { inherit IOKit Foundation; };
   polars = callPackage ./polars.nix { inherit IOKit Foundation; };
+  port-scan = callPackage ./port-scan.nix { inherit IOKit CoreFoundation; nushell-plugin-port-scan = self.port-scan; };
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
   net = callPackage ./net.nix { inherit IOKit CoreFoundation; };
   units = callPackage ./units.nix  { inherit IOKit Foundation; };

--- a/pkgs/shells/nushell/plugins/port-scan.nix
+++ b/pkgs/shells/nushell/plugins/port-scan.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  runCommand,
+  lib,
+  rustPlatform,
+  nix-update-script,
+  fetchFromGitHub,
+  CoreFoundation,
+  IOKit,
+  nushell,
+  nushell-plugin-port-scan,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nushell-plugin-port-scan";
+  version = "1.0.1-unstable-2024-12-23";
+
+  src = fetchFromGitHub {
+    owner = "FMotalleb";
+    repo = "nu_plugin_port_scan";
+    rev = "c3307b4bc135621a14a140ed2a8c2b51fd7c070c";
+    hash = "sha256-S0tM3KlC2S1VLZt9lyVif/aGDLMo8U0svS8KmtGUKxE=";
+  };
+
+  cargoHash = "sha256-8QAtHkbXm13cQEriQVH7i030w9i7mgFCD04E5sYP9Q8=";
+
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    CoreFoundation
+    IOKit
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.check =
+      let
+        nu = lib.getExe nushell;
+        plugin = lib.getExe nushell-plugin-port-scan;
+      in
+      runCommand "${pname}-test" { } ''
+        touch $out
+        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
+        ${nu} -n -c "plugin use --plugin-config $out port_scan"
+      '';
+  };
+
+  meta = with lib; {
+    description = "A nushell plugin for scanning ports on a target";
+    mainProgram = "nu_plugin_port_scan";
+    homepage = "https://github.com/FMotalleb/nu_plugin_port_scan";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aftix ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
Added package for [nushell_plugin_port_scan](https://github.com/FMotalleb/nu_plugin_port_scan). It includes a simple test that the passed in nushell can load the plugin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
