### PR TITLE
raycast: fix path in update script and bump to 1.84.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9740,6 +9740,13 @@
     githubId = 2179419;
     name = "Arseniy Seroka";
   };
+  jakecleary = {
+    email = "shout@jakecleary.net";
+    github = "jakecleary";
+    githubId = 4572429;
+    name = "Jake Cleary";
+    keys = [ { fingerprint = "6192 E5CC 28B8 FA7E F5F3  775F 3726 5B1E 496C 92A2"; } ];
+  };
   jakedevs = {
     email = "work@jakedevs.net";
     github = "jakedevs";

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -11,12 +11,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
-  version = "1.84.8";
+  version = "1.84.10";
 
   src = fetchurl {
     name = "Raycast.dmg";
     url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=universal";
-    hash = "sha256-MSxscz2c5eNfdlWxn8sEVtqg2iXlPnIfJHnaiMvwtgY=";
+    hash = "sha256-9y66rex0A7pWkdqS1R0mo5IAA6SkA2e6alGu9Rs6j6U=";
   };
 
   dontPatch = true;

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     text = ''
       url=$(curl --silent "https://releases.raycast.com/releases/latest?build=universal")
       version=$(echo "$url" | jq -r '.version')
-      update-source-version raycast "$version" --file=./pkgs/os-specific/darwin/raycast/default.nix
+      update-source-version raycast "$version" --file=./pkgs/by-name/ra/raycast/package.nix
     '';
   });
 

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -59,6 +59,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       lovesegfault
       stepbrobd
       donteatoreo
+      jakecleary
     ];
     platforms = [
       "aarch64-darwin"


### PR DESCRIPTION
Hey 👋

Firstly let me just say that this is my first time contributing to the project, so apologies in advance if I have misstepped. I'm happy to make any corrections necessary! Thank you.

I noticed that the update script is pointing to the old path (`./pkgs/os-specific/darwin/raycast/default.nix`) instead of the new path (`./pkgs/by-name/ra/raycast/package.nix`). I'm assuming this might be why we're a couple of minor versions behind, but to be honest I'm not sure, as it looks like most version bumps for this pkg are coming from manual PRs.

I've also bumped the pkg to 1.84.10, and tested the build locally by running `nix-build -A raycast` against a `default.nix` harness I copied from [here](https://nix.dev/tutorials/packaging-existing-software#building-with-nix-build). I also ran the outputted `Raycast.app` and checked that it showed 1.84.10 as the version, in the about section.

By the way, if anyone can recommend a way of testing pkg builds without needing to add a default file, please say! 😊 I'm very new to this, and it seemed a bit clunky. Is there maybe a CLI command I can run that wraps the pkg in the equivalent code for me?

## Things done

- Commits
	- Added myself (shout@jakecleary.net) as a maintainer.
		- The docs said to do this but shout if I'm overstepping here! I'm happy to help though 😊
	- Updated the update script to point to `./pkgs/by-name/ra/raycast/package.nix`
	- Updated the pkg to 1.84.10, which is the version returned by the raycast `latest` API
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
