### PR TITLE
xmlto: use strictDeps

### DIFF
--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -48,18 +48,14 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  strictDeps = true;
+
   # `libxml2' provides `xmllint', needed at build-time and run-time.
   # `libxslt' provides `xsltproc', used by `xmlto' at run-time.
   nativeBuildInputs = [
     autoreconfHook
     makeWrapper
-    flex
     getopt
-  ];
-
-  buildInputs = [
-    docbook_xml_dtd_45
-    docbook_xsl
     libxml2
     libxslt
   ];


### PR DESCRIPTION
In context of https://github.com/NixOS/nixpkgs/issues/178468.

When using `config.strictDepsByDefault = true`, xmlto build fails with:
```
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/cprpzcwj3cqjdfg43xj9dqs3ca0csij7-bash-5.2p32/bin/bash
make  all-am
make[1]: Entering directory '/build/xmlto'
gcc -DHAVE_CONFIG_H -I.     -g -O2 -c -o xmlif/xmlif.o xmlif/xmlif.c
gcc  -g -O2   -o xmlif/xmlif xmlif/xmlif.o  
FORMAT_DIR=./format /nix/store/cprpzcwj3cqjdfg43xj9dqs3ca0csij7-bash-5.2p32/bin/bash ./xmlto --skip-validation -o man/man1 man doc/xmlto.x>
xmlto: Can't continue, xsltproc tool not found or not executable.
make[1]: *** [Makefile:1381: man/man1/xmlto.1] Error 3
make[1]: Leaving directory '/build/xmlto'
make: *** [Makefile:599: all] Error 2
```

## Things done

Enabled `strictDeps` using Artturin/diffing tool to check that output does not change.
Using this tool, I also noticed that `flex`, `docbook_xml_dtd_45` and `docbook_xsl` are not used.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
