### PR TITLE
license-compliance-hook: init

### DIFF
--- a/pkgs/by-name/co/cosmic-wallpapers/package.nix
+++ b/pkgs/by-name/co/cosmic-wallpapers/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   fetchpatch,
+  license-compliance-hook,
   nix-update-script,
 }:
 
@@ -27,6 +28,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [ "prefix=$(out)" ];
+
+  __structuredAttrs = true;
+  nativeBuildInputs = [ license-compliance-hook ];
+
+  includeLicenses = {
+    inherit (lib.licensesSpdx) "CC-BY-4.0";
+    ATTRIBUTION = "README.md";
+  };
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/li/license-compliance-hook/common-licenses.nix
+++ b/pkgs/by-name/li/license-compliance-hook/common-licenses.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "common-licenses";
+  version = "3.25.0";
+
+  src = fetchFromGitHub {
+    owner = "spdx";
+    repo = "license-list-data";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-0UmeSwIWEYWyGkoVqh6cKv6lx+7fjBpDanr6yo3DN0s=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/common-licenses
+    for file in text/*; do
+      mv $file $out/share/common-licenses/$(basename $file | sed 's/\(.*\)\..*/\1/')
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SPDX common plaintext license files";
+    homepage = "https://spdx.org/licenses/";
+    license = lib.licenses.publicDomain; # Computer-generated files have no license
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/li/license-compliance-hook/package.nix
+++ b/pkgs/by-name/li/license-compliance-hook/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  makeSetupHook,
+  callPackage,
+  replaceVars,
+  jq,
+}:
+
+let
+  common-licenses = callPackage ./common-licenses.nix { };
+in
+makeSetupHook
+  {
+    name = "license-compliance-hook";
+
+    passthru = {
+      inherit common-licenses;
+    };
+
+    meta = {
+      description = "Setup hook for enforcing license compliance";
+      maintainers = with lib.maintainers; [ pandapip1 ];
+      platforms = lib.platforms.all;
+    };
+  }
+  (
+    replaceVars ./setup-hook.sh {
+      jq = lib.getExe jq;
+      common-licenses = "${common-licenses}/share/common-licenses";
+    }
+  )

--- a/pkgs/by-name/li/license-compliance-hook/setup-hook.sh
+++ b/pkgs/by-name/li/license-compliance-hook/setup-hook.sh
@@ -1,0 +1,71 @@
+postInstallHooks+=('licenseComplianceHook')
+
+licenseComplianceHook () {
+  # Ensure NIX_ATTRS_JSON_FILE exists
+  if [ -z $NIX_ATTRS_JSON_FILE ]; then
+    echo "license-compliance-hook: NIX_ATTRS_JSON_FILE not set, is __structuredAttrs set to true?" >&2
+    exit 1
+  fi
+  if [ ! -f $NIX_ATTRS_JSON_FILE ]; then
+    echo "license-compliance-hook: NIX_ATTRS_JSON_FILE not found" >&2
+    exit 1
+  fi
+
+  # Ensure that includeLicenses is set to an attribute set or list in NIX_ATTRS_JSON_FILE
+  includeLicenses=$(@jq@ -r '.includeLicenses' $NIX_ATTRS_JSON_FILE)
+  if [ "$includeLicenses" = "null" ]; then
+    echo "license-compliance-hook: includeLicenses not set in derivation" >&2
+    exit 1
+  fi
+  if [ $(@jq@ -r 'type' <<< $includeLicenses) != "object" ]; then
+    echo "license-compliance-hook: includeLicenses wrong type in derivation (expected AttrSet)" >&2
+    exit 1
+  fi
+
+  # Make license directory
+  mkdir -p $out/share/doc/licenses
+
+  ls -la .
+
+  # Iterate over includeLicenses keys
+  for license in $(@jq@ -r '.includeLicenses | keys[]' $NIX_ATTRS_JSON_FILE); do
+    licenseData=$(@jq@ ".includeLicenses[\"$license\"]" $NIX_ATTRS_JSON_FILE)
+    # If we're a string, look for a file
+    if @jq@ -r 'type' <<< $licenseData | grep -q string; then
+      echo "DEBUG 2: $license"
+      licenseFile=$(@jq@ -r ".includeLicenses[\"$license\"]" $NIX_ATTRS_JSON_FILE)
+      # Check that the file exists
+      if [ ! -f $licenseFile ]; then
+        echo "license-compliance-hook: $licenseFile not found" >&2
+        exit 1
+      fi
+      # Check that the license is not already in the licenses directory
+      if [ -f $out/share/doc/licenses/$license ]; then
+        echo "license-compliance-hook: $license already exists in licenses directory" >&2
+        exit 1
+      fi
+      # Copy the license
+      cp $licenseFile $out/share/doc/licenses/$license
+    fi
+    # If we're an object, look for spdxId
+    if @jq@ -r 'type' <<< $licenseData | grep -q object; then
+      spdxId=$(@jq@ -r '.spdxId' <<< $licenseData)
+      if [ $spdxId == "null" ]; then
+        echo "license-compliance-hook: spdxId not set for $license" >&2
+        exit 1
+      fi
+      # Check that the license is in common-licenses
+      if [ ! -f @common-licenses@/$spdxId ]; then
+        echo "license-compliance-hook: $spdxId not found in common-licenses" >&2
+        exit 1
+      fi
+      # Check that the license is not already in the licenses directory
+      if [ -f $out/share/doc/licenses/$license ]; then
+        echo "license-compliance-hook: $license already exists in licenses directory" >&2
+        exit 1
+      fi
+      # Symlink the license
+      ln -s @common-licenses@/$spdxId $out/share/doc/licenses/$license
+    fi
+  done
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a setup hook that allows for copying license files to `$out/share/doc/licenses/`, as a basic way to start addressing https://github.com/NixOS/nixpkgs/issues/342570.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
