### PR TITLE
ci: run shellcheck and shfmt on shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,15 @@ indent_size = 2
 [*.{pl,pm,py,sh}]
 indent_size = 4
 
+# Picked up by shfmt, too.
+[*.sh]
+indent_style = space
+indent_size = 4
+shell_variant = bash
+binary_next_line = true
+switch_case_indent = true
+space_redirects = true
+
 # Match gemfiles, set indent to spaces with width of two
 [Gemfile]
 indent_size = 2

--- a/.github/workflows/check-bash-scripts.yml
+++ b/.github/workflows/check-bash-scripts.yml
@@ -1,6 +1,6 @@
 # This file was copied from check-nix-format.yml for the logic to apply
 # this only to those files which are already conforming on the target branch.
-name: Check that shell scripts are shellcheck-ed
+name: Check that shell scripts are formatted and shellcheck-ed
 
 on:
   pull_request_target:
@@ -28,9 +28,9 @@ jobs:
           git worktree add "$base" "$baseRev"
           echo "baseRev=$baseRev" >> "$GITHUB_ENV"
           echo "base=$base" >> "$GITHUB_ENV"
-      - name: Get Nixpkgs revision for shellcheck
+      - name: Get Nixpkgs revision for shellcheck and shfmt
         run: |
-          # Pin to a commit from nixpkgs-unstable to avoid e.g. building shellcheck
+          # Pin to a commit from nixpkgs-unstable to avoid e.g. building shellcheck or shfmt
           # from staging.
           # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
           rev=$(jq -r .rev ci/pinned-nixpkgs.json)
@@ -40,10 +40,11 @@ jobs:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
           nix_path: nixpkgs=${{ env.url }}
-      - name: Install shellcheck
-        run: "nix-env -f '<nixpkgs>' -iAP shellcheck"
+      - name: Install shellcheck and shfmt
+        run: "nix-env -f '<nixpkgs>' -iAP shellcheck shfmt"
       - name: Check that shell scripts are conforming
         run: |
+          shfmtFiles=()
           shellcheckFiles=()
 
           # TODO: Make this more parallel
@@ -70,6 +71,13 @@ jobs:
                 continue
             esac
 
+            # Ignore files that weren't already formatted
+            if [[ -n "$source" ]] && ! shfmt --diff ${{ env.base }}/"$source" >/dev/null; then
+              echo "Ignoring file $file because it's not formatted in the base commit"
+            elif ! shfmt --diff "$dest"; then
+              shfmtFiles+=("$dest")
+            fi
+
             # Ignore files that weren't already shellcheck-ed
             if [[ -n "$source" ]] && ! shellcheck ${{ env.base }}/"$source" >/dev/null; then
               echo "Ignoring file $file because it's not shellcheck-ed in the base commit"
@@ -78,6 +86,13 @@ jobs:
             fi
           done < <(git diff -z --name-status ${{ env.baseRev }} -- '*.sh')
 
+          if (( "${#shfmtFiles[@]}" > 0 )); then
+            echo "Some new/changed shell scripts are not properly formatted"
+            echo "Please go to the Nixpkgs root directory, run \`nix-shell\`, then:"
+            echo "shfmt -w ${shfmtFiles[*]@Q}"
+            echo
+          fi
+
           if (( "${#shellcheckFiles[@]}" > 0 )); then
             echo "Some new/changed shell scripts are not properly shellcheck-ed"
             echo "Please go to the Nixpkgs root directory, run \`nix-shell\`, then:"
@@ -85,6 +100,6 @@ jobs:
             echo
           fi
 
-          if (( "${#shellcheckFiles[@]}" > 0 ))
+          if (( "${#shfmtFiles[@]}" + "${#shellcheckFiles[@]}" > 0 ))
             exit 1
           fi

--- a/.github/workflows/check-bash-scripts.yml
+++ b/.github/workflows/check-bash-scripts.yml
@@ -1,0 +1,90 @@
+# This file was copied from check-nix-format.yml for the logic to apply
+# this only to those files which are already conforming on the target branch.
+name: Check that shell scripts are shellcheck-ed
+
+on:
+  pull_request_target:
+    # See the comment at the same location in ./nixpkgs-vet.yml
+    types: [opened, synchronize, reopened, edited]
+permissions:
+  contents: read
+
+jobs:
+  nixos:
+    name: shell-check
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Fetches the merge commit and its parents
+          fetch-depth: 2
+      - name: Checking out base branch
+        run: |
+          base=$(mktemp -d)
+          baseRev=$(git rev-parse HEAD^1)
+          git worktree add "$base" "$baseRev"
+          echo "baseRev=$baseRev" >> "$GITHUB_ENV"
+          echo "base=$base" >> "$GITHUB_ENV"
+      - name: Get Nixpkgs revision for shellcheck
+        run: |
+          # Pin to a commit from nixpkgs-unstable to avoid e.g. building shellcheck
+          # from staging.
+          # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
+          rev=$(jq -r .rev ci/pinned-nixpkgs.json)
+          echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          # explicitly enable sandbox
+          extra_nix_config: sandbox = true
+          nix_path: nixpkgs=${{ env.url }}
+      - name: Install shellcheck
+        run: "nix-env -f '<nixpkgs>' -iAP shellcheck"
+      - name: Check that shell scripts are conforming
+        run: |
+          shellcheckFiles=()
+
+          # TODO: Make this more parallel
+
+          # Loop through all .sh files touched by the PR
+          while readarray -d '' -n 2 entry && (( ${#entry[@]} != 0 )); do
+            type=${entry[0]}
+            file=${entry[1]}
+            case $type in
+              A*)
+                source=""
+                dest=$file
+                ;;
+              M*)
+                source=$file
+                dest=$file
+                ;;
+              C*|R*)
+                source=$file
+                read -r -d '' dest
+                ;;
+              *)
+                echo "Ignoring file $file with type $type"
+                continue
+            esac
+
+            # Ignore files that weren't already shellcheck-ed
+            if [[ -n "$source" ]] && ! shellcheck ${{ env.base }}/"$source" >/dev/null; then
+              echo "Ignoring file $file because it's not shellcheck-ed in the base commit"
+            elif ! shellcheck "$dest"; then
+              shellcheckFiles+=("$dest")
+            fi
+          done < <(git diff -z --name-status ${{ env.baseRev }} -- '*.sh')
+
+          if (( "${#shellcheckFiles[@]}" > 0 )); then
+            echo "Some new/changed shell scripts are not properly shellcheck-ed"
+            echo "Please go to the Nixpkgs root directory, run \`nix-shell\`, then:"
+            echo "shellcheck ${shellcheckFiles[*]@Q}"
+            echo
+          fi
+
+          if (( "${#shellcheckFiles[@]}" > 0 ))
+            exit 1
+          fi

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -1,4 +1,4 @@
-name: "Check shell"
+name: "Check shell.nix"
 
 on:
   pull_request_target:
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   x86_64-linux:
-    name: shell-check-x86_64-linux
+    name: shell-nix-check-x86_64-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -19,7 +19,7 @@ jobs:
         run: nix-build shell.nix
 
   aarch64-darwin:
-    name: shell-check-aarch64-darwin
+    name: shell-nix-check-aarch64-darwin
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# supports source=pkgs/stdenv/generic/setup.sh directives
+external-sources=true
+source-path=pkgs/stdenv/generic
+shell=bash
+
+# Otherwise all xxxPhase=... will fail this rule:
+#   xxxPhase appears unused. Verify use (...).
+disable=SC2034

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -1,4 +1,7 @@
-# shellcheck shell=bash disable=SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
+
+declare cargoBuildType
 
 cargoBuildHook() {
     echo "Executing cargoBuildHook"

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,4 +1,7 @@
-# shellcheck shell=bash disable=SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
+
+declare cargoCheckType
 
 cargoCheckHook() {
     echo "Executing cargoCheckHook"

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -1,4 +1,7 @@
-# shellcheck shell=bash disable=SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
+
+declare cargoCheckType
 
 cargoNextestHook() {
     echo "Executing cargoNextestHook"

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -1,4 +1,5 @@
-# shellcheck shell=bash disable=SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
 
 maturinBuildHook() {
     echo "Executing maturinBuildHook"

--- a/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
+++ b/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
@@ -1,3 +1,6 @@
+# shellcheck source=stdenv.sh
+. /dev/null
+
 # populates LIBCLANG_PATH and BINDGEN_EXTRA_CLANG_ARGS for rust projects that
 # depend on the bindgen crate
 

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -45,20 +45,30 @@ _overrideFirst() {
 # Setup chains of sane default values with easy overridability.
 # The variables are global to be usable anywhere during the build.
 # Typical usage in package is defining outputBin = "dev";
+# Each variable is declare'd to make shellcheck aware of it.
 
+declare outputDev
 _overrideFirst outputDev "dev" "out"
+declare outputBin
 _overrideFirst outputBin "bin" "out"
 
+declare outputInclude
 _overrideFirst outputInclude "$outputDev"
 
 # so-libs are often among the main things to keep, and so go to $out
+declare outputLib
 _overrideFirst outputLib "lib" "out"
 
+declare outputDoc
 _overrideFirst outputDoc "doc" "out"
+declare outputDevdoc
 _overrideFirst outputDevdoc "devdoc" REMOVE # documentation for developers
 # man and info pages are small and often useful to distribute with binaries
+declare outputMan
 _overrideFirst outputMan "man" "$outputBin"
+declare outputDevman
 _overrideFirst outputDevman "devman" "devdoc" "$outputMan"
+declare outputInfo
 _overrideFirst outputInfo "info" "$outputBin"
 
 

--- a/pkgs/by-name/ca/cargo-tauri/hook.sh
+++ b/pkgs/by-name/ca/cargo-tauri/hook.sh
@@ -1,4 +1,5 @@
-# shellcheck shell=bash disable=SC2034,SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
 
 # We replace these
 export dontCargoBuild=true

--- a/pkgs/development/tools/build-managers/gn/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gn/setup-hook.sh
@@ -1,4 +1,5 @@
-# shellcheck shell=bash
+# shellcheck source=stdenv.sh
+. /dev/null
 
 gnConfigurePhase() {
     runHook preConfigure
@@ -9,7 +10,6 @@ gnConfigurePhase() {
     echoCmd 'gn flags' "${flagsArray[@]}"
 
     gn gen out/Release --args="${flagsArray[*]}"
-    # shellcheck disable=SC2164
     cd out/Release/
 
     runHook postConfigure

--- a/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
+++ b/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
@@ -1,6 +1,5 @@
-# shellcheck shell=bash
-# Variables we use here are set by the stdenv, no use complaining about them
-# shellcheck disable=SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
 
 ecmEnvHook() {
     addToSearchPath XDG_DATA_DIRS "$1/share"

--- a/pkgs/os-specific/bsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/setup-hook.sh
@@ -1,4 +1,5 @@
-# shellcheck shell=bash disable=SC2154,SC2164
+# shellcheck source=stdenv.sh
+. /dev/null
 
 # BSD makefiles should be able to detect this
 # but without they end up using gcc on Darwin stdenv

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -57,6 +57,7 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 
 let
   defaultNativeBuildInputs = extraNativeBuildInputs ++
+    # Please match this list of .sh files with those in pkgs/stdenv/generic/stdenv.sh for shellcheck.
     [
       ../../build-support/setup-hooks/audit-tmpdir.sh
       ../../build-support/setup-hooks/compress-man-pages.sh

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,4 +1,6 @@
-# shellcheck shell=bash
+# shellcheck source=shellcheck.sh
+. /dev/null
+
 # shellcheck disable=1090,2154,2123,2034,2178,2048,2068,1091
 __nixpkgs_setup_set_original=$-
 set -eu

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -181,7 +181,6 @@ runHook() {
     return 0
 }
 
-
 # Run all hooks with the specified name, until one succeeds (returns a
 # zero exit code). If none succeed, return a non-zero exit code.
 runOneHook() {
@@ -201,7 +200,6 @@ runOneHook() {
 
     return "$ret"
 }
-
 
 # Run the named hook, either by calling the function with that name or
 # by evaluating the variable with that name. This allows convenient
@@ -228,7 +226,6 @@ _callImplicitHook() {
     # return trap is no good because it would affect nested returns.
 }
 
-
 # A function wrapper around ‘eval’ that ensures that ‘return’ inside
 # hooks exits the hook, not the caller. Also will only pass args if
 # command can take them
@@ -239,7 +236,6 @@ _eval() {
         eval "$1"
     fi
 }
-
 
 ######################################################################
 # Logging.
@@ -254,7 +250,6 @@ echoCmd() {
     printf ' %q' "$@"
     echo
 }
-
 
 ######################################################################
 # Error handling.
@@ -272,7 +267,7 @@ exitHandler() {
         echo "system time for all child processes ${buildTimes[3]}"
     fi
 
-    if (( "$exitCode" != 0 )); then
+    if (("$exitCode" != 0)); then
         runHook failureHook
 
         # If the builder had a non-zero exit code and
@@ -295,17 +290,14 @@ exitHandler() {
 
 trap "exitHandler" EXIT
 
-
 ######################################################################
 # Helper functions.
-
 
 addToSearchPathWithCustomDelimiter() {
     local delimiter="$1"
     local varName="$2"
     local dir="$3"
-    if [[ -d "$dir" && "${!varName:+${delimiter}${!varName}${delimiter}}" \
-          != *"${delimiter}${dir}${delimiter}"* ]]; then
+    if [[ -d "$dir" && "${!varName:+${delimiter}${!varName}${delimiter}}" != *"${delimiter}${dir}${delimiter}"* ]]; then
         export "${varName}=${!varName:+${!varName}${delimiter}}${dir}"
     fi
 }
@@ -337,18 +329,21 @@ prependToVar() {
         case "${type#* }" in
             -A*)
                 echo "prependToVar(): ERROR: trying to use prependToVar on an associative array." >&2
-                return 1 ;;
+                return 1
+                ;;
             -a*)
-                useArray=true ;;
+                useArray=true
+                ;;
             *)
-                useArray=false ;;
+                useArray=false
+                ;;
         esac
     fi
 
     shift
 
     if $useArray; then
-        nameref=( "$@" ${nameref+"${nameref[@]}"} )
+        nameref=("$@" ${nameref+"${nameref[@]}"})
     else
         nameref="$* ${nameref-}"
     fi
@@ -370,18 +365,21 @@ appendToVar() {
         case "${type#* }" in
             -A*)
                 echo "appendToVar(): ERROR: trying to use appendToVar on an associative array, use variable+=([\"X\"]=\"Y\") instead." >&2
-                return 1 ;;
+                return 1
+                ;;
             -a*)
-                useArray=true ;;
+                useArray=true
+                ;;
             *)
-                useArray=false ;;
+                useArray=false
+                ;;
         esac
     fi
 
     shift
 
     if $useArray; then
-        nameref=( ${nameref+"${nameref[@]}"} "$@" )
+        nameref=(${nameref+"${nameref[@]}"} "$@")
     else
         nameref="${nameref-} $*"
     fi
@@ -394,28 +392,31 @@ appendToVar() {
 concatTo() {
     local -
     set -o noglob
-    local -n targetref="$1"; shift
+    local -n targetref="$1"
+    shift
     local arg default name type
     for arg in "$@"; do
         IFS="=" read -r name default <<< "$arg"
         local -n nameref="$name"
         if [[ -z "${nameref[*]}" && -n "$default" ]]; then
-            targetref+=( "$default" )
+            targetref+=("$default")
         elif type=$(declare -p "$name" 2> /dev/null); then
             case "${type#* }" in
                 -A*)
                     echo "concatTo(): ERROR: trying to use concatTo on an associative array." >&2
-                    return 1 ;;
+                    return 1
+                    ;;
                 -a*)
-                    targetref+=( "${nameref[@]}" ) ;;
+                    targetref+=("${nameref[@]}")
+                    ;;
                 *)
                     if [[ "$name" = *"Array" ]]; then
                         nixErrorLog "concatTo(): $name is not declared as array, treating as a singleton. This will become an error in future"
                         # Reproduces https://github.com/NixOS/nixpkgs/pull/318614/files#diff-7c7ca80928136cfc73a02d5b28350bd900e331d6d304857053ffc9f7beaad576L359
-                        targetref+=( ${nameref+"${nameref[@]}"} )
+                        targetref+=(${nameref+"${nameref[@]}"})
                     else
                         # shellcheck disable=SC2206
-                        targetref+=( ${nameref-} )
+                        targetref+=(${nameref-})
                     fi
                     ;;
             esac
@@ -443,12 +444,15 @@ concatStringsSep() {
         case "${type#* }" in
             -A*)
                 echo "concatStringsSep(): ERROR: trying to use concatStringsSep on an associative array." >&2
-                return 1 ;;
+                return 1
+                ;;
             -a*)
                 local IFS="$sep"
-                echo -n "${nameref[*]}" ;;
+                echo -n "${nameref[*]}"
+                ;;
             *)
-                echo -n "${nameref// /"${sep}"}" ;;
+                echo -n "${nameref// /"${sep}"}"
+                ;;
         esac
     fi
 }
@@ -489,15 +493,15 @@ isMachO() {
     # https://opensource.apple.com/source/lldb/lldb-310.2.36/examples/python/mach_o.py.auto.html
     if [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xcf") || "$magic" = $(echo -ne "\xcf\xfa\xed\xfe") ]]; then
         # MH_MAGIC_64 || MH_CIGAM_64
-        return 0;
+        return 0
     elif [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xce") || "$magic" = $(echo -ne "\xce\xfa\xed\xfe") ]]; then
         # MH_MAGIC || MH_CIGAM
-        return 0;
+        return 0
     elif [[ "$magic" = $(echo -ne "\xca\xfe\xba\xbe") || "$magic" = $(echo -ne "\xbe\xba\xfe\xca") ]]; then
         # FAT_MAGIC || FAT_CIGAM
-        return 0;
+        return 0
     else
-        return 1;
+        return 1
     fi
 }
 
@@ -515,12 +519,12 @@ isScript() {
 
 # printf unfortunately will print a trailing newline regardless
 printLines() {
-    (( "$#" > 0 )) || return 0
+    (("$#" > 0)) || return 0
     printf '%s\n' "$@"
 }
 
 printWords() {
-    (( "$#" > 0 )) || return 0
+    (("$#" > 0)) || return 0
     printf '%s ' "$@"
 }
 
@@ -535,7 +539,6 @@ if [[ -n $__structuredAttrs ]]; then
     done
 fi
 
-
 # Set a fallback default value for SOURCE_DATE_EPOCH, used by some build tools
 # to provide a deterministic substitute for the "current" time. Note that
 # 315532800 = 1980-01-01 12:00:00. We use this date because python's wheel
@@ -544,12 +547,10 @@ fi
 export SOURCE_DATE_EPOCH
 : "${SOURCE_DATE_EPOCH:=315532800}"
 
-
 # Wildcard expansions that don't match should expand to an empty list.
 # This ensures that, for instance, "for i in *; do ...; done" does the
 # right thing.
 shopt -s nullglob
-
 
 # Set up the initial path.
 PATH=
@@ -571,21 +572,21 @@ unset i
 nixWarnLog "initial path: $PATH"
 
 # Check that the pre-hook initialised SHELL.
-if [ -z "${SHELL:-}" ]; then echo "SHELL not set"; exit 1; fi
+if [ -z "${SHELL:-}" ]; then
+    echo "SHELL not set"
+    exit 1
+fi
 BASH="$SHELL"
 export CONFIG_SHELL="$SHELL"
-
 
 # Execute the pre-hook.
 if [ -z "${shell:-}" ]; then export shell="$SHELL"; fi
 runHook preHook
 
-
 # Allow the caller to augment buildInputs (it's not always possible to
 # do this before the call to setup.sh, since the PATH is empty at that
 # point; here we have a basic Unix environment).
 runHook addInputsHook
-
 
 # Package accumulators
 
@@ -598,7 +599,6 @@ declare -a pkgHostAccumVars=(pkgsHostHost pkgsHostTarget)
 declare -a pkgTargetAccumVars=(pkgsTargetTarget)
 
 declare -a pkgAccumVarVars=(pkgBuildAccumVars pkgHostAccumVars pkgTargetAccumVars)
-
 
 # Hooks
 
@@ -626,7 +626,6 @@ addEnvHooks() {
     done
 }
 
-
 # Propagated dep files
 
 declare -a propagatedBuildDepFiles=(
@@ -650,7 +649,6 @@ declare -a propagatedDepFilesVars=(
 # Platform offsets: build = -1, host = 0, target = 1
 declare -a allPlatOffsets=(-1 0 1)
 
-
 # Mutually-recursively find all build inputs. See the dependency section of the
 # stdenv chapter of the Nixpkgs manual for the specification this algorithm
 # implements.
@@ -660,7 +658,7 @@ findInputs() {
     local -r targetOffset="$3"
 
     # Sanity check
-    (( hostOffset <= targetOffset )) || exit 1
+    ((hostOffset <= targetOffset)) || exit 1
 
     # shellcheck disable=SC1087
     local varVar="${pkgAccumVarVars[hostOffset + 1]}"
@@ -694,7 +692,7 @@ findInputs() {
     function mapOffset() {
         local -r inputOffset="$1"
         local -n outputOffset="$2"
-        if (( inputOffset <= 0 )); then
+        if ((inputOffset <= 0)); then
             outputOffset=$((inputOffset + hostOffset))
         else
             outputOffset=$((inputOffset - 1 + targetOffset))
@@ -715,13 +713,13 @@ findInputs() {
 
         # Ensure we're in bounds relative to the package currently
         # being built.
-        (( -1 <= hostOffsetNext && hostOffsetNext <= 1 )) || continue
+        ((-1 <= hostOffsetNext && hostOffsetNext <= 1)) || continue
 
         # Target offset relative to the *host* offset of the package
         # whose immediate dependencies we are currently exploring.
         local relTargetOffset
         for relTargetOffset in "${allPlatOffsets[@]}"; do
-            (( "$relHostOffset" <= "$relTargetOffset" )) || continue
+            (("$relHostOffset" <= "$relTargetOffset")) || continue
 
             local fileRef="${files}[$relTargetOffset - $relHostOffset]"
             local file="${!fileRef}"
@@ -734,7 +732,7 @@ findInputs() {
 
             # Once again, ensure we're in bounds relative to the
             # package currently being built.
-            (( -1 <= hostOffsetNext && hostOffsetNext <= 1 )) || continue
+            ((-1 <= hostOffsetNext && hostOffsetNext <= 1)) || continue
 
             [[ -f "$pkg/nix-support/$file" ]] || continue
 
@@ -763,26 +761,26 @@ for pkg in ${depsBuildBuild[@]} ${depsBuildBuildPropagated[@]}; do
     findInputs "$pkg" -1 -1
 done
 for pkg in ${nativeBuildInputs[@]} ${propagatedNativeBuildInputs[@]}; do
-    findInputs "$pkg" -1  0
+    findInputs "$pkg" -1 0
 done
 for pkg in ${depsBuildTarget[@]} ${depsBuildTargetPropagated[@]}; do
-    findInputs "$pkg" -1  1
+    findInputs "$pkg" -1 1
 done
 for pkg in ${depsHostHost[@]} ${depsHostHostPropagated[@]}; do
-    findInputs "$pkg"  0  0
+    findInputs "$pkg" 0 0
 done
-for pkg in ${buildInputs[@]} ${propagatedBuildInputs[@]} ; do
-    findInputs "$pkg"  0  1
+for pkg in ${buildInputs[@]} ${propagatedBuildInputs[@]}; do
+    findInputs "$pkg" 0 1
 done
 for pkg in ${depsTargetTarget[@]} ${depsTargetTargetPropagated[@]}; do
-    findInputs "$pkg"  1  1
+    findInputs "$pkg" 1 1
 done
 # Default inputs must be processed last
 for pkg in ${defaultNativeBuildInputs[@]}; do
-    findInputs "$pkg" -1  0
+    findInputs "$pkg" -1 0
 done
 for pkg in ${defaultBuildInputs[@]}; do
-    findInputs "$pkg"  0  1
+    findInputs "$pkg" 0 1
 done
 
 # Add package to the future PATH and run setup hooks
@@ -792,7 +790,7 @@ activatePackage() {
     local -r targetOffset="$3"
 
     # Sanity check
-    (( hostOffset <= targetOffset )) || exit 1
+    ((hostOffset <= targetOffset)) || exit 1
 
     if [ -f "$pkg" ]; then
         nixTalkativeLog "sourcing setup hook '$pkg'"
@@ -810,7 +808,7 @@ activatePackage() {
         addToSearchPath _PATH "$pkg/bin"
     fi
 
-    if (( hostOffset <= -1 )); then
+    if ((hostOffset <= -1)); then
         addToSearchPath _XDG_DATA_DIRS "$pkg/share"
     fi
 
@@ -831,7 +829,7 @@ _activatePkgs() {
     for hostOffset in "${allPlatOffsets[@]}"; do
         local pkgsVar="${pkgAccumVarVars[hostOffset + 1]}"
         for targetOffset in "${allPlatOffsets[@]}"; do
-            (( hostOffset <= targetOffset )) || continue
+            ((hostOffset <= targetOffset)) || continue
             local pkgsRef="${pkgsVar}[$targetOffset - $hostOffset]"
             local pkgsSlice="${!pkgsRef}[@]"
             for pkg in ${!pkgsSlice+"${!pkgsSlice}"}; do
@@ -860,7 +858,7 @@ _addToEnv() {
         local hookVar="${pkgHookVarVars[depHostOffset + 1]}"
         local pkgsVar="${pkgAccumVarVars[depHostOffset + 1]}"
         for depTargetOffset in "${allPlatOffsets[@]}"; do
-            (( depHostOffset <= depTargetOffset )) || continue
+            ((depHostOffset <= depTargetOffset)) || continue
             local hookRef="${hookVar}[$depTargetOffset - $depHostOffset]"
             if [[ -z "${strictDeps-}" ]]; then
 
@@ -877,8 +875,7 @@ _addToEnv() {
                     "${pkgsBuildTarget[@]}" \
                     "${pkgsHostHost[@]}" \
                     "${pkgsHostTarget[@]}" \
-                    "${pkgsTargetTarget[@]}"
-                do
+                    "${pkgsTargetTarget[@]}"; do
                     if [[ "$visitedPkgs" = *"$pkg"* ]]; then
                         continue
                     fi
@@ -899,34 +896,29 @@ _addToEnv() {
 # Run the package-specific hooks set by the setup-hook scripts.
 _addToEnv
 
-
 # Unset setup-specific declared variables
 unset allPlatOffsets
 unset pkgBuildAccumVars pkgHostAccumVars pkgTargetAccumVars pkgAccumVarVars
 unset pkgBuildHookVars pkgHostHookVars pkgTargetHookVars pkgHookVarVars
 unset propagatedDepFilesVars
 
-
 _addRpathPrefix "$out"
-
 
 # Set the TZ (timezone) environment variable, otherwise commands like
 # `date' will complain (e.g., `Tue Mar 9 10:01:47 Local time zone must
 # be set--see zic manual page 2004').
 export TZ=UTC
 
-
 # Set the prefix.  This is generally $out, but it can be overriden,
 # for instance if we just want to perform a test build/install to a
 # temporary location and write a build report to $out.
 if [ -z "${prefix:-}" ]; then
-    prefix="$out";
+    prefix="$out"
 fi
 
 if [ "${useTempPrefix:-}" = 1 ]; then
-    prefix="$NIX_BUILD_TOP/tmp_prefix";
+    prefix="$NIX_BUILD_TOP/tmp_prefix"
 fi
-
 
 PATH="${_PATH-}${_PATH:+${PATH:+:}}$PATH"
 HOST_PATH="${_HOST_PATH-}${_HOST_PATH:+${HOST_PATH:+:}}$HOST_PATH"
@@ -940,29 +932,26 @@ unset _PATH
 unset _HOST_PATH
 unset _XDG_DATA_DIRS
 
-
 # Normalize the NIX_BUILD_CORES variable. The value might be 0, which
 # means that we're supposed to try and auto-detect the number of
 # available CPU cores at run-time.
 
 NIX_BUILD_CORES="${NIX_BUILD_CORES:-1}"
 if ((NIX_BUILD_CORES <= 0)); then
-  guess=$(nproc 2>/dev/null || true)
-  ((NIX_BUILD_CORES = guess <= 0 ? 1 : guess))
+    guess=$(nproc 2> /dev/null || true)
+    ((NIX_BUILD_CORES = guess <= 0 ? 1 : guess))
 fi
 export NIX_BUILD_CORES
-
 
 # Prevent SSL libraries from using certificates in /etc/ssl, unless set explicitly.
 # Leave it in impure shells for convenience.
 if [[ -z "${NIX_SSL_CERT_FILE:-}" && "${IN_NIX_SHELL:-}" != "impure" ]]; then
-  export NIX_SSL_CERT_FILE=/no-cert-file.crt
+    export NIX_SSL_CERT_FILE=/no-cert-file.crt
 fi
 # Another variant left for compatibility.
 if [[ -z "${SSL_CERT_FILE:-}" && "${IN_NIX_SHELL:-}" != "impure" ]]; then
-  export SSL_CERT_FILE=/no-cert-file.crt
+    export SSL_CERT_FILE=/no-cert-file.crt
 fi
-
 
 ######################################################################
 # Textual substitution functions.
@@ -975,7 +964,7 @@ substituteStream() {
     local description=$2
     shift 2
 
-    while (( "$#" )); do
+    while (("$#")); do
         local replace_mode="$1"
         case "$1" in
             --replace)
@@ -987,7 +976,7 @@ substituteStream() {
                 fi
                 replace_mode='--replace-warn'
                 ;&
-            --replace-quiet|--replace-warn|--replace-fail)
+            --replace-quiet | --replace-warn | --replace-fail)
                 pattern="$2"
                 replacement="$3"
                 shift 3
@@ -1044,7 +1033,7 @@ substituteStream() {
 # fail loudly if provided with a binary (containing null bytes)
 consumeEntire() {
     # read returns non-0 on EOF, so we want read to fail
-    if IFS='' read -r -d '' "$1" ; then
+    if IFS='' read -r -d '' "$1"; then
         echo "consumeEntire(): ERROR: Input null bytes, won't process" >&2
         return 1
     fi
@@ -1115,17 +1104,14 @@ substituteAll() {
     substitute "$input" "$output" "${args[@]}"
 }
 
-
 substituteAllInPlace() {
     local fileName="$1"
     shift
     substituteAll "$fileName" "$fileName" "$@"
 }
 
-
 ######################################################################
 # What follows is the generic builder.
-
 
 # This function is useful for debugging broken Nix builds.  It dumps
 # all environment variables to a file `env-vars' in the build
@@ -1138,12 +1124,11 @@ dumpVars() {
         # so first we create the file and then write to it
         # See https://github.com/NixOS/nixpkgs/issues/335016
         {
-            install -m 0600 /dev/null "$NIX_BUILD_TOP/env-vars" &&
-            export 2>/dev/null >| "$NIX_BUILD_TOP/env-vars"
+            install -m 0600 /dev/null "$NIX_BUILD_TOP/env-vars" \
+                && export 2> /dev/null >| "$NIX_BUILD_TOP/env-vars"
         } || true
     fi
 }
-
 
 # Utility function: echo the base name of the given path, with the
 # prefix `HASH-' removed, if present.
@@ -1158,9 +1143,8 @@ stripHash() {
     else
         echo "$strippedName"
     fi
-    if (( casematchOpt )); then shopt -s nocasematch; fi
+    if ((casematchOpt)); then shopt -s nocasematch; fi
 }
-
 
 recordPropagatedDependencies() {
     # Propagate dependencies into the development output.
@@ -1193,7 +1177,6 @@ recordPropagatedDependencies() {
         printWords ${!propagatedInputsSlice} > "${!outputDev}/nix-support/$propagatedInputsFile"
     done
 }
-
 
 unpackCmdHooks+=(_defaultUnpack)
 _defaultUnpack() {
@@ -1228,7 +1211,10 @@ _defaultUnpack() {
                 # disregard the error code from the xz invocation. Otherwise,
                 # it can happen that tar exits earlier, causing xz to fail
                 # from a SIGPIPE.
-                (XZ_OPT="--threads=$NIX_BUILD_CORES" xz -d < "$fn"; true) | tar xf - --mode=+w --warning=no-timestamp
+                (
+                    XZ_OPT="--threads=$NIX_BUILD_CORES" xz -d < "$fn"
+                    true
+                ) | tar xf - --mode=+w --warning=no-timestamp
                 ;;
             *.tar | *.tar.* | *.tgz | *.tbz2 | *.tbz)
                 # GNU tar can automatically select the decompression method
@@ -1243,7 +1229,6 @@ _defaultUnpack() {
     fi
 }
 
-
 unpackFile() {
     curSrc="$1"
     echo "unpacking source archive $curSrc"
@@ -1252,7 +1237,6 @@ unpackFile() {
         exit 1
     fi
 }
-
 
 unpackPhase() {
     runHook preUnpack
@@ -1296,8 +1280,7 @@ unpackPhase() {
         for i in *; do
             if [ -d "$i" ]; then
                 case $dirsBefore in
-                    *\ $i\ *)
-                        ;;
+                    *\ $i\ *) ;;
                     *)
                         if [ -n "$sourceRoot" ]; then
                             echo "unpacker produced multiple directories"
@@ -1326,7 +1309,6 @@ unpackPhase() {
 
     runHook postUnpack
 }
-
 
 patchPhase() {
     runHook prePatch
@@ -1362,7 +1344,6 @@ patchPhase() {
     runHook postPatch
 }
 
-
 fixLibtool() {
     local search_path
     for flag in $NIX_LDFLAGS; do
@@ -1377,7 +1358,6 @@ fixLibtool() {
         -e "s^eval \(sys_lib_search_path=\).*^\1'${search_path:-}'^" \
         -e 's^eval sys_lib_.+search_path=.*^^'
 }
-
 
 configurePhase() {
     runHook preConfigure
@@ -1403,13 +1383,13 @@ configurePhase() {
         # autoreconf'ing themselves
         CONFIGURE_MTIME_REFERENCE=$(mktemp configure.mtime.reference.XXXXXX)
         find . \
-          -executable \
-          -type f \
-          -name configure \
-          -exec grep -l 'GNU Libtool is free software; you can redistribute it and/or modify' {} \; \
-          -exec touch -r {} "$CONFIGURE_MTIME_REFERENCE" \; \
-          -exec sed -i s_/usr/bin/file_file_g {} \;    \
-          -exec touch -r "$CONFIGURE_MTIME_REFERENCE" {} \;
+            -executable \
+            -type f \
+            -name configure \
+            -exec grep -l 'GNU Libtool is free software; you can redistribute it and/or modify' {} \; \
+            -exec touch -r {} "$CONFIGURE_MTIME_REFERENCE" \; \
+            -exec sed -i s_/usr/bin/file_file_g {} \; \
+            -exec touch -r "$CONFIGURE_MTIME_REFERENCE" {} \;
         rm -f "$CONFIGURE_MTIME_REFERENCE"
     fi
 
@@ -1452,11 +1432,10 @@ configurePhase() {
     runHook postConfigure
 }
 
-
 buildPhase() {
     runHook preBuild
 
-    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
+    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! (-e Makefile || -e makefile || -e GNUmakefile) ]]; then
         echo "no Makefile or custom buildPhase, doing nothing"
     else
         foundMakefile=1
@@ -1476,7 +1455,6 @@ buildPhase() {
     runHook postBuild
 }
 
-
 checkPhase() {
     runHook preCheck
 
@@ -1488,9 +1466,9 @@ checkPhase() {
 
     if [[ -z "${checkTarget:-}" ]]; then
         #TODO(@oxij): should flagsArray influence make -n?
-        if make -n ${makefile:+-f $makefile} check >/dev/null 2>&1; then
+        if make -n ${makefile:+-f $makefile} check > /dev/null 2>&1; then
             checkTarget="check"
-        elif make -n ${makefile:+-f $makefile} test >/dev/null 2>&1; then
+        elif make -n ${makefile:+-f $makefile} test > /dev/null 2>&1; then
             checkTarget="test"
         fi
     fi
@@ -1516,12 +1494,11 @@ checkPhase() {
     runHook postCheck
 }
 
-
 installPhase() {
     runHook preInstall
 
     # Dont reuse 'foundMakefile' set in buildPhase, a makefile may have been created in buildPhase
-    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
+    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! (-e Makefile || -e makefile || -e GNUmakefile) ]]; then
         echo "no Makefile or custom installPhase, doing nothing"
         runHook postInstall
         return
@@ -1548,7 +1525,6 @@ installPhase() {
     runHook postInstall
 }
 
-
 # The fixup phase performs generic, package-independent stuff, like
 # stripping binaries, running patchelf and setting
 # propagated-build-inputs.
@@ -1567,7 +1543,6 @@ fixupPhase() {
     for output in $(getAllOutputNames); do
         prefix="${!output}" runHook fixupOutput
     done
-
 
     # record propagated dependencies & setup hook into the development output.
     recordPropagatedDependencies
@@ -1604,7 +1579,6 @@ fixupPhase() {
     runHook postFixup
 }
 
-
 installCheckPhase() {
     runHook preInstallCheck
 
@@ -1612,7 +1586,7 @@ installCheckPhase() {
         echo "no Makefile or custom installCheckPhase, doing nothing"
     #TODO(@oxij): should flagsArray influence make -n?
     elif [[ -z "${installCheckTarget:-}" ]] \
-       && ! make -n ${makefile:+-f $makefile} "${installCheckTarget:-installcheck}" >/dev/null 2>&1; then
+        && ! make -n ${makefile:+-f $makefile} "${installCheckTarget:-installcheck}" > /dev/null 2>&1; then
         echo "no installcheck target in ${makefile:-Makefile}, doing nothing"
     else
         # Old bash empty array hack
@@ -1623,7 +1597,7 @@ installCheckPhase() {
         )
 
         concatTo flagsArray makeFlags makeFlagsArray \
-          installCheckFlags installCheckFlagsArray installCheckTarget=installcheck
+            installCheckFlags installCheckFlagsArray installCheckTarget=installcheck
 
         echoCmd 'installcheck flags' "${flagsArray[@]}"
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -1632,7 +1606,6 @@ installCheckPhase() {
 
     runHook postInstallCheck
 }
-
 
 distPhase() {
     runHook preDist
@@ -1655,7 +1628,6 @@ distPhase() {
     runHook postDist
 }
 
-
 showPhaseHeader() {
     local phase="$1"
     echo "Running phase: $phase"
@@ -1668,23 +1640,21 @@ showPhaseHeader() {
     printf "@nix { \"action\": \"setPhase\", \"phase\": \"%s\" }\n" "$phase" >&"$NIX_LOG_FD"
 }
 
-
 showPhaseFooter() {
     local phase="$1"
     local startTime="$2"
     local endTime="$3"
-    local delta=$(( endTime - startTime ))
-    (( delta < 30 )) && return
+    local delta=$((endTime - startTime))
+    ((delta < 30)) && return
 
-    local H=$((delta/3600))
-    local M=$((delta%3600/60))
-    local S=$((delta%60))
+    local H=$((delta / 3600))
+    local M=$((delta % 3600 / 60))
+    local S=$((delta % 60))
     echo -n "$phase completed in "
-    (( H > 0 )) && echo -n "$H hours "
-    (( M > 0 )) && echo -n "$M minutes "
+    ((H > 0)) && echo -n "$H hours "
+    ((M > 0)) && echo -n "$M minutes "
     echo "$S seconds"
 }
-
 
 runPhase() {
     local curPhase="$*"
@@ -1720,7 +1690,6 @@ runPhase() {
     fi
 }
 
-
 genericBuild() {
     # variable used by our gzip wrapper to add -n.
     # gzip is in common-path.nix and is added to nix-shell but we only want to change its behaviour in nix builds. do not move to a setupHook in gzip.
@@ -1739,7 +1708,7 @@ genericBuild() {
         phases="${prePhases[*]:-} unpackPhase patchPhase ${preConfigurePhases[*]:-} \
             configurePhase ${preBuildPhases[*]:-} buildPhase checkPhase \
             ${preInstallPhases[*]:-} installPhase ${preFixupPhases[*]:-} fixupPhase installCheckPhase \
-            ${preDistPhases[*]:-} distPhase ${postPhases[*]:-}";
+            ${preDistPhases[*]:-} distPhase ${postPhases[*]:-}"
     fi
 
     # The use of ${phases[*]} gives the correct behavior both with and
@@ -1751,19 +1720,15 @@ genericBuild() {
     done
 }
 
-
 # Execute the post-hooks.
 runHook postHook
-
 
 # Execute the global user hook (defined through the Nixpkgs
 # configuration option ‘stdenv.userHook’).  This can be used to set
 # global compiler optimisation flags, for instance.
 runHook userHook
 
-
 dumpVars
-
 
 # Restore the original options for nix-shell
 [[ $__nixpkgs_setup_set_original == *e* ]] || set +e

--- a/pkgs/stdenv/generic/stdenv.sh
+++ b/pkgs/stdenv/generic/stdenv.sh
@@ -1,0 +1,63 @@
+# This file is only used for shellcheck, not actually sourced via bash.
+# The name of the file makes it, so that it can be included via directive like this:
+#   # shellcheck source=stdenv.sh
+#
+# Shellcheck has rule SC2154 "var is referenced but not assigned":
+#   https://www.shellcheck.net/wiki/SC2154
+# Naturally, this rule is hard to validate for all our setup hooks, because they
+# depend on variables:
+#   - set in stdenv/generic/setup.sh
+#   - set in default setup-hooks defined in stdenv/generic/default.nix (.../build-support/setup-hooks/...)
+#   - passed as derivation arguments
+#
+# We can tell shellcheck about "dependencies" indirectly, with the following construct:
+#   # shellcheck source=setup.sh
+#   . /dev/null
+# This will source /dev/null, so nothing. The shellcheck meta command will replace this
+# with sourcing the generic/setup.sh file. Thus, all variables defined in stdenv will be
+# known to shellcheck.
+
+# All paths are relative to pkgs/stdenv/generic, thanks to .shellcheckrc.
+# shellcheck source=setup.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/audit-tmpdir.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/compress-man-pages.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/make-symlinks-relative.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/move-docs.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/move-lib64.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/move-sbin.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/move-systemd-user-units.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/multiple-outputs.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/patch-shebangs.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/prune-libtool-files.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/reproducible-builds.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+. /dev/null
+# shellcheck source=../../build-support/setup-hooks/strip.sh
+. /dev/null
+
+# We can't do the same for derivation arguments. We are left with the following choices:
+#   - Putting shellcheck disable comments for that rule on each reference to a derivation argument.
+#   - Disable the rule in a broader scope (per file / globally).
+#   - "declare" the variables somewhere to have them be picked up by shellcheck.
+#
+# The last approach has the advantage that we don't need to miss out on the benefits of the rule, i.e.
+# preventing spelling mistakes. More so, we get that check for those known derivation arguments as well.
+# The best place to put those declaration is right in the file they are invented. Sometimes this might
+# not be possible, in this case they can be redefined below.
+#
+# TLDR: The following code is **not** actually run by bash, only loaded by shellcheck.
+
+# Note: Keeping this list nicely sorted will make it easier to prevent duplicates.
+# ... nothing here, yet ...

--- a/shell.nix
+++ b/shell.nix
@@ -26,5 +26,7 @@ pkgs.mkShellNoCC {
     # Helper to review Nixpkgs PRs
     # See CONTRIBUTING.md
     nixpkgs-review
+    # Linter for shell scripts
+    shellcheck
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -26,7 +26,8 @@ pkgs.mkShellNoCC {
     # Helper to review Nixpkgs PRs
     # See CONTRIBUTING.md
     nixpkgs-review
-    # Linter for shell scripts
+    # Linter and Formatter for shell scripts
     shellcheck
+    shfmt
   ];
 }


### PR DESCRIPTION
There have been various efforts for single files to keep them shellcheck'ed and nicely formatted. But none of that will persist without CI.

So let's do that. Here's a proposal to start discussion.

Assuming that the `shellcheck` part is less controversional than the `shfmt` part, I added the latter as a second commit on top.

CC @emilazy @ShamrockLee with whom this came up in discussions lately.
CC @NixOS/nix-formatting even though this is not about nix files, you might still have an opinion?

Note for how to look at the changed files:
- The changes in `stdenv/generic/setup.sh` are all how `shfmt` works (except the very top lines about shellcheck).
- All the other setup hooks show how using shellcheck with "dependency declarations via `source=`" would look like.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
