### PR TITLE
nixos/guix: add declarative substituters option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -561,6 +561,11 @@
 
 - `/share/vim-plugins` now only gets linked if `programs.vim.enable` is enabled
 
+- The `services.guix` module now manages trusted substitute servers
+  declaratively. Instead of `guix archive --authorize`, list keys with
+  `services.guix.substituters.authorizedKeys`. Default substitute servers can be
+  set via `services.guix.substituters.urls`.
+
 - The `tracy` package no longer works on X11, since it's moved to Wayland
   support, which is the intended default behavior by Tracy maintainers.
   X11 users have to switch to the new package `tracy-x11`.

--- a/nixos/tests/guix/publish.nix
+++ b/nixos/tests/guix/publish.nix
@@ -47,12 +47,12 @@ in {
       services.guix = {
         enable = true;
 
-        extraArgs = [
-          # Force to only get all substitutes from the local server. We don't
-          # have anything in the Guix store directory and we cannot get
-          # anything from the official substitute servers anyways.
-          "--substitute-urls='http://server.local:${toString publishPort}'"
+        # Force to only get all substitutes from the local server. We don't
+        # have anything in the Guix store directory and we cannot get
+        # anything from the official substitute servers anyways.
+        substituters.urls = [ "http://server.local:${toString publishPort}" ];
 
+        extraArgs = [
           # Enable autodiscovery of the substitute servers in the local
           # network. This machine shouldn't need to import the signing key from
           # the substitute server since it is automatically done anyways.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hopefully we can get this in for 24.11. I have tested adding keys and URLs in my system configuration.

- Fix: https://github.com/NixOS/nixpkgs/issues/293742 
- Fix: https://github.com/NixOS/nixpkgs/issues/294672
- Close: https://github.com/NixOS/nixpkgs/pull/294686

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
