### PR TITLE
portmod: 2.6.2 -> 2.8.0

### DIFF
--- a/pkgs/by-name/po/portmod/package.nix
+++ b/pkgs/by-name/po/portmod/package.nix
@@ -1,18 +1,19 @@
-{ lib
-, bubblewrap
-, cacert
-, fetchFromGitLab
-, git
-, openmw
-, jre
-, perl
-, python3Packages
-, rustPlatform
-, fontconfig
-, freetype
-, libX11
-, harfbuzz
-, fribidi
+{
+  lib,
+  bubblewrap,
+  cacert,
+  fetchFromGitLab,
+  git,
+  openmw,
+  jre,
+  perl,
+  python3Packages,
+  rustPlatform,
+  fontconfig,
+  freetype,
+  libX11,
+  harfbuzz,
+  fribidi,
 }:
 
 let
@@ -96,9 +97,12 @@ python3Packages.buildPythonApplication {
     distutils
   ];
 
-  nativeCheckInputs = with python3Packages; [
-    pytestCheckHook
-  ] ++ bin-programs;
+  nativeCheckInputs =
+    with python3Packages;
+    [
+      pytestCheckHook
+    ]
+    ++ bin-programs;
 
   preCheck = ''
     cp ${portmod-rust}/lib/libportmod.so portmodlib/portmod.so
@@ -126,14 +130,15 @@ python3Packages.buildPythonApplication {
 
     makeWrapperArgs+=("--prefix" "GIT_SSL_CAINFO" ":" "${cacert}/etc/ssl/certs/ca-bundle.crt" \
       "--prefix" "PATH" ":" "${lib.makeBinPath bin-programs}" \
-      "--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath extra-libs }" \
+      "--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath extra-libs}" \
       "--set-default" "OPENMW_VERSION_FILE" "${openmw}/share/games/openmw/resources/version")
   '';
 
-  meta = with lib; {
+  meta = {
     description = "mod manager for openMW based on portage";
     homepage = "https://gitlab.com/portmod/portmod";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ marius851000 ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ marius851000 ];
+    mainProgram = "portmod";
   };
 }

--- a/pkgs/by-name/po/portmod/package.nix
+++ b/pkgs/by-name/po/portmod/package.nix
@@ -125,8 +125,9 @@ python3Packages.buildPythonApplication {
     cp ${portmod-rust}/lib/libportmod.so $out/${python3Packages.python.sitePackages}/portmodlib/portmod.so
 
     makeWrapperArgs+=("--prefix" "GIT_SSL_CAINFO" ":" "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      "--prefix" "PATH" ":" "${lib.makeBinPath bin-programs }" \
-      "--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath extra-libs }")
+      "--prefix" "PATH" ":" "${lib.makeBinPath bin-programs}" \
+      "--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath extra-libs }" \
+      "--set-default" "OPENMW_VERSION_FILE" "${openmw}/share/games/openmw/resources/version")
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updated to 2.8.0, and adapted change for the fact it now fetch some binaries (and their deps) from it’s own repo.

portmod-gui doesn’t work (but presumably didn’t previously too). This might be the subject of another PR.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

I see there is another already opened PR regarding this: https://github.com/NixOS/nixpkgs/pull/353046
only tried with openmw. I’ll update this PR with some idea from there. And make it run on my hydra. And update my hydra for portmod package CI ( at https://hydra.mariusdavid.fr/jobset/portmod/openmw-mods )

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
