### PR TITLE
ark-pixel-font: fix build for ZHF

### DIFF
--- a/pkgs/by-name/ar/ark-pixel-font/package.nix
+++ b/pkgs/by-name/ar/ark-pixel-font/package.nix
@@ -1,9 +1,21 @@
-{ lib
-, python312Packages
-, fetchFromGitHub
-, nix-update-script
+{
+  lib,
+  python312Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  fetchPypi,
 }:
 
+let
+  pixel-font-builder-compat = python312Packages.pixel-font-builder.overrideAttrs rec {
+    version = "0.0.26";
+    src = fetchPypi {
+      inherit version;
+      pname = "pixel_font_builder";
+      hash = "sha256-bgs2FbOA5tcUXe5+KuVztWGAv5yFxQNBaiZMeZ+ic+8=";
+    };
+  };
+in
 python312Packages.buildPythonPackage rec {
   pname = "ark-pixel-font";
   version = "2024.05.12";
@@ -18,7 +30,7 @@ python312Packages.buildPythonPackage rec {
   format = "other";
 
   nativeBuildInputs = with python312Packages; [
-    pixel-font-builder
+    pixel-font-builder-compat
     unidata-blocks
     character-encoding-utils
     pypng


### PR DESCRIPTION
ark-pixel-font uses a custom build system, 
and the latest release is incompatible with pixel-font-builder 0.0.28 introduced in commit 985dd2a1f0f51a5b1e9bdf04c8ed4462dfceedeb.

To fix the build I've overridden the used version of pixel-font-builder to 0.0.26

The main branch of the repo does use the newer version of pixel-font-builder but it completely changed the build system as well.
I am not knowlegable enough yet to make a new derivation for the newer commits since it still doesn't use a standard python build system.

ZHF #352882
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
