### PR TITLE
haskell.compiler.ghc94{5,6}: remove at 9.4.5 and 9.4.6, respectively

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -57,7 +57,7 @@ Available compilers are collected under `haskell.compiler`.
 Each of those compiler versions has a corresponding attribute set `packages` built with
 it. However, the non-standard package sets are not tested regularly and, as a
 result, contain fewer working packages. The corresponding package set for GHC
-9.4.5 is `haskell.packages.ghc945`. In fact `haskellPackages` (at the time of writing) is just an alias
+9.4.8 is `haskell.packages.ghc948`. In fact `haskellPackages` (at the time of writing) is just an alias
 for `haskell.packages.ghc966`:
 
 Every package set also re-exposes the GHC used to build its packages as `haskell.packages.*.ghc`.

--- a/pkgs/development/compilers/ghc/9.4.5.nix
+++ b/pkgs/development/compilers/ghc/9.4.5.nix
@@ -1,6 +1,0 @@
-# DO NOT port this expression to hadrian. It is not possible to build a GHC
-# cross compiler with 9.4.* and hadrian.
-import ./common-make-native-bignum.nix {
-  version = "9.4.5";
-  sha256 = "6256cf9caf6d6dc7b611dcfbb247df2d528e85aa39d22a698e870e5a590e8601";
-}

--- a/pkgs/development/compilers/ghc/9.4.6.nix
+++ b/pkgs/development/compilers/ghc/9.4.6.nix
@@ -1,6 +1,0 @@
-# DO NOT port this expression to hadrian. It is not possible to build a GHC
-# cross compiler with 9.4.* and hadrian.
-import ./common-make-native-bignum.nix {
-  version = "9.4.6";
-  sha256 = "1b705cf52692f9d4d6707cdf8e761590f5f56ec8ea6a65e36610db392d3d24b9";
-}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -174,56 +174,6 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc92 = compiler.ghc928;
-    ghc945 = callPackage ../development/compilers/ghc/9.4.5.nix {
-      bootPkgs =
-        # Building with 9.2 is broken due to
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/21914
-        # Use 8.10 as a workaround where possible to keep bootstrap path short.
-
-        # On ARM text won't build with GHC 8.10.*
-        if stdenv.buildPlatform.isAarch then
-          # TODO(@sternenseemann): package bindist
-          bb.packages.ghc902
-        # No suitable bindists for powerpc64le
-        else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
-          bb.packages.ghc902
-        else
-          bb.packages.ghc8107Binary;
-      inherit (buildPackages.python311Packages) sphinx; # a distutils issue with 3.12
-      python3 = buildPackages.python311; # so that we don't have two of them
-      # Need to use apple's patched xattr until
-      # https://github.com/xattr/xattr/issues/44 and
-      # https://github.com/xattr/xattr/issues/55 are solved.
-      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-      # Support range >= 10 && < 14
-      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
-      llvmPackages = pkgs.llvmPackages_12;
-    };
-    ghc946 = callPackage ../development/compilers/ghc/9.4.6.nix {
-      bootPkgs =
-        # Building with 9.2 is broken due to
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/21914
-        # Use 8.10 as a workaround where possible to keep bootstrap path short.
-
-        # On ARM text won't build with GHC 8.10.*
-        if stdenv.buildPlatform.isAarch then
-          # TODO(@sternenseemann): package bindist
-          bb.packages.ghc902
-        # No suitable bindists for powerpc64le
-        else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
-          bb.packages.ghc902
-        else
-          bb.packages.ghc8107Binary;
-      inherit (buildPackages.python311Packages) sphinx; # a distutils issue with 3.12
-      python3 = buildPackages.python311; # so that we don't have two of them
-      # Need to use apple's patched xattr until
-      # https://github.com/xattr/xattr/issues/44 and
-      # https://github.com/xattr/xattr/issues/55 are solved.
-      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-      # Support range >= 10 && < 14
-      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
-      llvmPackages = pkgs.llvmPackages_12;
-    };
     ghc947 = callPackage ../development/compilers/ghc/9.4.7.nix {
       bootPkgs =
         # Building with 9.2 is broken due to
@@ -532,16 +482,6 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.2.x.nix { };
     };
     ghc92 = packages.ghc928;
-    ghc945 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc945;
-      ghc = bh.compiler.ghc945;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
-    };
-    ghc946 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc946;
-      ghc = bh.compiler.ghc946;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
-    };
     ghc947 = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc947;
       ghc = bh.compiler.ghc947;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -65,8 +65,6 @@ let
     ghc926
     ghc927
     ghc928
-    ghc945
-    ghc946
     ghc947
     ghc948
     ghc963
@@ -555,8 +553,6 @@ let
         compilerNames.ghc926
         compilerNames.ghc927
         compilerNames.ghc928
-        compilerNames.ghc945
-        compilerNames.ghc946
         compilerNames.ghc947
         compilerNames.ghc948
         compilerNames.ghc9101


### PR DESCRIPTION
Both are affected by <https://gitlab.haskell.org/ghc/ghc/-/issues/23762> which is now cropping up on our CI (for Cabal 3.14). I don't really see why we absolutely have to keep them, so it seems just better overall to use this as an excuse to remove them (**after NixOS 24.11 branch off**).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
