### PR TITLE
openvsp: init at 3.41.0

### DIFF
--- a/pkgs/by-name/op/openvsp/package.nix
+++ b/pkgs/by-name/op/openvsp/package.nix
@@ -1,0 +1,114 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  git,
+  pkg-config,
+  python3,
+  eigen,
+  fltk,
+  glm,
+  glew,
+  cminpack,
+  libxml2,
+  graphviz,
+  lib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openvsp";
+  version = "3.40.1";
+
+  src = fetchFromGitHub {
+    owner = "OpenVSP";
+    repo = "OpenVSP";
+    rev = "OpenVSP_${version}";
+    hash = "sha256-PfXqnd75D06vER7X5w+VOm12mvLbcSe4sxmhtwBmPps=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    git
+  ];
+
+  # swig & doxygen are not included as the build would fail since it tries to call
+  # "swig -doxygen" which fails Make as this is not a valid command.
+  # Seems like an upstream problem.
+  buildInputs = [
+    cminpack
+    eigen
+    fltk
+    glew
+    glm
+    graphviz
+    libxml2
+  ];
+
+  configurePhase = ''
+    mkdir -p build buildlibs
+
+    pushd buildlibs
+
+    cmake \
+      -DVSP_USE_SYSTEM_ADEPT2=false \
+      -DVSP_USE_SYSTEM_CLIPPER2=false \
+      -DVSP_USE_SYSTEM_CMINPACK=false \
+      -DVSP_USE_SYSTEM_CODEELI=false \
+      -DVSP_USE_SYSTEM_CPPTEST=false \
+      -DVSP_USE_SYSTEM_DELABELLA=false \
+      -DVSP_USE_SYSTEM_EIGEN=false \
+      -DVSP_USE_SYSTEM_EXPRPARSE=false \
+      -DVSP_USE_SYSTEM_FLTK=false \
+      -DVSP_USE_SYSTEM_GLEW=false \
+      -DVSP_USE_SYSTEM_GLM=false \
+      -DVSP_USE_SYSTEM_LIBIGES=false \
+      -DVSP_USE_SYSTEM_LIBXML2=false \
+      -DVSP_USE_SYSTEM_OPENABF=false \
+      -DVSP_USE_SYSTEM_PINOCCHIO=false \
+      -DVSP_USE_SYSTEM_STEPCODE=false \
+      -DVSP_USE_SYSTEM_TRIANGLE=false \
+      $src/Libraries \
+      -DCMAKE_BUILD_TYPE=Release
+
+    make -j$cores
+    popd
+
+    pushd build
+    cmake $src/src/ -DVSP_LIBRARY_PATH=$PWD/../buildlibs -DCMAKE_BUILD_TYPE=Release -DVSP_CPACK_GEN=DEB
+    popd
+  '';
+
+  buildPhase = ''
+    pushd build
+    make -j$cores VERBOSE=1
+    popd
+  '';
+
+  installPhase = ''
+    pushd build
+    mkdir -p $out/bin
+
+    cp ./vsp/vsp $out/bin
+    cp ./vsp/vspscript $out/bin
+    cp ./src/vsp/vspviewer $out/bin
+    cp ./src/vsp/vspaero $out/bin
+    cp ./src/vsp/vsploads $out/bin
+    cp ./vsp_aero/Solver/vspaero $out/bin
+    cp ./vsp_aero/Solver/vspaero_complex $out/bin
+    cp ./vsp_aero/Solver/vspaero_opt $out/bin
+    cp ./vsp_aero/Solver/vspaero_adjoint $out/bin
+    cp ./vsp_aero/Viewer/vspviewer $out/bin
+    cp ./vsp_aero/Adb2Load/vsploads $out/bin
+
+    popd
+  '';
+
+  meta = {
+    description = "Parametric aircraft geometry tool";
+    homepage = "https://openvsp.org/";
+    license = lib.licenses.nasa13;
+    maintainers = with lib.maintainers; [ kekschen ];
+    mainProgram = "vsp";
+  };
+}


### PR DESCRIPTION
The openvsp software package for nixpkgs.

Resolves #349534 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
