### PR TITLE
python312Packages.mmengine: fix test

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -48,6 +48,13 @@ buildPythonPackage rec {
       url = "https://github.com/open-mmlab/mmengine/commit/4c22f78cdea2981a2b48a167e9feffe4721f8901.patch";
       hash = "sha256-k+IFLeqTEVUGGiqmZg56LK64H/UTvpGN20GJT59wf4A=";
     })
+    (fetchpatch2 {
+      # Bug reported upstream in https://github.com/open-mmlab/mmengine/issues/1575
+      # PR: https://github.com/open-mmlab/mmengine/pull/1589
+      name = "adapt-to-pytest-breaking-change";
+      url = "https://patch-diff.githubusercontent.com/raw/open-mmlab/mmengine/pull/1589.patch";
+      hash = "sha256-lyKf1GCLOPMpDttJ4s9hbATIGCVkiQhtyLfH9WzMWrw=";
+    })
   ];
 
   build-system = [ setuptools ];
@@ -64,7 +71,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    # bitsandbytes (broken as of 2024-07-06)
+    bitsandbytes
     coverage
     dvclive
     lion-pytorch
@@ -77,7 +84,7 @@ buildPythonPackage rec {
 
   preCheck =
     ''
-      export HOME=$TMPDIR
+      export HOME=$(mktemp -d)
     ''
     # Otherwise, the backprop hangs forever. More precisely, this exact line:
     # https://github.com/open-mmlab/mmengine/blob/02f80e8bdd38f6713e04a872304861b02157905a/tests/test_runner/test_activation_checkpointing.py#L46
@@ -95,14 +102,6 @@ buildPythonPackage rec {
     "tests/test_runner/test_activation_checkpointing.py"
     # missing dependencies
     "tests/test_visualizer/test_vis_backend.py"
-    # Tests are outdated (runTest instead of run_test)
-    "mmengine/testing/_internal"
-    "tests/test_dist/test_dist.py"
-    "tests/test_dist/test_utils.py"
-    "tests/test_hooks/test_sync_buffers_hook.py"
-    "tests/test_model/test_wrappers/test_model_wrapper.py"
-    "tests/test_optim/test_optimizer/test_optimizer.py"
-    "tests/test_optim/test_optimizer/test_optimizer_wrapper.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Things done

Re-enable "broken" tests by fetching the necessary patch upstream.

Context: https://github.com/open-mmlab/mmengine/issues/1575, https://github.com/open-mmlab/mmengine/pull/1589

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
