### PR TITLE
genericUpdater: silence grep in version_is_ignored

### DIFF
--- a/pkgs/common-updater/generic-updater.nix
+++ b/pkgs/common-updater/generic-updater.nix
@@ -54,7 +54,7 @@ let
 
     function version_is_ignored() {
       local tag="$1"
-      [ -n "$ignored_versions" ] && ${grep} -E -e "$ignored_versions" <<< "$tag"
+      [ -n "$ignored_versions" ] && ${grep} -q -E -e "$ignored_versions" <<< "$tag"
     }
 
     function version_is_unstable() {


### PR DESCRIPTION
## Description of changes

`version_is_ignored` must not emit matching versions on `stdout`, as that violates the commit protocol.

The issue can currently be demonstrated with the package `hatsu`, while no new release version is available.

<details><summary><tt>nix-shell maintainers/scripts/update.nix --argstr skip-prompt true --argstr commit true --argstr package hatsu</tt></summary>

```console
$ nix-shell maintainers/scripts/update.nix --argstr skip-prompt true --argstr commit true --argstr package hatsu

Going to be running update for following packages:
 - hatsu-0.2.2


Running update for:
Preparing worktree (new branch 'update-tmp1i6gns25')
Updating files: 100% (43991/43991), done.
HEAD is now at aede1a0f2ef9 woodpecker-server: 2.7.1 -> 2.7.2 (#353384)
 - hatsu-0.2.2: UPDATING ...
Deleted branch update-tmp1i6gns25 (was aede1a0f2ef9).
Traceback (most recent call last):
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 249, in <module>
    main(args.max_workers, args.keep_going, args.commit, args.packages, args.skip_prompt)
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 229, in main
    asyncio.run(start_updates(max_workers, keep_going, commit, packages))
  File "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 203, in start_updates
    await updaters
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 168, in updater
    await run_update_script(nixpkgs_root, merge_lock, temp_dir, package, keep_going)
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 70, in run_update_script
    await merge_changes(merge_lock, package, update_info, temp_dir)
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 149, in merge_changes
    changes = await check_changes(package, worktree, update_info)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/qli6b8pdydp2b9k7240qj9nb7vsn7csa-update.py", line 116, in check_changes
    changes = json.loads(update_info)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7/lib/python3.12/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 4 (char 3)
```
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc