### PR TITLE
rio: fix darwin build by providing libutil

### DIFF
--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -1,51 +1,55 @@
-{ lib
-, stdenv
-, darwin
-, fetchFromGitHub
-, rustPlatform
-, nixosTests
-, nix-update-script
+{
+  lib,
+  stdenv,
+  darwin,
+  fetchFromGitHub,
+  rustPlatform,
+  nixosTests,
+  nix-update-script,
 
-, autoPatchelfHook
-, cmake
-, ncurses
-, pkg-config
+  autoPatchelfHook,
+  cmake,
+  ncurses,
+  pkg-config,
 
-, gcc-unwrapped
-, fontconfig
-, libGL
-, vulkan-loader
-, libxkbcommon
+  gcc-unwrapped,
+  fontconfig,
+  libGL,
+  vulkan-loader,
+  libxkbcommon,
 
-, withX11 ? !stdenv.hostPlatform.isDarwin
-, libX11
-, libXcursor
-, libXi
-, libXrandr
-, libxcb
+  withX11 ? !stdenv.hostPlatform.isDarwin,
+  libX11,
+  libXcursor,
+  libXi,
+  libXrandr,
+  libxcb,
 
-, withWayland ? !stdenv.hostPlatform.isDarwin
-, wayland
+  withWayland ? !stdenv.hostPlatform.isDarwin,
+  wayland,
 
-, testers
-, rio
+  testers,
+  rio,
 }:
 let
-  rlinkLibs = lib.optionals stdenv.hostPlatform.isLinux [
-    (lib.getLib gcc-unwrapped)
-    fontconfig
-    libGL
-    libxkbcommon
-    vulkan-loader
-  ] ++ lib.optionals withX11 [
-    libX11
-    libXcursor
-    libXi
-    libXrandr
-    libxcb
-  ] ++ lib.optionals withWayland [
-    wayland
-  ];
+  rlinkLibs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      (lib.getLib gcc-unwrapped)
+      fontconfig
+      libGL
+      libxkbcommon
+      vulkan-loader
+    ]
+    ++ lib.optionals withX11 [
+      libX11
+      libXcursor
+      libXi
+      libXrandr
+      libxcb
+    ]
+    ++ lib.optionals withWayland [
+      wayland
+    ];
 in
 rustPlatform.buildRustPackage rec {
   pname = "rio";
@@ -60,69 +64,85 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-yGOvY5+ThSey/k8ilTTC0CzaOIJtc4hDYmdrHJC3HyE=";
 
-  nativeBuildInputs = [
-    ncurses
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    cmake
-    pkg-config
-    autoPatchelfHook
-  ];
+  nativeBuildInputs =
+    [
+      ncurses
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      cmake
+      pkg-config
+      autoPatchelfHook
+    ];
 
   runtimeDependencies = rlinkLibs;
 
-  buildInputs = rlinkLibs ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.libutil
+  buildInputs =
+    rlinkLibs
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.libutil
+    ];
+
+  outputs = [
+    "out"
+    "terminfo"
   ];
 
-  outputs = [ "out" "terminfo" ];
-
   buildNoDefaultFeatures = true;
-  buildFeatures = [ ]
-    ++ lib.optional withX11 "x11"
-    ++ lib.optional withWayland "wayland";
+  buildFeatures = [ ] ++ lib.optional withX11 "x11" ++ lib.optional withWayland "wayland";
 
   checkFlags = [
     # Fail to run in sandbox environment.
     "--skip=sys::unix::eventedfd::EventedFd"
   ];
 
-  postInstall = ''
-    install -D -m 644 misc/rio.desktop -t $out/share/applications
-    install -D -m 644 misc/logo.svg \
-                      $out/share/icons/hicolor/scalable/apps/rio.svg
+  postInstall =
+    ''
+      install -D -m 644 misc/rio.desktop -t $out/share/applications
+      install -D -m 644 misc/logo.svg \
+                        $out/share/icons/hicolor/scalable/apps/rio.svg
 
-    install -dm 755 "$terminfo/share/terminfo/r/"
-    tic -xe rio,rio-direct -o "$terminfo/share/terminfo" misc/rio.terminfo
-    mkdir -p $out/nix-support
-    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir $out/Applications/
-    mv misc/osx/Rio.app/ $out/Applications/
-    mkdir $out/Applications/Rio.app/Contents/MacOS/
-    ln -s $out/bin/rio $out/Applications/Rio.app/Contents/MacOS/
-  '';
+      install -dm 755 "$terminfo/share/terminfo/r/"
+      tic -xe rio,rio-direct -o "$terminfo/share/terminfo" misc/rio.terminfo
+      mkdir -p $out/nix-support
+      echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir $out/Applications/
+      mv misc/osx/Rio.app/ $out/Applications/
+      mkdir $out/Applications/Rio.app/Contents/MacOS/
+      ln -s $out/bin/rio $out/Applications/Rio.app/Contents/MacOS/
+    '';
 
   passthru = {
     updateScript = nix-update-script {
-      extraArgs = [ "--version-regex" "v([0-9.]+)" ];
+      extraArgs = [
+        "--version-regex"
+        "v([0-9.]+)"
+      ];
     };
 
-    tests = {
-      version = testers.testVersion { package = rio; };
-    } // lib.optionalAttrs stdenv.buildPlatform.isLinux {
-      # FIXME: Restrict test execution inside nixosTests for Linux devices as ofborg
-      # 'passthru.tests' nixosTests are failing on Darwin architectures.
-      #
-      # Ref: https://github.com/NixOS/nixpkgs/issues/345825
-      test = nixosTests.terminal-emulators.rio;
-    };
+    tests =
+      {
+        version = testers.testVersion { package = rio; };
+      }
+      // lib.optionalAttrs stdenv.buildPlatform.isLinux {
+        # FIXME: Restrict test execution inside nixosTests for Linux devices as ofborg
+        # 'passthru.tests' nixosTests are failing on Darwin architectures.
+        #
+        # Ref: https://github.com/NixOS/nixpkgs/issues/345825
+        test = nixosTests.terminal-emulators.rio;
+      };
   };
 
   meta = {
     description = "Hardware-accelerated GPU terminal emulator powered by WebGPU";
     homepage = "https://raphamorim.io/rio";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tornax otavio oluceps ];
+    maintainers = with lib.maintainers; [
+      tornax
+      otavio
+      oluceps
+    ];
     platforms = lib.platforms.unix;
     changelog = "https://github.com/raphamorim/rio/blob/v${version}/docs/docs/releases.md";
     mainProgram = "rio";

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -17,6 +17,7 @@
   libGL,
   vulkan-loader,
   libxkbcommon,
+  apple-sdk_11,
 
   withX11 ? !stdenv.hostPlatform.isDarwin,
   libX11,
@@ -80,6 +81,7 @@ rustPlatform.buildRustPackage rec {
     rlinkLibs
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.libutil
+      apple-sdk_11 # Needs _NSPasteboardTypeFileURL, can be removed once x86_64-darwin defaults to a higher SDK
     ];
 
   outputs = [

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -31,13 +31,7 @@
 , rio
 }:
 let
-  rlinkLibs = if stdenv.hostPlatform.isDarwin then [
-    darwin.libobjc
-    darwin.apple_sdk_11_0.frameworks.AppKit
-    darwin.apple_sdk_11_0.frameworks.AVFoundation
-    darwin.apple_sdk_11_0.frameworks.MetalKit
-    darwin.apple_sdk_11_0.frameworks.Vision
-  ] else [
+  rlinkLibs = lib.optionals stdenv.hostPlatform.isLinux [
     (lib.getLib gcc-unwrapped)
     fontconfig
     libGL
@@ -76,7 +70,9 @@ rustPlatform.buildRustPackage rec {
 
   runtimeDependencies = rlinkLibs;
 
-  buildInputs = rlinkLibs;
+  buildInputs = rlinkLibs ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.libutil
+  ];
 
   outputs = [ "out" "terminfo" ];
 


### PR DESCRIPTION
https://hydra.nixos.org/build/276908293

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
