### PR TITLE
notmuch: move the vim plugin to another output

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -27,6 +27,11 @@
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)
   for more information.
 
+- the notmuch vim plugin now lives in a separate output of the `notmuch`
+  package. Installing `notmuch` will not bring the notmuch vim package anymore,
+  add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the
+  vim plugin.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-25.05-notable-changes}

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -38,6 +38,7 @@
   languagetool,
   llvmPackages,
   meson,
+  notmuch,
   neovim-unwrapped,
   nim1,
   nodePackages,
@@ -1779,6 +1780,8 @@ in
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "null-ls";
   };
+
+  notmuch-vim = notmuch.vim;
 
   NotebookNavigator-nvim = super.NotebookNavigator-nvim.overrideAttrs {
     nvimRequireCheck = "notebook-navigator";

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -11,6 +11,7 @@
 , withEmacs ? true
 , withRuby ? true
 , withSfsexp ? true # also installs notmuch-git, which requires sexp-support
+# TODO upstream: it takes too long ! 800 ms here
 , withVim ? true
 }:
 
@@ -76,7 +77,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   outputs = [ "out" "man" "info" "bindingconfig" ]
-    ++ lib.optional withEmacs "emacs";
+    ++ lib.optional withEmacs "emacs"
+    ++ lib.optional withVim "vim";
 
   # if notmuch is built with s-expression support, the testsuite (T-850.sh) only
   # passes if notmuch-git can be executed, so we need to patch its shebang.
@@ -133,14 +135,14 @@ stdenv.mkDerivation (finalAttrs: {
     cp notmuch-git $out/bin/notmuch-git
     wrapProgram $out/bin/notmuch-git --prefix PATH : $out/bin:${lib.getBin git}/bin
   '' + lib.optionalString withVim ''
-    make -C vim DESTDIR="$out/share/vim-plugins/notmuch" prefix="" install
-    mkdir -p $out/share/nvim
-    ln -s $out/share/vim-plugins/notmuch $out/share/nvim/site
+    make -C vim DESTDIR="$vim/share/vim-plugins/notmuch" prefix="" install
+    mkdir -p $vim/share/nvim
+    ln -s $vim/share/vim-plugins/notmuch $vim/share/nvim/site
   '' + lib.optionalString (withVim && withRuby) ''
-    PLUG=$out/share/vim-plugins/notmuch/plugin/notmuch.vim
+    PLUG=$vim/share/vim-plugins/notmuch/plugin/notmuch.vim
     cat >> $PLUG << EOF
       let \$GEM_PATH=\$GEM_PATH . ":${finalAttrs.passthru.gemEnv}/${ruby.gemPath}"
-      let \$RUBYLIB=\$RUBYLIB . ":$out/${ruby.libPath}/${ruby.system}"
+      let \$RUBYLIB=\$RUBYLIB . ":$vim/${ruby.libPath}/${ruby.system}"
       if has('nvim')
     EOF
     for gem in ${finalAttrs.passthru.gemEnv}/${ruby.gemPath}/gems/*/lib; do


### PR DESCRIPTION
I wondered why my neovim was slow. Turned out notmuch.vim loading took > 500ms to load (ruby and all). And I dont even use it ! I suspect the plugin could be improved to lazyload more stuff but I think it's ok to have the vim plugin installer be a user decision as well. I moved it to a new "vim" output : you can install the plugin via "notmuch.vim"

since it might require a transition phase for notmuch users, I mark it as draft just so that users with the same issue can find this. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
