### PR TITLE
rockbox-utility: 1.4.1 -> 1.5.1

### DIFF
--- a/pkgs/by-name/ro/rockbox-utility/package.nix
+++ b/pkgs/by-name/ro/rockbox-utility/package.nix
@@ -1,24 +1,35 @@
-{ lib
-, stdenv
-, fetchurl
-, cryptopp
-, libusb1
-, makeWrapper
-, pkg-config
-, qt5
-, withEspeak ? false, espeak ? null
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cryptopp,
+  cmake,
+  libusb1,
+  makeWrapper,
+  pkg-config,
+  qt5,
+  withEspeak ? false,
+  espeak ? null,
+  makeDesktopItem,
 }:
-
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation rec {
   pname = "rockbox-utility";
-  version = "1.4.1";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "https://download.rockbox.org/rbutil/source/RockboxUtility-v${version}-src.tar.bz2";
-    hash = "sha256-PhlJ+fNY4/Qjoc72zV9WO+kNqF5bZQuwOh4EpAJwqX4=";
+    hash = "sha256-guNO11a0d30RexPEAAQGIgV9W17zgTjZ/LNz/oUn4HM=";
   };
 
+  patches = [
+    (fetchurl {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-misc/rbutil/files/rbutil-1.5.1-cmake.patch";
+      sha256 = "sha256-rA5avWAb5F9A4SLaurGgMcBsRj0UjVrw7egup9/cNQg=";
+    })
+  ];
+
   nativeBuildInputs = [
+    cmake
     makeWrapper
     pkg-config
     qt5.qmake
@@ -30,32 +41,20 @@ stdenv.mkDerivation  rec {
     libusb1
     qt5.qtbase
     qt5.qttools
-  ]
-  ++ lib.optional withEspeak espeak;
+    qt5.qtmultimedia
+  ] ++ lib.optional withEspeak espeak;
 
-  postPatch = ''
-    sed -i rbutil/rbutilqt/rbutilqt.pro \
-        -e '/^lrelease.commands =/ s|$$\[QT_INSTALL_BINS\]/lrelease -silent|${lib.getDev qt5.qttools}/bin/lrelease|'
-  '';
-
-  preConfigure = ''
-    cd rbutil/rbutilqt
-    lrelease rbutilqt.pro
-  '';
-
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: libmkimxboot.a(elf.c.o):utils/imxtools/sbtools/misc.h:43: multiple definition of `g_nr_keys';
-  #     libmkimxboot.a(mkimxboot.c.o):utils/imxtools/sbtools/misc.h:43: first defined here
-  # TODO: try to remove with 1.5.1 update.
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  preConfigure = "cd utils";
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 RockboxUtility $out/bin/rockboxutility
-    ln -s $out/bin/rockboxutility $out/bin/RockboxUtility
-    wrapProgram $out/bin/rockboxutility \
+    install -Dm755 ../build/ipodpatcher $out/bin/ipodpatcher
+    install -Dm755 ../build/sansapatcher $out/bin/sansapatcher
+    install -Dm755 ../build/rbutilqt/RockboxUtility $out/bin/RockboxUtility
+    install -Dm644 ../../docs/logo/rockbox-clef.svg $out/share/icons/hicolor/scalable/apps/rockbox-clef.svg
+
+    wrapProgram $out/bin/RockboxUtility \
     ${lib.optionalString withEspeak ''
       --prefix PATH : ${espeak}/bin
     ''}
@@ -63,18 +62,26 @@ stdenv.mkDerivation  rec {
     runHook postInstall
   '';
 
-  # `make build/rcc/qrc_rbutilqt-lang.cpp` fails with
-  #      RCC: Error in 'rbutilqt-lang.qrc': Cannot find file 'lang/rbutil_cs.qm'
-  # Do not add `lrelease rbutilqt.pro` into preConfigure, otherwise `make lrelease`
-  # may clobber the files read by the parallel `make build/rcc/qrc_rbutilqt-lang.cpp`.
-  enableParallelBuilding = false;
+  desktopItems = [
+    (makeDesktopItem {
+      name = "RockboxUtility";
+      desktopName = "Rockbox Utility";
+      comment = "Automated installer tool for Rockbox";
+      icon = "rockbox-clef";
+      exec = "RockboxUtility";
+      categories = [ "Utility" ];
+    })
+  ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.rockbox.org";
     description = "Open source firmware for digital music players";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      AndersonTorres
+      j0hax
+    ];
     mainProgram = "RockboxUtility";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update Rockbox Utility to the latest version

Further changes:
-  I also took the opportunity to format the package expression according to nixfmt and https://github.com/NixOS/nixpkgs/issues/208242
- A lot of compile-time Stdenv workarounds from previous versions do not seem to be required anymore.
- The building of the package has changed a little; Cmake is now required.
- One patch from Gentoo is used, (the default source release includes other components apparently not required for core functionality)
- Added myself as a maintainer.
- [Rockbox Utility Changelog](https://www.rockbox.org/wiki/RockboxUtility#Change_Log)

This PR is currently a draft until I have the chance to test my package by installing Rockbox on real hardware with it (probably by Monday or Tuesday)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
