### PR TITLE
freedv: clean up and add pre‐release version

### DIFF
--- a/pkgs/applications/radio/freedv/default.nix
+++ b/pkgs/applications/radio/freedv/default.nix
@@ -1,36 +1,37 @@
-{ config
-, lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, macdylibbundler
-, makeWrapper
-, darwin
-, codec2
-, libpulseaudio
-, libsamplerate
-, libsndfile
-, lpcnetfreedv
-, portaudio
-, speexdsp
-, hamlib_4
-, wxGTK32
-, sioclient
-, pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
-, AppKit
-, AVFoundation
-, Cocoa
-, CoreMedia
+{
+  config,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  macdylibbundler,
+  makeWrapper,
+  darwin,
+  codec2,
+  libpulseaudio,
+  libsamplerate,
+  libsndfile,
+  lpcnetfreedv,
+  portaudio,
+  speexdsp,
+  hamlib_4,
+  wxGTK32,
+  sioclient,
+  pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  AppKit,
+  AVFoundation,
+  Cocoa,
+  CoreMedia,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "freedv";
   version = "1.9.9.2";
 
   src = fetchFromGitHub {
     owner = "drowe67";
     repo = "freedv-gui";
-    rev = "v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-oFuAH81mduiSQGIDgDDy1IPskqqCBmfWbpqQstUIw9g=";
   };
 
@@ -42,30 +43,34 @@ stdenv.mkDerivation rec {
     sed -i "/codesign/d;/hdiutil/d" src/CMakeLists.txt
   '';
 
-  nativeBuildInputs = [
-    cmake
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    macdylibbundler
-    makeWrapper
-    darwin.autoSignDarwinBinariesHook
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      macdylibbundler
+      makeWrapper
+      darwin.autoSignDarwinBinariesHook
+    ];
 
-  buildInputs = [
-    codec2
-    libsamplerate
-    libsndfile
-    lpcnetfreedv
-    speexdsp
-    hamlib_4
-    wxGTK32
-    sioclient
-  ] ++ (if pulseSupport then [ libpulseaudio ] else [ portaudio ])
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    AppKit
-    AVFoundation
-    Cocoa
-    CoreMedia
-  ];
+  buildInputs =
+    [
+      codec2
+      libsamplerate
+      libsndfile
+      lpcnetfreedv
+      speexdsp
+      hamlib_4
+      wxGTK32
+      sioclient
+    ]
+    ++ (if pulseSupport then [ libpulseaudio ] else [ portaudio ])
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      AppKit
+      AVFoundation
+      Cocoa
+      CoreMedia
+    ];
 
   cmakeFlags = [
     "-DUSE_INTERNAL_CODEC2:BOOL=FALSE"
@@ -74,9 +79,11 @@ stdenv.mkDerivation rec {
     "-DUSE_PULSEAUDIO:BOOL=${if pulseSupport then "TRUE" else "FALSE"}"
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    "-DAPPLE_OLD_XCODE"
-  ]);
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      "-DAPPLE_OLD_XCODE"
+    ]
+  );
 
   doCheck = true;
 
@@ -86,12 +93,15 @@ stdenv.mkDerivation rec {
     makeWrapper $out/Applications/FreeDV.app/Contents/MacOS/FreeDV $out/bin/freedv
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://freedv.org/";
     description = "Digital voice for HF radio";
-    license = licenses.lgpl21;
-    maintainers = with maintainers; [ mvs wegank ];
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [
+      mvs
+      wegank
+    ];
+    platforms = lib.platforms.unix;
     mainProgram = "freedv";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29305,6 +29305,13 @@ with pkgs;
     };
   };
 
+  freedv_pre = freedv.overrideAttrs (prevAttrs: {
+    version = "2.0.0-20241018";
+    src = prevAttrs.src.override {
+      hash = "sha256-ZY5k30iQ/bnyoDBiwlXPZrXkspGYvimtzwenFzQr1Nk=";
+    };
+  });
+
   freemind = callPackage ../applications/misc/freemind {
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731


### PR DESCRIPTION
- use `finalAttrs` pattern
- remove uses of `with lib;`
- re‐format according to RFC 166
- add pre‐release package version 2.0.0-20241018 (as per #351264)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
