### PR TITLE
tetrio-plus: split tpsecore into seperate package

### DIFF
--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -2,74 +2,25 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  rustPlatform,
-  rustc,
-  wasm-pack,
-  wasm-bindgen-cli,
-  binaryen,
-
   fetchYarnDeps,
   yarn,
   fixup-yarn-lock,
   nodejs,
   asar,
 
+  tpsecore,
   tetrio-desktop,
 }:
 
 let
-  version = "0.27.4";
+  version = "0.27.5";
   rev = "electron-v${version}-tetrio-v${tetrio-desktop.version}";
 
   src = fetchFromGitLab {
     owner = "UniQMG";
     repo = "tetrio-plus";
     inherit rev;
-    hash = "sha256-HwGFg8dxqtqghdP+PXWXr6Fi5vfgopThs+QNa3N1awk=";
-    fetchSubmodules = true;
-  };
-
-  wasm-bindgen-82 = wasm-bindgen-cli.override {
-    version = "0.2.82";
-    hash = "sha256-BQ8v3rCLUvyCCdxo5U+NHh30l9Jwvk9Sz8YQv6fa0SU=";
-    cargoHash = "sha256-mP85+qi2KA0GieaBzbrQOBqYxBZNRJipvd2brCRGyOM=";
-  };
-
-  tpsecore = rustPlatform.buildRustPackage {
-    pname = "tpsecore";
-    inherit version src;
-
-    sourceRoot = "${src.name}/tpsecore";
-
-    cargoHash = "sha256-zqeoPeGZvSz7W3c7MXnvvq73hvavg1RGzPc3iTqAjBo=";
-
-    nativeBuildInputs = [
-      wasm-pack
-      wasm-bindgen-82
-      binaryen
-      rustc.llvmPackages.lld
-    ];
-
-    buildPhase = ''
-      HOME=$(mktemp -d) wasm-pack build --target web --release
-    '';
-
-    installPhase = ''
-      cp -r pkg/ $out
-    '';
-
-    doCheck = false;
-
-    meta = {
-      description = "Self contained toolkit for creating, editing, and previewing TPSE files";
-      homepage = "https://gitlab.com/UniQMG/tpsecore";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [
-        huantian
-        wackbyte
-      ];
-      platforms = lib.platforms.linux;
-    };
+    hash = "sha256-hbHofrC2dJOh2kh3VLb/d0dHrcszyqTyID1PAaGApxY=";
   };
 
   offlineCache = fetchYarnDeps {
@@ -119,16 +70,12 @@ stdenv.mkDerivation (finalAttrs: {
     # Actually install tetrio-plus where the above patch script expects
     cp -r $src out/tetrioplus
     chmod -R u+w out/tetrioplus
-
     # Install tpsecore
     cp ${tpsecore}/{tpsecore_bg.wasm,tpsecore.js} out/tetrioplus/source/lib/
-    # Remove uneeded tpsecore source code
-    rm -rf out/tetrioplus/tpsecore/
 
     # Disable useless uninstall button in the tetrio-plus popup
     substituteInPlace out/tetrioplus/desktop-manifest.js \
       --replace-fail '"show_uninstaller_button": true' '"show_uninstaller_button": false'
-
     # Display 'nixpkgs' next to version in tetrio-plus popup
     echo "nixpkgs" > out/tetrioplus/resources/override-commit
 

--- a/pkgs/by-name/tp/tpsecore/package.nix
+++ b/pkgs/by-name/tp/tpsecore/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitLab,
+  rustPlatform,
+  rustc,
+  wasm-pack,
+  wasm-bindgen-cli,
+  binaryen,
+}:
+
+let
+  version = "0.1.1";
+
+  wasm-bindgen-cli-95 = wasm-bindgen-cli.override {
+    version = "0.2.95";
+    hash = "sha256-prMIreQeAcbJ8/g3+pMp1Wp9H5u+xLqxRxL+34hICss=";
+    cargoHash = "sha256-6iMebkD7FQvixlmghGGIvpdGwFNLfnUcFke/Rg8nPK4=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "tpsecore";
+  inherit version;
+
+  src = fetchFromGitLab {
+    owner = "UniQMG";
+    repo = "tpsecore";
+    rev = "v${version}";
+    hash = "sha256-+OynnLMBEiYwdFzxGzgkcBN6xrHoH1Q6O5i+OW7RBLo=";
+  };
+
+  cargoHash = "sha256-mPaWXiDjJd/uTBpktauKWg8X9sNBb3FXw5BSGB33NxI=";
+
+  nativeBuildInputs = [
+    wasm-pack
+    wasm-bindgen-cli-95
+    binaryen
+    rustc.llvmPackages.lld
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    HOME=$(mktemp -d) wasm-pack build --target web --release
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r pkg/ $out
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Self contained toolkit for creating, editing, and previewing TPSE files";
+    homepage = "https://gitlab.com/UniQMG/tpsecore";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      huantian
+      wackbyte
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Main purpose of this is to allow tpsecore to be built by hydra.adding tetrio-plus to top level packages didn't cause it to be built, since tetrio-plus is marked unfree

Also includes a minor version bump for tetrio-plus/tpsecore itself. This update for tpsecore fixes #352897 as it includes a version bump for wasm-bindgen, allowing us to also increase wasm-bindgen-cli version


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
