### PR TITLE
{qt6Packages,libsForQt5}.*: don’t propagate Darwin version inputs

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -4,7 +4,7 @@
 , coreutils, bison, flex, gdb, gperf, lndir, perl, pkg-config, python3
 , which
   # darwin support
-, darwinMinVersionHook, apple-sdk, apple-sdk_10_14, apple-sdk_13, xcbuild
+, apple-sdk_13, darwinMinVersionHook, xcbuild
 
 , dbus, fontconfig, freetype, glib, harfbuzz, icu, libdrm, libX11, libXcomposite
 , libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng , libxcb
@@ -41,12 +41,11 @@ let
   # Per https://doc.qt.io/qt-5/macos.html#supported-versions: deployment target = 10.13, build SDK = 13.x or 14.x.
   # Despite advertising support for the macOS 14 SDK, the build system sets the maximum to 13 and complains
   # about 14, so we just use that.
-  # Note that Qt propagates the 10.14 SDK instead of the 10.13 SDK to make sure that applications linked to Qt
-  # support automatic dark mode on x86_64-darwin (see: https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app).
-  propagatedAppleSDK = if lib.versionOlder (lib.getVersion apple-sdk) "10.14" then apple-sdk_10_14 else apple-sdk;
   deploymentTarget = "10.13";
-  propagatedMinVersionHook = darwinMinVersionHook deploymentTarget;
-  buildAppleSDK = apple-sdk_13;
+  darwinVersionInputs = [
+    apple-sdk_13
+    (darwinMinVersionHook deploymentTarget)
+  ];
 in
 
 stdenv.mkDerivation (finalAttrs: ({
@@ -63,11 +62,8 @@ stdenv.mkDerivation (finalAttrs: ({
     # Image formats
     libjpeg libpng
     pcre2
-  ] ++ (
-    if stdenv.hostPlatform.isDarwin then [
-      propagatedAppleSDK
-      propagatedMinVersionHook
-    ] else [
+  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) (
+    [
       dbus glib udev
 
       # Text rendering
@@ -87,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: ({
       [ libinput ]
       ++ lib.optional withGtk3 gtk3
     )
-    ++ lib.optional stdenv.isDarwin buildAppleSDK
+    ++ lib.optional stdenv.isDarwin darwinVersionInputs
     ++ lib.optional developerBuild gdb
     ++ lib.optional (cups != null) cups
     ++ lib.optional (mysqlSupport) libmysqlclient

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -20,7 +20,7 @@
 , systemd
 , enableProprietaryCodecs ? true
 , gn
-, apple-sdk_13, cctools, cups, bootstrap_cmds, xcbuild, writeScriptBin
+, cctools, cups, bootstrap_cmds, xcbuild, writeScriptBin
 , ffmpeg ? null
 , lib, stdenv
 , version ? null
@@ -51,8 +51,7 @@ let
 
 in
 
-# Override the SDK because Qt WebEngine doesn’t seem to build using the 14.4 SDK.
-(qtModule.override { apple-sdk_for_qt = apple-sdk_13; }) ({
+qtModule ({
   pname = "qtwebengine";
   nativeBuildInputs = [
     bison flex git gperf ninja pkg-config (python.withPackages(ps: [ ps.html5lib ])) which gn nodejs

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -30,6 +30,7 @@ mkDerivation (args // {
     # Per https://doc.qt.io/qt-5/macos.html#supported-versions
     ++ lib.optionals stdenv.isDarwin [
       apple-sdk_13
+      (darwinMinVersionHook "10.13")
     ];
 
   nativeBuildInputs =

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -2,8 +2,8 @@
 , stdenv
 , buildPackages
 , mkDerivation
-, apple-sdk_14
-, apple-sdk_for_qt ? apple-sdk_14
+, apple-sdk_13
+, darwinMinVersionHook
 , perl
 , qmake
 , patches
@@ -28,7 +28,9 @@ mkDerivation (args // {
   buildInputs =
     args.buildInputs or [ ]
     # Per https://doc.qt.io/qt-5/macos.html#supported-versions
-    ++ lib.optionals stdenv.isDarwin [ apple-sdk_for_qt ];
+    ++ lib.optionals stdenv.isDarwin [
+      apple-sdk_13
+    ];
 
   nativeBuildInputs =
     (args.nativeBuildInputs or []) ++ [

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -11,7 +11,6 @@
 , libglvnd
 , darwin
 , apple-sdk_15
-, apple-sdk_12
 , darwinMinVersionHook
 , buildPackages
 , python3
@@ -32,11 +31,10 @@ let
       });
 
       # Per <https://doc.qt.io/qt-6/macos.html#supported-versions>.
-      # This should reflect the lowest “Target Platform” and the
-      # highest “Build Environment”.
-      apple-sdk_qt = apple-sdk_15;
-      darwinDeploymentTargetDeps = [
-        apple-sdk_12
+      # This should reflect the highest “Build Environment” and the
+      # lowest “Target Platform”.
+      darwinVersionInputs = [
+        apple-sdk_15
         (darwinMinVersionHook "12.0")
       ];
     in
@@ -45,12 +43,12 @@ let
       inherit callPackage srcs;
 
       qtModule = callPackage ./qtModule.nix {
-        inherit apple-sdk_qt;
+        inherit darwinVersionInputs;
       };
 
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = !stdenv.hostPlatform.isMinGW;
-        inherit apple-sdk_qt darwinDeploymentTargetDeps;
+        inherit darwinVersionInputs;
         inherit (srcs.qtbase) src version;
         patches = [
           ./patches/0001-qtbase-qmake-always-use-libname-instead-of-absolute-.patch

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -67,8 +67,7 @@
 , unixODBCDrivers
   # darwin
 , moveBuildTree
-, apple-sdk_qt
-, darwinDeploymentTargetDeps
+, darwinVersionInputs
 , xcbuild
   # mingw
 , pkgsBuildBuild
@@ -155,8 +154,7 @@ stdenv.mkDerivation rec {
     xorg.libXtst
     xorg.xcbutilcursor
     libepoxy
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin darwinDeploymentTargetDeps
-  ++ lib.optionals libGLSupported [
+  ] ++ lib.optionals libGLSupported [
     libGL
   ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
     vulkan-headers
@@ -167,9 +165,7 @@ stdenv.mkDerivation rec {
     at-spi2-core
   ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform libinput) [
     libinput
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_qt
-  ]
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin darwinVersionInputs
   ++ lib.optional withGtk3 gtk3
   ++ lib.optional (libmysqlclient != null && !stdenv.hostPlatform.isMinGW) libmysqlclient
   ++ lib.optional (postgresql != null && lib.meta.availableOn stdenv.hostPlatform postgresql) postgresql;

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, apple-sdk_qt
+, darwinVersionInputs
 , cmake
 , ninja
 , perl
@@ -22,7 +22,7 @@ stdenv.mkDerivation (args // {
 
   buildInputs =
     args.buildInputs or [ ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin darwinVersionInputs;
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cmake ninja perl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
   propagatedBuildInputs =


### PR DESCRIPTION
After a discussion in the macOS room on Matrix, we decided that libraries propagating the SDKs for their deployment targets is a Bad Thing, as it only works down one level deep, and can result in libraries causing confusing breaking changes for their users when their minimum supported version changes. Much better to be explicit when required and avoid this kind of magic. Qt is the only library we know of that presently does this, and since Qt 6.8 is now making it propagate the macOS 12 SDK instead of the macOS 11 that will be the default come 25.05, we ought to fix that before it becomes a bigger problem. Docs updates to clarify that you shouldn’t do this will follow later.

Expected fallout: some packages that use Qt directly may need `apple-sdk_11` adding to their build inputs because of `x86_64-darwin`’s old default; probably not that many, as it would only apply for packages that use both Qt and modern macOS APIs directly. These regressions will be easy to triage during the last 24.11-pre `staging` cycle, which already contains some Darwin breaking changes of comparable magnitude. On 25.05-pre, every package will implicitly get the SDK that Qt had previously been propagating anyway. However, this is still a new breaking change being added on to that cycle, so I’m pinging @RossComputerGuy for sign‐off. Sorry about the number of late Darwin‐related breaking changes this release cycle; it’s been a rush to get the new SDK pattern in place and refined over the course of a few weeks and we really don’t want to stabilize bad practice that will come back to bite us for six months.

Drafted because I haven’t built any of this yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
