### PR TITLE
nixos-container: do not touch os-release if it is a symlink

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -92,7 +92,7 @@ let
       chmod 0755 "$root/etc" "$root/var/lib"
       mkdir -p "$root/var/lib/private" "$root/root" /run/nixos-containers
       chmod 0700 "$root/var/lib/private" "$root/root" /run/nixos-containers
-      if ! [ -e "$root/etc/os-release" ]; then
+      if ! [ -e "$root/etc/os-release" ] && ! [ -h "$root/etc/os-release" ]; then
         touch "$root/etc/os-release"
       fi
 


### PR DESCRIPTION
`/etc/os-release` of NixOS containers, which are `/var/lib/nixos-containers/*/etc/os-release` on the host, are usually symlinks to the absolute path `/etc/static/os-release` but it doesn't exist in non-NixOS host.  Since `startScript` is evaluated by the host system, both `[ -e "$root/etc/os-release" ]` and `touch "$root/etc/os-release"` fail, so that the container fails to start on the second boot (on the first boot, the symlink doesn't exist, so the command succeeds).

This commit avoids `touch "$root/etc/os-release"` if `$root/etc/os-release` is a symlink, so imperative NixOS containers are usable on non-NixOS host.

It seems that NixOS containers are intended to be run on NixOS host but I want to run NixOS containers on my Raspberry Pi 5 without having to hustle with installing NixOS on it.

How to test:

```
# On non-NixOS host:
nixos-container create foo
ln -s '/nix/var/nix/profiles/per-container/foo/system/etc/systemd/system/container@.service' '/etc/systemd/system/'
systemctl daemon-reload
systemctl start 'container@foo'
systemctl stop 'container@foo'
systemctl start 'container@foo'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
