### PR TITLE
regripper: update-2023-07-23 -> 0-unstable-2024-11-02

### DIFF
--- a/pkgs/by-name/re/regripper/package.nix
+++ b/pkgs/by-name/re/regripper/package.nix
@@ -1,29 +1,27 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, perl
-, perlPackages
-, runtimeShell
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  perlPackages,
+  runtimeShell,
 }:
 
 stdenv.mkDerivation rec {
   pname = "regripper";
-  version = "unstable-2023-07-23";
+  version = "0-unstable-2024-11-02";
 
   src = fetchFromGitHub {
     owner = "keydet89";
     repo = "RegRipper3.0";
-    rev = "cee174fb6f137b14c426e97d17945ddee0d31051";
-    hash = "sha256-vejIRlcVjxQJpxJabJJcljODYr+lLJjYINVtAPObvkQ=";
+    rev = "89f3cac57e10bce1a79627e6038353e8e8a0c378";
+    hash = "sha256-dW3Gr4HQH484i47Bg+CEnBYoGQQRMBJr88+YeuU+iV4=";
   };
 
-  propagatedBuildInputs = [ perl perlPackages.ParseWin32Registry ];
-
-  postPatch = ''
-    substituteInPlace rip.pl rr.pl \
-      --replace \"plugins/\" \"$out/share/regripper/plugins/\" \
-      --replace \"plugins\" \"$out/share/regripper/plugins\"
-  '';
+  propagatedBuildInputs = [
+    perl
+    perlPackages.ParseWin32Registry
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Despite added the right `perlPackages.ParseWin32Registry` dependency, when I run the binary, I get:
```
Can't locate Parse/Win32Registry.pm in @INC (you may need to install the Parse::Win32Registry module) (@INC entries checked: /nix/store/mnnp3qlmkwgzl3lbnz7qlaqddwjjwa7v-perl-5.40.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/mnnp3qlmkwgzl3lbnz7qlaqddwjjwa7v-perl-5.40.0/lib/perl5/site_perl/5.40.0 /nix/store/mnnp3qlmkwgzl3lbnz7qlaqddwjjwa7v-perl-5.40.0/lib/perl5/5.40.0/x86_64-linux-thread-multi /nix/store/mnnp3qlmkwgzl3lbnz7qlaqddwjjwa7v-perl-5.40.0/lib/perl5/5.40.0) at /nix/store/hnyx3cddhbp510ccj34jwnws4bdxz96h-regripper-0-unstable-2024-11-02/share/regripper/rip.pl line 34.
BEGIN failed--compilation aborted at /nix/store/hnyx3cddhbp510ccj34jwnws4bdxz96h-regripper-0-unstable-2024-11-02/share/regripper/rip.pl line 34.
```
Not clear why not able to find the dependency

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
