### PR TITLE
s7: move `patchPhase` to `postPatch`, fix `installCheck` problem

### DIFF
--- a/pkgs/by-name/s7/s7/package.nix
+++ b/pkgs/by-name/s7/s7/package.nix
@@ -2,11 +2,17 @@
   lib,
   fetchFromGitLab,
   stdenv,
-  notcurses,
-  gmp,
-  mpfr,
-  libmpc,
+
   flint3,
+  gmp,
+  libmpc,
+  mpfr,
+  notcurses,
+
+  gsl,
+  man,
+  pkg-config,
+
   unstableGitUpdater,
   writeScript,
 }:
@@ -33,13 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # The following scripts are modified from [Guix's](https://packages.guix.gnu.org/packages/s7/).
 
-  patchPhase = ''
-    runHook prePatch
-
+  postPatch = ''
     substituteInPlace s7.c \
         --replace-fail libc_s7.so $out/lib/libc_s7.so
-
-    runHook postPatch
   '';
 
   buildPhase = ''
@@ -78,11 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
         -O2 -I. \
         -ldl -lm
 
-    cc ffitest.c s7.o -o ffitest \
-        -I. \
-        -Wl,-export-dynamic \
-        -ldl -lm
-
     ./s7-repl libc.scm
 
     runHook postBuild
@@ -99,9 +96,9 @@ stdenv.mkDerivation (finalAttrs: {
     dst_doc=$out/share/doc/s7
     mkdir -p $dst_bin $dst_lib $dst_inc $dst_share $dst_scm $dst_doc
 
-    cp -pr -t $dst_bin s7-repl s7-nrepl
+    mv -t $dst_bin s7-repl s7-nrepl
     ln -s s7-nrepl $dst_bin/s7
-    cp -pr -t $dst_lib libarb_s7.so libnotcurses_s7.so libc_s7.so
+    mv -t $dst_lib libarb_s7.so libnotcurses_s7.so libc_s7.so
     cp -pr -t $dst_share s7.c
     cp -pr -t $dst_inc s7.h
     cp -pr -t $dst_scm *.scm
@@ -112,10 +109,36 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
+  nativeInstallCheckInputs = [
+    man
+    pkg-config
+  ];
+
+  installCheckInputs = [
+    gsl
+  ];
+
+  /*
+    XXX: The upstream assumes that `$HOME` is `/home/$USER`, and the source files
+    lie in `$HOME/cl` . The script presented here uses a fake `$USER` and a
+    symbolic linked `$HOME/cl` , which make the test suite work but do not meet
+    the conditions completely.
+  */
   installCheckPhase = ''
     runHook preInstallCheck
 
-    $dst_bin/s7-repl s7test.scm
+    cc ffitest.c s7.o -o ffitest \
+        -I. \
+        -Wl,-export-dynamic \
+        -ldl -lm
+    mv ffitest $dst_bin
+    mkdir -p nix-build/home
+    ln -sr . nix-build/home/cl
+
+    USER=nix-s7-builder PATH="$dst_bin:$PATH" HOME=$PWD/nix-build/home \
+        s7-repl s7test.scm
+
+    rm $dst_bin/ffitest
 
     runHook postInstallCheck
   '';


### PR DESCRIPTION
Move the `patchPhase` of s7 to `postPatch` to allow custom patches applied by the users.

Fix [the problem](https://github.com/NixOS/nixpkgs/pull/326772#discussion_r1826998678) of `installCheckPhase` found by @jian-lin.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Limitations

The upstream assumes that `$HOME` is `/home/$USER`, and the source files lie in `$HOME/cl` . The `installCheck` script uses a fake `$USER` and a symbolic linked `$HOME/cl` , which make the test suite work but do not meet the conditions completely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
