### PR TITLE
neatvnc: fix build with latest ffmpeg

### DIFF
--- a/pkgs/development/libraries/neatvnc/default.nix
+++ b/pkgs/development/libraries/neatvnc/default.nix
@@ -24,6 +24,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-2gPDcFcu1kGIDubguL38Z0K+k7WGFf7DX8yZteedcNg=";
   };
 
+  patches = [
+    # Fix build with latest ffmpeg
+    # Backport of https://github.com/any1/neatvnc/commit/7e008743bf872598b4fcdb2a821041064ce5dd01
+    # FIXME: remove in next update
+    ./fix-ffmpeg.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/neatvnc/fix-ffmpeg.patch
+++ b/pkgs/development/libraries/neatvnc/fix-ffmpeg.patch
@@ -1,0 +1,13 @@
+diff --git a/src/h264-encoder.c b/src/h264-encoder.c
+index 6ad0262..f4a4421 100644
+--- a/src/h264-encoder.c
++++ b/src/h264-encoder.c
+@@ -547,7 +547,7 @@ struct h264_encoder* h264_encoder_create(uint32_t width, uint32_t height,
+ 		goto codec_context_failure;
+ 
+ 	self->codec_ctx->hw_frames_ctx =
+-		av_buffer_ref(self->filter_out->inputs[0]->hw_frames_ctx);
++		av_buffer_ref(av_buffersink_get_hw_frames_ctx(self->filter_out));
+ 
+ 	AVDictionary *opts = NULL;
+ 	av_dict_set_int(&opts, "async_depth", 1, 0);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Dependency of Weston, which also builds now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
