### PR TITLE
supercollider: Enable darwin platform support

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, mkDerivation, fetchurl, cmake, runtimeShell
+{ lib, stdenv, mkDerivation, boost, fetchurl, cmake, runtimeShell
 , pkg-config, alsa-lib, libjack2, libsndfile, fftw
-, curl, gcc, libXt, qtbase, qttools, qtwebengine
+, curl, gcc, libXt, libyamlcpp, qtbase, qtmacextras, qttools, qtwebengine
 , readline, qtwebsockets, useSCEL ? false, emacs
 , gitUpdater, supercollider-with-plugins
 , supercolliderPlugins, writeText, runCommand
@@ -30,13 +30,21 @@ mkDerivation rec {
     ++ lib.optionals useSCEL [ emacs ];
 
   buildInputs = [ gcc libjack2 libsndfile fftw curl libXt qtbase qtwebengine qtwebsockets readline ]
-    ++ lib.optional (!stdenv.hostPlatform.isDarwin) alsa-lib;
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) alsa-lib
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ boost libyamlcpp qtmacextras ];
 
   hardeningDisable = [ "stackprotector" ];
 
   cmakeFlags = [
     "-DSC_WII=OFF"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DSYSTEM_BOOST=ON"
+    "-DSYSTEM_YAMLCPP=ON"
+    # FIXME: Enabling darwin support but with the IDE disabled due to
+    # `macdeployqt` segfault in `installPhase`.
+    # Remove this when attempting to get the IDE building on darwin.
+    "-DSC_IDE=OFF"
   ];
 
   passthru = {
@@ -67,12 +75,38 @@ mkDerivation rec {
     };
   };
 
+  # The darwin target doesn't install headers by default.
+  # We copy them during `preConfigure` as configure phase appears to rm them.
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/include
+    cp -r include $out/include/SuperCollider
+    cp SCVersion.txt $out/include/SuperCollider
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Move the `.app` into the conventional `Applications` directory.
+    mkdir -p $out/Applications
+    mkdir -p $out/share/SuperCollider
+    mv $out/SuperCollider/SuperCollider.app $out/Applications
+    mv $out/SuperCollider/examples $out/share/SuperCollider
+    rm -r $out/SuperCollider
+
+    # Make the plugins available under `lib` (where `SC_PLUGIN_DIR` expects them).
+    mkdir -p $out/lib/SuperCollider/plugins
+    ln -s $out/Applications/SuperCollider.app/Contents/Resources/plugins/* $out/lib/SuperCollider/plugins/
+
+    # Expose the `sclang` and `scsynth` bins from the `.app` on darwin.
+    mkdir -p $out/bin
+    ln -s $out/Applications/SuperCollider.app/Contents/MacOS/sclang $out/bin/sclang
+    ln -s $out/Applications/SuperCollider.app/Contents/Resources/scsynth $out/bin/scsynth
+  '';
+
   meta = with lib; {
     description = "Programming language for real time audio synthesis";
     homepage = "https://supercollider.github.io";
     changelog = "https://github.com/supercollider/supercollider/blob/Version-${version}/CHANGELOG.md";
-    maintainers = [ ];
+    maintainers = with maintainers; [ mitchmindtree ];
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = with platforms; darwin ++ linux;
   };
 }

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "https://supercollider.github.io/sc3-plugins/";
     maintainers = [ ];
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = with platforms; darwin ++ linux;
   };
 }


### PR DESCRIPTION
This enables the `darwin` platform for the `supercollider` package, making the main `SuperCollider` (IDE), `scsynth` and `sclang` CLI binaries available to macOS users. My main motivation is enabling darwin support in tidalcycles.nix

https://github.com/mitchmindtree/tidalcycles.nix

## Runtime Error (Help Wanted)

Currently I can build the package seemingly successfully, however when attempting to run the `SuperCollider` IDE executable it crashes with the following:

```
> nix run --print-build-logs .#supercollider
objc[36283]: Class QMacAutoReleasePoolTracker is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x10767d330) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11c2f5330). One of the two will be used. Which one is undefined.
objc[36283]: Class QT_ROOT_LEVEL_POOL__THESE_OBJECTS_WILL_BE_RELEASED_WHEN_QAPP_GOES_OUT_OF_SCOPE is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x10767d3a8) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11c2f53a8). One of the two will be used. Which one is undefined.
objc[36283]: Class KeyValueObserver is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x10767d3d0) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11c2f53d0). One of the two will be used. Which one is undefined.
objc[36283]: Class RunLoopModeTracker is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x10767d420) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11c2f5420). One of the two will be used. Which one is undefined.
objc[36283]: Class QCocoaPageLayoutDelegate is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5PrintSupport.5.dylib (0x104fe9188) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5PrintSupport.5.15.15.dylib (0x118045188). One of the two will be used. Which one is undefined.
objc[36283]: Class QCocoaPrintPanelDelegate is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5PrintSupport.5.dylib (0x104fe9200) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5PrintSupport.5.15.15.dylib (0x118045200). One of the two will be used. Which one is undefined.
QObject::moveToThread: Current thread (0x60000220c060) is not the object's thread (0x60000220c860).
Cannot move to target thread (0x60000220c060)

You might be loading two sets of Qt binaries into the same process. Check that all plugins are compiled against the right Qt binaries. Export DYLD_PRINT_LIBRARIES=1 and check that only one set of binaries are being loaded.
qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: cocoa, minimal, offscreen.

zsh: abort      nix run --print-build-logs .#supercollider
```

<details>
    <summary>Output with `DYLD_PRINT_LIBRARIES=1`</summary>

    ```
    > DYLD_PRINT_LIBRARIES=1 ./result/Applications/SuperCollider.app/Contents/MacOS/SuperCollider
    dyld[36356]: <975F1458-0B29-3813-979D-6A3A71E2F47B> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/MacOS/SuperCollider
    dyld[36356]: <56834D23-1BFF-310F-89FB-622D1F16A1BF> /usr/lib/libSystem.B.dylib
    dyld[36356]: <FEA038BA-CC59-3085-93B0-AB8437AA6CE2> /usr/lib/system/libcache.dylib
    dyld[36356]: <34AC4B05-E145-3C58-8C24-1190770EAB31> /usr/lib/system/libcommonCrypto.dylib
    dyld[36356]: <1D6552C4-49C4-374F-8371-198BCFC4174D> /usr/lib/system/libcompiler_rt.dylib
    dyld[36356]: <E61C2838-9EA2-33CE-B96B-85FF38DB7744> /usr/lib/system/libcopyfile.dylib
    dyld[36356]: <4A9F9101-A1B1-3FB7-89EA-746CFCE95099> /usr/lib/system/libcorecrypto.dylib
    dyld[36356]: <C2FD3094-B465-39A4-B774-16583FF53C4B> /usr/lib/system/libdispatch.dylib
    dyld[36356]: <A2947B47-B494-36D4-96C6-95977FFB51FB> /usr/lib/system/libdyld.dylib
    dyld[36356]: <C4512BA5-7CA3-30AE-9793-5CC5417F0FC3> /usr/lib/system/libkeymgr.dylib
    dyld[36356]: <91A88FDF-FD27-32AF-A2CE-70F7E4065C3B> /usr/lib/system/libmacho.dylib
    dyld[36356]: <A2D17FF6-CBC6-3D19-89E1-F5E57191E8A3> /usr/lib/system/libquarantine.dylib
    dyld[36356]: <2213EE66-253B-3234-AA4D-B46F07C3540E> /usr/lib/system/libremovefile.dylib
    dyld[36356]: <68D76774-F8B4-36EA-AA35-0AB4044D56C7> /usr/lib/system/libsystem_asl.dylib
    dyld[36356]: <5541DF62-A795-3F57-A54C-1AEC4DD3E44C> /usr/lib/system/libsystem_blocks.dylib
    dyld[36356]: <95A70E20-1DF3-3DDF-900C-315ED0B2C067> /usr/lib/system/libsystem_c.dylib
    dyld[36356]: <BEB9DE52-6F49-370A-B45B-CBE6780E7083> /usr/lib/system/libsystem_collections.dylib
    dyld[36356]: <121F8B4D-3939-300D-BE22-979D6B476361> /usr/lib/system/libsystem_configuration.dylib
    dyld[36356]: <7CE9526A-B673-363A-8905-71D080974C0E> /usr/lib/system/libsystem_containermanager.dylib
    dyld[36356]: <54BF691A-0908-3548-95F2-34CFD58E5617> /usr/lib/system/libsystem_coreservices.dylib
    dyld[36356]: <579733C7-851D-3B3E-83B5-FD203BA50D02> /usr/lib/system/libsystem_darwin.dylib
    dyld[36356]: <4EFF0147-928F-3321-8268-655FE71DC209> /usr/lib/system/libsystem_dnssd.dylib
    dyld[36356]: <5068382F-DC0F-3824-8ED5-18A24B35FEF9> /usr/lib/system/libsystem_featureflags.dylib
    dyld[36356]: <4448FB99-7B1D-3E15-B7EE-3340FF0DA88D> /usr/lib/system/libsystem_info.dylib
    dyld[36356]: <82E529F5-C4DF-3D42-9113-3A4F87FEF1A0> /usr/lib/system/libsystem_m.dylib
    dyld[36356]: <0AC99C6E-CB01-30E5-AB10-65AB990652A5> /usr/lib/system/libsystem_malloc.dylib
    dyld[36356]: <3B2CC4A9-A5EE-3627-8293-4AF4D891074E> /usr/lib/system/libsystem_networkextension.dylib
    dyld[36356]: <E4AA6E5F-2501-3382-BFB3-64464E6D8254> /usr/lib/system/libsystem_notify.dylib
    dyld[36356]: <99FDEFF2-36F1-3436-B8B2-DE0003B5A4BF> /usr/lib/system/libsystem_sandbox.dylib
    dyld[36356]: <E529D1AC-D20A-3308-9033-E1712A9C655E> /usr/lib/system/libsystem_secinit.dylib
    dyld[36356]: <34A49B54-82B2-37A1-9314-F6A4A2BB3FF8> /usr/lib/system/libsystem_kernel.dylib
    dyld[36356]: <F80C6971-C080-31F5-AB6E-BE01311154AF> /usr/lib/system/libsystem_platform.dylib
    dyld[36356]: <46D35233-A051-3F4F-BBA4-BA56DDDC4D1A> /usr/lib/system/libsystem_pthread.dylib
    dyld[36356]: <F9F1F4BE-D97F-37A7-8382-552C22DF1BB4> /usr/lib/system/libsystem_symptoms.dylib
    dyld[36356]: <3F3E75B7-F0A7-30BB-9FD7-FD1307FE6055> /usr/lib/system/libsystem_trace.dylib
    dyld[36356]: <E3BF7A76-2CBE-3DB9-8496-8BB6DBBE0CFC> /usr/lib/system/libunwind.dylib
    dyld[36356]: <F3F19227-FF8F-389C-A094-6F4C16E458AF> /usr/lib/system/libxpc.dylib
    dyld[36356]: <52AA13E2-567C-36C2-9494-7B892FDBF245> /usr/lib/libc++abi.dylib
    dyld[36356]: <5BEAFA2B-3AF4-3ED2-B054-1F58A7C851EF> /usr/lib/libobjc.A.dylib
    dyld[36356]: <FB664621-26AE-3F46-8F5A-DD5D890A5CE7> /usr/lib/liboah.dylib
    dyld[36356]: <54E8FBE1-DF0D-33A2-B8FA-356565C12929> /usr/lib/libc++.1.dylib
    dyld[36356]: <8D7CBF8E-0DE6-384C-86AC-21694C58AFCD> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/MacOS/.SuperCollider-wrapped
    dyld[36356]: <0602A6A0-0638-3EC3-9EDD-77FFE80BBC81> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Concurrent.5.dylib
    dyld[36356]: <17100CD8-380B-35BC-8332-6ED3FB7B5DC1> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5WebEngineWidgets.5.dylib
    dyld[36356]: <19C3D37B-38FB-3E3D-BD9C-0337AEAD04C4> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5WebEngineCore.5.dylib
    dyld[36356]: <DE06E6E6-084C-3AAD-B620-E543EF9C4F12> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5WebChannel.5.dylib
    dyld[36356]: <DC8558F2-C10E-3537-9683-AC1D8AE25248> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Positioning.5.dylib
    dyld[36356]: <40AC16BC-8F03-3F41-A46A-28BFCE751B9B> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Quick.5.dylib
    dyld[36356]: <3B287EE5-0F33-3644-832E-C48C48A0F3D7> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5QmlModels.5.dylib
    dyld[36356]: <2D2172D7-924C-30AE-8E36-5C510A1618E4> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Qml.5.dylib
    dyld[36356]: <73A9DB10-6438-3ACD-9435-E68CBE47FF36> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5PrintSupport.5.dylib
    dyld[36356]: <AF71DCB9-AC56-3830-8622-A05B9C57B070> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Widgets.5.dylib
    dyld[36356]: <9762697A-1BFE-313E-B4D8-8960FA77B5A6> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Gui.5.dylib
    dyld[36356]: <EE42F9E2-C422-3D2B-BCCD-B099A65C4EFF> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5WebSockets.5.dylib
    dyld[36356]: <24745035-5D83-31A9-8EB9-4ACE57FE841A> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Network.5.dylib
    dyld[36356]: <306C75E2-418F-3767-B1F1-CB2F843E6700> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib
    dyld[36356]: <29DF1886-C6E9-3B16-A1FB-7E6552B7EF08> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libyaml-cpp.0.8.dylib
    dyld[36356]: <62DEC0D4-DB4E-3D1F-8479-43593A9D7194> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libboost_system.dylib
    dyld[36356]: <DEF00C67-E993-358B-AF89-381A0EFE7D89> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libboost_filesystem.dylib
    dyld[36356]: <C47EC699-410A-3B6E-83D5-C9799164DB8A> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libc++.1.0.dylib
    dyld[36356]: <369631C6-BC26-399A-9B9B-E516CE16B411> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libintl.8.dylib
    dyld[36356]: <FC18D34F-66E8-3345-9311-DF7D224E57AC> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libz.dylib
    dyld[36356]: <848089F7-5B79-3FB5-A5CF-D9461A2EEEF0> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libicui18n.74.2.dylib
    dyld[36356]: <40BB0E3F-6BE4-3050-8A34-05FA71C479C5> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libicuuc.74.2.dylib
    dyld[36356]: <FEEBB38F-1098-30BE-9DE6-EEB2BC943323> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libicudata.74.2.dylib
    dyld[36356]: <EFDB1A2F-25BB-352C-83E5-1D0077057591> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libpcre2-16.0.dylib
    dyld[36356]: <C058E1DB-8E26-33DF-8B30-81996C47A8EF> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libzstd.1.5.6.dylib
    dyld[36356]: <84DC2126-A3B4-390C-BC92-6A2AF3B80340> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libgthread-2.0.0.dylib
    dyld[36356]: <99479E2E-6144-3523-A329-136EDECF8D30> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libglib-2.0.0.dylib
    dyld[36356]: <0270F40C-070E-35CA-8AB6-E9787D156322> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    dyld[36356]: <203E4401-8C2E-3157-A24B-92F52551D43E> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    dyld[36356]: <5299A9D2-E26E-3368-AD3A-A0A1ECCC0310> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    dyld[36356]: <EACF1749-882E-30E2-9965-D8AFAE0C7127> /System/Library/Frameworks/Security.framework/Versions/A/Security
    dyld[36356]: <56834D23-1BFF-310F-89FB-622D1F16A1BF> /usr/lib/libSystem.B.dylib
    dyld[36356]: <5BEAFA2B-3AF4-3ED2-B054-1F58A7C851EF> /usr/lib/libobjc.A.dylib
    dyld[36356]: <DC429505-F838-3D6D-9B03-5A826EFE86A4> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    dyld[36356]: <FB664621-26AE-3F46-8F5A-DD5D890A5CE7> /usr/lib/liboah.dylib
    dyld[36356]: <6B73638E-12CE-3F14-8013-7E2A4FB15038> /usr/lib/libfakelink.dylib
    dyld[36356]: <ECD01450-C5B1-3E4E-973B-C3D9C66582AF> /usr/lib/libicucore.A.dylib
    dyld[36356]: <967060A4-534B-3795-B350-B7C1B6254A53> /System/Library/PrivateFrameworks/SoftLinking.framework/Versions/A/SoftLinking
    dyld[36356]: <52AA13E2-567C-36C2-9494-7B892FDBF245> /usr/lib/libc++abi.dylib
    dyld[36356]: <54E8FBE1-DF0D-33A2-B8FA-356565C12929> /usr/lib/libc++.1.dylib
    dyld[36356]: <FEA038BA-CC59-3085-93B0-AB8437AA6CE2> /usr/lib/system/libcache.dylib
    dyld[36356]: <34AC4B05-E145-3C58-8C24-1190770EAB31> /usr/lib/system/libcommonCrypto.dylib
    dyld[36356]: <1D6552C4-49C4-374F-8371-198BCFC4174D> /usr/lib/system/libcompiler_rt.dylib
    dyld[36356]: <E61C2838-9EA2-33CE-B96B-85FF38DB7744> /usr/lib/system/libcopyfile.dylib
    dyld[36356]: <4A9F9101-A1B1-3FB7-89EA-746CFCE95099> /usr/lib/system/libcorecrypto.dylib
    dyld[36356]: <C2FD3094-B465-39A4-B774-16583FF53C4B> /usr/lib/system/libdispatch.dylib
    dyld[36356]: <A2947B47-B494-36D4-96C6-95977FFB51FB> /usr/lib/system/libdyld.dylib
    dyld[36356]: <C4512BA5-7CA3-30AE-9793-5CC5417F0FC3> /usr/lib/system/libkeymgr.dylib
    dyld[36356]: <91A88FDF-FD27-32AF-A2CE-70F7E4065C3B> /usr/lib/system/libmacho.dylib
    dyld[36356]: <A2D17FF6-CBC6-3D19-89E1-F5E57191E8A3> /usr/lib/system/libquarantine.dylib
    dyld[36356]: <2213EE66-253B-3234-AA4D-B46F07C3540E> /usr/lib/system/libremovefile.dylib
    dyld[36356]: <68D76774-F8B4-36EA-AA35-0AB4044D56C7> /usr/lib/system/libsystem_asl.dylib
    dyld[36356]: <5541DF62-A795-3F57-A54C-1AEC4DD3E44C> /usr/lib/system/libsystem_blocks.dylib
    dyld[36356]: <95A70E20-1DF3-3DDF-900C-315ED0B2C067> /usr/lib/system/libsystem_c.dylib
    dyld[36356]: <BEB9DE52-6F49-370A-B45B-CBE6780E7083> /usr/lib/system/libsystem_collections.dylib
    dyld[36356]: <121F8B4D-3939-300D-BE22-979D6B476361> /usr/lib/system/libsystem_configuration.dylib
    dyld[36356]: <7CE9526A-B673-363A-8905-71D080974C0E> /usr/lib/system/libsystem_containermanager.dylib
    dyld[36356]: <54BF691A-0908-3548-95F2-34CFD58E5617> /usr/lib/system/libsystem_coreservices.dylib
    dyld[36356]: <579733C7-851D-3B3E-83B5-FD203BA50D02> /usr/lib/system/libsystem_darwin.dylib
    dyld[36356]: <4EFF0147-928F-3321-8268-655FE71DC209> /usr/lib/system/libsystem_dnssd.dylib
    dyld[36356]: <5068382F-DC0F-3824-8ED5-18A24B35FEF9> /usr/lib/system/libsystem_featureflags.dylib
    dyld[36356]: <4448FB99-7B1D-3E15-B7EE-3340FF0DA88D> /usr/lib/system/libsystem_info.dylib
    dyld[36356]: <82E529F5-C4DF-3D42-9113-3A4F87FEF1A0> /usr/lib/system/libsystem_m.dylib
    dyld[36356]: <0AC99C6E-CB01-30E5-AB10-65AB990652A5> /usr/lib/system/libsystem_malloc.dylib
    dyld[36356]: <3B2CC4A9-A5EE-3627-8293-4AF4D891074E> /usr/lib/system/libsystem_networkextension.dylib
    dyld[36356]: <E4AA6E5F-2501-3382-BFB3-64464E6D8254> /usr/lib/system/libsystem_notify.dylib
    dyld[36356]: <99FDEFF2-36F1-3436-B8B2-DE0003B5A4BF> /usr/lib/system/libsystem_sandbox.dylib
    dyld[36356]: <E529D1AC-D20A-3308-9033-E1712A9C655E> /usr/lib/system/libsystem_secinit.dylib
    dyld[36356]: <34A49B54-82B2-37A1-9314-F6A4A2BB3FF8> /usr/lib/system/libsystem_kernel.dylib
    dyld[36356]: <F80C6971-C080-31F5-AB6E-BE01311154AF> /usr/lib/system/libsystem_platform.dylib
    dyld[36356]: <46D35233-A051-3F4F-BBA4-BA56DDDC4D1A> /usr/lib/system/libsystem_pthread.dylib
    dyld[36356]: <F9F1F4BE-D97F-37A7-8382-552C22DF1BB4> /usr/lib/system/libsystem_symptoms.dylib
    dyld[36356]: <3F3E75B7-F0A7-30BB-9FD7-FD1307FE6055> /usr/lib/system/libsystem_trace.dylib
    dyld[36356]: <E3BF7A76-2CBE-3DB9-8496-8BB6DBBE0CFC> /usr/lib/system/libunwind.dylib
    dyld[36356]: <F3F19227-FF8F-389C-A094-6F4C16E458AF> /usr/lib/system/libxpc.dylib
    dyld[36356]: <C10A5C6A-B4A3-3457-89A6-081585D72C7E> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    dyld[36356]: <D18937A2-3F28-328F-BCEB-9B6F0C750EB7> /usr/lib/libDiagnosticMessagesClient.dylib
    dyld[36356]: <CFB7A795-FC64-3585-BEC5-482F44C873E4> /usr/lib/libenergytrace.dylib
    dyld[36356]: <E0D4F1CD-2193-38F1-9049-E4A5D5558D3A> /usr/lib/libbsm.0.dylib
    dyld[36356]: <80F58A75-B306-353B-BF77-1382A792D3E7> /usr/lib/libz.1.dylib
    dyld[36356]: <F111EBE9-5F2C-399B-884F-0F2E911F6FEC> /usr/lib/system/libkxld.dylib
    dyld[36356]: <0E79CB17-3EA4-33F7-8589-DA01432AFDE4> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    dyld[36356]: <B44C0B34-8C7B-31F9-AF20-6FDF4B2E85CB> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    dyld[36356]: <5890DA87-2C6B-3798-9F72-D90D8716739A> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    dyld[36356]: <28095504-F2C8-3B94-A13E-DD7976B28EFA> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    dyld[36356]: <D072219B-86C7-34B3-8813-74CE741CFF73> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    dyld[36356]: <76F7D8FD-A9B2-353E-A1C2-81DFC1429B17> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    dyld[36356]: <5CDA7016-E781-3E53-961C-4978B61C2DF1> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    dyld[36356]: <556590F5-8FED-36A6-830B-EA49BD95B1FE> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    dyld[36356]: <7A18189D-E039-3A2A-9251-821AA96A7265> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    dyld[36356]: <DDAD0141-3797-3195-B0F1-8CE28609A7C5> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    dyld[36356]: <CEBC104B-395E-3A6E-B588-CB44BF2B907E> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    dyld[36356]: <71BA43A4-8EA5-34EA-AAB9-A5F4F0538E09> /usr/lib/libapple_nghttp2.dylib
    dyld[36356]: <5F4D482C-9AE0-39BE-B4F2-14E6FB91A396> /usr/lib/libcompression.dylib
    dyld[36356]: <05EAE86F-3A19-3B84-B389-B528453863E5> /usr/lib/libnetwork.dylib
    dyld[36356]: <710E4989-2656-3774-8114-0C2936A8FC33> /usr/lib/libsqlite3.dylib
    dyld[36356]: <D5337CC6-A075-3CA0-B5BF-B49DA8878337> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    dyld[36356]: <F62B9AAC-1492-3A32-A6BF-77F8C26A0262> /System/Library/Frameworks/Network.framework/Versions/A/Network
    dyld[36356]: <751353A3-EABC-3B52-B450-CF57A8D18C46> /usr/lib/libCoreEntitlements.dylib
    dyld[36356]: <800749B8-32C8-3B55-A949-11AF54B4A897> /System/Library/PrivateFrameworks/MessageSecurity.framework/Versions/A/MessageSecurity
    dyld[36356]: <E864483F-DC34-3E95-A004-F8CA0BB17AB3> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
    dyld[36356]: <47EC7C0A-9667-375E-BB9F-04028D6D518E> /usr/lib/libMobileGestalt.dylib
    dyld[36356]: <35EAC215-5E89-3E4D-950C-12AA9431E050> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    dyld[36356]: <6F05EEBE-D184-3328-95EA-2875FBF41494> /usr/lib/libcoretls.dylib
    dyld[36356]: <39D837D9-29DE-38B1-8EF4-2E90DCF2BB38> /usr/lib/libcoretls_cfhelpers.dylib
    dyld[36356]: <CD3ADB84-518E-3D61-AC4F-7FF5D2062A15> /usr/lib/libpam.2.dylib
    dyld[36356]: <093F5DAE-3AFF-35E3-8610-181D07A862E5> /usr/lib/libxar.1.dylib
    dyld[36356]: <F1BE0781-EDDF-3599-92F5-723C88C2110C> /System/Library/PrivateFrameworks/CoreAutoLayout.framework/Versions/A/CoreAutoLayout
    dyld[36356]: <DE2B20B1-4AA9-30E0-9F98-9508C814081F> /usr/lib/libarchive.2.dylib
    dyld[36356]: <68CB4305-30E2-38C3-B1DB-276947869EE7> /usr/lib/libxml2.2.dylib
    dyld[36356]: <F0BA5B75-8FA1-3811-8D2E-59262915142D> /usr/lib/liblangid.dylib
    dyld[36356]: <647B4DF3-2E19-30F9-A4D4-D9CFFACCD880> /System/Library/Frameworks/Combine.framework/Versions/A/Combine
    dyld[36356]: <5285709C-F140-3A18-95FF-AB77B12DC473> /usr/lib/swift/libswiftCore.dylib
    dyld[36356]: <9836BB91-759F-341E-930C-2323DB4A7400> /usr/lib/swift/libswiftCoreFoundation.dylib
    dyld[36356]: <28572C4D-7D27-3457-A7DF-A921F03A9CEE> /usr/lib/swift/libswiftDarwin.dylib
    dyld[36356]: <E504BB5B-2325-3872-BDF3-17FF4ECBB53F> /usr/lib/swift/libswiftDispatch.dylib
    dyld[36356]: <BA9AB50B-500E-3F4E-827E-C5C463049A4D> /usr/lib/swift/libswiftIOKit.dylib
    dyld[36356]: <23EE9423-4652-3832-976F-8487C6CEDC06> /usr/lib/swift/libswiftObjectiveC.dylib
    dyld[36356]: <531D3F74-E5DC-3607-82D7-8A5FAD2DC558> /usr/lib/swift/libswiftXPC.dylib
    dyld[36356]: <A60D651E-1F8B-35B9-A760-F4E4B0647F32> /usr/lib/swift/libswift_Concurrency.dylib
    dyld[36356]: <1BCD41D4-42FD-3F7B-953B-41F7E8ABE164> /usr/lib/swift/libswift_StringProcessing.dylib
    dyld[36356]: <0F40167B-099D-3A6C-B206-8B9001B703DE> /usr/lib/swift/libswiftos.dylib
    dyld[36356]: <AE83BFA8-7E57-30A5-BCF9-AE97636D081E> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
    dyld[36356]: <7AC531B7-05F5-38FE-92E5-DA6D86D22A14> /System/Library/PrivateFrameworks/IOMobileFramebuffer.framework/Versions/A/IOMobileFramebuffer
    dyld[36356]: <2B44B850-7D19-34F3-AB8E-A3B93016A96D> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    dyld[36356]: <C5324546-A0FB-3C4E-9D22-8420306E2A4D> /usr/lib/libpcap.A.dylib
    dyld[36356]: <392039AF-BE63-3655-92FA-410FA8426484> /usr/lib/libdns_services.dylib
    dyld[36356]: <D0CF8623-5E85-35D2-8ABA-8A7F0002AB0A> /usr/lib/liblzma.5.dylib
    dyld[36356]: <C8BCFB5B-3E58-3658-B079-0C9CA979FC98> /usr/lib/libbz2.1.0.dylib
    dyld[36356]: <567709E5-6109-35A8-9E7E-C31E7A3D7CB4> /usr/lib/libiconv.2.dylib
    dyld[36356]: <CC9C48D2-201B-3DA7-B514-9CC91573C12A> /usr/lib/libcharset.1.dylib
    dyld[36356]: <8F897DC0-916E-3EA6-B262-36F07EE2729D> /usr/lib/swift/libswift_RegexParser.dylib
    dyld[36356]: <4173E692-98C1-3AE5-8180-6CB85553FF9B> /usr/lib/libheimdal-asn1.dylib
    dyld[36356]: <0B996757-0E56-3173-B9B9-B1542197046A> /usr/lib/libCheckFix.dylib
    dyld[36356]: <1238D7CA-719A-36A4-94B1-2F387E6B3BF1> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    dyld[36356]: <07DB6A99-E7A7-333A-B168-2E9189F0273E> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    dyld[36356]: <0B7F36BF-AFD9-38FC-AA39-090B56C0DE1B> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    dyld[36356]: <56DB5D71-E187-36CD-B890-FA9FC308642B> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    dyld[36356]: <2F149984-9314-3397-9133-8CB60600A3FF> /usr/lib/libmecab.dylib
    dyld[36356]: <B11A2474-53A7-3E6D-A864-05771AA7E609> /usr/lib/libCRFSuite.dylib
    dyld[36356]: <0A6097EB-20DE-31EA-AE8B-817F568FEF15> /usr/lib/libgermantok.dylib
    dyld[36356]: <F7004859-1B05-3569-9348-8A6008C3DE2D> /usr/lib/libThaiTokenizer.dylib
    dyld[36356]: <1A7D6863-4320-3E32-AF39-10A49D20DC85> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    dyld[36356]: <F5957B1E-039A-3004-8465-5E94E991DACB> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    dyld[36356]: <6338DDBB-28CB-36D6-ACC1-EABD87B83DA9> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    dyld[36356]: <D0B58FC0-4581-3D65-A013-25C0E1EF9638> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    dyld[36356]: <21906AC0-A134-3B6E-A280-3B34B5108159> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    dyld[36356]: <C289597C-737B-358A-ABDF-D8FAFD44103B> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    dyld[36356]: <4B306B37-EE56-3B18-B1D7-D5C1686C1986> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    dyld[36356]: <B1AAE316-1897-3ECB-8987-FA21BBD40EFD> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    dyld[36356]: <C318A15E-2D13-367B-B5B0-65BB3114A2F1> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    dyld[36356]: <73DB6CA3-038A-3B12-917A-24D9E843CA75> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    dyld[36356]: <7EA4D2F0-4D87-3A43-9999-FA92FD7E9695> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    dyld[36356]: <0E29645B-8970-3B56-9028-A32FE25BA3A5> /System/Library/PrivateFrameworks/MIL.framework/Versions/A/MIL
    dyld[36356]: <D08A1016-6A66-3BD1-A3F3-67567D3F5D43> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    dyld[36356]: <84D7F13A-B6B7-3AD4-B791-12A49E8EFBE6> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    dyld[36356]: <0C6501C8-65D4-32F6-810C-C0B83D2A2A39> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    dyld[36356]: <F7338D13-C97A-3088-B73A-2F9110ED155D> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    dyld[36356]: <2BE0C5BF-AB2E-3262-93B8-76C37EE213CE> /usr/lib/libutil.dylib
    dyld[36356]: <3BFA5169-F09E-3471-972B-9077F20253CF> /System/Library/PrivateFrameworks/InstalledContentLibrary.framework/Versions/A/InstalledContentLibrary
    dyld[36356]: <DC0F826F-29E8-3E40-8B5A-7838CD4A6BEF> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
    dyld[36356]: <7F84860B-C9A6-3FC5-A0A1-8859597F4B70> /usr/lib/libapp_launch_measurement.dylib
    dyld[36356]: <192386A4-74DC-37B3-BE79-B505FABB4AAE> /System/Library/PrivateFrameworks/AppleMobileFileIntegrity.framework/Versions/A/AppleMobileFileIntegrity
    dyld[36356]: <6A0A6312-0EB6-3F26-944E-D5B0AFD83ABF> /usr/lib/libmis.dylib
    dyld[36356]: <9A738073-064B-3DC5-892B-A1C071433FD8> /System/Library/PrivateFrameworks/MobileSystemServices.framework/Versions/A/MobileSystemServices
    dyld[36356]: <75A1B8E0-F913-33B4-AF2D-41689C99118B> /System/Library/PrivateFrameworks/ConfigProfileHelper.framework/Versions/A/ConfigProfileHelper
    dyld[36356]: <9B506B48-201C-3617-B175-F4FF5CCD0F29> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
    dyld[36356]: <3DE8B7BC-B0C6-3A0B-AE03-C03A9ADE6F0B> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    dyld[36356]: <17112FFD-38B7-3AE0-8BA8-712F411881B3> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    dyld[36356]: <19527623-6844-3A3B-8834-22756E61B643> /usr/lib/libxslt.1.dylib
    dyld[36356]: <33C650BD-34BB-3EB0-9D53-5088A9923E25> /usr/lib/libcmph.dylib
    dyld[36356]: <54E4C718-1890-3946-B184-20D752443718> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    dyld[36356]: <8FEA83FA-B740-365A-9B86-58387AB35FA0> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    dyld[36356]: <E05E8F32-5625-3856-92E6-A3883ED6D471> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    dyld[36356]: <AEA11273-BFDB-37A4-8244-9D973CCF15D9> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    dyld[36356]: <E2CBFE03-3A04-37F9-99D3-E96E5D8D5666> /usr/lib/libTLE.dylib
    dyld[36356]: <041C7D21-21CC-3EEA-AE53-D39F5CA6A24E> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    dyld[36356]: <5C5F174F-9495-3750-A861-70081D5A14A5> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
    dyld[36356]: <A427F7C3-D06C-3F7B-8B2C-4EA89B5FF64D> /System/Library/PrivateFrameworks/CollectionViewCore.framework/Versions/A/CollectionViewCore
    dyld[36356]: <562C5A17-92E9-330B-B887-A9DC78ECFA3A> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    dyld[36356]: <C60C26EE-4246-365C-A7DF-5C28604AD42A> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
    dyld[36356]: <10CF1690-1739-3FDE-A149-8D1732978BE6> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
    dyld[36356]: <0FD0F6DB-F243-3148-8620-F4B17FA81072> /System/Library/PrivateFrameworks/UserActivity.framework/Versions/A/UserActivity
    dyld[36356]: <08A8DE1C-A402-3D20-93B0-043EC6EE3813> /System/Library/PrivateFrameworks/WindowManagement.framework/Versions/A/WindowManagement
    dyld[36356]: <A4A8EC55-1A9A-394D-9C23-089BB025E2AE> /usr/lib/libspindump.dylib
    dyld[36356]: <198098B2-9212-30A4-BDE3-9CCB49B56356> /System/Library/Frameworks/UniformTypeIdentifiers.framework/Versions/A/UniformTypeIdentifiers
    dyld[36356]: <942AA4B8-655F-3E1E-8DE6-FF9E86BF9AE9> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    dyld[36356]: <2BAB169C-42DA-36E3-955A-F30B709EC2AD> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    dyld[36356]: <FB9B58CB-684A-328B-A23F-246B2ECBE18D> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
    dyld[36356]: <96676A53-B1E0-3D7E-B98B-B73873CD1880> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
    dyld[36356]: <FDC3C9F5-51DB-3AC8-81DA-CC9E19958B29> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    dyld[36356]: <1D606610-E39F-3BE7-A402-256E7D3FB765> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    dyld[36356]: <C577D979-1DC2-3E84-AD8E-CE237E835BAF> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    dyld[36356]: <4DCAD3E0-31FE-38CB-8E2B-39C62DB97E14> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
    dyld[36356]: <BEF3C5CF-2A8D-3FED-8859-E9E4AEB84FA4> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    dyld[36356]: <8FB60F12-0967-39E9-B3DE-DAE5F9767E01> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    dyld[36356]: <BFC8E3A0-B97E-30E1-97C3-368307BDD562> /System/Library/PrivateFrameworks/TextInput.framework/Versions/A/TextInput
    dyld[36356]: <D800278B-4E6C-3032-B56F-027A938A51D6> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    dyld[36356]: <CF853BBD-01B6-3F46-ADA1-EC70FD2DC9DC> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    dyld[36356]: <F83CFC18-B5D6-3D37-960B-66CE9B118152> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    dyld[36356]: <1A566282-B444-3F61-B250-59E0681D30B7> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    dyld[36356]: <4C6D842E-31F6-30CA-984E-6281D387FE72> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    dyld[36356]: <83D12FA6-0922-3461-9CBC-9B705828B846> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    dyld[36356]: <0A74EAE0-B22B-3EF5-8747-AD668E073503> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    dyld[36356]: <B37B4068-1E62-30D0-AF3E-DD1A3C1AC2CB> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    dyld[36356]: <BD12C6EA-F028-3ADB-83E3-B954D80095E5> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
    dyld[36356]: <A2D85652-F36F-3185-93A4-8A413994404C> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
    dyld[36356]: <780B768C-4B54-36C3-AC8E-9D6138C86592> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
    dyld[36356]: <0A16ED1B-C27C-362B-B868-B199EF5AD2F7> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    dyld[36356]: <F474EB8C-596A-39DE-AF02-E14E2459274E> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    dyld[36356]: <00220615-3226-3C76-8FF7-129C02E5C0AF> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
    dyld[36356]: <CC3D100A-F59B-3AB7-90D8-617B22643512> /usr/lib/libate.dylib
    dyld[36356]: <5EA31AB4-5413-38B4-BA31-F802E9A003C6> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
    dyld[36356]: <17A30CCE-FF07-3D11-803C-4DF88E8A5265> /usr/lib/libexpat.1.dylib
    dyld[36356]: <411F2DDB-D104-3556-906D-2431EF373C28> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    dyld[36356]: <152A482C-B51E-3E94-B0A8-91C8FD177A78> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    dyld[36356]: <DDC789C7-6BC9-3231-98F1-B847E07ABD7D> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    dyld[36356]: <075720A6-E6B1-3172-880B-B0750121F627> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    dyld[36356]: <8B55537E-657B-3CF5-84BC-2967EB367245> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    dyld[36356]: <3B154AEA-01FA-3517-B595-CAF88E2B0656> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    dyld[36356]: <E72D838D-6B86-3756-8C6F-3743B45D135D> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
    dyld[36356]: <AAF3F8D3-CAF8-331B-9268-4E5A50B85247> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
    dyld[36356]: <EFF13F2D-1DFC-3BB5-AAA3-1701BB07FD4B> /System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/Versions/A/IOSurfaceAccelerator
    dyld[36356]: <26D9D5E9-E9BB-327E-9ECC-3341A164BFD7> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
    dyld[36356]: <D2BEF1C5-2028-369B-BF5F-C7E0C962662B> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
    dyld[36356]: <7A87E668-9ED8-3B36-8ED3-23305CB791C0> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
    dyld[36356]: <0A7853CE-21E3-33F9-9940-D9B0F7BD9A4A> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    dyld[36356]: <23A7C243-4552-3F81-B4F7-B9723EE40A45> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    dyld[36356]: <3666089A-6A28-381B-A69C-98E10867598B> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    dyld[36356]: <B060C5C6-0C27-30E7-A378-A79C1F9D73EA> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
    dyld[36356]: <F90AF017-14E4-3342-B9CA-6C08072405DC> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
    dyld[36356]: <9088F5DF-F41E-3324-878C-7C40C5F064FD> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
    dyld[36356]: <FDE4E3A0-490C-3462-823A-C9455D43367B> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
    dyld[36356]: <1CD33E61-B20E-37D0-BF4C-9C313440900F> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
    dyld[36356]: <78E06653-715E-36E1-A49A-C9104A0A1032> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/31001/Libraries/libllvm-flatbuffers.dylib
    dyld[36356]: <75A8B838-5345-3BC0-B200-E32FB8BC8554> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
    dyld[36356]: <10F90176-A9F4-3536-9248-2AB007A04970> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/31001/Libraries/libGPUCompilerUtils.dylib
    dyld[36356]: <71DE8CFA-A377-3B68-8EF8-D197197DFC00> /System/Library/PrivateFrameworks/CMCaptureCore.framework/Versions/A/CMCaptureCore
    dyld[36356]: <740D9B87-0CC4-38DA-8C8F-23F866BA0A00> /System/Library/Frameworks/ExtensionFoundation.framework/Versions/A/ExtensionFoundation
    dyld[36356]: <E2377CCA-A763-3AD9-964E-F7FCC6C1B8BC> /System/Library/PrivateFrameworks/CoreTime.framework/Versions/A/CoreTime
    dyld[36356]: <63AF4E94-1463-30AC-90BC-EA13FB2B8F56> /System/Library/PrivateFrameworks/AppServerSupport.framework/Versions/A/AppServerSupport
    dyld[36356]: <9E89D0BC-6941-39BD-A400-987EE4AF7288> /System/Library/PrivateFrameworks/perfdata.framework/Versions/A/perfdata
    dyld[36356]: <B130545C-372F-3AC3-873D-7C4036801345> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
    dyld[36356]: <D793971D-25BE-323D-83A4-CC72FADAFE8D> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
    dyld[36356]: <47357360-75D2-37ED-BEB3-4F7DC8D17755> /usr/lib/libAudioStatistics.dylib
    dyld[36356]: <B7C0C806-ACCA-3C98-94D4-C6E8283FACDC> /System/Library/PrivateFrameworks/SystemPolicy.framework/Versions/A/SystemPolicy
    dyld[36356]: <F6CC5D1E-7EE4-31E1-96AA-C7F6B89E5B98> /usr/lib/libSMC.dylib
    dyld[36356]: <73C9204E-07EF-3E4D-8401-3516BFC38586> /System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI
    dyld[36356]: <6D8A1FFD-3BD6-3050-8D96-CDFE68EB973C> /usr/lib/libAudioToolboxUtility.dylib
    dyld[36356]: <A4BDFF57-307A-38D3-A7B6-BC9F9C944AA0> /System/Library/PrivateFrameworks/OSAServicesClient.framework/Versions/A/OSAServicesClient
    dyld[36356]: <084992D4-46BD-362E-9B53-15CFE3CB153F> /usr/lib/libperfcheck.dylib
    dyld[36356]: <6722746E-C383-35A7-84AA-F035AE585DAF> /System/Library/PrivateFrameworks/PlugInKit.framework/Versions/A/PlugInKit
    dyld[36356]: <59764C2E-46C0-30FB-B077-1861BCF6A13A> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
    dyld[36356]: <4C7DD63C-6B9E-3F8F-9F2F-7D1949DD94C0> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    dyld[36356]: <B6E4D423-0EEF-3DFD-AFC5-4E4EE680D52B> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    dyld[36356]: <29942D11-A1DC-33A3-8F20-B57ABA0D925D> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    dyld[36356]: <333E34E8-D0AD-3BA8-859F-C9E49E2B3BF3> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    dyld[36356]: <F79C4C41-AA2F-39A1-8719-642DD101BE22> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    dyld[36356]: <FB664621-26AE-3F46-8F5A-DD5D890A5CE7> /usr/lib/libRosetta.dylib
    dyld[36356]: <D10AE90B-B0E0-3A07-B6AC-78EE8A940526> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    dyld[36356]: <315E13C7-26D8-3553-B717-53AC0D0551BA> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSCore.framework/Versions/A/MPSCore
    dyld[36356]: <96288960-0947-39B4-A0C8-D15D21279024> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSImage.framework/Versions/A/MPSImage
    dyld[36356]: <BDB06F82-0AF0-33AC-B92D-A0124C345C6D> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    dyld[36356]: <5A6C9771-2CC0-3B76-98D4-6607883B9538> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    dyld[36356]: <38E41677-8870-3348-8F2A-4D85912E7572> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    dyld[36356]: <2DAA4967-9285-3E4C-84B9-655E0D74D77C> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
    dyld[36356]: <D3E130C6-EDB3-3020-A156-D18220717064> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSFunctions.framework/Versions/A/MPSFunctions
    dyld[36356]: <254E6227-786F-37A6-9931-387244AB5F9A> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    dyld[36356]: <710CC45C-FCEE-3D94-8EE9-A446E1532B8E> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    dyld[36356]: <13E3F4E9-9B2A-38A4-89F8-AD2095F52B72> /usr/lib/libIOReport.dylib
    dyld[36356]: <462D4F65-60CB-3D47-B960-FD29C45EB1EA> /System/Library/PrivateFrameworks/ASEProcessing.framework/Versions/A/ASEProcessing
    dyld[36356]: <2A3A90EF-B178-3C59-98EB-666C6A1BE544> /System/Library/PrivateFrameworks/PhotosensitivityProcessing.framework/Versions/A/PhotosensitivityProcessing
    dyld[36356]: <77E72764-8F14-342E-A33C-1AA3588A24F9> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
    dyld[36356]: <82C05A20-2C8B-30CA-9F1F-8AA0C73525E7> /System/Library/PrivateFrameworks/FontServices.framework/Versions/A/FontServices
    dyld[36356]: <B6CCF813-86C2-3E9B-A5E8-CDBAC9DAFD05> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
    dyld[36356]: <1AE72D0F-73B0-3A9D-8D8E-D5140F037741> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    dyld[36356]: <483DEB04-F841-3EEF-9F11-52D32721E2E1> /System/Library/PrivateFrameworks/FontServices.framework/libhvf.dylib
    dyld[36356]: <E377092A-9CBD-380E-AA5D-9878E5A4E6FB> /System/Library/PrivateFrameworks/FontServices.framework/libXTFontStaticRegistryData.dylib
    dyld[36356]: <D9532F3F-8DE9-3947-9315-0EDC29F93891> /usr/lib/swift/libswiftMetal.dylib
    dyld[36356]: <337BEB90-AF70-36BA-B683-9C3382B24653> /usr/lib/swift/libswiftsimd.dylib
    dyld[36356]: <D59E4582-E2E9-3A04-8240-06357816903C> /System/Library/PrivateFrameworks/VideoToolboxParavirtualizationSupport.framework/Versions/A/VideoToolboxParavirtualizationSupport
    dyld[36356]: <FE89E886-CDB0-3CAF-979A-9E38764C4F0B> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
    dyld[36356]: <20BC0059-C0CF-3CB7-BFF2-4AF4A46B9A73> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    dyld[36356]: <AB1464A5-20E6-3C95-8548-1C03866FB283> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    dyld[36356]: <EB9ACEFA-8DA0-3D43-A020-436EB558A55C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    dyld[36356]: <51C3B8A6-AB5A-362C-A16E-6A28552D7E3D> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    dyld[36356]: <0C278563-9E72-38D2-9A4B-89BC774E0106> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
    dyld[36356]: <28D3EE05-0AE8-336D-B1EA-51481A40ADA1> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    dyld[36356]: <F5CF3FB0-C0F0-373B-A389-036A567B19AC> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
    dyld[36356]: <33ADBC73-7355-35D2-A639-7E7C1C04AA60> /usr/lib/libcups.2.dylib
    dyld[36356]: <46D89D8B-5AC1-3151-BF3E-1FB71C7DBC2F> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    dyld[36356]: <04A66201-3864-3A1B-9D57-49FF9E6974CD> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    dyld[36356]: <4F634BA6-D08F-314B-9FE3-1A742F69FF8D> /usr/lib/libresolv.9.dylib
    dyld[36356]: <5CF43D99-D4C6-3956-AF9B-265366E88252> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    dyld[36356]: <44F42A1C-D4AF-3CB8-AA60-A22B93A77E75> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
    dyld[36356]: <A9DB1E80-07F9-36C4-85E5-4B5C3AB01491> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    dyld[36356]: <ED96D21E-C06D-3103-9D1F-5B6F4F6DBC15> /System/Library/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
    dyld[36356]: <4EFF0CCF-30A9-3325-BB79-0947C8360B39> /System/Library/PrivateFrameworks/AXCoreUtilities.framework/Versions/A/AXCoreUtilities
    dyld[36356]: <946D8043-F693-3762-BE95-AD647C0D5BBF> /System/Library/PrivateFrameworks/AudioSession.framework/Versions/A/AudioSession
    dyld[36356]: <768098BA-02A5-341B-AD79-DEADD377CAFD> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
    dyld[36356]: <1CE3941F-B96B-3265-8438-F73138D3E9D1> /System/Library/PrivateFrameworks/MediaExperience.framework/Versions/A/MediaExperience
    dyld[36356]: <37A87337-1111-39E3-AD69-02298A9D3685> /System/Library/PrivateFrameworks/AudioSession.framework/libSessionUtility.dylib
    dyld[36356]: <615ED68A-1FF5-3EAB-84BE-0BA8A3BA438A> /System/Library/PrivateFrameworks/AudioResourceArbitration.framework/Versions/A/AudioResourceArbitration
    dyld[36356]: <16258A6C-CA4B-3125-8445-488B55041765> /System/Library/PrivateFrameworks/PowerLog.framework/Versions/A/PowerLog
    dyld[36356]: <9AF6FF93-BA86-3891-81D7-F1E741E0D0AA> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
    dyld[36356]: <C95E9414-392C-3796-AD62-0CDA8CC96FB5> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    dyld[36356]: <43355267-36E8-3D1F-A37C-101A6C811215> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
    dyld[36356]: <1595C0BF-F7AE-37A9-A4EB-C9496318C4CC> /System/Library/PrivateFrameworks/CoreUtilsExtras.framework/Versions/A/CoreUtilsExtras
    dyld[36356]: <990ACF94-FB90-3108-8A4C-31AFAF470AC1> /System/Library/PrivateFrameworks/IO80211.framework/Versions/A/IO80211
    dyld[36356]: <8CF23E40-DAAF-3C18-A3C9-3F3EEA400423> /System/Library/PrivateFrameworks/IconFoundation.framework/Versions/A/IconFoundation
    dyld[36356]: <5FCB6A68-0E00-3431-A401-B1B71041F245> /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
    dyld[36356]: <40BB0E3F-6BE4-3050-8A34-05FA71C479C5> /nix/store/8im9477m7wsis4cykl0brgf6fdvfm8fl-icu4c-74.2/lib/libicuuc.74.2.dylib
    dyld[36356]: <FEEBB38F-1098-30BE-9DE6-EEB2BC943323> /nix/store/8im9477m7wsis4cykl0brgf6fdvfm8fl-icu4c-74.2/lib/libicudata.74.2.dylib
    dyld[36356]: <C47EC699-410A-3B6E-83D5-C9799164DB8A> /nix/store/dz88k1z9k73yksm4x78qx7w4mxcgirpi-libcxx-16.0.6/lib/libc++.1.0.dylib
    dyld[36356]: <179BA0D8-5A38-3076-8D47-7B181D6ADFC1> /nix/store/dz88k1z9k73yksm4x78qx7w4mxcgirpi-libcxx-16.0.6/lib/libc++abi.1.0.dylib
    dyld[36356]: <47A687FC-69A9-38BF-9D8C-A7BD5206C507> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libiconv.2.dylib
    dyld[36356]: <DCC8BAA0-CB12-3073-AA8C-57CF30CFA4B7> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libpcre2-8.0.dylib
    dyld[36356]: <290A6EC6-D0DD-3A3B-A583-D604C7711A22> /nix/store/dvmq3xa54hfik85259wyf281m076s14h-libiconv-107/lib/libcharset.1.dylib
    dyld[36356]: <F494B747-1A93-30B9-9294-DF3947D9F75A> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5QuickWidgets.5.dylib
    dyld[36356]: <D04865F2-AEAB-3FC7-B078-7B1161C0EAEE> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libavformat.61.dylib
    dyld[36356]: <288D20B4-EDDD-300E-B6CD-B76AC53B02A3> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libavcodec.61.dylib
    dyld[36356]: <660D2B8A-73A8-382E-A85E-3E55CAB46B7D> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libavutil.59.dylib
    dyld[36356]: <58F38FBA-B2F0-38B6-8B4E-1A28A6C7B9B3> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libresolv.9.dylib
    dyld[36356]: <988D2593-2376-31BA-976F-72C8FD29DC11> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libcups.2.dylib
    dyld[36356]: <E53B37EE-171C-3ADF-8263-1744CB0E1502> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libswresample.5.dylib
    dyld[36356]: <63A5901B-2084-3332-BEBA-8703CD756FFD> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libbz2.1.dylib
    dyld[36356]: <5230DB2C-05F3-3EF1-809A-501658069DAB> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libgnutls.30.dylib
    dyld[36356]: <9F9D7ED5-B408-359A-8A79-9481953A27AC> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libsrt.1.5.dylib
    dyld[36356]: <F420C433-E98D-3466-9877-AA678C563F63> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libssh.4.dylib
    dyld[36356]: <67109EFD-51A4-3830-8918-75952B734E57> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libwebpmux.3.dylib
    dyld[36356]: <7CDE97FD-54F9-3706-96AF-46C62F3519D3> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/liblzma.5.dylib
    dyld[36356]: <F7A4064B-273A-336B-8B45-AB207BD25C86> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libcelt0.2.dylib
    dyld[36356]: <93F20F98-8965-366E-81A8-88A34B5B5AA5> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libdav1d.7.dylib
    dyld[36356]: <21F42388-BD84-3A9C-8540-EFEF975D801B> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libaom.3.dylib
    dyld[36356]: <5E5E1BAB-80BC-33D2-805B-65795E58962D> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libvmaf.3.dylib
    dyld[36356]: <3DE6E6B3-2548-3961-AE94-C61050494CDC> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libmp3lame.0.dylib
    dyld[36356]: <1FE46245-5D42-30C7-BCD4-E2E7171E8F2A> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libopenjp2.7.dylib
    dyld[36356]: <A22B925C-6815-33A0-8D79-29DF125B5697> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libopus.0.dylib
    dyld[36356]: <071E876A-84A0-3B34-8E9D-758E4A37C976> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libspeex.1.dylib
    dyld[36356]: <505FA142-20C3-3EBE-93CC-593D9DBF69B4> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libtheoraenc.1.dylib
    dyld[36356]: <EACB8DC0-6611-3494-B50C-2B578F0C9DB2> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libtheoradec.1.dylib
    dyld[36356]: <8DC5C443-6F76-32BC-BA99-02B26944C1B2> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libvorbis.0.dylib
    dyld[36356]: <6AE2A0BF-FF59-363A-8264-1B9E596F6898> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libvorbisenc.2.dylib
    dyld[36356]: <ECF691E0-3ED5-329E-9528-0680DA68DAA7> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libwebp.7.dylib
    dyld[36356]: <A43D2A87-D36C-33E9-A8D8-7759C924F4D6> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libx264.164.dylib
    dyld[36356]: <ABA8901F-96AD-3F3D-8259-A738AC73C157> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libx265.209.dylib
    dyld[36356]: <B1966ABF-8B51-3696-B6A0-3151BE016B5A> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libsoxr.0.dylib
    dyld[36356]: <3CCAFDEF-59AE-3335-8967-F88A53FDA5C8> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libvdpau.1.dylib
    dyld[36356]: <3487D0EF-F27B-3BFC-AFDB-EB1081A95F21> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libX11.6.dylib
    dyld[36356]: <E2FB491D-AEB6-377C-8FB7-CE20D1A07B74> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libXext.6.dylib
    dyld[36356]: <9487D6F4-D969-3D73-A1EA-13EA67E6F2C3> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libxcb.1.dylib
    dyld[36356]: <CF846207-0A88-3C16-B71B-E85C336C9834> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libXau.6.dylib
    dyld[36356]: <DC39A8D7-3E29-34DD-8723-A0BCA73A9B36> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libXdmcp.6.dylib
    dyld[36356]: <EA90550C-E6DC-3392-94CE-A8A0FD5672B8> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libsharpyuv.0.dylib
    dyld[36356]: <F01C505B-D42B-32DB-B16C-739863D2EAE9> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libp11-kit.0.dylib
    dyld[36356]: <3D598034-ED63-3782-B4CC-C133EE025A2D> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libidn2.0.dylib
    dyld[36356]: <965902AD-DE7A-3288-91E4-769284334DBA> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libunistring.5.dylib
    dyld[36356]: <7383B291-339E-338E-9B90-55D66C75ACAF> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libtasn1.6.dylib
    dyld[36356]: <936CF804-852F-3F38-917D-2A955553FF45> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libnettle.8.dylib
    dyld[36356]: <6B472118-7874-3260-B228-3DA1C866BEB6> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libhogweed.6.dylib
    dyld[36356]: <C5086914-72CD-3C74-BDFC-20AC8B32CB56> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libgmp.10.dylib
    dyld[36356]: <F7696736-B5AB-3334-A945-B54F650353BC> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libffi.8.dylib
    dyld[36356]: <2537CCF6-0C98-36FF-A652-8A29B9CB0D67> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libssl.3.dylib
    dyld[36356]: <D8172422-DE12-31C2-B089-0FB2662DE473> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libcrypto.3.dylib
    dyld[36356]: <1C35301E-0F21-3C2B-8EE3-2C53023BB575> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libharfbuzz.0.dylib
    dyld[36356]: <6AC0DD4E-F25B-35DE-88DB-66B44037C038> /System/Library/Frameworks/AGL.framework/Versions/A/AGL
    dyld[36356]: <BAE979FB-4976-3456-AB6C-206E642A1F3C> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
    dyld[36356]: <4FB67984-59A8-36DE-974E-D0B5B012CF52> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
    dyld[36356]: <82E7EF46-BC3C-35A4-93C0-7C0A88A1FC1A> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
    dyld[36356]: <EB078321-C98E-342A-A025-B6528A39B647> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
    dyld[36356]: <89048DDE-7C0F-3FEC-A24C-89D75E478A11> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
    dyld[36356]: <41CFCB60-E02C-3FED-A518-A2684C7D4248> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
    dyld[36356]: <DA107EC1-ECEA-365A-83D0-C1305834E7BC> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
    dyld[36356]: <4A83B746-FCE4-3038-9227-0B016597FE2E> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
    dyld[36356]: <ABDA3105-B2BB-3C8B-BDA3-8F377FBB4755> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libfreetype.6.dylib
    dyld[36356]: <825CB3AF-71E1-39E6-8F18-2483B8A9F154> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libgraphite2.3.dylib
    dyld[36356]: <EE5EFBEE-E4D6-331F-AC14-795807FE9454> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libpng16.16.dylib
    dyld[36356]: <CD79D406-0E79-3406-9163-A5BD715CA49E> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libbrotlidec.1.dylib
    dyld[36356]: <C0C5FF21-05FC-39FD-8B8C-B89AEAEF2C4C> /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libbrotlicommon.1.dylib
    dyld[36356]: <5939DB55-DB14-3C23-BAEB-68A93256B5D0> /usr/lib/libpmenergy.dylib
    dyld[36356]: <C35E3069-981F-3B28-8C12-929BFF66617A> /usr/lib/libpmsample.dylib
    dyld[36356]: <5DA39D18-8A4D-3042-9147-7EB7DBE17E05> /System/Library/PrivateFrameworks/NetworkStatistics.framework/Versions/A/NetworkStatistics
    dyld[36356]: <54317EC5-EE06-308B-A9F4-CC0D9914BCD4> /usr/lib/libsandbox.1.dylib
    dyld[36356]: <DC8426D3-876E-3170-8524-85A8AD321A32> /usr/lib/libMatch.1.dylib
    dyld[36356]: <4040DA79-1357-345B-BE97-FF324A1EA54D> /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
    dyld[36356]: <819F9C94-04B6-374A-852E-4309091A1503> /System/Library/PrivateFrameworks/AVFCore.framework/Versions/A/AVFCore
    dyld[36356]: <BE0BE160-6F1E-3AD8-8B26-D98EABA5E0C8> /System/Library/PrivateFrameworks/AVFCapture.framework/Versions/A/AVFCapture
    dyld[36356]: <B6A3DB77-D326-3E0A-B1EB-95BDDF77AA57> /System/Library/PrivateFrameworks/AirPlaySync.framework/Versions/A/AirPlaySync
    dyld[36356]: <DDBDDD7B-EAA5-3316-B222-1D2135398410> /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
    dyld[36356]: <F9139C2F-61F3-3151-9912-10A28D0565F3> /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
    dyld[36356]: <2124BAF0-98E1-34D2-B7A0-23F364EE9256> /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
    dyld[36356]: <CA9F1535-8FB1-31D9-AF1D-1FA13E361964> /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
    dyld[36356]: <F0B49B0A-5D45-39AE-8B48-E7D320DDD02F> /System/Library/PrivateFrameworks/CMPhoto.framework/Versions/A/CMPhoto
    dyld[36356]: <A53184D7-46B7-3E18-9E57-8ADB9EF82364> /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
    dyld[36356]: <3D3C8A5B-AA78-344D-8928-D3221252395F> /System/Library/PrivateFrameworks/CMImaging.framework/Versions/A/CMImaging
    dyld[36356]: <C9642139-B08E-3FC6-ADF9-9082C239150A> /System/Library/PrivateFrameworks/Quagga.framework/Versions/A/Quagga
    dyld[36356]: <1C216272-81EC-3D1D-B691-E4CF6A526C87> /System/Library/PrivateFrameworks/CMCapture.framework/Versions/A/CMCapture
    dyld[36356]: <43927A9E-F222-3D4C-B950-4CA3BABD9B3D> /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
    dyld[36356]: <D5DF5131-B4F0-3817-A141-E9A44572E014> /System/Library/PrivateFrameworks/LoggingSupport.framework/Versions/A/LoggingSupport
    dyld[36356]: <66D65142-8AFE-34C0-9036-F2AA888A6F08> /System/Library/PrivateFrameworks/FrontBoardServices.framework/Versions/A/FrontBoardServices
    dyld[36356]: <44CB61CE-2058-35F5-859C-0CE9BDC5244F> /System/Library/PrivateFrameworks/BoardServices.framework/Versions/A/BoardServices
    dyld[36356]: <679EFF0D-272E-3D12-B11E-4C64DF7E8D48> /System/Library/PrivateFrameworks/BackBoardServices.framework/Versions/A/BackBoardServices
    dyld[36356]: <16CF37EE-B732-3147-82E6-D07F702FE2FE> /System/Library/Frameworks/Quartz.framework/Versions/A/Quartz
    dyld[36356]: <E773765A-1A50-3907-B785-05C282A0EE2B> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    dyld[36356]: <C63F35A6-57F3-3E58-AE69-90DBBB272785> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/QuartzComposer.framework/Versions/A/QuartzComposer
    dyld[36356]: <AD313256-3F36-387B-84F5-A151DE54EDD4> /System/Library/Frameworks/PDFKit.framework/Versions/A/PDFKit
    dyld[36356]: <298EEC52-3C49-3164-AB31-1AD2B17CDEE1> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/QuartzFilters.framework/Versions/A/QuartzFilters
    dyld[36356]: <B8B17538-9D8D-304F-9FD0-EF28AB78C686> /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Versions/A/ImageKit
    dyld[36356]: <A7A9D6EA-D813-3FEA-8F55-71841169EFF8> /System/Library/Frameworks/QuickLookUI.framework/Versions/A/QuickLookUI
    dyld[36356]: <83CD4D54-D7DB-3ECA-98EF-4586EFC2DEDE> /System/Library/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore
    dyld[36356]: <31249F42-CB9E-3CA7-AB6B-183F5A9CD78B> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    dyld[36356]: <BC824684-0A53-3D9B-B531-BB11D11B1843> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    dyld[36356]: <58A85202-E2E4-3D90-92BE-1BDDFAC7C7A3> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    dyld[36356]: <837AAB16-14AE-34D5-B354-E23674FD7941> /System/Library/PrivateFrameworks/CorePDF.framework/Versions/A/CorePDF
    dyld[36356]: <BA0E146E-26CA-3F4F-A059-2D3AD9AF47CF> /System/Library/PrivateFrameworks/URLFormatting.framework/Versions/A/URLFormatting
    dyld[36356]: <2DF5A4ED-64CE-3D49-B300-ABD05FF35843> /System/Library/Frameworks/QuickLook.framework/Versions/A/QuickLook
    dyld[36356]: <DC61B460-4975-3BEA-A527-B6DB1796D700> /System/Library/PrivateFrameworks/DisplayServices.framework/Versions/A/DisplayServices
    dyld[36356]: <38D8705A-210C-3292-B9A3-5985127D73CA> /System/Library/Frameworks/ImageCaptureCore.framework/Versions/A/ImageCaptureCore
    dyld[36356]: <E7AD5B80-ECAE-34DB-9430-C1912D67F1F8> /System/Library/Frameworks/MetalKit.framework/Versions/A/MetalKit
    dyld[36356]: <AA857B21-8F23-3054-89D0-8EB1F3C5CC80> /System/Library/PrivateFrameworks/VisionKitCore.framework/Versions/A/VisionKitCore
    dyld[36356]: <33451C4D-C359-3B85-8C3D-5E82081E9ED8> /System/Library/PrivateFrameworks/QuickLookSupport.framework/Versions/A/QuickLookSupport
    dyld[36356]: <5379A4BA-A8EF-30D5-8644-02C2D99BD315> /System/Library/Frameworks/FileProvider.framework/Versions/A/FileProvider
    dyld[36356]: <C50CA826-6AB0-338A-B227-32186B6B4FE3> /System/Library/PrivateFrameworks/DiskManagement.framework/Versions/A/DiskManagement
    dyld[36356]: <90DF5B06-1125-3FFC-813C-301127B7E5D8> /System/Library/Frameworks/QuickLookThumbnailing.framework/Versions/A/QuickLookThumbnailing
    dyld[36356]: <50D4E468-5B9E-3D55-A8CF-BAE3D3C9B0A9> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
    dyld[36356]: <8E06978A-BFA1-37E3-B92C-B8DAA5612CC6> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
    dyld[36356]: <4153B80F-4624-37A1-A250-1B1A76556ABE> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
    dyld[36356]: <05EDDCB3-72C9-3FA6-B1F0-9137DAAB7622> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
    dyld[36356]: <C76AB28E-02A7-3D20-A294-9DABB94C4313> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    dyld[36356]: <5D7A4FD7-3A3C-3D4C-B208-D52B7B3C201C> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    dyld[36356]: <3074748D-4D5A-35E3-BC6F-C9C91E109A26> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    dyld[36356]: <98FB8D31-39E2-35C3-B04E-E094611AF16A> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
    dyld[36356]: <38B09F48-C4B1-3662-8882-B9E7C9517F91> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
    dyld[36356]: <BB674941-BE2E-3EA2-BD0B-7C17C2DCB774> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
    dyld[36356]: <C547F4AA-6747-3AA9-A6EA-AD96407B273C> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    dyld[36356]: <07CC87F1-DAA2-3E3E-8B1E-1425B34ACE18> /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
    dyld[36356]: <9412F7B1-7D79-30A6-8255-C219A74FA61D> /System/Library/PrivateFrameworks/WiFiPeerToPeer.framework/Versions/A/WiFiPeerToPeer
    dyld[36356]: <595C0FF5-800C-308C-8234-308AB71B5A13> /System/Library/Frameworks/UserNotifications.framework/Versions/A/UserNotifications
    dyld[36356]: <24F31F21-7590-362D-8209-2FECA653CC5F> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
    dyld[36356]: <C75B88C9-B831-32C7-848D-A4EC81649EC5> /System/Library/PrivateFrameworks/MultiverseSupport.framework/Versions/A/MultiverseSupport
    dyld[36356]: <150A524A-2870-302C-8A83-F6C0C257ED04> /System/Library/PrivateFrameworks/RemoteServiceDiscovery.framework/Versions/A/RemoteServiceDiscovery
    dyld[36356]: <0A62F692-C963-37A6-A977-D8FA78008D68> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
    dyld[36356]: <2C179AB6-A95B-32ED-BF66-8AD00CB1526A> /System/Library/PrivateFrameworks/AAAFoundation.framework/Versions/A/AAAFoundation
    dyld[36356]: <ED4E1334-3B2F-345E-A58E-59BE8A2719A2> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
    dyld[36356]: <5D4A0A3E-5865-3C29-A1AB-CE2FD652570F> /System/Library/PrivateFrameworks/RemoteXPC.framework/Versions/A/RemoteXPC
    dyld[36356]: <0DA4E80C-9330-3431-BA43-7CFE4E6F4E3A> /System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
    dyld[36356]: <DCEF358F-5F4D-395E-968A-FD65D1241A04> /System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
    dyld[36356]: <D53475A1-E4A7-3D0F-B0E7-CDFD1589DFD2> /usr/lib/libCoreStorage.dylib
    dyld[36356]: <6BF8E714-ECDD-3F23-B734-F9DB84BC3661> /usr/lib/libcsfde.dylib
    dyld[36356]: <960B0BEA-74C4-3559-B928-C5D10562BE30> /System/Library/PrivateFrameworks/ProtectedCloudStorage.framework/Versions/A/ProtectedCloudStorage
    dyld[36356]: <F38395AA-BBD2-380D-B543-E5263F85EAF7> /System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
    dyld[36356]: <C7780805-1630-3936-B546-66836768946A> /System/Library/PrivateFrameworks/OctagonTrust.framework/Versions/A/OctagonTrust
    dyld[36356]: <0B57BCB7-B783-3A59-855F-1781FBB98AC4> /System/Library/PrivateFrameworks/CoreBrightness.framework/Versions/A/CoreBrightness
    dyld[36356]: <4589066E-382E-39B6-B9DD-BBF478131410> /System/Library/PrivateFrameworks/HID.framework/Versions/A/HID
    dyld[36356]: <7505465F-56A9-3DC7-8C3C-8A4833FD587F> /System/Library/Frameworks/SafariServices.framework/Versions/A/SafariServices
    dyld[36356]: <3BC12E60-6ACF-3F66-91A0-E1D72620D1D3> /System/Library/PrivateFrameworks/QuickLookNonBaseSystem.framework/Versions/A/QuickLookNonBaseSystem
    dyld[36356]: <9277A476-277B-3422-99F5-F49FB3B99D01> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
    dyld[36356]: <05573EE4-77F1-3A87-B1FB-751D5AE388A4> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    dyld[36356]: <7CDA85EE-0972-3753-8E4B-DBEF357A9887> /System/Library/Frameworks/WebKit.framework/Versions/A/WebKit
    dyld[36356]: <7E4D86A8-034D-3E77-B833-3654E42E9D91> /System/Library/PrivateFrameworks/OSAnalytics.framework/Versions/A/OSAnalytics
    dyld[36356]: <DE20BE8F-B29C-3641-9C3F-C4753B1FE66B> /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
    dyld[36356]: <4EBDD521-38B2-3735-8DE9-47873B853986> /System/Library/PrivateFrameworks/MallocStackLogging.framework/Versions/A/MallocStackLogging
    dyld[36356]: <B05195B2-E7F3-3A50-9AE8-59C864EE0F02> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebKitLegacy.framework/Versions/A/WebKitLegacy
    dyld[36356]: <EC1612CF-E036-3D73-886C-787969315E2C> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/WebCore
    dyld[36356]: <02F8AA15-0DBD-3EC9-A570-F99C3D0305D7> /usr/lib/libAccessibility.dylib
    dyld[36356]: <652C3627-1E44-3629-A6B0-785B784DEAB9> /System/Library/PrivateFrameworks/ApplePushService.framework/Versions/A/ApplePushService
    dyld[36356]: <767DEA8B-ADFE-396E-A9A6-6D6C99D21DD4> /System/Library/PrivateFrameworks/CorePrediction.framework/Versions/A/CorePrediction
    dyld[36356]: <733ED68F-3A44-3A61-8767-0F1914870431> /usr/lib/libnetworkextension.dylib
    dyld[36356]: <0CA4C96B-65A0-36C3-855A-4FA1185C31C1> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libwebrtc.dylib
    dyld[36356]: <2D59EDE6-9AE1-314B-BFD0-8F7751F856FA> /System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/Versions/A/SafariSafeBrowsing
    dyld[36356]: <EE982366-3D42-31AF-AB84-A10B127B7231> /System/Library/Frameworks/SecurityInterface.framework/Versions/A/SecurityInterface
    dyld[36356]: <C8D1CBFB-EF56-3102-AE51-E53ADE1A02EF> /System/Library/PrivateFrameworks/WebInspectorUI.framework/Versions/A/WebInspectorUI
    dyld[36356]: <DF3A8484-CEBD-3897-9053-BDBFBB420391> /System/Library/Frameworks/CryptoTokenKit.framework/Versions/A/CryptoTokenKit
    dyld[36356]: <369F5849-9937-37C0-85E0-24AE43900EEF> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libANGLE-shared.dylib
    dyld[36356]: <4BCAA410-06FA-36BF-AC37-87521BA713A4> /System/Library/PrivateFrameworks/WebGPU.framework/Versions/A/WebGPU
    dyld[36356]: <760D63D8-2CE9-380B-AED3-C6385C708BFB> /System/Library/Frameworks/NetworkExtension.framework/Versions/A/NetworkExtension
    dyld[36356]: <8ABBC9A1-5971-3597-80CA-2AC2AFE960A8> /System/Library/Frameworks/SceneKit.framework/Versions/A/SceneKit
    dyld[36356]: <0EEC6904-0452-392D-8AE9-34DE8221DE5B> /System/Library/PrivateFrameworks/CaptiveNetwork.framework/Versions/A/CaptiveNetwork
    dyld[36356]: <48A1C150-E319-3531-9D41-3E1CBF534AA2> /System/Library/PrivateFrameworks/EAP8021X.framework/Versions/A/EAP8021X
    dyld[36356]: <2991A5BB-321B-371D-93B6-D535D95C4BB0> /System/Library/Frameworks/ModelIO.framework/Versions/A/ModelIO
    dyld[36356]: <505C6D00-E521-3CCC-97E4-0A50B38A3DE7> /System/Library/Frameworks/GLKit.framework/Versions/A/GLKit
    dyld[36356]: <24FD3F28-32DE-3529-8254-E55FAA3AF3D3> /usr/lib/usd/libIex.dylib
    dyld[36356]: <FE3000CD-6BC9-360D-BE37-95C08D0FFCE2> /usr/lib/usd/libHalf.dylib
    dyld[36356]: <FC893C3D-2111-3CE3-A437-62CCA818FC8B> /usr/lib/usd/libAlembic.dylib
    dyld[36356]: <DCBD07DF-1061-36C9-ABF2-6DABA77E3DE4> /usr/lib/usd/libusd_ms.dylib
    dyld[36356]: <6168113F-EC40-36FC-96C6-749424303DA3> /usr/lib/usd/libosdCPU.dylib
    dyld[36356]: <EF88E590-A5E5-3CBC-815B-0AFBF67F52D1> /usr/lib/usd/libImath.dylib
    dyld[36356]: <91C812E9-16D1-3549-BE8A-096769E6B55B> /usr/lib/usd/libIlmThread.dylib
    dyld[36356]: <6477BBD9-9A65-38F3-8E55-E1247E8F169C> /usr/lib/usd/libIexMath.dylib
    dyld[36356]: <D6000AB3-2E72-37EA-A49E-40B27F2AAA25> /usr/lib/usd/libtbb.dylib
    dyld[36356]: <6B2B7C37-EA3D-383E-A66F-FC9E19C79FA8> /usr/lib/usd/libMaterialXCore.dylib
    dyld[36356]: <9A09CDDD-1B0C-33F4-BAA6-A29D1C4F0F45> /usr/lib/usd/libMaterialXFormat.dylib
    dyld[36356]: <F4BF0AE8-2667-3A29-911F-3FD603EB09CA> /System/Library/PrivateFrameworks/USDLib_FormatLoaderProxy.framework/Versions/A/USDLib_FormatLoaderProxy
    dyld[36356]: <5B073851-A50B-30ED-A6D6-9E36714A4276> /System/Library/PrivateFrameworks/CommonUtilities.framework/Versions/A/CommonUtilities
    dyld[36356]: <5DD97ED2-BAE4-3742-B99B-47F04284282D> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
    dyld[36356]: <5D2D62FE-B40A-3274-B55F-8E5465DE0F77> /usr/lib/libParallelCompression.dylib
    dyld[36356]: <706D77FC-BF21-3897-9D10-04D82F738BB1> /System/Library/PrivateFrameworks/CoreOptimization.framework/Versions/A/CoreOptimization
    dyld[36356]: <703F700B-F9B2-3023-B481-A898FA05917B> /System/Library/PrivateFrameworks/WirelessDiagnostics.framework/Versions/A/WirelessDiagnostics
    dyld[36356]: <4DC48E53-0BB7-3756-86C3-FF04C553819D> /System/Library/PrivateFrameworks/WirelessDiagnostics.framework/Versions/A/Libraries/libAWDSupportFramework.dylib
    dyld[36356]: <6665E306-EB0A-3734-BEDA-6AC8E02384A8> /System/Library/PrivateFrameworks/WirelessDiagnostics.framework/Versions/A/Libraries/libAWDSupport.dylib
    dyld[36356]: <86FBEC99-A33D-3526-836B-C8FECFEB2FF4> /System/Library/PrivateFrameworks/WirelessDiagnostics.framework/Versions/A/Libraries/libprotobuf-lite.dylib
    dyld[36356]: <AC52D1B7-B641-33C5-8624-E63CA56827DD> /usr/lib/libTelephonyUtilDynamic.dylib
    dyld[36356]: <6BE35946-556F-354C-A0D2-88F544305F22> /System/Library/PrivateFrameworks/WirelessDiagnostics.framework/Versions/A/Libraries/libprotobuf.dylib
    dyld[36356]: <CD71399E-507F-32E0-A1F3-830F471FE6D2> /System/Library/PrivateFrameworks/MSUDataAccessor.framework/Versions/A/MSUDataAccessor
    dyld[36356]: <41A054A0-86D6-3BF3-A6BB-BABC2F298538> /usr/lib/libpartition2_dynamic.dylib
    dyld[36356]: <062D24FC-5068-3808-8F47-C9C94541275A> /usr/lib/libbootpolicy.dylib
    dyld[36356]: <8B8CFB70-02F0-3DB1-B650-ECDF7EEE6D13> /System/Library/Frameworks/LocalAuthentication.framework/Versions/A/LocalAuthentication
    dyld[36356]: <F257B9B9-5A7E-365C-85B5-3B07846F6BF1> /System/Library/Frameworks/LocalAuthentication.framework/Support/SharedUtils.framework/Versions/A/SharedUtils
    dyld[36356]: <F8696F60-BC6F-3E37-8A3E-8312754EB366> /System/Library/PrivateFrameworks/MarkupUI.framework/Versions/A/MarkupUI
    dyld[36356]: <7C1D858D-EC37-32E6-A876-2430E21A1D76> /System/Library/PrivateFrameworks/SidecarCore.framework/Versions/A/SidecarCore
    dyld[36356]: <AB97BDF7-BF58-382B-8E06-90047D77D0D0> /System/Library/PrivateFrameworks/AnnotationKit.framework/Versions/A/AnnotationKit
    dyld[36356]: <37BFA0B6-6627-3BCC-A8DC-B4451FDFC939> /System/Library/PrivateFrameworks/DataDetectors.framework/Versions/A/DataDetectors
    dyld[36356]: <8BDC3070-BA9A-3996-BF0E-3774C142E426> /System/Library/PrivateFrameworks/MediaAnalysisServices.framework/Versions/A/MediaAnalysisServices
    dyld[36356]: <27E90756-EB9F-3A94-96CB-B5E66F6733C3> /System/Library/Frameworks/Vision.framework/Versions/A/Vision
    dyld[36356]: <A16D78ED-CA5F-3291-BD7B-072FBE43B086> /System/Library/PrivateFrameworks/RevealCore.framework/Versions/A/RevealCore
    dyld[36356]: <1D6AE380-F0FE-397C-AB06-1CBBD8287407> /System/Library/PrivateFrameworks/Reveal.framework/Versions/A/Reveal
    dyld[36356]: <FC03ECE3-BA1E-3172-9E1B-5821FF56E75F> /System/Library/PrivateFrameworks/TextRecognition.framework/Versions/A/TextRecognition
    dyld[36356]: <E38E0EF6-146E-3F3A-8CC5-F73EACF08D96> /System/Library/PrivateFrameworks/Translation.framework/Versions/A/Translation
    dyld[36356]: <F894246B-B303-36BA-9789-37807F6C2AB5> /System/Library/PrivateFrameworks/Lookup.framework/Versions/A/Lookup
    dyld[36356]: <62168FB5-BA0E-3AD2-8314-CEDA29F9A3AB> /System/Library/PrivateFrameworks/AddressBookCore.framework/Versions/A/AddressBookCore
    dyld[36356]: <40B09A8A-9448-35A3-B2CB-6D038E2B2440> /System/Library/PrivateFrameworks/PhoneNumbers.framework/Versions/A/PhoneNumbers
    dyld[36356]: <BF8A3913-2B85-318E-8BB8-C400BF8B17FA> /System/Library/PrivateFrameworks/IDS.framework/Versions/A/IDS
    dyld[36356]: <A00A4931-59FD-3535-8BB4-5A2E4874F288> /System/Library/Frameworks/NaturalLanguage.framework/Versions/A/NaturalLanguage
    dyld[36356]: <1612CA65-0E65-30F7-949C-9B64EAE3700D> /System/Library/Frameworks/CoreML.framework/Versions/A/CoreML
    dyld[36356]: <CB0F3D87-4343-367D-902E-1E94F17DAD19> /System/Library/PrivateFrameworks/Montreal.framework/Versions/A/Montreal
    dyld[36356]: <A1B7BE90-EE67-35A8-A524-587D31D3A94A> /System/Library/Frameworks/MLCompute.framework/Versions/A/MLCompute
    dyld[36356]: <977E7CB6-6E6E-311B-A100-F24B90E3506A> /System/Library/Frameworks/CloudKit.framework/Versions/A/CloudKit
    dyld[36356]: <CB2DB131-70EE-31AE-9B48-2DD6AEDC6C05> /System/Library/PrivateFrameworks/Espresso.framework/Versions/A/Espresso
    dyld[36356]: <607DB955-3CFB-3062-8B66-7B82D3238BF9> /System/Library/PrivateFrameworks/MLAssetIO.framework/Versions/A/MLAssetIO
    dyld[36356]: <5658E520-D755-3507-AF08-7F141210C533> /System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Versions/A/MetalPerformanceShadersGraph
    dyld[36356]: <CB709EF6-D095-3B99-B436-0071A9F905FF> /System/Library/PrivateFrameworks/ANECompiler.framework/Versions/A/ANECompiler
    dyld[36356]: <D4D000F9-3F73-3DC4-A18D-B2D41BE8EF2E> /System/Library/PrivateFrameworks/AppleNeuralEngine.framework/Versions/A/AppleNeuralEngine
    dyld[36356]: <C2026193-F20E-3201-93F1-C8E5F7B172C2> /usr/lib/libncurses.5.4.dylib
    dyld[36356]: <CB38D918-D13B-3ED6-BFCE-F71EF63D59B0> /System/Library/PrivateFrameworks/ANEServices.framework/Versions/A/ANEServices
    dyld[36356]: <84A5A9E8-0CBF-3CB9-B7C7-C9891D21EA1D> /System/Library/Frameworks/SharedWithYouCore.framework/Versions/A/SharedWithYouCore
    dyld[36356]: <F5A24311-C0D4-3B7E-A1AE-B29720A23CEF> /usr/lib/libBASupport.dylib
    dyld[36356]: <F023BBDD-6922-3D7F-91EF-EE28B35C382B> /System/Library/PrivateFrameworks/AppleAccount.framework/Versions/A/AppleAccount
    dyld[36356]: <9376B020-AF87-3858-AD25-721A3A761520> /System/Library/PrivateFrameworks/C2.framework/Versions/A/C2
    dyld[36356]: <E9D8FA9B-E7C2-3038-8847-5BE447B49E15> /System/Library/Frameworks/CoreLocation.framework/Versions/A/CoreLocation
    dyld[36356]: <FC4DC723-F2DE-3715-B7B9-BDBE2F240105> /System/Library/PrivateFrameworks/CloudKitDistributedSync.framework/Versions/A/CloudKitDistributedSync
    dyld[36356]: <3803BD43-7C3E-365A-8553-6E0D1596B491> /System/Library/Frameworks/PushKit.framework/Versions/A/PushKit
    dyld[36356]: <72DE2DB3-4CD6-32CC-A1F3-5E58A1483644> /System/Library/Frameworks/CoreTransferable.framework/Versions/A/CoreTransferable
    dyld[36356]: <1166FBBA-F78A-3883-AA4F-EA982BD4546E> /System/Library/Frameworks/CryptoKit.framework/Versions/A/CryptoKit
    dyld[36356]: <6A87AFA6-61F4-3A35-A26E-FAC61E3EC343> /System/Library/PrivateFrameworks/FeatureFlags.framework/Versions/A/FeatureFlags
    dyld[36356]: <4137CD39-9CE2-3136-AF2D-BE6A08D6F426> /usr/lib/swift/libswiftAVFoundation.dylib
    dyld[36356]: <2C763DC1-1ABA-3421-8044-772B26710507> /usr/lib/swift/libswiftCoreAudio.dylib
    dyld[36356]: <16DAD8B8-359E-31B0-A52D-38E5D3F24368> /usr/lib/swift/libswiftCoreLocation.dylib
    dyld[36356]: <E443730C-44A4-34EE-8793-9CEAEFDC1A0D> /usr/lib/swift/libswiftCoreMIDI.dylib
    dyld[36356]: <3E00C712-6EB3-38A4-9720-0AA7E211F8C7> /usr/lib/swift/libswiftCoreMedia.dylib
    dyld[36356]: <45EF5B78-7AE8-3262-BB5D-0047E52840E8> /usr/lib/swift/libswiftQuartzCore.dylib
    dyld[36356]: <C2EBF905-EE8A-3E62-8A7C-F36B02B9F021> /usr/lib/swift/libswiftUniformTypeIdentifiers.dylib
    dyld[36356]: <619A1284-5F03-35BF-85C6-20BFE6DDA78E> /System/Library/PrivateFrameworks/AppleIDSSOAuthentication.framework/Versions/A/AppleIDSSOAuthentication
    dyld[36356]: <77EF884A-5EB1-3F5E-A12A-4755BCF26904> /System/Library/PrivateFrameworks/AppSupport.framework/Versions/A/AppSupport
    dyld[36356]: <753C8FA4-53D9-3BDE-83B9-4BDA7223AFAF> /System/Library/PrivateFrameworks/IMFoundation.framework/Versions/A/IMFoundation
    dyld[36356]: <297D954F-F2A5-3AAA-84C5-964D0BCFE2F7> /System/Library/PrivateFrameworks/Marco.framework/Versions/A/Marco
    dyld[36356]: <2D52BF7E-1FC0-366B-B52B-3136B1D7401D> /System/Library/PrivateFrameworks/IDSFoundation.framework/Versions/A/IDSFoundation
    dyld[36356]: <AD9D6323-9F72-39CD-8CA6-550227B5EEF6> /System/Library/PrivateFrameworks/FTServices.framework/Versions/A/FTServices
    dyld[36356]: <C39D2732-7257-3360-909D-62E1DFEEB68A> /System/Library/PrivateFrameworks/Engram.framework/Versions/A/Engram
    dyld[36356]: <06BF8286-04A5-3172-8B19-566F260EF84D> /usr/lib/libtidy.A.dylib
    dyld[36356]: <73471DCA-EC48-343B-9722-6CD9CD0D978A> /System/Library/PrivateFrameworks/FTAWD.framework/Versions/A/FTAWD
    dyld[36356]: <27F3D8B0-EF2B-33C0-83F4-B3ACEEA1BA08> /System/Library/PrivateFrameworks/RTCReporting.framework/Versions/A/RTCReporting
    dyld[36356]: <F86EA071-CB5A-30B5-8628-B564132B4207> /System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
    dyld[36356]: <629657F0-4CD3-3558-A689-309F7FC527FB> /System/Library/PrivateFrameworks/LocationSupport.framework/Versions/A/LocationSupport
    dyld[36356]: <CA7E1445-AE03-37D8-A987-05A10B3462B0> /System/Library/PrivateFrameworks/GeoServicesCore.framework/Versions/A/GeoServicesCore
    dyld[36356]: <8CE1A00E-9383-3CB9-8817-19E36AA0E069> /usr/lib/swift/libswiftNetwork.dylib
    dyld[36356]: <459B1D97-D807-3DC4-AA4D-FA6A0B91D67F> /System/Library/PrivateFrameworks/CryptoKitCBridging.framework/Versions/A/CryptoKitCBridging
    dyld[36356]: <7339B9F9-2149-350D-96F7-7C37D0D7AC66> /usr/lib/swift/libswiftCryptoTokenKit.dylib
    dyld[36356]: <895F4324-65D7-3814-B679-7C94A665EB31> /usr/lib/swift/libswiftCoreGraphics.dylib
    dyld[36356]: <2E5B2725-49AB-31A1-86F5-E2FB0A5173FB> /System/Library/PrivateFrameworks/MilAneflow.framework/Versions/A/MilAneflow
    dyld[36356]: <C98FAD57-67E2-3C56-8A44-C46C71218403> /System/Library/PrivateFrameworks/ContactsPersistence.framework/Versions/A/ContactsPersistence
    dyld[36356]: <76D52182-8DAB-35F1-89CE-AC4BD4E9DE77> /System/Library/Frameworks/Contacts.framework/Versions/A/Contacts
    dyld[36356]: <65DD2B41-7539-3FBA-BAF0-89B5A174110B> /System/Library/PrivateFrameworks/ContactsFoundation.framework/Versions/A/ContactsFoundation
    dyld[36356]: <20A0237B-7220-3604-B418-BC4FAC27FFF7> /System/Library/PrivateFrameworks/login.framework/Versions/A/login
    dyld[36356]: <BC916075-ED0B-34F5-8E2F-16DD34AA2AD5> /System/Library/PrivateFrameworks/vCard.framework/Versions/A/vCard
    dyld[36356]: <52108B7A-3124-39B0-AFAB-9BF13AB48B2B> /System/Library/PrivateFrameworks/ContactsMetrics.framework/Versions/A/ContactsMetrics
    dyld[36356]: <0DF4325D-A20B-334A-AA79-1B8343A8A43B> /System/Library/PrivateFrameworks/AppleLDAP.framework/Versions/A/AppleLDAP
    dyld[36356]: <B668A74B-1AA6-30E4-90D0-180DB7A12CD4> /System/Library/Frameworks/ClassKit.framework/Versions/A/ClassKit
    dyld[36356]: <0B7C6F9B-4298-3F53-AEE5-3A939F8071FC> /System/Library/PrivateFrameworks/CoreSuggestions.framework/Versions/A/CoreSuggestions
    dyld[36356]: <38B32BC2-4ACA-3F77-AEA1-2632AFE53122> /usr/lib/swift/libswiftOSLog.dylib
    dyld[36356]: <8C2BE998-BF70-31F8-8132-3ECC6BE7B89D> /System/Library/PrivateFrameworks/CloudDocs.framework/Versions/A/CloudDocs
    dyld[36356]: <DA903A2D-4992-39D9-A7ED-A51803E850D0> /System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
    dyld[36356]: <FFE03274-553A-3192-85A0-0B1D99839D51> /System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
    dyld[36356]: <265C0E3E-F9D3-39BE-8E12-AB63F2D4DDA5> /System/Library/Frameworks/Intents.framework/Versions/A/Intents
    dyld[36356]: <11891727-AAEC-321A-855E-1B486883A12F> /System/Library/PrivateFrameworks/ProactiveSupport.framework/Versions/A/ProactiveSupport
    dyld[36356]: <60930694-AB49-330D-998B-63F8BA268535> /System/Library/Frameworks/CoreSpotlight.framework/Versions/A/CoreSpotlight
    dyld[36356]: <B0BDE245-260C-38E1-B5D0-B85BCB43A55E> /System/Library/PrivateFrameworks/ProactiveEventTracker.framework/Versions/A/ProactiveEventTracker
    dyld[36356]: <D43BF6EF-DBF8-38A4-93B8-3C1CB738FD00> /System/Library/PrivateFrameworks/IntentsFoundation.framework/Versions/A/IntentsFoundation
    dyld[36356]: <D0ADEA26-5350-3735-AF36-ACCE15ED7731> /System/Library/PrivateFrameworks/MobileAsset.framework/Versions/A/MobileAsset
    dyld[36356]: <802AFB6A-7D02-3FB3-9909-C046833C0B61> /System/Library/PrivateFrameworks/InternationalTextSearch.framework/Versions/A/InternationalTextSearch
    dyld[36356]: <CC5CBD7E-55F9-3561-9B5C-C3CA8FA61972> /System/Library/PrivateFrameworks/SoftwareUpdateCoreSupport.framework/Versions/A/SoftwareUpdateCoreSupport
    dyld[36356]: <3658B44D-6DCC-37F5-987F-74BA9A6AEE68> /System/Library/PrivateFrameworks/SoftwareUpdateCoreConnect.framework/Versions/A/SoftwareUpdateCoreConnect
    dyld[36356]: <347B71DF-0056-3AB3-A68C-B3B44AAFC504> /System/Library/PrivateFrameworks/StreamingZip.framework/Versions/A/StreamingZip
    dyld[36356]: <57A34E64-89B0-357F-9701-A9B2E3F83A09> /System/Library/PrivateFrameworks/InternalSwiftProtobuf.framework/Versions/A/InternalSwiftProtobuf
    dyld[36356]: <DB1E557F-750A-3796-917C-0EC20C9106BC> /System/Library/Frameworks/OSLog.framework/Versions/A/OSLog
    dyld[36356]: <A09A5611-A4A2-34BB-B215-85AE67E6BEB6> /System/Library/Frameworks/Vision.framework/libfaceCore.dylib
    dyld[36356]: <EC131079-870B-3934-BA7E-2DCC674BD11C> /System/Library/PrivateFrameworks/Futhark.framework/Versions/A/Futhark
    dyld[36356]: <A06A2F45-6107-3DD7-A183-C01028366A77> /System/Library/PrivateFrameworks/InertiaCam.framework/Versions/A/InertiaCam
    dyld[36356]: <0633B39B-8338-34CA-84E5-D246BFC08AEB> /System/Library/PrivateFrameworks/CVNLP.framework/Versions/A/CVNLP
    dyld[36356]: <A6F2E488-973A-3745-8FCF-6394973677E9> /System/Library/PrivateFrameworks/TranslationUIServices.framework/Versions/A/TranslationUIServices
    dyld[36356]: <0156D5E2-8924-3C1C-9E94-E4E065AFA23B> /System/Library/PrivateFrameworks/EmbeddedAcousticRecognition.framework/Versions/A/EmbeddedAcousticRecognition
    dyld[36356]: <0BA9EBC7-8E02-3D6F-B055-D4DB037B3FB2> /System/Library/PrivateFrameworks/Osprey.framework/Versions/A/Osprey
    dyld[36356]: <7DB9FB76-593B-3383-931C-E3E101CD3B4A> /usr/lib/libmorphun.dylib
    dyld[36356]: <858A2DD4-B65F-3048-A3E5-33C74AF062DE> /System/Library/PrivateFrameworks/SiriInstrumentation.framework/Versions/A/SiriInstrumentation
    dyld[36356]: <5F1FD23A-7BE6-3C4B-89A8-1FCFCA7F0F9B> /System/Library/PrivateFrameworks/SiriAnalytics.framework/Versions/A/SiriAnalytics
    dyld[36356]: <2007354F-27DF-3AFC-B4A4-C9B70F14FFE9> /System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/AssistantServices
    dyld[36356]: <F1970F9F-0C22-38A8-A144-A58922CBADBF> /System/Library/Frameworks/SoundAnalysis.framework/Versions/A/SoundAnalysis
    dyld[36356]: <87943BB0-3381-3EB2-9D79-12E65AE6F23B> /System/Library/PrivateFrameworks/EmojiFoundation.framework/Versions/A/EmojiFoundation
    dyld[36356]: <A41D63E9-2662-3222-AFCE-E85CE0767908> /System/Library/PrivateFrameworks/SDAPI.framework/Versions/A/SDAPI
    dyld[36356]: <D9BB128D-4CEF-3C04-9AFB-856798B09339> /System/Library/PrivateFrameworks/DifferentialPrivacy.framework/Versions/A/DifferentialPrivacy
    dyld[36356]: <AD50AF42-27B3-32F4-AB43-E70E115EB7BA> /System/Library/PrivateFrameworks/FeedbackLogger.framework/Versions/A/FeedbackLogger
    dyld[36356]: <713BE652-A1B0-3077-857D-B28FE66726E0> /System/Library/PrivateFrameworks/SAObjects.framework/Versions/A/SAObjects
    dyld[36356]: <37B01F06-EDF5-341F-830F-D6279BE69D3C> /System/Library/PrivateFrameworks/MediaRemote.framework/Versions/A/MediaRemote
    dyld[36356]: <5177D485-5F8C-3D5E-A88C-243DD94509AA> /System/Library/PrivateFrameworks/SiriTTSService.framework/Versions/A/SiriTTSService
    dyld[36356]: <49E8856E-96C0-3510-A9AF-259BFBC93956> /System/Library/PrivateFrameworks/SiriCrossDeviceArbitrationFeedback.framework/Versions/A/SiriCrossDeviceArbitrationFeedback
    dyld[36356]: <BA05F4F7-05B2-30FD-8458-A5BCE2850B1D> /System/Library/PrivateFrameworks/Rapport.framework/Versions/A/Rapport
    dyld[36356]: <FEA45BDF-B480-3659-96AF-6B5707F3DED4> /System/Library/PrivateFrameworks/MediaServices.framework/Versions/A/MediaServices
    dyld[36356]: <0CB22428-82C7-3BBB-82B6-724A14C64FC3> /System/Library/PrivateFrameworks/PersistentConnection.framework/Versions/A/PersistentConnection
    dyld[36356]: <B20611EF-AEA3-3DE0-815D-D905ACF1998E> /System/Library/PrivateFrameworks/Trial.framework/Versions/A/Trial
    dyld[36356]: <8C6B2391-127A-32EB-85CD-5AA78DB10766> /System/Library/PrivateFrameworks/TrialProto.framework/Versions/A/TrialProto
    dyld[36356]: <E9DAA723-549F-38F1-A512-E8730C290F9B> /usr/lib/libtailspin.dylib
    dyld[36356]: <1CF5A927-F573-30B8-BEF4-2E17CC4C0329> /System/Library/PrivateFrameworks/UnifiedAssetFramework.framework/Versions/A/UnifiedAssetFramework
    dyld[36356]: <03B950D1-EED4-3FE6-B76B-8417AC09C14E> /System/Library/PrivateFrameworks/SiriTTS.framework/Versions/A/SiriTTS
    dyld[36356]: <A0B76214-9287-352E-9035-0DCE89FEE908> /System/Library/PrivateFrameworks/SiriPowerInstrumentation.framework/Versions/A/SiriPowerInstrumentation
    dyld[36356]: <9D4A9551-A08A-3E21-8A5E-8E5DFCC48924> /usr/lib/swift/libswiftAccelerate.dylib
    dyld[36356]: <642C7EC5-611B-3444-B62A-B429B120CEB5> /System/Library/PrivateFrameworks/TailspinSymbolication.framework/Versions/A/TailspinSymbolication
    dyld[36356]: <C9971D46-FA6E-3D81-8DDD-9279A4445624> /System/Library/PrivateFrameworks/Darwinup.framework/Versions/A/Darwinup
    dyld[36356]: <2C23D9AE-210C-3F1F-9578-FADB1DDF2907> /System/Library/PrivateFrameworks/SignpostSupport.framework/Versions/A/SignpostSupport
    dyld[36356]: <1C911F1E-90BD-3556-9CD6-DBA83444166E> /System/Library/PrivateFrameworks/FeatureFlagsSupport.framework/Versions/A/FeatureFlagsSupport
    dyld[36356]: <3A927CF1-3B50-33DD-9D9B-746014C464EE> /System/Library/PrivateFrameworks/ktrace.framework/Versions/A/ktrace
    dyld[36356]: <F2D6315F-ADDA-3E78-9C4F-FF4803892216> /System/Library/PrivateFrameworks/SampleAnalysis.framework/Versions/A/SampleAnalysis
    dyld[36356]: <5E47C34C-9BA5-34EC-8D5C-760733FFBDA0> /System/Library/PrivateFrameworks/kperfdata.framework/Versions/A/kperfdata
    dyld[36356]: <5FAD0311-50A9-3D3D-93D5-4D2AB899D770> /usr/lib/libdscsym.dylib
    dyld[36356]: <343B3E76-EF1D-3B5C-8A3B-429952AF9E5E> /System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf
    dyld[36356]: <86B5DB81-ADFB-3566-88E3-19CCD2E542DA> /System/Library/PrivateFrameworks/BulkSymbolication.framework/Versions/A/BulkSymbolication
    dyld[36356]: <2D3D4644-7476-31B8-85B0-FD01B91635C2> /usr/lib/libedit.3.dylib
    dyld[36356]: <5C04308B-B1CB-363B-8699-33B1A5FD982E> /System/Library/Frameworks/PencilKit.framework/Versions/A/PencilKit
    dyld[36356]: <462DA60D-B253-363D-9658-A3534BB0E8AB> /System/Library/PrivateFrameworks/SidecarUI.framework/Versions/A/SidecarUI
    dyld[36356]: <329B529E-A594-3A13-9C73-5AC4EF8F3B56> /System/Library/PrivateFrameworks/CoreHandwriting.framework/Versions/A/CoreHandwriting
    dyld[36356]: <1783125D-0A67-370E-A7C4-31E86C522CAC> /usr/lib/swift/libswiftAppKit.dylib
    dyld[36356]: <AD06B061-2DA4-37A7-BD48-D092631FD5E9> /usr/lib/swift/libswiftCoreImage.dylib
    dyld[36356]: <522D213F-4E8D-3132-ADD3-0916C9C6D630> /usr/lib/libmecabra.dylib
    dyld[36356]: <C84D67B7-1A6D-36C0-943A-7D42916A80B4> /usr/lib/libChineseTokenizer.dylib
    dyld[36356]: <48FE8CC6-A7FF-3CAF-93AC-2BA052AC2A32> /System/Library/Frameworks/Accessibility.framework/Versions/A/Accessibility
    dyld[36356]: <2E26B300-6CBE-3BDC-90FD-0B1EED18B518> /System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback
    dyld[36356]: <D92FA2D8-6751-3503-B5E1-0FE41FFA6ACD> /System/Library/Frameworks/GameController.framework/Versions/A/GameController
    dyld[36356]: <59AE758F-356F-3B93-9F91-5A34D0E8E20B> /System/Library/PrivateFrameworks/GameControllerFoundation.framework/Versions/A/GameControllerFoundation
    dyld[36356]: <72E5CA1E-C698-30EF-8820-BD6B579BAF4D> /System/Library/PrivateFrameworks/GameControllerSettings.framework/Versions/A/GameControllerSettings
    dyld[36356]: <B03F9707-0525-37F4-8698-365F94D15969> /System/Library/Frameworks/ExternalAccessory.framework/ExternalAccessory
    dyld[36356]: <98A56B4B-A81E-3E67-8EE5-C89EA07C7094> /System/Library/Frameworks/CoreHaptics.framework/Versions/A/CoreHaptics
    dyld[36356]: <54DA14BD-D015-3739-A318-1A5202FEB1D8> /System/Library/PrivateFrameworks/IAP.framework/Versions/A/IAP
    dyld[36356]: <49BC7D1D-52C2-3015-A2EB-77405FB9E56B> /System/Library/Frameworks/MediaPlayer.framework/Versions/A/MediaPlayer
    dyld[36356]: <79FC3FCD-49F9-39A5-9DD5-4CC09E739687> /System/Library/PrivateFrameworks/iTunesCloud.framework/Versions/A/iTunesCloud
    dyld[36356]: <17BD6EDF-8ED8-310E-883D-36647869D391> /System/Library/PrivateFrameworks/AppleMediaServices.framework/Versions/A/AppleMediaServices
    dyld[36356]: <71FA6DC7-016E-3FB2-8144-1712AE46FC00> /System/Library/PrivateFrameworks/Symptoms.framework/Frameworks/SymptomPresentationFeed.framework/Versions/A/SymptomPresentationFeed
    dyld[36356]: <AAD5C560-0E1F-3585-A2A6-4BFCBE33ECCF> /System/Library/PrivateFrameworks/AVFoundationCF.framework/Versions/A/AVFoundationCF
    dyld[36356]: <30027473-59B6-373E-B961-FED4E02F753B> /System/Library/PrivateFrameworks/DAAPKit.framework/Versions/A/DAAPKit
    dyld[36356]: <A36B524A-1787-34F8-86F6-7C1EC37C2123> /System/Library/PrivateFrameworks/CacheDelete.framework/Versions/A/CacheDelete
    dyld[36356]: <3BE4F91C-3CFC-30BF-AC67-4A352201ED2D> /System/Library/Frameworks/CoreTelephony.framework/Versions/A/CoreTelephony
    dyld[36356]: <6B5F55C9-2AF7-3866-A6DF-682F1B9956C2> /System/Library/PrivateFrameworks/Symptoms.framework/Frameworks/SymptomAnalytics.framework/Versions/A/SymptomAnalytics
    dyld[36356]: <B0F34120-21CA-36AC-8D27-EE61D93276DA> /System/Library/PrivateFrameworks/SystemAdministration.framework/Versions/A/SystemAdministration
    dyld[36356]: <1C9A283E-DDBE-3A77-9F00-9766819EA38F> /usr/lib/swift/libswiftCompression.dylib
    dyld[36356]: <7CBFE839-8A70-3779-9EBD-9A3A34C1F4FB> /usr/lib/swift/libswiftExtensionFoundation.dylib
    dyld[36356]: <DA7B0595-151A-38E6-9FC0-95926FF63A47> /System/Library/Frameworks/DirectoryService.framework/Versions/A/DirectoryService
    dyld[36356]: <5DEECE65-1E7B-3E17-9D82-6BD6800B42D7> /System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
    dyld[36356]: <A004431F-0727-3252-B84F-958CBCD6E5C2> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    dyld[36356]: <7D9FD8BF-8217-318A-9F63-69E6E1BE580A> /System/Library/PrivateFrameworks/LoginUIKit.framework/Versions/A/Frameworks/LoginUICore.framework/Versions/A/LoginUICore
    dyld[36356]: <77767EA4-E2B4-3ECB-AB44-9A3FF768AD3D> /usr/lib/libodfde.dylib
    dyld[36356]: <FCF6A10D-1845-33E4-B80B-30F949B8DDF1> /usr/lib/libcurl.4.dylib
    dyld[36356]: <DC43B360-C18E-38F9-ABDC-542A598A3DDE> /usr/lib/libcrypto.46.dylib
    dyld[36356]: <8F6DA158-8F55-34B8-BC57-A81C4C509F86> /usr/lib/libssl.48.dylib
    dyld[36356]: <BAE86DB5-4D27-3D4B-AC17-1A402D33802E> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
    dyld[36356]: <74A51125-7236-31F3-95AF-24B6EE052994> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
    dyld[36356]: <42F8E335-BC69-3C99-A8D1-80EA29B6560A> /usr/lib/libsasl2.2.dylib
    dyld[36356]: <06B7F9F0-3137-34C1-B59C-BBB97FCE08F9> /nix/store/siy4c88aiwdm5bbzmdl2asb2f2kcccmy-boost-1.81.0/lib/libboost_atomic.dylib
    dyld[36356]: <9E8D9DC5-5EA7-31EC-A4F5-B6EEAB251FFF> /nix/store/6x1wkf3ijprhmb79aflkvv90cifkhgcg-qtbase-5.15.15-bin/lib/qt-5.15.15/plugins/platforms/libqcocoa.dylib
    dyld[36356]: <988D2593-2376-31BA-976F-72C8FD29DC11> /nix/store/4av46fsjkzjhdqmf63vbiwi4fhd3smp5-cups-2.4.11-lib/lib/libcups.2.dylib
    dyld[36356]: <5C017CEF-D601-39D1-BAA1-AF854EE0E450> /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5DBus.5.15.15.dylib
    dyld[36356]: <FC18D34F-66E8-3345-9311-DF7D224E57AC> /nix/store/lcdcai6gs0dbsx7a0hz43xb3xwwmb9dl-zlib-1.3.1/lib/libz.1.3.1.dylib
    dyld[36356]: <73A9DB10-6438-3ACD-9435-E68CBE47FF36> /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5PrintSupport.5.15.15.dylib
    dyld[36356]: <AF71DCB9-AC56-3830-8622-A05B9C57B070> /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Widgets.5.15.15.dylib
    dyld[36356]: <9762697A-1BFE-313E-B4D8-8960FA77B5A6> /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Gui.5.15.15.dylib
    dyld[36356]: <306C75E2-418F-3767-B1F1-CB2F843E6700> /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib
    dyld[36356]: <369631C6-BC26-399A-9B9B-E516CE16B411> /nix/store/ymlrvh4zq6imlr4fqsricmhzyrf7g6s9-gettext-0.21.1/lib/libintl.8.dylib
    dyld[36356]: <5230DB2C-05F3-3EF1-809A-501658069DAB> /nix/store/nzppdv1in773gy4dpgm64mkmjhza6yay-gnutls-3.8.6/lib/libgnutls.30.dylib
    dyld[36356]: <58F38FBA-B2F0-38B6-8B4E-1A28A6C7B9B3> /nix/store/bka1xflm8s6yapz6dpagbgb2gv8adic3-libresolv-83/lib/libresolv.9.dylib
    dyld[36356]: <47A687FC-69A9-38BF-9D8C-A7BD5206C507> /nix/store/dvmq3xa54hfik85259wyf281m076s14h-libiconv-107/lib/libiconv.2.dylib
    dyld[36356]: <F01C505B-D42B-32DB-B16C-739863D2EAE9> /nix/store/ydyibkv86khz08kijyadqk3nbrbfnh73-p11-kit-0.25.5/lib/libp11-kit.0.dylib
    dyld[36356]: <3D598034-ED63-3782-B4CC-C133EE025A2D> /nix/store/9pnqzwrdzy6lwd9yz274r6minvl2sn3b-libidn2-2.3.7/lib/libidn2.0.dylib
    dyld[36356]: <965902AD-DE7A-3288-91E4-769284334DBA> /nix/store/z33whgdab8a9kqhgqx6jrv7wvwqzq4m0-libunistring-1.2/lib/libunistring.5.dylib
    dyld[36356]: <7383B291-339E-338E-9B90-55D66C75ACAF> /nix/store/vfmsfaz4gqqngvzkz36a6w3gfxbjln9b-libtasn1-4.19.0/lib/libtasn1.6.dylib
    dyld[36356]: <936CF804-852F-3F38-917D-2A955553FF45> /nix/store/0ajys10266h0fb60d11d43niiw80xa4i-nettle-3.10/lib/libnettle.8.9.dylib
    dyld[36356]: <6B472118-7874-3260-B228-3DA1C866BEB6> /nix/store/0ajys10266h0fb60d11d43niiw80xa4i-nettle-3.10/lib/libhogweed.6.9.dylib
    dyld[36356]: <C5086914-72CD-3C74-BDFC-20AC8B32CB56> /nix/store/2nhsw1az2lh38gkj4mkyiiag375h735k-gmp-with-cxx-6.3.0/lib/libgmp.10.dylib
    dyld[36356]: <F7696736-B5AB-3334-A945-B54F650353BC> /nix/store/zzf996fcjnhj1w2w0zr62jm6xhlqsiga-libffi-3.4.6/lib/libffi.8.dylib
    dyld[36356]: <CB1BD0A6-7C5C-3DF9-B838-E7358CD35D53> /nix/store/gqklzl5k96422rpgm1aljqnzk4xgcjxx-dbus-1.14.10-lib/lib/libdbus-1.3.dylib
    dyld[36356]: <848089F7-5B79-3FB5-A5CF-D9461A2EEEF0> /nix/store/8im9477m7wsis4cykl0brgf6fdvfm8fl-icu4c-74.2/lib/libicui18n.74.2.dylib
    dyld[36356]: <EFDB1A2F-25BB-352C-83E5-1D0077057591> /nix/store/7srv57hn2b24q7idwdc9a4y3pqkn6wy8-pcre2-10.44/lib/libpcre2-16.0.dylib
    dyld[36356]: <C058E1DB-8E26-33DF-8B30-81996C47A8EF> /nix/store/r284h4kprzms7n8bg67hkvwr738av9sq-zstd-1.5.6/lib/libzstd.1.5.6.dylib
    dyld[36356]: <84DC2126-A3B4-390C-BC92-6A2AF3B80340> /nix/store/6a4qvifcnrd42jd6fb8vrxm4a5d7rp2d-glib-2.82.1/lib/libgthread-2.0.0.dylib
    dyld[36356]: <99479E2E-6144-3523-A329-136EDECF8D30> /nix/store/6a4qvifcnrd42jd6fb8vrxm4a5d7rp2d-glib-2.82.1/lib/libglib-2.0.0.dylib
    dyld[36356]: <DCC8BAA0-CB12-3073-AA8C-57CF30CFA4B7> /nix/store/7srv57hn2b24q7idwdc9a4y3pqkn6wy8-pcre2-10.44/lib/libpcre2-8.0.dylib
    dyld[36356]: <1C35301E-0F21-3C2B-8EE3-2C53023BB575> /nix/store/1jx7118l25b253mf1480bavnff0846pv-harfbuzz-9.0.0/lib/libharfbuzz.0.dylib
    dyld[36356]: <ABDA3105-B2BB-3C8B-BDA3-8F377FBB4755> /nix/store/2h2k39fa4ca33xs192xmdyc4bis4idpp-freetype-2.13.3/lib/libfreetype.6.dylib
    dyld[36356]: <825CB3AF-71E1-39E6-8F18-2483B8A9F154> /nix/store/dkmw3wf7gi4li42pgp2f6vcnc5aa09aj-graphite2-1.3.14/lib/libgraphite2.3.2.1.dylib
    dyld[36356]: <63A5901B-2084-3332-BEBA-8703CD756FFD> /nix/store/csmw5z12f3v60fgjcy4bl2a266nxyil4-bzip2-1.0.8/lib/libbz2.1.dylib
    dyld[36356]: <EE5EFBEE-E4D6-331F-AC14-795807FE9454> /nix/store/wz08i6kwvgxv46aqyggj6z72f1rhng37-libpng-apng-1.6.43/lib/libpng16.16.dylib
    dyld[36356]: <CD79D406-0E79-3406-9163-A5BD715CA49E> /nix/store/p8h72rh12jhd3qqvkfjsjr1z4j1ybwcj-brotli-1.1.0-lib/lib/libbrotlidec.1.1.0.dylib
    dyld[36356]: <C0C5FF21-05FC-39FD-8B8C-B89AEAEF2C4C> /nix/store/p8h72rh12jhd3qqvkfjsjr1z4j1ybwcj-brotli-1.1.0-lib/lib/libbrotlicommon.1.1.0.dylib
    objc[36356]: Class QMacAutoReleasePoolTracker is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x106d91330) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11ba09330). One of the two will be used. Which one is undefined.
    objc[36356]: Class QT_ROOT_LEVEL_POOL__THESE_OBJECTS_WILL_BE_RELEASED_WHEN_QAPP_GOES_OUT_OF_SCOPE is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x106d913a8) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11ba093a8). One of the two will be used. Which one is undefined.
    objc[36356]: Class KeyValueObserver is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x106d913d0) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11ba093d0). One of the two will be used. Which one is undefined.
    objc[36356]: Class RunLoopModeTracker is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5Core.5.dylib (0x106d91420) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5Core.5.15.15.dylib (0x11ba09420). One of the two will be used. Which one is undefined.
    objc[36356]: Class QCocoaPageLayoutDelegate is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5PrintSupport.5.dylib (0x1046fd188) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5PrintSupport.5.15.15.dylib (0x117759188). One of the two will be used. Which one is undefined.
    objc[36356]: Class QCocoaPrintPanelDelegate is implemented in both /nix/store/16csn863369kv6jnkflpff6y2i3lgz1f-supercollider-3.13.0/Applications/SuperCollider.app/Contents/Frameworks/libQt5PrintSupport.5.dylib (0x1046fd200) and /nix/store/gihkajig3vc4zlnj4zzgz158s2ay105w-qtbase-5.15.15/lib/libQt5PrintSupport.5.15.15.dylib (0x117759200). One of the two will be used. Which one is undefined.
    QObject::moveToThread: Current thread (0x6000034382b0) is not the object's thread (0x600003434820).
    Cannot move to target thread (0x6000034382b0)

    You might be loading two sets of Qt binaries into the same process. Check that all plugins are compiled against the right Qt binaries. Export DYLD_PRINT_LIBRARIES=1 and check that only one set of binaries are being loaded.
    qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
    This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

    Available platform plugins are: cocoa, minimal, offscreen.

    zsh: abort      DYLD_PRINT_LIBRARIES=1
    ```

</details>

The error seems to imply there is a conflict between the `libQt5Core.5.dylib` and `libQt5PrintSupport.5.dylib` bundled libs, and those provided via nix's `qtbase` when the wrapper is applied with `QT_PLUGIN_PATH`.

If I set `dontWrapQtApps = true;` to disclude the libs from the nix-store, I get:

```
> ./result/Applications/SuperCollider.app/Contents/MacOS/SuperCollider
qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

On the other hand, if I instead try to remove the two bundled `Qt5Core` and `Qt5PrintSupport` libs manually in the postInstall phase, I get:

```
> ./result/Applications/SuperCollider.app/Contents/MacOS/SuperCollider
dyld[320]: Library not loaded: @loader_path/../Frameworks/libQt5PrintSupport.5.dylib
  Referenced from: <8D7CBF8E-0DE6-384C-86AC-21694C58AFCD> /nix/store/vbcckk5wlqnr4gyhxj25zan8xn66rhm9-supercollider-3.13.0/Applications/SuperCollider.app/Contents/MacOS/.SuperCollider-wrapped
  Reason: tried: '/nix/store/vbcckk5wlqnr4gyhxj25zan8xn66rhm9-supercollider-3.13.0/Applications/SuperCollider.app/Contents/MacOS/../Frameworks/libQt5PrintSupport.5.dylib' (no such file), '/usr/local/lib/libQt5PrintSupport.5.dylib' (no such file), '/usr/lib/libQt5PrintSupport.5.dylib' (no such file, not in dyld cache)
```

Any advice on how to move forward appreciated!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true` (supercollider only builds with `relaxed`)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
