### PR TITLE
neatvnc: revert to ffmpeg 6

### DIFF
--- a/pkgs/development/libraries/neatvnc/default.nix
+++ b/pkgs/development/libraries/neatvnc/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , pkg-config
 , aml
-, ffmpeg
+, ffmpeg_6
 , gnutls
 , libjpeg_turbo
 , mesa
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     aml
-    ffmpeg
+    ffmpeg_6
     gnutls
     libjpeg_turbo
     mesa


### PR DESCRIPTION
Regression from #337855

Fixes #353337

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).