### PR TITLE
gobject-introspection: Conditionalize `depsTargetTargetPropagated`

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -94,7 +94,10 @@ else
         unwrapped = overriddenUnwrappedGir;
       };
       dontStrip = true;
-      depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];
+      # Conditional is for `pkgsCross.x86_64-freebsd.pkgsBuildHost.gobject-introspection` `error: Don't know how to run x86_64-unknown-freebsd executables.`
+      # `pkgsCross.x86_64-freebsd.buildPackages.python3.withPackages (pp: [ pp.pygobject3 ])`
+      # Using the python module does not need this propagation
+      depsTargetTargetPropagated = lib.optionals (stdenv.targetPlatform.emulatorAvailable buildPackages) [ overridenTargetUnwrappedGir ];
       buildCommand = ''
         eval fixupPhase
         ${lib.concatMapStrings (output: ''


### PR DESCRIPTION
Fixes ↓

```
nix-repl> pkgsCross.x86_64-freebsd.pkgsBuildHost.gobject-introspection
error: Don't know how to run x86_64-unknown-freebsd executables.
```

The unwrapped already doesn't error

```
nix-repl> pkgsCross.x86_64-freebsd.pkgsBuildHost.gobject-introspection-unwrapped
«derivation /nix/store/xq4q4vigy2glmfng2h6bbr4sysyk8ipz-gobject-introspection-1.82.0.drv»
```

https://www.github.com/NixOS/nixpkgs/blob/7b1cffdd2e13b2cdad5b37e259016efd0ea48fcd/pkgs/development/libraries/gobject-introspection/default.nix#L114

It's caused by `depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];` in the wrapper

In `graphene` there is
`PATH=${python3.withPackages (pp: [ pp.pygobject3 pp.tappy ])}/bin:$PATH patchShebangs tests/introspection.py`

Which causes the `Don't know` error in `pkgsCross.x86_64-freebsd.pkgsBuildHost.graphene`

because `python3` and `pygobject3` will be from `pkgsHostTarget`

and then `pygobject3` has `gobject-introspection` from `pkgsHostTarget`

and then that `gobject-introspection` will have `pkgsCross.x86_64-freebsd.pkgsCross.x86_64-freebsd.buildPackages.pkgsTargetTarget.gobject-introspection.gobject-introspection` in `depsTargetTargetPropagated`


To test that importing the python library `gi` works without `depsTargetTargetPropagated`

```nix
let
  pkgs =
    (import ./. {
      crossSystem = (import ./lib).systems.examples.aarch64-multiplatform;
      # On `master` uncomment this and comment `propagatedBuildInputs` below and you'll get
      # error: Don't know how to run x86_64-unknown-freebsd executables.
      #crossSystem = (import ./lib).systems.examples.x86_64-freebsd;
      overlays = [
        (_: prev: {
          pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
            (_: pprev: {
              pygobject3-test = pprev.pygobject3.overrideAttrs {
                propagatedBuildInputs = [
                  pprev.pycairo
                  (prev.gobject-introspection.overrideAttrs { depsTargetTargetPropagated = [ ]; })
                ];
              };
            })
          ];
        })
      ];
    }).pkgs;
  pyr = pkgs.pkgsBuildHost.python3Packages.python.withPackages (pp: [ pp.pygobject3-test ]);
in
pkgs.pkgsBuildBuild.runCommand "test" { } ''
  "${pyr.interpreter}" -c "import gi" && touch "$out"
''
```