### PR TITLE
python312Packages.pythonnet: fix build

### DIFF
--- a/pkgs/development/python-modules/pythonnet/deps.nix
+++ b/pkgs/development/python-modules/pythonnet/deps.nix
@@ -4,948 +4,138 @@
 { fetchNuGet }:
 [
   (fetchNuGet {
-    pname = "BenchmarkDotNet";
-    version = "0.13.1";
-    sha256 = "1kgypxfp34vjy9kvqq8csznsjbnv37pp4r0457i5l1j6zrsm76rp";
-  })
-  (fetchNuGet {
-    pname = "BenchmarkDotNet.Annotations";
-    version = "0.13.1";
-    sha256 = "0fizarpvdajwcvfhd45c35xrnrci5rbn5ksf3zvlw4q300hnlsir";
-  })
-  (fetchNuGet {
-    pname = "CommandLineParser";
-    version = "2.4.3";
-    sha256 = "1aca3q25n3dg55v4j3kzlzfzd5k2jpy6zhp8x7g74pdfdqzrhg55";
-  })
-  (fetchNuGet {
-    pname = "Iced";
-    version = "1.8.0";
-    sha256 = "12cgd9p3jm81wd7m8bp3pm20gmrmbad2hcwzynhz644h3062nn24";
-  })
-  (fetchNuGet {
     pname = "Lost.Compat.NullabilityAttributes";
     version = "0.0.4";
-    sha256 = "1h8m1n4x1p69xh86ia1rf4dcr17w965fpxws7d3458r4w1wl143a";
+    hash = "sha256-apBAeeAko0JGO5r364pJ/ITMGnE5qGgQ7Mnc0IkNFcE=";
   })
   (fetchNuGet {
     pname = "Microsoft.Build.Tasks.Git";
     version = "1.1.1";
-    sha256 = "1bb5p4zlnfn88skkvymxfsn0jybqncl4356hwnic9jxdq2d4fz1w";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeAnalysis.Analyzers";
-    version = "2.6.1";
-    sha256 = "1plk343h9fyxg08b9bcnlqyaq00cbnc1v73pj9nbcyphmgf5bqfp";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeAnalysis.Common";
-    version = "2.10.0";
-    sha256 = "1l690xqrhmkasns5ghz0vqj8n2xyl5yrwan5gs52hwfxdwahqaaj";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeAnalysis.CSharp";
-    version = "2.10.0";
-    sha256 = "0saabsr81crawdzs2cnzyjp5cgg2hk5k6q7n0i0pxghswb0m4dxk";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeCoverage";
-    version = "16.11.0";
-    sha256 = "0f41l3kks6wk5vjaxpjh8m2flnrvlbvqgqflamhv8rfz4y8ifgdv";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeCoverage";
-    version = "17.0.0";
-    sha256 = "18gdbsqf6i79ld4ikqr4jhx9ndsggm865b5xj1xmnmgg12ydp19a";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeCoverage";
-    version = "17.6.2";
-    sha256 = "1wwmg6hn4dp2mvwn2bm81wccdw149lq17xdnpz17mvg4zcwmax7g";
+    hash = "sha256-PHxHmsCty8Si5dCUQSizeHkJrHa9+j2nRsg6Sz+5Za0=";
   })
   (fetchNuGet {
     pname = "Microsoft.CSharp";
     version = "4.7.0";
-    sha256 = "0gd67zlw554j098kabg887b5a6pq9kzavpa3jjy5w53ccjzjfy8j";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Diagnostics.NETCore.Client";
-    version = "0.2.61701";
-    sha256 = "1ic1607jj4ln8dbibf1fz5v9svk9x2kqlgvhndc6ijaqnbc4wcr1";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Diagnostics.Runtime";
-    version = "1.1.126102";
-    sha256 = "0w7jcxkd4cix6dbh0szawilmykjmdc1rqysllrpwb7ivrxzazypn";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Diagnostics.Tracing.TraceEvent";
-    version = "2.0.61";
-    sha256 = "0gq51l4yyyn8dir6w41im9fwhw9r6jz6n7jm4zhmvvway5ijbcac";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.DotNet.InternalAbstractions";
-    version = "1.0.0";
-    sha256 = "0mp8ihqlb7fsa789frjzidrfjc1lrhk88qp3xm5qvr7vf4wy4z8x";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.DotNet.PlatformAbstractions";
-    version = "2.1.0";
-    sha256 = "1qydvyyinj3b5mraazjal3n2k7jqhn05b6n1a2f3qjkqkxi63dmy";
+    hash = "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0=";
   })
   (fetchNuGet {
     pname = "Microsoft.Net.Compilers.Toolset";
     version = "4.0.1";
-    sha256 = "08njbdnmjzjd6phys94w0di3vcxfq7pniad6s3jc5f65r9s1f0w2";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NET.Test.Sdk";
-    version = "16.11.0";
-    sha256 = "1a2y6vw6p9xp3w72zq2lwrjl8bxv87s9d7zd2dh4zwbzh1c5slxl";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NET.Test.Sdk";
-    version = "17.0.0";
-    sha256 = "0bknyf5kig5icwjxls7pcn51x2b2qf91dz9qv67fl70v6cczaz2r";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NET.Test.Sdk";
-    version = "17.6.2";
-    sha256 = "1a658bnh5q3lfkrr81h3lyx1mc3hggnjr1bpmim71rr2s42ad70v";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETCore.Platforms";
-    version = "1.0.1";
-    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+    hash = "sha256-ggMXdMrFuMLk0KapaO/BrrM9YgOcJO3hNU1+WW1b0iI=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Platforms";
     version = "1.1.0";
-    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETCore.Targets";
-    version = "1.0.1";
-    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+    hash = "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Targets";
     version = "1.1.0";
-    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETFramework.ReferenceAssemblies";
-    version = "1.0.0";
-    sha256 = "0na724xhvqm63vq9y18fl9jw9q2v99bdwr353378s5fsi11qzxp9";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETFramework.ReferenceAssemblies.net461";
-    version = "1.0.0";
-    sha256 = "00vkn4c6i0rn1l9pv912y0wgb9h6ks76qah8hvk441nari8fqbm1";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETFramework.ReferenceAssemblies.net472";
-    version = "1.0.0";
-    sha256 = "1bqinq2nxnpqxziypg1sqy3ly0nymxxjpn8fwkn3rl4vl6gdg3rc";
+    hash = "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.SourceLink.Common";
     version = "1.1.1";
-    sha256 = "0xkdqs7az2cprar7jzjlgjpd64l6f8ixcmwmpkdm03fyb4s5m0bg";
+    hash = "sha256-b4FaNFneDVDbvJVX1iNyhhLTrnxUfnmyypeJr47GbXY=";
   })
   (fetchNuGet {
     pname = "Microsoft.SourceLink.GitHub";
     version = "1.1.1";
-    sha256 = "099y35f2npvva3jk1zp8hn0vb9pwm2l0ivjasdly6y2idv53s5yy";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.ObjectModel";
-    version = "16.11.0";
-    sha256 = "1fc0ghk1cny4i8w43b94pxhl0srxisv6kaflkkp30ncsa9szhkxh";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.ObjectModel";
-    version = "17.6.2";
-    sha256 = "0asbrbdyyig1p034smf79lszzbfv1cn6q181i7d4p2vsiqpjp9sj";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.TestHost";
-    version = "16.11.0";
-    sha256 = "0hp1vndf2jhyg1f3miq4g2068z5kpfzy6nmswm25vymghxp1ws4k";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.TestHost";
-    version = "17.6.2";
-    sha256 = "0lcj8kkcnxbwiaw6j0xf4fxqpa6z0s41nq52spvckfg4367lg4fg";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Win32.Primitives";
-    version = "4.3.0";
-    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Win32.Registry";
-    version = "4.3.0";
-    sha256 = "1gxyzxam8163vk1kb6xzxjj4iwspjsz9zhgn1w9rjzciphaz0ig7";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Win32.Registry";
-    version = "4.5.0";
-    sha256 = "1zapbz161ji8h82xiajgriq6zgzmb1f3ar517p2h63plhsq5gh2q";
-  })
-  (fetchNuGet {
-    pname = "NETStandard.Library";
-    version = "2.0.0";
-    sha256 = "1bc4ba8ahgk15m8k4nd7x406nhi0kwqzbgjk2dmw52ss553xz7iy";
+    hash = "sha256-3hc9ym5ReONp00ruCKio/Ka1gYXo/jDlUHtfK1wZPiU=";
   })
   (fetchNuGet {
     pname = "NETStandard.Library";
     version = "2.0.3";
-    sha256 = "1fn9fxppfcg4jgypp2pmrpr6awl3qz1xmnri0cygpkwvyx27df1y";
-  })
-  (fetchNuGet {
-    pname = "Newtonsoft.Json";
-    version = "13.0.1";
-    sha256 = "0fijg0w6iwap8gvzyjnndds0q4b8anwxxvik7y8vgq97dram4srb";
-  })
-  (fetchNuGet {
-    pname = "Newtonsoft.Json";
-    version = "9.0.1";
-    sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+    hash = "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo=";
   })
   (fetchNuGet {
     pname = "NonCopyableAnalyzer";
     version = "0.7.0";
-    sha256 = "1jry36p53fkk3fn9pawgg7qiv79j30y0kvd4xrnd58d7zg7zzdj0";
-  })
-  (fetchNuGet {
-    pname = "NuGet.Frameworks";
-    version = "5.0.0";
-    sha256 = "18ijvmj13cwjdrrm52c8fpq021531zaz4mj4b4zapxaqzzxf2qjr";
-  })
-  (fetchNuGet {
-    pname = "NuGet.Frameworks";
-    version = "6.5.0";
-    sha256 = "0s37d1p4md0k6d4cy6sq36f2dgkd9qfbzapxhkvi8awwh0vrynhj";
-  })
-  (fetchNuGet {
-    pname = "NUnit";
-    version = "3.12.0";
-    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
-  })
-  (fetchNuGet {
-    pname = "NUnit";
-    version = "3.13.3";
-    sha256 = "0wdzfkygqnr73s6lpxg5b1pwaqz9f414fxpvpdmf72bvh4jaqzv6";
-  })
-  (fetchNuGet {
-    pname = "NUnit3TestAdapter";
-    version = "3.16.1";
-    sha256 = "1pzhmapfdszsfza7zjr3zrlz4fssdxsyiwmlj76a40mbhxhfa4q9";
-  })
-  (fetchNuGet {
-    pname = "NUnit3TestAdapter";
-    version = "3.17.0";
-    sha256 = "0kxc6z3b8ccdrcyqz88jm5yh5ch9nbg303v67q8sp5hhs8rl8nk6";
-  })
-  (fetchNuGet {
-    pname = "NUnit3TestAdapter";
-    version = "4.5.0";
-    sha256 = "1srx1629s0k1kmf02nmz251q07vj6pv58mdafcr5dr0bbn1fh78i";
-  })
-  (fetchNuGet {
-    pname = "Perfolizer";
-    version = "0.2.1";
-    sha256 = "012aqqi3y3nfikqmn26yajpwd52c04zlzp0p91iyslw7mf26qncy";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Collections";
-    version = "4.3.0";
-    sha256 = "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Diagnostics.Tools";
-    version = "4.3.0";
-    sha256 = "1wl76vk12zhdh66vmagni66h5xbhgqq7zkdpgw21jhxhvlbcl8pk";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Diagnostics.Tracing";
-    version = "4.3.0";
-    sha256 = "00j6nv2xgmd3bi347k00m7wr542wjlig53rmj28pmw7ddcn97jbn";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Globalization";
-    version = "4.3.0";
-    sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
+    hash = "sha256-QLb/z/unodJs7qTtCTwYMp0d8XmPq5usG3O6Ua4ZPss=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.IO";
     version = "4.3.0";
-    sha256 = "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x";
+    hash = "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Reflection";
     version = "4.3.0";
-    sha256 = "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Reflection.Extensions";
-    version = "4.3.0";
-    sha256 = "0zyri97dfc5vyaz9ba65hjj1zbcrzaffhsdlpxc9bh09wy22fq33";
+    hash = "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Reflection.Primitives";
     version = "4.3.0";
-    sha256 = "0x1mm8c6iy8rlxm8w9vqw7gb7s1ljadrn049fmf70cyh42vdfhrf";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Resources.ResourceManager";
-    version = "4.3.0";
-    sha256 = "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl";
+    hash = "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Runtime";
     version = "4.3.0";
-    sha256 = "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Runtime.Handles";
-    version = "4.3.0";
-    sha256 = "0bh5bi25nk9w9xi8z23ws45q5yia6k7dg3i4axhfqlnj145l011x";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Runtime.InteropServices";
-    version = "4.3.0";
-    sha256 = "0c3g3g3jmhlhw4klrc86ka9fjbl7i59ds1fadsb2l8nqf8z3kb19";
+    hash = "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Text.Encoding";
     version = "4.3.0";
-    sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Text.Encoding.Extensions";
-    version = "4.3.0";
-    sha256 = "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8";
+    hash = "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Threading.Tasks";
     version = "4.3.0";
-    sha256 = "03mnvkhskbzxddz4hm113zsch1jyzh2cs450dk3rgfjp8crlw1va";
-  })
-  (fetchNuGet {
-    pname = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
-  })
-  (fetchNuGet {
-    pname = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
-  })
-  (fetchNuGet {
-    pname = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+    hash = "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4=";
   })
   (fetchNuGet {
     pname = "runtime.native.System";
     version = "4.3.0";
-    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
-  })
-  (fetchNuGet {
-    pname = "runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
-  })
-  (fetchNuGet {
-    pname = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
-  })
-  (fetchNuGet {
-    pname = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
-  })
-  (fetchNuGet {
-    pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
-  })
-  (fetchNuGet {
-    pname = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.Microsoft.Win32.Primitives";
-    version = "4.3.0";
-    sha256 = "0y61k9zbxhdi0glg154v30kkq7f8646nif8lnnxbvkjpakggd5id";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.System.Diagnostics.Debug";
-    version = "4.3.0";
-    sha256 = "1lps7fbnw34bnh3lm31gs5c0g0dh7548wfmb8zz62v0zqz71msj5";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.System.IO.FileSystem";
-    version = "4.3.0";
-    sha256 = "14nbkhvs7sji5r1saj2x8daz82rnf9kx28d3v2qss34qbr32dzix";
+    hash = "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.Private.Uri";
     version = "4.3.0";
-    sha256 = "1jx02q6kiwlvfksq1q9qr17fj78y5v6mwsszav4qcz9z25d5g6vk";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.System.Runtime.Extensions";
-    version = "4.3.0";
-    sha256 = "0pnxxmm8whx38dp6yvwgmh22smknxmqs5n513fc7m4wxvs1bvi4p";
-  })
-  (fetchNuGet {
-    pname = "System.AppContext";
-    version = "4.1.0";
-    sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
-  })
-  (fetchNuGet {
-    pname = "System.AppContext";
-    version = "4.3.0";
-    sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
-  })
-  (fetchNuGet {
-    pname = "System.Buffers";
-    version = "4.3.0";
-    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
-  })
-  (fetchNuGet {
-    pname = "System.Buffers";
-    version = "4.4.0";
-    sha256 = "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19";
-  })
-  (fetchNuGet {
-    pname = "System.Collections";
-    version = "4.0.11";
-    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
-  })
-  (fetchNuGet {
-    pname = "System.Collections";
-    version = "4.3.0";
-    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
-  })
-  (fetchNuGet {
-    pname = "System.Collections.Concurrent";
-    version = "4.3.0";
-    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
-  })
-  (fetchNuGet {
-    pname = "System.Collections.Immutable";
-    version = "1.5.0";
-    sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
-  })
-  (fetchNuGet {
-    pname = "System.Collections.NonGeneric";
-    version = "4.3.0";
-    sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
-  })
-  (fetchNuGet {
-    pname = "System.Collections.Specialized";
-    version = "4.3.0";
-    sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel";
-    version = "4.3.0";
-    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel.EventBasedAsync";
-    version = "4.3.0";
-    sha256 = "1rv9bkb8yyhqqqrx6x95njv6mdxlbvv527b44mrd93g8fmgkifl7";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel.Primitives";
-    version = "4.3.0";
-    sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel.TypeConverter";
-    version = "4.3.0";
-    sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
-  })
-  (fetchNuGet {
-    pname = "System.Console";
-    version = "4.3.0";
-    sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Debug";
-    version = "4.0.11";
-    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Debug";
-    version = "4.3.0";
-    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.FileVersionInfo";
-    version = "4.3.0";
-    sha256 = "094hx249lb3vb336q7dg3v257hbxvz2jnalj695l7cg5kxzqwai7";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Process";
-    version = "4.3.0";
-    sha256 = "0g4prsbkygq8m21naqmcp70f24a1ksyix3dihb1r1f71lpi3cfj7";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.StackTrace";
-    version = "4.3.0";
-    sha256 = "0ash4h9k0m7xsm0yl79r0ixrdz369h7y922wipp5gladmlbvpyjd";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Tools";
-    version = "4.0.1";
-    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Tools";
-    version = "4.3.0";
-    sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.Tracing";
-    version = "4.3.0";
-    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
-  })
-  (fetchNuGet {
-    pname = "System.Dynamic.Runtime";
-    version = "4.0.11";
-    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
-  })
-  (fetchNuGet {
-    pname = "System.Dynamic.Runtime";
-    version = "4.3.0";
-    sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
-  })
-  (fetchNuGet {
-    pname = "System.Globalization";
-    version = "4.0.11";
-    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
-  })
-  (fetchNuGet {
-    pname = "System.Globalization";
-    version = "4.3.0";
-    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
-  })
-  (fetchNuGet {
-    pname = "System.Globalization.Extensions";
-    version = "4.3.0";
-    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
-  })
-  (fetchNuGet {
-    pname = "System.IO";
-    version = "4.1.0";
-    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+    hash = "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs=";
   })
   (fetchNuGet {
     pname = "System.IO";
     version = "4.3.0";
-    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
-  })
-  (fetchNuGet {
-    pname = "System.IO.Compression";
-    version = "4.3.0";
-    sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
-  })
-  (fetchNuGet {
-    pname = "System.IO.FileSystem";
-    version = "4.0.1";
-    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
-  })
-  (fetchNuGet {
-    pname = "System.IO.FileSystem";
-    version = "4.3.0";
-    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
-  })
-  (fetchNuGet {
-    pname = "System.IO.FileSystem.Primitives";
-    version = "4.0.1";
-    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
-  })
-  (fetchNuGet {
-    pname = "System.IO.FileSystem.Primitives";
-    version = "4.3.0";
-    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
-  })
-  (fetchNuGet {
-    pname = "System.Linq";
-    version = "4.1.0";
-    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
-  })
-  (fetchNuGet {
-    pname = "System.Linq";
-    version = "4.3.0";
-    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
-  })
-  (fetchNuGet {
-    pname = "System.Linq.Expressions";
-    version = "4.1.0";
-    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
-  })
-  (fetchNuGet {
-    pname = "System.Linq.Expressions";
-    version = "4.3.0";
-    sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
-  })
-  (fetchNuGet {
-    pname = "System.Management";
-    version = "4.5.0";
-    sha256 = "19z5x23n21xi94bgl531l9hrm64nyw9d5fpd7klfvr5xfsbh9jwr";
-  })
-  (fetchNuGet {
-    pname = "System.Memory";
-    version = "4.5.3";
-    sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
-  })
-  (fetchNuGet {
-    pname = "System.Numerics.Vectors";
-    version = "4.4.0";
-    sha256 = "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba";
-  })
-  (fetchNuGet {
-    pname = "System.ObjectModel";
-    version = "4.0.12";
-    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+    hash = "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY=";
   })
   (fetchNuGet {
     pname = "System.Private.Uri";
     version = "4.3.0";
-    sha256 = "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection";
-    version = "4.1.0";
-    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+    hash = "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM=";
   })
   (fetchNuGet {
     pname = "System.Reflection";
     version = "4.3.0";
-    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit";
-    version = "4.0.1";
-    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+    hash = "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit";
     version = "4.3.0";
-    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit.ILGeneration";
-    version = "4.0.1";
-    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
+    hash = "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit.ILGeneration";
     version = "4.3.0";
-    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit.Lightweight";
-    version = "4.0.1";
-    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit.Lightweight";
-    version = "4.3.0";
-    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Extensions";
-    version = "4.0.1";
-    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Extensions";
-    version = "4.3.0";
-    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Metadata";
-    version = "1.6.0";
-    sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Primitives";
-    version = "4.0.1";
-    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+    hash = "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Primitives";
     version = "4.3.0";
-    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.TypeExtensions";
-    version = "4.1.0";
-    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.TypeExtensions";
-    version = "4.3.0";
-    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
-  })
-  (fetchNuGet {
-    pname = "System.Resources.ResourceManager";
-    version = "4.0.1";
-    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
-  })
-  (fetchNuGet {
-    pname = "System.Resources.ResourceManager";
-    version = "4.3.0";
-    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime";
-    version = "4.1.0";
-    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+    hash = "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM=";
   })
   (fetchNuGet {
     pname = "System.Runtime";
     version = "4.3.0";
-    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.CompilerServices.Unsafe";
-    version = "4.5.2";
-    sha256 = "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Extensions";
-    version = "4.1.0";
-    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Extensions";
-    version = "4.3.0";
-    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Handles";
-    version = "4.0.1";
-    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Handles";
-    version = "4.3.0";
-    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.InteropServices";
-    version = "4.1.0";
-    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.InteropServices";
-    version = "4.3.0";
-    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.InteropServices.RuntimeInformation";
-    version = "4.0.0";
-    sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.InteropServices.RuntimeInformation";
-    version = "4.3.0";
-    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Numerics";
-    version = "4.3.0";
-    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Serialization.Primitives";
-    version = "4.1.1";
-    sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
-  })
-  (fetchNuGet {
-    pname = "System.Security.AccessControl";
-    version = "4.5.0";
-    sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.Algorithms";
-    version = "4.3.0";
-    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.Encoding";
-    version = "4.3.0";
-    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.Primitives";
-    version = "4.3.0";
-    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.X509Certificates";
-    version = "4.3.0";
-    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Principal.Windows";
-    version = "4.5.0";
-    sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
-  })
-  (fetchNuGet {
-    pname = "System.Text.Encoding";
-    version = "4.0.11";
-    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+    hash = "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding";
     version = "4.3.0";
-    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
-  })
-  (fetchNuGet {
-    pname = "System.Text.Encoding.CodePages";
-    version = "4.3.0";
-    sha256 = "0lgxg1gn7pg7j0f942pfdc9q7wamzxsgq3ng248ikdasxz0iadkv";
-  })
-  (fetchNuGet {
-    pname = "System.Text.Encoding.Extensions";
-    version = "4.0.11";
-    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
-  })
-  (fetchNuGet {
-    pname = "System.Text.Encoding.Extensions";
-    version = "4.3.0";
-    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
-  })
-  (fetchNuGet {
-    pname = "System.Text.RegularExpressions";
-    version = "4.1.0";
-    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
-  })
-  (fetchNuGet {
-    pname = "System.Text.RegularExpressions";
-    version = "4.3.0";
-    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
-  })
-  (fetchNuGet {
-    pname = "System.Threading";
-    version = "4.0.11";
-    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
-  })
-  (fetchNuGet {
-    pname = "System.Threading";
-    version = "4.3.0";
-    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks";
-    version = "4.0.11";
-    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+    hash = "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks";
     version = "4.3.0";
-    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks.Extensions";
-    version = "4.0.0";
-    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks.Extensions";
-    version = "4.3.0";
-    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks.Extensions";
-    version = "4.5.2";
-    sha256 = "1sh63dz0dymqcwmprp0nadm77b83vmm7lyllpv578c397bslb8hj";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks.Parallel";
-    version = "4.3.0";
-    sha256 = "1rr3qa4hxwyj531s4nb3bwrxnxxwz617i0n9gh6x7nr7dd3ayzgh";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Thread";
-    version = "4.3.0";
-    sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.ThreadPool";
-    version = "4.3.0";
-    sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
-  })
-  (fetchNuGet {
-    pname = "System.ValueTuple";
-    version = "4.5.0";
-    sha256 = "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.ReaderWriter";
-    version = "4.0.11";
-    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.ReaderWriter";
-    version = "4.3.0";
-    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XDocument";
-    version = "4.0.11";
-    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XDocument";
-    version = "4.3.0";
-    sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XmlDocument";
-    version = "4.3.0";
-    sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XPath";
-    version = "4.3.0";
-    sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XPath.XDocument";
-    version = "4.3.0";
-    sha256 = "1wxckyb7n1pi433xzz0qcwcbl1swpra64065mbwwi8dhdc4kiabn";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XPath.XmlDocument";
-    version = "4.3.0";
-    sha256 = "1h9lh7qkp0lff33z847sdfjj8yaz98ylbnkbxlnsbflhj9xyfqrm";
+    hash = "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w=";
   })
 ]


### PR DESCRIPTION
- Specify dotnet project file and regenerate dependencies.

This fixes the build when csproj files have been stripped, and reduces the number of dependencies.

- Switch from pypi to github, since the former is stripping out tests.

Fixes: 097acfb2563c2c82958764dd41f937edd207325b


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
