### PR TITLE
[24.05] vesktop: 1.5.2 -> 1.5.3; refactoring

### DIFF
--- a/pkgs/by-name/ve/vesktop/disable_update_checking.patch
+++ b/pkgs/by-name/ve/vesktop/disable_update_checking.patch
@@ -1,12 +1,12 @@
-diff --git a/src/updater/main.ts b/src/updater/main.ts
-index 059afb9..274802e 100644
---- a/src/updater/main.ts
-+++ b/src/updater/main.ts
-@@ -77,6 +77,7 @@ function isOutdated(oldVersion: string, newVersion: string) {
+diff --git a/src/main/index.ts b/src/main/index.ts
+index 2e0d6f7..1108c0f 100644
+--- a/src/main/index.ts
++++ b/src/main/index.ts
+@@ -20,7 +20,6 @@ import { isDeckGameMode } from "./utils/steamOS";
+ if (IS_DEV) {
+     require("source-map-support").install();
+ } else {
+-    autoUpdater.checkForUpdatesAndNotify();
  }
  
- export async function checkUpdates() {
-+    return;
-     if (Settings.store.checkUpdates === false) return;
- 
-     try {
+ // Make the Vencord files use our DATA_DIR

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -73,7 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./use_system_vencord.patch;
     });
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
 
   # disable code signing on macos
   # https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -15,6 +15,7 @@
   autoPatchelfHook,
   pnpm_9,
   nodejs,
+  nix-update-script,
   withTTS ? true,
   withMiddleClickScroll ? false,
   # Enables the use of vencord from nixpkgs instead of
@@ -164,6 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit (finalAttrs) pnpmDeps;
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  stdenvNoCC,
   fetchFromGitHub,
   substituteAll,
   makeWrapper,
@@ -10,13 +9,11 @@
   vencord,
   electron,
   libicns,
-  jq,
-  moreutils,
-  cacert,
-  nodePackages,
   pipewire,
   libpulseaudio,
   autoPatchelfHook,
+  pnpm,
+  nodejs,
   withTTS ? true,
   # Enables the use of vencord from nixpkgs instead of
   # letting vesktop manage it's own version
@@ -33,66 +30,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-cZOyydwpIW9Xq716KVi1RGtSlgVnOP3w8vXDwouS70E=";
   };
 
-  # NOTE: This requires pnpm 8.10.0 or newer
-  # https://github.com/pnpm/pnpm/pull/7214
-  pnpmDeps =
-    assert lib.versionAtLeast nodePackages.pnpm.version "8.10.0";
-    stdenvNoCC.mkDerivation {
-      pname = "${finalAttrs.pname}-pnpm-deps";
-      inherit (finalAttrs)
-        src
-        version
-        patches
-        ELECTRON_SKIP_BINARY_DOWNLOAD
-        ;
-
-      nativeBuildInputs = [
-        cacert
-        jq
-        moreutils
-        nodePackages.pnpm
-      ];
-
-      # inspired by https://github.com/NixOS/nixpkgs/blob/763e59ffedb5c25774387bf99bc725df5df82d10/pkgs/applications/misc/pot/default.nix#L56
-      # and based on https://github.com/NixOS/nixpkgs/pull/290715
-      installPhase = ''
-        runHook preInstall
-
-        export HOME=$(mktemp -d)
-        pnpm config set store-dir $out
-        # Some packages produce platform dependent outputs. We do not want to cache those in the global store
-        pnpm config set side-effects-cache false
-        # pnpm is going to warn us about using --force
-        # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
-        pnpm install --force --frozen-lockfile --ignore-script
-
-      '';
-
-      fixupPhase = ''
-        runHook preFixup
-
-        # Remove timestamp and sort the json files
-        rm -rf $out/v3/tmp
-        for f in $(find $out -name "*.json"); do
-          sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
-          jq --sort-keys . $f | sponge $f
-        done
-
-        runHook postFixup
-      '';
-
-      dontConfigure = true;
-      dontBuild = true;
-      outputHashMode = "recursive";
-      outputHash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
-    };
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src patches;
+    hash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
+  };
 
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
     makeWrapper
-    nodePackages.pnpm
-    nodePackages.nodejs
+    nodejs
+    pnpm.configHook
   ];
 
   buildInputs = [
@@ -109,22 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     });
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-
-  configurePhase = ''
-    runHook preConfigure
-
-    export HOME=$(mktemp -d)
-    export STORE_PATH=$(mktemp -d)
-
-    cp -Tr "$pnpmDeps" "$STORE_PATH"
-    chmod -R +w "$STORE_PATH"
-
-    pnpm config set store-dir "$STORE_PATH"
-    pnpm install --frozen-lockfile --ignore-script --offline
-    patchShebangs node_modules/{*,.*}
-
-    runHook postConfigure
-  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   substituteAll,
+  makeBinaryWrapper,
   makeWrapper,
   makeDesktopItem,
   copyDesktopItems,
@@ -31,19 +32,35 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   pnpmDeps = pnpm.fetchDeps {
-    inherit (finalAttrs) pname version src patches;
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
     hash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
   };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    copyDesktopItems
-    makeWrapper
-    nodejs
-    pnpm.configHook
-  ];
+  nativeBuildInputs =
+    [
+      nodejs
+      pnpm.configHook
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      # vesktop uses venmic, which is a shipped as a prebuilt node module
+      # and needs to be patched
+      autoPatchelfHook
+      copyDesktopItems
+      # we use a script wrapper here for environment variable expansion at runtime
+      # https://github.com/NixOS/nixpkgs/issues/172583
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # on macos we don't need to expand variables, so we can use the faster binary wrapper
+      makeBinaryWrapper
+    ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.isLinux [
     libpulseaudio
     pipewire
     stdenv.cc.cc.lib
@@ -58,63 +75,88 @@ stdenv.mkDerivation (finalAttrs: {
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
+  # disable code signing on macos
+  # https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
+  postConfigure = lib.optionalString stdenv.isDarwin ''
+    export CSC_IDENTITY_AUTO_DISCOVERY=false
+  '';
+
+  # electron builds must be writable on darwin
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    cp -r ${electron}/Applications/Electron.app .
+    chmod -R u+w Electron.app
+  '';
+
   buildPhase = ''
     runHook preBuild
 
     pnpm build
-    # using `pnpm exec` here apparently makes it ignore ELECTRON_SKIP_BINARY_DOWNLOAD
-    ./node_modules/.bin/electron-builder \
+    pnpm exec electron-builder \
       --dir \
       -c.asarUnpack="**/*.node" \
-      -c.electronDist=${electron}/libexec/electron \
+      -c.electronDist=${if stdenv.isDarwin then "." else "${electron}/libexec/electron"} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild
   '';
 
-  # this is consistent with other nixpkgs electron packages and upstream, as far as I am aware
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/opt/Vesktop
-    cp -r dist/linux-*unpacked/resources $out/opt/Vesktop/
-
+  postBuild = lib.optionalString stdenv.isLinux ''
     pushd build
     ${libicns}/bin/icns2png -x icon.icns
-    for file in icon_*x32.png; do
-      file_suffix=''${file//icon_}
-      install -Dm0644 $file $out/share/icons/hicolor/''${file_suffix//x32.png}/apps/vesktop.png
-    done
-
-    makeWrapper ${electron}/bin/electron $out/bin/vesktop \
-      --add-flags $out/opt/Vesktop/resources/app.asar \
-      ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
-
-    runHook postInstall
+    popd
   '';
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "vesktop";
-      desktopName = "Vesktop";
-      exec = "vesktop %U";
-      icon = "vesktop";
-      startupWMClass = "Vesktop";
-      genericName = "Internet Messenger";
-      keywords = [
-        "discord"
-        "vencord"
-        "electron"
-        "chat"
-      ];
-      categories = [
-        "Network"
-        "InstantMessaging"
-        "Chat"
-      ];
-    })
-  ];
+  installPhase =
+    ''
+      runHook preInstall
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/opt/Vesktop
+      cp -r dist/*unpacked/resources $out/opt/Vesktop/
+
+      for file in build/icon_*x32.png; do
+        file_suffix=''${file//icon_}
+        install -Dm0644 $file $out/share/icons/hicolor/''${file_suffix//x32.png}/apps/vesktop.png
+      done
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/{Applications,bin}
+      mv dist/mac*/Vesktop.App $out/Applications
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  postFixup =
+    lib.optionalString stdenv.isLinux ''
+      makeWrapper ${electron}/bin/electron $out/bin/vesktop \
+        --add-flags $out/opt/Vesktop/resources/app.asar \
+        ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      makeWrapper $out/Applications/Vesktop.app/Contents/MacOS/Vesktop $out/bin/vesktop
+    '';
+
+  desktopItems = lib.optional stdenv.isLinux (makeDesktopItem {
+    name = "vesktop";
+    desktopName = "Vesktop";
+    exec = "vesktop %U";
+    icon = "vesktop";
+    startupWMClass = "Vesktop";
+    genericName = "Internet Messenger";
+    keywords = [
+      "discord"
+      "vencord"
+      "electron"
+      "chat"
+    ];
+    categories = [
+      "Network"
+      "InstantMessaging"
+      "Chat"
+    ];
+  });
 
   passthru = {
     inherit (finalAttrs) pnpmDeps;
@@ -131,10 +173,12 @@ stdenv.mkDerivation (finalAttrs: {
       vgskye
       pluiedev
     ];
+    mainProgram = "vesktop";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
-    mainProgram = "vesktop";
   };
 })

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
       cp -r dist/*unpacked/resources $out/opt/Vesktop/
 
       for file in build/icon_*x32.png; do
-        file_suffix=''${file//icon_}
+        file_suffix=''${file//build\/icon_}
         install -Dm0644 $file $out/share/icons/hicolor/''${file_suffix//x32.png}/apps/vesktop.png
       done
     ''

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -13,7 +13,7 @@
   pipewire,
   libpulseaudio,
   autoPatchelfHook,
-  pnpm,
+  pnpm_9,
   nodejs,
   withTTS ? true,
   withMiddleClickScroll ? false,
@@ -23,29 +23,29 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vesktop";
-  version = "1.5.2";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "Vencord";
     repo = "Vesktop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-cZOyydwpIW9Xq716KVi1RGtSlgVnOP3w8vXDwouS70E=";
+    hash = "sha256-HlT7ddlrMHG1qOCqdaYjuWhJD+5FF1Nkv2sfXLWd07o=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs)
       pname
       version
       src
       patches
       ;
-    hash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
+    hash = "sha256-rizJu6v04wFEpJtakC2tfPg/uylz7gAOzJiXvUwdDI4=";
   };
 
   nativeBuildInputs =
     [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ]
     ++ lib.optionals stdenv.isLinux [
       # vesktop uses venmic, which is a shipped as a prebuilt node module

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -16,6 +16,7 @@
   pnpm,
   nodejs,
   withTTS ? true,
+  withMiddleClickScroll ? false,
   # Enables the use of vencord from nixpkgs instead of
   # letting vesktop manage it's own version
   withSystemVencord ? false,
@@ -134,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper ${electron}/bin/electron $out/bin/vesktop \
         --add-flags $out/opt/Vesktop/resources/app.asar \
         ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
+        ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
     ''
     + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString stdenv.isDarwin ''
       mkdir -p $out/{Applications,bin}
-      mv dist/mac*/Vesktop.App $out/Applications
+      mv dist/mac*/Vesktop.app $out/Applications/Vesktop.app
     ''
     + ''
       runHook postInstall

--- a/pkgs/by-name/ve/vesktop/use_system_vencord.patch
+++ b/pkgs/by-name/ve/vesktop/use_system_vencord.patch
@@ -1,13 +1,13 @@
 diff --git a/src/main/constants.ts b/src/main/constants.ts
-index d5c5fa6..a1b32f1 100644
+index 40d91a5..7b46bbf 100644
 --- a/src/main/constants.ts
 +++ b/src/main/constants.ts
-@@ -16,7 +16,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
- // needs to be inline require because of circular dependency
+@@ -49,7 +49,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
  // as otherwise "DATA_DIR" (which is used by ./settings) will be uninitialised
  export const VENCORD_FILES_DIR =
--    (require("./settings") as typeof import("./settings")).Settings.store.vencordDir || join(DATA_DIR, "vencordDist");
-+    (require("./settings") as typeof import("./settings")).Settings.store.vencordDir || "@vencord@";
+     (require("./settings") as typeof import("./settings")).State.store.vencordDir ||
+-    join(SESSION_DATA_DIR, "vencordFiles");
++    "@vencord@";
  
  export const USER_AGENT = `Vesktop/${app.getVersion()} (https://github.com/Vencord/Vesktop)`;
  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24754,8 +24754,6 @@ with pkgs;
 
   vencord-web-extension = callPackage ../by-name/ve/vencord/package.nix { buildWebExtension = true; };
 
-  vesktop = callPackage ../by-name/ve/vesktop/package.nix { pnpm = pnpm_8; };
-
   vid-stab = callPackage ../development/libraries/vid-stab {
     inherit (llvmPackages) openmp;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24754,6 +24754,8 @@ with pkgs;
 
   vencord-web-extension = callPackage ../by-name/ve/vencord/package.nix { buildWebExtension = true; };
 
+  vesktop = callPackage ../by-name/ve/vesktop/package.nix { pnpm = pnpm_8; };
+
   vid-stab = callPackage ../development/libraries/vid-stab {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
- **vesktop: use pnpm.fetchDeps**
- Skipped: treewide: Remove indefinite article from meta.description
- **vesktop: add support for darwin**
- **vesktop: use attrset for env vars**
- **vesktop: fix icon file locations**
- **vesktop: Add option for middle click scroll**
- **vesktop: 1.5.2 -> 1.5.3**
- **vesktop: add updateScript**
- Skipped: vesktop: use electron.dist
- Skipped: treewide: replace `stdenv.is` with `stdenv.hostPlatform.is`
- **vesktop: fix darwin extension `.App` -> `.app`**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
