### PR TITLE
darwin stdenv fixes needed for llvm_19

### DIFF
--- a/pkgs/by-name/ld/ld64/package.nix
+++ b/pkgs/by-name/ld/ld64/package.nix
@@ -128,6 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0006-Add-libcd_is_blob_a_linker_signature-implementation.patch
     # Add OpenSSL implementation of CoreCrypto digest functions. Avoids use of private and non-free APIs.
     ./0007-Add-OpenSSL-based-CoreCrypto-digest-functions.patch
+    ./remove-unused-and-incomplete-blob-clone.diff
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ld/ld64/remove-unused-and-incomplete-blob-clone.diff
+++ b/pkgs/by-name/ld/ld64/remove-unused-and-incomplete-blob-clone.diff
@@ -1,0 +1,14 @@
+diff --git a/src/ld/code-sign-blobs/blob.h b/src/ld/code-sign-blobs/blob.h
+index 19c63a9..1dfb380 100644
+--- a/src/ld/code-sign-blobs/blob.h
++++ b/src/ld/code-sign-blobs/blob.h
+@@ -180,9 +180,6 @@ public:
+ 		return NULL;
+ 	}
+ 	
+-	BlobType *clone() const
+-	{ assert(validateBlob()); return specific(this->BlobCore::clone());	}
+-
+ 	static BlobType *readBlob(int fd)
+ 	{ return specific(BlobCore::readBlob(fd, _magic, sizeof(BlobType), 0), true); }
+ 

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -188,6 +188,13 @@ stdenv.mkDerivation ({
     substituteInPlace ../libcxx/utils/merge_archives.py \
       --replace-fail "import distutils.spawn" "from shutil import which as find_executable" \
       --replace-fail "distutils.spawn." ""
+  '' + lib.optionalString (lib.versionAtLeast release_version "19")
+    # codesign in sigtool doesn't support the various options used by the build
+    # and is present in the bootstrap-tools. Removing find_program prevents the
+    # build from trying to use it and failing.
+    ''
+    substituteInPlace cmake/Modules/AddCompilerRT.cmake \
+      --replace-fail 'find_program(CODESIGN codesign)' ""
   '';
 
   # Hack around weird upsream RPATH bug

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
   # cgit) that are needed here should be included directly in Nixpkgs as
   # files.
   patches = [
+    # https://github.com/libffi/libffi/pull/857
+    # function label needs to come before .cfi_startproc
+    ./label-before-cfi_startproc.patch
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/libffi/label-before-cfi_startproc.patch
+++ b/pkgs/development/libraries/libffi/label-before-cfi_startproc.patch
@@ -1,0 +1,47 @@
+From 3065c530d3aa50c2b5ee9c01f88a9c0b61732805 Mon Sep 17 00:00:00 2001
+From: Ivan Tadeu Ferreira Antunes Filho <antunesi@google.com>
+Date: Mon, 16 Sep 2024 16:10:39 -0400
+Subject: [PATCH] Move cfi_startproc after CNAME(label)
+
+This is a fix for https://github.com/libffi/libffi/issues/852: error: invalid CFI advance_loc expression on apple targets.
+
+The CFI for darwin arm64 was broken because the CNAME macro was being used after the
+cfi_startproc macro.
+---
+ src/aarch64/sysv.S | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/aarch64/sysv.S b/src/aarch64/sysv.S
+index 6a9a5611f..e83bc65de 100644
+--- a/src/aarch64/sysv.S
++++ b/src/aarch64/sysv.S
+@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+    x5 closure
+ */
+ 
+-	cfi_startproc
+ CNAME(ffi_call_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	PAC_CFI_WINDOW_SAVE
+ 	/* Sign the lr with x1 since that is the CFA which is the modifer used in auth instructions */
+@@ -348,8 +348,8 @@ CNAME(ffi_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_closure_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	SIGN_LR
+ 	PAC_CFI_WINDOW_SAVE
+@@ -647,8 +647,8 @@ CNAME(ffi_go_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_go_closure_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	SIGN_LR_LINUX_ONLY
+ 	PAC_CFI_WINDOW_SAVE

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -191,6 +191,7 @@ let
         shell = bash + "/bin/bash";
         initialPath = [
           bash
+          prevStage.file
           bootstrapTools
         ];
 
@@ -370,6 +371,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
       ld64 = null;
 
       coreutils = null;
+      file = null;
       gnugrep = null;
 
       pbzx = null;
@@ -416,6 +418,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
         coreutils = bootstrapTools;
         cpio = bootstrapTools;
+        file = null;
         gnugrep = bootstrapTools;
         pbzx = bootstrapTools;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add minor fixes to various stdenv packages which break when llvm_19 is used as the stdenv compiler.

- darwin.stdenv: add `file` package to early stage stdenv. needed for llvm_19.tests
- ld64: remove a broken unused function that calls a function which doesn't exists
- libffi: apply upstream patch which reorders `.cfi_startproc` with the function label.
- compiler-rt: remove `find_program(CODESIGN codesign)` to avoid build locating codesign in bootstrap tools

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
