### PR TITLE
sile: 0.14.17 -> 0.15.5

### DIFF
--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -15,7 +15,6 @@
   makeFontsConf,
   gentium,
   runCommand,
-  sile,
 }:
 
 let
@@ -86,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
         {
           nativeBuildInputs = [
             poppler_utils
-            sile
+            finalAttrs.finalPackage
           ];
           inherit (finalAttrs) FONTCONFIG_FILE;
         }

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -1,20 +1,27 @@
 {
   lib,
   stdenv,
-  darwin,
   fetchurl,
-  makeWrapper,
-  pkg-config,
-  poppler_utils,
+
+  # nativeBuildInputs
   gitMinimal,
+  pkg-config,
+  makeWrapper,
+
+  # buildInputs
+  lua,
   harfbuzz,
   icu,
   fontconfig,
-  lua,
   libiconv,
+  darwin,
+  # FONTCONFIG_FILE
   makeFontsConf,
   gentium,
+
+  # passthru.tests
   runCommand,
+  poppler_utils,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -1,47 +1,54 @@
-{ lib
-, stdenv
-, darwin
-, fetchurl
-, makeWrapper
-, pkg-config
-, poppler_utils
-, gitMinimal
-, harfbuzz
-, icu
-, fontconfig
-, lua
-, libiconv
-, makeFontsConf
-, gentium
-, runCommand
-, sile
+{
+  lib,
+  stdenv,
+  darwin,
+  fetchurl,
+  makeWrapper,
+  pkg-config,
+  poppler_utils,
+  gitMinimal,
+  harfbuzz,
+  icu,
+  fontconfig,
+  lua,
+  libiconv,
+  makeFontsConf,
+  gentium,
+  runCommand,
+  sile,
 }:
 
 let
-  luaEnv = lua.withPackages(ps: with ps; [
-    cassowary
-    cldr
-    cosmo
-    fluent
-    linenoise
-    loadkit
-    lpeg
-    lua-zlib
-    lua_cliargs
-    luaepnf
-    luaexpat
-    luafilesystem
-    luarepl
-    luasec
-    luasocket
-    luautf8
-    penlight
-    vstruct
-  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
-    bit32
-  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
-    compat53
-  ]);
+  luaEnv = lua.withPackages (
+    ps:
+    with ps;
+    [
+      cassowary
+      cldr
+      cosmo
+      fluent
+      linenoise
+      loadkit
+      lpeg
+      lua-zlib
+      lua_cliargs
+      luaepnf
+      luaexpat
+      luafilesystem
+      luarepl
+      luasec
+      luasocket
+      luautf8
+      penlight
+      vstruct
+    ]
+    ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
+      bit32
+    ]
+    ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
+      compat53
+    ]
+  );
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -69,9 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     icu
     fontconfig
     libiconv
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit
-  ;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit;
   passthru = {
     # So it will be easier to inspect this environment, in comparison to others
     inherit luaEnv;
@@ -79,20 +84,27 @@ stdenv.mkDerivation (finalAttrs: {
     tests.test = lib.optionalAttrs (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) (
       runCommand "sile-test"
         {
-          nativeBuildInputs = [ poppler_utils sile ];
+          nativeBuildInputs = [
+            poppler_utils
+            sile
+          ];
           inherit (finalAttrs) FONTCONFIG_FILE;
-        } ''
-        output=$(mktemp -t selfcheck-XXXXXX.pdf)
-        echo "<sile>foo</sile>" | sile -o $output -
-        pdfinfo $output | grep "SILE v${finalAttrs.version}" > $out
-      '');
+        }
+        ''
+          output=$(mktemp -t selfcheck-XXXXXX.pdf)
+          echo "<sile>foo</sile>" | sile -o $output -
+          pdfinfo $output | grep "SILE v${finalAttrs.version}" > $out
+        ''
+    );
   };
 
-  postPatch = ''
-    patchShebangs build-aux/*.sh
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    sed -i -e 's|@import AppKit;|#import <AppKit/AppKit.h>|' src/macfonts.m
-  '';
+  postPatch =
+    ''
+      patchShebangs build-aux/*.sh
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      sed -i -e 's|@import AppKit;|#import <AppKit/AppKit.h>|' src/macfonts.m
+    '';
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AppKit";
 
@@ -118,7 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  outputs = [ "out" "doc" "man" "dev" ];
+  outputs = [
+    "out"
+    "doc"
+    "man"
+    "dev"
+  ];
 
   meta = with lib; {
     description = "Typesetting system";
@@ -135,7 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sile-typesetter.org";
     changelog = "https://github.com/sile-typesetter/sile/raw/v${finalAttrs.version}/CHANGELOG.md";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ doronbehar alerque ];
+    maintainers = with maintainers; [
+      doronbehar
+      alerque
+    ];
     license = licenses.mit;
     mainProgram = "sile";
   };

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -43,13 +43,17 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     makeWrapper
   ];
-  buildInputs = [
-    finalAttrs.finalPackage.passthru.luaEnv
-    harfbuzz
-    icu
-    fontconfig
-    libiconv
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit;
+  buildInputs =
+    [
+      finalAttrs.finalPackage.passthru.luaEnv
+      harfbuzz
+      icu
+      fontconfig
+      libiconv
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+    ];
   passthru = {
     luaEnv = lua.withPackages (
       ps:

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -17,39 +17,6 @@
   runCommand,
 }:
 
-let
-  luaEnv = lua.withPackages (
-    ps:
-    with ps;
-    [
-      cassowary
-      cldr
-      cosmo
-      fluent
-      linenoise
-      loadkit
-      lpeg
-      lua-zlib
-      lua_cliargs
-      luaepnf
-      luaexpat
-      luafilesystem
-      luarepl
-      luasec
-      luasocket
-      luautf8
-      penlight
-      vstruct
-    ]
-    ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
-      bit32
-    ]
-    ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
-      compat53
-    ]
-  );
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "sile";
   version = "0.14.17";
@@ -70,15 +37,43 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
   buildInputs = [
-    luaEnv
+    finalAttrs.finalPackage.passthru.luaEnv
     harfbuzz
     icu
     fontconfig
     libiconv
   ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit;
   passthru = {
-    # So it will be easier to inspect this environment, in comparison to others
-    inherit luaEnv;
+    luaEnv = lua.withPackages (
+      ps:
+      with ps;
+      [
+        cassowary
+        cldr
+        cosmo
+        fluent
+        linenoise
+        loadkit
+        lpeg
+        lua-zlib
+        lua_cliargs
+        luaepnf
+        luaexpat
+        luafilesystem
+        luarepl
+        luasec
+        luasocket
+        luautf8
+        penlight
+        vstruct
+      ]
+      ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
+        bit32
+      ]
+      ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
+        compat53
+      ]
+    );
     # Copied from Makefile.am
     tests.test = lib.optionalAttrs (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) (
       runCommand "sile-test"

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Typesetting system";
     longDescription = ''
       SILE is a typesetting system; its job is to produce beautiful
@@ -151,12 +151,12 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://sile-typesetter.org";
     changelog = "https://github.com/sile-typesetter/sile/raw/v${finalAttrs.version}/CHANGELOG.md";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       doronbehar
       alerque
     ];
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "sile";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12107,10 +12107,6 @@ with pkgs;
 
   silc_server = callPackage ../servers/silc-server { };
 
-  sile = callPackage ../tools/typesetting/sile {
-    lua = lua5_3;
-  };
-
   silenthound = callPackage ../tools/security/silenthound { };
 
   silice = callPackage ../development/compilers/silice { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
