### PR TITLE
python312Packages.harlequin-mysql: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11510,6 +11510,12 @@
     githubId = 361496;
     name = "Nikola Knežević";
   };
+  knvpk = {
+    email = "katakampavan.btech@gmail.com";
+    github = "knvpk";
+    githubId = 6078669;
+    name = "Pavan Katakam";
+  };
   kolaente = {
     email = "k@knt.li";
     github = "kolaente";

--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -8,6 +8,7 @@
   versionCheckHook,
   withPostgresAdapter ? true,
   withBigQueryAdapter ? true,
+  withMySQLAdapter ? true,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "harlequin";
@@ -43,7 +44,8 @@ python3Packages.buildPythonApplication rec {
       packaging
     ]
     ++ lib.optionals withPostgresAdapter [ harlequin-postgres ]
-    ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ];
+    ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ]
+    ++ lib.optionals withMySQLAdapter [ harlequin-mysql ];
 
   pythonRelaxDeps = [
     "textual"

--- a/pkgs/development/python-modules/harlequin-mysql/default.nix
+++ b/pkgs/development/python-modules/harlequin-mysql/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  python3Packages,
+}:
+
+buildPythonPackage rec {
+  pname = "harlequin-mysql";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "harlequin_mysql";
+    inherit version;
+    hash = "sha256-Ru9CxbZYVo9TQO5TwkHLEzPz4EkUgHwfg3Qeg1F4eLM=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = with python3Packages; [
+    mysql-connector
+  ];
+
+  pythonRelaxDeps = [
+    "mysql-connector-python"
+  ];
+
+
+  # To prevent circular dependency
+  # as harlequin-mysql requires harlequin which requires harlequin-mysql
+  doCheck = false;
+  pythonRemoveDeps = [
+    "harlequin"
+  ];
+
+  meta = {
+    description = "A Harlequin adapter for MySQL";
+    homepage = "https://pypi.org/project/harlequin-mysql/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/development/python-modules/harlequin-mysql/default.nix
+++ b/pkgs/development/python-modules/harlequin-mysql/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
     "mysql-connector-python"
   ];
 
-
   # To prevent circular dependency
   # as harlequin-mysql requires harlequin which requires harlequin-mysql
   doCheck = false;

--- a/pkgs/development/python-modules/harlequin-mysql/default.nix
+++ b/pkgs/development/python-modules/harlequin-mysql/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "A Harlequin adapter for MySQL";
+    description = "Harlequin adapter for MySQL";
     homepage = "https://pypi.org/project/harlequin-mysql/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ knvpk ];

--- a/pkgs/development/python-modules/harlequin-mysql/default.nix
+++ b/pkgs/development/python-modules/harlequin-mysql/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "A Harlequin adapter for MySQL";
     homepage = "https://pypi.org/project/harlequin-mysql/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pcboy ];
+    maintainers = with lib.maintainers; [ knvpk ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5604,6 +5604,8 @@ self: super: with self; {
 
   harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };
 
+  harlequin-mysql = callPackage ../development/python-modules/harlequin-mysql { };
+
   harlequin-postgres = callPackage ../development/python-modules/harlequin-postgres { };
 
   hass-client = callPackage ../development/python-modules/hass-client { };


### PR DESCRIPTION
## Things done

Added harlequin-mysql python package, its basically an Mysql adapter for the Harlequin terminal IDE for sql.
HomePage: https://github.com/tconbeer/harlequin-mysql

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
