### PR TITLE
iggy-cli: init at 0.8.2

### DIFF
--- a/pkgs/by-name/ig/iggy-cli/package.nix
+++ b/pkgs/by-name/ig/iggy-cli/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  pkg-config,
+  openssl,
+  installShellFiles,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "iggy-cli";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "iggy-rs";
+    repo = "iggy";
+    rev = "refs/tags/iggy-cli-${version}";
+    hash = "sha256-GRmufkrwRjX7hC57mSKijbAswM0C6aYWrNwuFAIdtGY=";
+  };
+
+  cargoHash = "sha256-XNwfgKUXayIN88Zg/2yj+oyPSqbxuLofhiCay7B0SQE=";
+
+  cargoBuildFlags = [
+    "--bin"
+    "iggy"
+  ];
+
+  cargoTestFlags = cargoBuildFlags;
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [ openssl ];
+
+  OPENSSL_NO_VENDOR = 1;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd iggy \
+      --bash <($out/bin/iggy --generate bash) \
+      --zsh <($out/bin/iggy --generate zsh) \
+      --fish <($out/bin/iggy --generate fish)
+  '';
+
+  meta = {
+    description = "CLI for Iggy message streaming platform";
+    homepage = "https://github.com/iggy-rs/iggy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "iggy";
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
