### PR TITLE
nixos/conduwuit: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -24,6 +24,8 @@
 
 - [MaryTTS](https://github.com/marytts/marytts), an open-source, multilingual text-to-speech synthesis system written in pure Java. Available as [services.marytts](options.html#opt-services.marytts).
 
+- [Conduwuit](https://conduwuit.puppyirl.gay/), a federated chat server implementing the Matrix protocol, forked from Conduit. Available as [services.conduwuit](#opt-services.conduwuit.enable).
+
 - [Traccar](https://www.traccar.org/), a modern GPS Tracking Platform. Available as [services.traccar](#opt-services.traccar.enable).
 
 - [crab-hole](https://github.com/LuckyTurtleDev/crab-hole), a cross platform Pi-hole clone written in Rust using hickory-dns/trust-dns. Available as [services.crab-hole](#opt-services.crab-hole.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -715,6 +715,7 @@
   ./services/matrix/appservice-discord.nix
   ./services/matrix/appservice-irc.nix
   ./services/matrix/conduit.nix
+  ./services/matrix/conduwuit.nix
   ./services/matrix/dendrite.nix
   ./services/matrix/hebbot.nix
   ./services/matrix/hookshot.nix

--- a/nixos/modules/services/matrix/conduwuit.nix
+++ b/nixos/modules/services/matrix/conduwuit.nix
@@ -1,0 +1,279 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.conduwuit;
+  defaultUser = "conduwuit";
+  defaultGroup = "conduwuit";
+
+  format = pkgs.formats.toml { };
+  configFile = format.generate "conduwuit.toml" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [ niklaskorz ];
+  options.services.conduwuit = {
+    enable = lib.mkEnableOption "conduwuit";
+
+    user = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      description = ''
+        The user {command}`conduwuit` is run as.
+      '';
+      default = defaultUser;
+    };
+
+    group = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      description = ''
+        The group {command}`conduwuit` is run as.
+      '';
+      default = defaultGroup;
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      description = "Extra Environment variables to pass to the conduwuit server.";
+      default = { };
+      example = {
+        RUST_BACKTRACE = "yes";
+      };
+    };
+
+    package = lib.mkPackageOption pkgs "conduwuit" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          global.server_name = lib.mkOption {
+            type = lib.types.nonEmptyStr;
+            example = "example.com";
+            description = "The server_name is the name of this server. It is used as a suffix for user and room ids.";
+          };
+          global.address = lib.mkOption {
+            type = lib.types.nullOr (lib.types.listOf lib.types.nonEmptyStr);
+            default = null;
+            example = [
+              "127.0.0.1"
+              "::1"
+            ];
+            description = ''
+              Addresses (IPv4 or IPv6) to listen on for connections by the reverse proxy/tls terminator.
+              If set to `null`, conduwuit will listen on IPv4 and IPv6 localhost.
+              Must be `null` if `unix_socket_path` is set.
+            '';
+          };
+          global.port = lib.mkOption {
+            type = lib.types.listOf lib.types.port;
+            default = [ 6167 ];
+            description = ''
+              The port(s) conduwuit will be running on.
+              You need to set up a reverse proxy in your web server (e.g. apache or nginx),
+              so all requests to /_matrix on port 443 and 8448 will be forwarded to the conduwuit
+              instance running on this port.
+            '';
+          };
+          global.unix_socket_path = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = ''
+              Listen on a UNIX socket at the specified path. If listening on a UNIX socket,
+              listening on an address will be disabled. The `address` option must be set to
+              `null` (the default value). The option {option}`services.conduwuit.group` must
+              be set to a group your reverse proxy is part of.
+
+              This will automatically add a system user "conduwuit" to your system if
+              {option}`services.conduwuit.user` is left at the default, and a "conduwuit"
+              group if {option}`services.conduwuit.group` is left at the default.
+            '';
+          };
+          global.unix_socket_perms = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 660;
+            description = "The default permissions (in octal) to create the UNIX socket with.";
+          };
+          global.max_request_size = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 20000000;
+            description = "Max request size in bytes. Don't forget to also change it in the proxy.";
+          };
+          global.allow_registration = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether new users can register on this server.
+
+              Registration with token requires `registration_token` or `registration_token_file` to be set.
+
+              If set to true without a token configured, and
+              `yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse`
+              is set to true, users can freely register.
+            '';
+          };
+          global.allow_encryption = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether new encrypted rooms can be created. Note: existing rooms will continue to work.";
+          };
+          global.allow_federation = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether this server federates with other servers.
+            '';
+          };
+          global.trusted_servers = lib.mkOption {
+            type = lib.types.listOf lib.types.nonEmptyStr;
+            default = [ "matrix.org" ];
+            description = ''
+              Servers listed here will be used to gather public keys of other servers
+              (notary trusted key servers).
+
+              Currently, conduwuit doesn't support inbound batched key requests, so
+              this list should only contain other Synapse servers.
+
+              Example: `[ "matrix.org" "constellatory.net" "tchncs.de" ]`
+            '';
+          };
+          global.database_path = lib.mkOption {
+            readOnly = true;
+            type = lib.types.path;
+            default = "/var/lib/conduwuit/";
+            description = ''
+              Path to the conduwuit database, the directory where conduwuit will save its data.
+              Note that database_path cannot be edited because of the service's reliance on systemd StateDir.
+            '';
+          };
+          global.allow_check_for_updates = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              If enabled, conduwuit will send a simple GET request periodically to
+              <https://pupbrain.dev/check-for-updates/stable> for any new announcements made.
+              Despite the name, this is not an update check endpoint, it is simply an announcement check endpoint.
+
+              Disabled by default.
+            '';
+          };
+        };
+      };
+      default = { };
+      # TOML does not allow null values, so we use null to omit those fields
+      apply = lib.filterAttrsRecursive (_: v: v != null);
+      description = ''
+        Generates the conduwuit.toml configuration file. Refer to
+        <https://conduwuit.puppyirl.gay/configuration.html>
+        for details on supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.settings ? global.unix_socket_path) || !(cfg.settings ? global.address);
+        message = ''
+          In `services.conduwuit.settings.global`, `unix_socket_path` and `address` cannot be set at the
+          same time.
+          Leave one of the two options unset or explicitly set them to `null`.
+        '';
+      }
+      {
+        assertion = cfg.user != defaultUser -> config ? users.users.${cfg.user};
+        message = "If `services.conduwuit.user` is changed, the configured user must already exist.";
+      }
+      {
+        assertion = cfg.group != defaultGroup -> config ? users.groups.${cfg.group};
+        message = "If `services.conduwuit.group` is changed, the configured group must already exist.";
+      }
+    ];
+
+    users.users = lib.mkIf (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        group = cfg.group;
+        home = cfg.settings.global.database_path;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == defaultGroup) {
+      ${defaultGroup} = { };
+    };
+
+    systemd.services.conduwuit = {
+      description = "Conduwuit Matrix Server";
+      documentation = [ "https://conduwuit.puppyirl.gay/" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = lib.mkMerge ([
+        { CONDUWUIT_CONFIG = configFile; }
+        cfg.extraEnvironment
+      ]);
+      startLimitBurst = 5;
+      startLimitIntervalSec = 60;
+      serviceConfig = {
+        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
+
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        PrivateIPC = true;
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@resources"
+          "~@clock"
+          "@debug"
+          "@module"
+          "@mount"
+          "@reboot"
+          "@swap"
+          "@cpu-emulation"
+          "@obsolete"
+          "@timer"
+          "@chown"
+          "@setuid"
+          "@privileged"
+          "@keyring"
+          "@ipc"
+        ];
+        SystemCallErrorNumber = "EPERM";
+
+        StateDirectory = "conduwuit";
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "conduwuit";
+        RuntimeDirectoryMode = "0750";
+
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = 10;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -217,6 +217,7 @@ in {
   coder = handleTest ./coder.nix {};
   collectd = handleTest ./collectd.nix {};
   commafeed = handleTest ./commafeed.nix {};
+  conduwuit = runTest ./matrix/conduwuit.nix;
   connman = handleTest ./connman.nix {};
   consul = handleTest ./consul.nix {};
   consul-template = handleTest ./consul-template.nix {};

--- a/nixos/tests/matrix/conduwuit.nix
+++ b/nixos/tests/matrix/conduwuit.nix
@@ -1,0 +1,103 @@
+{ lib, ... }:
+let
+  name = "conduwuit";
+in
+{
+  inherit name;
+
+  nodes = {
+    conduwuit = {
+      services.conduwuit = {
+        enable = true;
+        settings.global = {
+          server_name = name;
+          address = [ "0.0.0.0" ];
+          allow_registration = true;
+          yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = true;
+        };
+        extraEnvironment.RUST_BACKTRACE = "yes";
+      };
+      networking.firewall.allowedTCPPorts = [ 6167 ];
+    };
+    client =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          (pkgs.writers.writePython3Bin "do_test" { libraries = [ pkgs.python3Packages.matrix-nio ]; } ''
+            import asyncio
+            import nio
+
+
+            async def main() -> None:
+                # Connect to conduwuit
+                client = nio.AsyncClient("http://conduwuit:6167", "alice")
+
+                # Register as user alice
+                response = await client.register("alice", "my-secret-password")
+
+                # Log in as user alice
+                response = await client.login("my-secret-password")
+
+                # Create a new room
+                response = await client.room_create(federate=False)
+                print("Matrix room create response:", response)
+                assert isinstance(response, nio.RoomCreateResponse)
+                room_id = response.room_id
+
+                # Join the room
+                response = await client.join(room_id)
+                print("Matrix join response:", response)
+                assert isinstance(response, nio.JoinResponse)
+
+                # Send a message to the room
+                response = await client.room_send(
+                    room_id=room_id,
+                    message_type="m.room.message",
+                    content={
+                        "msgtype": "m.text",
+                        "body": "Hello conduwuit!"
+                    }
+                )
+                print("Matrix room send response:", response)
+                assert isinstance(response, nio.RoomSendResponse)
+
+                # Sync responses
+                response = await client.sync(timeout=30000)
+                print("Matrix sync response:", response)
+                assert isinstance(response, nio.SyncResponse)
+
+                # Check the message was received by conduwuit
+                last_message = response.rooms.join[room_id].timeline.events[-1].body
+                assert last_message == "Hello conduwuit!"
+
+                # Leave the room
+                response = await client.room_leave(room_id)
+                print("Matrix room leave response:", response)
+                assert isinstance(response, nio.RoomLeaveResponse)
+
+                # Close the client
+                await client.close()
+
+
+            if __name__ == "__main__":
+                asyncio.run(main())
+          '')
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("start conduwuit"):
+          conduwuit.wait_for_unit("conduwuit.service")
+          conduwuit.wait_for_open_port(6167)
+
+    with subtest("ensure messages can be exchanged"):
+          client.succeed("do_test >&2")
+  '';
+
+  meta.maintainers = with lib.maintainers; [
+    niklaskorz
+  ];
+}

--- a/pkgs/by-name/co/conduwuit/package.nix
+++ b/pkgs/by-name/co/conduwuit/package.nix
@@ -17,6 +17,7 @@
   rust-jemalloc-sys,
   enableLiburing ? stdenv.hostPlatform.isLinux,
   liburing,
+  nixosTests,
 }:
 let
   rust-jemalloc-sys' = rust-jemalloc-sys.override {
@@ -84,10 +85,16 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = conduwuit;
-      version = "${version}";
-    };
+    tests =
+      {
+        version = testers.testVersion {
+          inherit version;
+          package = conduwuit;
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        inherit (nixosTests) conduwuit;
+      };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As conduwuit deviates more and more from its conduit origins, it makes sense to give conduwuit its own module.
A custom module has been wished by upstream maintainers (@girlbossceo) as well as fellow nixpkgs maintainers (@nyabinary).

This allows us to cover breaking changes such as:

- conduwuit does not support sqlite as database backend (unlike conduit)
- conduwuit supports listening to unix sockets (unlike conduit)

Also includes the conduwuit-specific(?) fix from #353634.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
