### PR TITLE
sqruff: 0.17.0 → 0.20.2

### DIFF
--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  installShellFiles,
   stdenv,
   darwin,
   rust-jemalloc-sys,
@@ -11,21 +10,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sqruff";
-  version = "0.17.0";
+  version = "0.20.2";
 
   src = fetchFromGitHub {
     owner = "quarylabs";
     repo = "sqruff";
     rev = "refs/tags/v${version}";
-    hash = "sha256-uUtbVf4U59jne5uORXpyzpqhFQoviKi2O9KQ5s1CfhU=";
+    hash = "sha256-Vlre3D1ydDqFdysf5no2rW2V2U/BimhCeV1vWZ2JPSM=";
   };
 
-  cargoHash = "sha256-kIBjPh+rL4vzIAqGNYMpw39A0vADbHxi/PkhoG+QL6c=";
-
-  # Requires nightly features (feature(let_chains) and feature(trait_upcasting))
-  RUSTC_BOOTSTRAP = true;
-
-  nativeBuildInputs = [ installShellFiles ];
+  cargoHash = "sha256-WqkHZcA4FBm8zubAnDrJGH+fgLVIxsNNm3B+mdj5Sxw=";
 
   buildInputs = [
     rust-jemalloc-sys
@@ -35,8 +29,8 @@ rustPlatform.buildRustPackage rec {
   postPatch = ''
     substituteInPlace crates/cli/tests/ui.rs \
       --replace-fail \
-      'config.program.program = format!("../../target/{profile}/sqruff").into();' \
-      'config.program.program = "../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/sqruff".into();'
+      'sqruff_path.push(format!("../../target/{}/sqruff", profile));' \
+      'sqruff_path.push(format!("../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/{}/sqruff", profile));'
   '';
 
   nativeCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
[Release notes](https://github.com/quarylabs/sqruff/releases)

Close #353374

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
