### PR TITLE
python312Packages.unifi-ap: fix failing build

### DIFF
--- a/pkgs/development/python-modules/unifi-ap/default.nix
+++ b/pkgs/development/python-modules/unifi-ap/default.nix
@@ -4,8 +4,8 @@
   fetchFromGitHub,
   setuptools,
   paramiko,
+  pythonRelaxDepsHook,
 }:
-
 buildPythonPackage rec {
   pname = "unifi-ap";
   version = "0.0.1";
@@ -18,19 +18,15 @@ buildPythonPackage rec {
     hash = "sha256-dEaDRcQEx+n+zvxVHD58B1AdFj004L76AtVDesnP+gQ=";
   };
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "paramiko" ];
 
-  dependencies = [
-    paramiko
-  ];
+  dependencies = [ paramiko ];
 
-  pythonImportsCheck = [
-    "unifi_ap"
-  ];
+  pythonImportsCheck = [ "unifi_ap" ];
 
   doCheck = false; # no tests
 


### PR DESCRIPTION
ZHF: #352882

## Things done

Added `pythonRelaxDepsHook`. `pythonRelaxDeps` was already set but we need to explicitly specify `pythonRelaxDepsHook` in `nativeBuildInputs` according to [the docs](https://nixos.org/manual/nixpkgs/stable/#using-pythonrelaxdepshook) (the `paramiko` version in nixpkgs probably just happened to match when this was initially added).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
