### PR TITLE
python312Packages.great-expectations: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/great-expectations/default.nix
+++ b/pkgs/development/python-modules/great-expectations/default.nix
@@ -1,0 +1,135 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  altair,
+  cryptography,
+  jinja2,
+  jsonschema,
+  marshmallow,
+  mistune,
+  numpy,
+  packaging,
+  pandas,
+  posthog,
+  pydantic,
+  pyparsing,
+  python-dateutil,
+  requests,
+  ruamel-yaml,
+  scipy,
+  tqdm,
+  tzlocal,
+
+  # test
+  pytestCheckHook,
+  pytest-mock,
+  pytest-order,
+  pytest-random-order,
+  click,
+  flaky,
+  freezegun,
+  invoke,
+  moto,
+  psycopg2,
+  requirements-parser,
+  responses,
+  sqlalchemy,
+}:
+
+buildPythonPackage rec {
+  pname = "great-expectations";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "great-expectations";
+    repo = "great_expectations";
+    rev = "refs/tags/${version}";
+    hash = "sha256-TV07vmc0XdP6ICv7Kws79zACCsahZ6FlhplJHbpDFNk=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/conftest.py --replace 'locale.setlocale(locale.LC_ALL, "en_US.UTF-8")' ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    altair
+    cryptography
+    jinja2
+    jsonschema
+    marshmallow
+    mistune
+    numpy
+    packaging
+    pandas
+    posthog
+    pydantic
+    pyparsing
+    python-dateutil
+    requests
+    ruamel-yaml
+    scipy
+    tqdm
+    tzlocal
+  ];
+
+  pythonRelaxDeps = [
+    "altair"
+    "pandas"
+    "posthog"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    pytest-order
+    pytest-random-order
+    click
+    flaky
+    freezegun
+    invoke
+    moto
+    psycopg2
+    requirements-parser
+    responses
+    sqlalchemy
+  ] ++ moto.optional-dependencies.s3 ++ moto.optional-dependencies.sns;
+
+  disabledTestPaths = [
+    # try to access external URLs:
+    "tests/integration/cloud/rest_contracts"
+    "tests/integration/spark"
+
+    # moto-related import errors:
+    "tests/actions"
+    "tests/data_context"
+    "tests/datasource"
+    "tests/execution_engine"
+
+    # locale-related rendering issues, mostly:
+    "tests/core/test__docs_decorators.py"
+    "tests/expectations/test_expectation_atomic_renderers.py"
+    "tests/render"
+  ];
+
+  disabledTests = [
+    # tries to access network:
+    "test_checkpoint_run_with_data_docs_and_slack_actions_emit_page_links"
+    "test_checkpoint_run_with_slack_action_no_page_links"
+  ];
+
+  pythonImportsCheck = [ "great_expectations" ];
+  pytestFlagsArray = [ "-m 'not spark and not postgresql and not snowflake'" ];
+
+  meta = {
+    description = "Library for writing unit tests for data validation";
+    homepage = "https://docs.greatexpectations.io";
+    changelog = "https://github.com/great-expectations/great_expectations/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -162,6 +162,7 @@ buildPythonPackage rec {
       pyyaml
       py-partiql-parser
     ];
+    sns = [ ];
     stepfunctions = [
       antlr4-python3-runtime
       jsonpath-ng

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5451,6 +5451,8 @@ self: super: with self; {
 
   greatfet = callPackage ../development/python-modules/greatfet { };
 
+  great-expectations = callPackage ../development/python-modules/great-expectations { };
+
   great-tables = callPackage ../development/python-modules/great-tables { };
 
   greeclimate = callPackage ../development/python-modules/greeclimate { };


### PR DESCRIPTION
Init `python312Packages.great-expectations`, a [package for writing tests against data sources and distributions](https://docs.greatexpectations.io/).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
