### PR TITLE
cynthion: init at 0.1.7

### DIFF
--- a/pkgs/by-name/cy/cynthion/package.nix
+++ b/pkgs/by-name/cy/cynthion/package.nix
@@ -1,0 +1,26 @@
+{
+  python3,
+  fetchFromGitHub,
+}:
+
+let
+  python = python3.override {
+    self = python3;
+    packageOverrides = _: super: {
+      amaranth = super.amaranth.overridePythonAttrs rec {
+        version = "0.4.1";
+
+        src = fetchFromGitHub {
+          owner = "amaranth-lang";
+          repo = "amaranth";
+          rev = "refs/tags/v${version}";
+          sha256 = "sha256-VMgycvxkphdpWIib7aZwh588En145RgYlG2Zfi6nnDo=";
+        };
+
+        postPatch = null;
+      };
+    };
+  };
+in
+
+python.pkgs.toPythonApplication python.pkgs.cynthion

--- a/pkgs/development/python-modules/apollo-fpga/default.nix
+++ b/pkgs/development/python-modules/apollo-fpga/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  deprecation,
+  prompt-toolkit,
+  pyusb,
+  pyvcd,
+  pyxdg,
+}:
+
+buildPythonPackage rec {
+  pname = "apollo-fpga";
+  version = "1.1.0";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "apollo";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-9BoHGdqjnWkP83zXdjzyoAhYB6n7SJ/zlr8pvqb+9kg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    deprecation
+    prompt-toolkit
+    pyusb
+    pyvcd
+    pyxdg
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "apollo_fpga"
+  ];
+
+  meta = {
+    changelog = "https://github.com/greatscottgadgets/apollo/releases/tag/v${version}";
+    description = "microcontroller-based FPGA / JTAG programmer";
+    homepage = "https://github.com/greatscottgadgets/apollo";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ carlossless ];
+  };
+}

--- a/pkgs/development/python-modules/cynthion/default.nix
+++ b/pkgs/development/python-modules/cynthion/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  amaranth,
+  apollo-fpga,
+  future,
+  libusb1,
+  luna-soc,
+  luna-usb,
+  prompt-toolkit,
+  pyfwup,
+  pygreat,
+  pyserial,
+  pyusb,
+  tabulate,
+  tomli,
+  tqdm,
+
+  # tests
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "cynthion";
+  version = "0.1.7";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "cynthion";
+    rev = "refs/tags/${version}";
+    hash = "sha256-2nVfODAg4t5hoSKUEP4IN23R+JGe3lw/rpfjW/UIsYw=";
+  };
+
+  sourceRoot = "${src.name}/cynthion/python";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    amaranth
+    apollo-fpga
+    future
+    libusb1
+    luna-soc
+    luna-usb
+    prompt-toolkit
+    pyfwup
+    pygreat
+    pyserial
+    pyusb
+    tabulate
+    tomli
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "cynthion" ];
+
+  meta = {
+    changelog = "https://github.com/greatscottgadgets/cynthion/releases/tag/${version}";
+    description = "Python package and utilities for the Great Scott Gadgets Cynthion USB Test Instrument";
+    homepage = "https://github.com/greatscottgadgets/cynthion";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ carlossless ];
+    broken = lib.versionAtLeast amaranth.version "0.5";
+  };
+}

--- a/pkgs/development/python-modules/luna-soc/default.nix
+++ b/pkgs/development/python-modules/luna-soc/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  luna-usb,
+}:
+
+buildPythonPackage rec {
+  pname = "luna-soc";
+  version = "0.2.0";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "luna-soc";
+    rev = "refs/tags/${version}";
+    hash = "sha256-P8P32hM1cVXENcDpCrmPe8BvkMCWdeEgHwbIU94uLe8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ luna-usb ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "luna_soc"
+  ];
+
+  meta = {
+    changelog = "https://github.com/greatscottgadgets/luna-soc/releases/tag/${version}";
+    description = "Amaranth HDL library for building USB-capable SoC designs";
+    homepage = "https://github.com/greatscottgadgets/luna-soc";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ carlossless ];
+  };
+}

--- a/pkgs/development/python-modules/luna-usb/default.nix
+++ b/pkgs/development/python-modules/luna-usb/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  amaranth,
+  libusb1,
+  pyserial,
+  pyusb,
+  pyvcd,
+  usb-protocol,
+
+  # tests
+  pytestCheckHook,
+  apollo-fpga,
+}:
+buildPythonPackage rec {
+  pname = "luna-usb";
+  version = "0.1.2";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "luna";
+    rev = "refs/tags/${version}";
+    hash = "sha256-T9V0rI6vcEpM3kN/duRni6v2plCU4B379Zx07dBGKjk=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    amaranth
+    libusb1
+    pyserial
+    pyusb
+    pyvcd
+    usb-protocol
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    apollo-fpga
+  ];
+
+  pytestFlagsArray = [
+    "tests/"
+  ];
+
+  pythonImportsCheck = [
+    "luna"
+  ];
+
+  meta = {
+    changelog = "https://github.com/greatscottgadgets/luna/releases/tag/${version}";
+    description = "Amaranth HDL framework for monitoring, hacking, and developing USB devices";
+    homepage = "https://github.com/greatscottgadgets/luna";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ carlossless ];
+    broken = lib.versionAtLeast amaranth.version "0.5";
+  };
+}

--- a/pkgs/development/python-modules/usb-protocol/default.nix
+++ b/pkgs/development/python-modules/usb-protocol/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  construct,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "usb-protocol";
+  version = "0.9.1";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "python-usb-protocol";
+    rev = "refs/tags/${version}";
+    hash = "sha256-CYbXs/SRC1FAVEzfw0gwf6U0qQ9Q34nyuj5yfjHfDn8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ construct ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "usb_protocol"
+  ];
+
+  meta = {
+    changelog = "https://github.com/greatscottgadgets/python-usb-protocol/releases/tag/${version}";
+    description = "Python library providing utilities, data structures, constants, parsers, and tools for working with the USB protocol";
+    homepage = "https://github.com/greatscottgadgets/python-usb-protocol";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ carlossless ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2826,6 +2826,8 @@ self: super: with self; {
 
   cymruwhois = callPackage ../development/python-modules/cymruwhois { };
 
+  cynthion = callPackage ../development/python-modules/cynthion { };
+
   cypari2 = callPackage ../development/python-modules/cypari2 { };
 
   cypherpunkpay = callPackage ../development/python-modules/cypherpunkpay { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17308,6 +17308,8 @@ self: super: with self; {
 
   usb-monitor = callPackage ../development/python-modules/usb-monitor { };
 
+  usb-protocol = callPackage ../development/python-modules/usb-protocol { };
+
   usbrelay-py = callPackage ../os-specific/linux/usbrelay/python.nix { };
 
   usbtmc = callPackage ../development/python-modules/usbtmc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7610,6 +7610,8 @@ self: super: with self; {
 
   lunarcalendar = callPackage ../development/python-modules/lunarcalendar { };
 
+  luna-usb = callPackage ../development/python-modules/luna-usb { };
+
   luqum = callPackage ../development/python-modules/luqum { };
 
   luxor = callPackage ../development/python-modules/luxor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -698,6 +698,8 @@ self: super: with self; {
 
   aplpy = callPackage ../development/python-modules/aplpy { };
 
+  apollo-fpga = callPackage ../development/python-modules/apollo-fpga { };
+
   app-model = callPackage ../development/python-modules/app-model { };
 
   appdirs = callPackage ../development/python-modules/appdirs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7610,6 +7610,8 @@ self: super: with self; {
 
   lunarcalendar = callPackage ../development/python-modules/lunarcalendar { };
 
+  luna-soc = callPackage ../development/python-modules/luna-soc { };
+
   luna-usb = callPackage ../development/python-modules/luna-usb { };
 
   luqum = callPackage ../development/python-modules/luqum { };


### PR DESCRIPTION
Python package and utilities for the [Great Scott Gadgets Cynthion USB Test Instrument](https://greatscottgadgets.com/cynthion/) https://github.com/greatscottgadgets/cynthion

Packages (dependencies) also included in this PR:
* python312Packages.usb-protocol: init at 0.9.1
* python312Packages.apollo-fpga: init at 1.1.0
* python312Packages.luna-usb: init at 0.1.2
* python312Packages.luna-soc: init at 0.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
