### PR TITLE
python312Packages.fsspec: 2024.3.0 -> 2024.12.0; python312Packages.s3fs: 2024.9.0 -> 2024.12.0

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -4,6 +4,8 @@
   aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
   numpy,
   paramiko,
   pytest-asyncio,
@@ -31,7 +33,7 @@
 buildPythonPackage rec {
   pname = "fsspec";
   version = "2024.12.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -42,18 +44,15 @@ buildPythonPackage rec {
     hash = "sha256-Vc0vBayPg6zZ4+pxJsHChSGg0kjA0Q16+Gk0bO0IEpI=";
   };
 
-  propagatedBuildInputs = [
-    aiohttp
-    paramiko
-    requests
-    smbprotocol
-    tqdm
+  build-system = [
+    hatchling
+    hatch-vcs
   ];
 
   optional-dependencies = {
-    entrypoints = [ ];
     abfs = [ adlfs ];
     adl = [ adlfs ];
+    arrow = [ pyarrow ];
     dask = [
       dask
       distributed
@@ -63,28 +62,49 @@ buildPythonPackage rec {
       requests
       dropbox
     ];
+    entrypoints = [ ];
+    full = [
+      adlfs
+      aiohttp
+      dask
+      distributed
+      dropbox
+      # dropboxdrivefs
+      fusepy
+      gcsfs
+      libarchive-c
+      ocifs
+      panel
+      paramiko
+      pyarrow
+      pygit2
+      requests
+      s3fs
+      smbprotocol
+      tqdm
+    ];
+    fuse = [ fusepy ];
     gcs = [ gcsfs ];
     git = [ pygit2 ];
     github = [ requests ];
     gs = [ gcsfs ];
+    gui = [ panel ];
     hdfs = [ pyarrow ];
-    arrow = [ pyarrow ];
     http = [
       aiohttp
       requests
     ];
-    sftp = [ paramiko ];
-    s3 = [ s3fs ];
+    libarchive = [ libarchive-c ];
     oci = [ ocifs ];
+    s3 = [ s3fs ];
+    sftp = [ paramiko ];
     smb = [ smbprotocol ];
     ssh = [ paramiko ];
-    fuse = [ fusepy ];
-    libarchive = [ libarchive-c ];
-    gui = [ panel ];
     tqdm = [ tqdm ];
   };
 
   nativeCheckInputs = [
+    aiohttp
     numpy
     pytest-asyncio
     pytest-mock
@@ -127,11 +147,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fsspec" ];
 
-  meta = with lib; {
+  meta = {
     description = "Specification that Python filesystems should adhere to";
     homepage = "https://github.com/fsspec/filesystem_spec";
     changelog = "https://github.com/fsspec/filesystem_spec/raw/${version}/docs/source/changelog.rst";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "2024.3.0";
+  version = "2024.12.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     owner = "fsspec";
     repo = "filesystem_spec";
     tag = version;
-    hash = "sha256-C+47BcIELZTEARXW8fAMHMjyKUWxU1tNKWGoPPtt/fQ=";
+    hash = "sha256-Vc0vBayPg6zZ4+pxJsHChSGg0kjA0Q16+Gk0bO0IEpI=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "s3fs";
-  version = "2024.9.0";
+  version = "2024.12.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ZJNwWrtQN01reZT5YW0nrb3YohnIY1EAvcKGOC79kfU=";
+    hash = "sha256-Gw86j1lGzKW6KYcdZ5KrHkUo7XYjJ9iu+vyBtzuZ/VY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -5,46 +5,56 @@
   buildPythonPackage,
   docutils,
   fetchPypi,
+  flask,
+  flask-cors,
   fsspec,
+  moto,
+  pytestCheckHook,
   pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "s3fs";
   version = "2024.12.0";
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-Gw86j1lGzKW6KYcdZ5KrHkUo7XYjJ9iu+vyBtzuZ/VY=";
   };
 
-  postPatch = ''
-    sed -i 's/fsspec==.*/fsspec/' requirements.txt
-  '';
-
   buildInputs = [ docutils ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     aiobotocore
     aiohttp
     fsspec
   ];
 
-  # Depends on `moto` which has a long dependency chain with exact
-  # version requirements that can't be made to work with current
-  # pythonPackages.
-  doCheck = false;
-
   pythonImportsCheck = [ "s3fs" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    flask
+    flask-cors
+    moto
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # require network access
+    "test_async_close"
+  ];
+
+  meta = {
     description = "Pythonic file interface for S3";
     homepage = "https://github.com/fsspec/s3fs";
     changelog = "https://github.com/fsspec/s3fs/raw/${version}/docs/source/changelog.rst";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ teh ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ teh ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/fsspec/filesystem_spec/compare/refs/tags/2024.3.0...2024.10.0
Changelog: https://github.com/fsspec/filesystem_spec/raw/2024.10.0/docs/source/changelog.rst

Changelog: https://github.com/fsspec/s3fs/raw/2024.10.0/docs/source/changelog.rst
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
