### PR TITLE
nixos/postgresql: change option `enableTCPIP` to actually mean TCP/IP.

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -485,9 +485,9 @@ in
       '';
     }) cfg.ensureUsers;
 
-    warnings = lib.optional (cfg.enableTCPIP == true)
-     "Behaviour of `services.postgresql.enableTCPIP` changed from binding on all interfaces to binding
-     on localhost in addition to the unix socket.";
+    warnings = lib.optional (cfg.enableTCPIP == true) ''
+      Behaviour of `services.postgresql.enableTCPIP` changed from binding on all interfaces to binding on localhost in addition to the unix socket.
+    '';
 
     services.postgresql.settings =
       {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -377,7 +377,7 @@ in
         description = ''
           The TCP/IP address(es) on which the server is to listen for connections from client applications.
           The value takes the form of a comma-separated list of host names and/or numeric IP addresses.
-          The special entry * corresponds to all available IP interfaces.
+          The special entry `*` corresponds to all available IP interfaces.
 
           See the PostgreSQL documentation on [listen_address](https://www.postgresql.org/docs/16/runtime-config-connection.html#GUC-LISTEN-ADDRESSES).
         '';

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -379,7 +379,7 @@ in
           The value takes the form of a comma-separated list of host names and/or numeric IP addresses.
           The special entry `*` corresponds to all available IP interfaces.
 
-          See the PostgreSQL documentation on [listen_address](https://www.postgresql.org/docs/16/runtime-config-connection.html#GUC-LISTEN-ADDRESSES).
+          See the PostgreSQL documentation on [listen_address](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-LISTEN-ADDRESSES).
         '';
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -803,6 +803,7 @@ in {
   apache_datasketches = handleTest ./apache_datasketches.nix {};
   postgresql = handleTest ./postgresql.nix {};
   postgresql-jit = handleTest ./postgresql-jit.nix {};
+  postgresql-listen-addresses = handleTest ./postgresql-listen-addresses.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};
   postgresql-tls-client-cert = handleTest ./postgresql-tls-client-cert.nix {};
   powerdns = handleTest ./powerdns.nix {};

--- a/nixos/tests/postgresql-listen-addresses.nix
+++ b/nixos/tests/postgresql-listen-addresses.nix
@@ -1,0 +1,75 @@
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../.. { inherit system config; }
+}:
+
+pkgs.testers.runNixOSTest {
+  name = "postgresql-listen-addresses";
+  # Test that PostgreSQL defaults to "localhost" when enableTCPIP = true.
+
+  nodes = {
+    default = { pkgs, lib, ... }: {
+      # Default behaviour of the service
+      services.postgresql = {
+        enable = true;
+      };
+      environment.systemPackages = with pkgs; [
+        lsof
+      ];
+    };
+    listenall = { pkgs, lib, ... }: {
+      services.postgresql = {
+        enable = true;
+        listenAddresses = "0.0.0.0";
+        enableTCPIP = true;
+        # settings.listen_addresses = "0.0.0.0";
+      };
+      environment.systemPackages = with pkgs; [
+        lsof
+      ];
+    };
+    unixonly = { pkgs, lib, ... }: {
+      services.postgresql = {
+        enable = true;
+        enableTCPIP = false;
+      };
+      environment.systemPackages = with pkgs; [
+        lsof
+      ];
+    };
+  };
+
+  testScript = ''
+    machines = [ default, listenall, unixonly ]
+
+    for machine in machines:
+        machine.start()
+        machine.wait_for_unit("postgresql.service")
+
+    with subtest("Configured to listen on localhost"):
+        default.succeed(
+            "sudo -u postgres psql <<<'SHOW listen_addresses' 2>/dev/null | grep 'localhost'")
+
+    with subtest("Actually listening on localhost"):
+        output = default.succeed("lsof -i tcp -P | grep 'localhost:5432'")
+
+    with subtest("Configured to listen on localhost"):
+        listenall.succeed(
+            "sudo -u postgres psql <<<'SHOW listen_addresses' 2>/dev/null | grep '0.0.0.0'")
+
+    with subtest("Actually listening on localhost"):
+        listenall.succeed("lsof -i tcp -P | grep '*:5432'")
+
+    with subtest("Configured not to listen on localhost or 0.0.0.0"):
+        unixonly.fail(
+            "sudo -u postgres psql <<<'SHOW listen_addresses' 2>/dev/null | grep 'localhost'")
+        unixonly.fail(
+            "sudo -u postgres psql <<<'SHOW listen_addresses' 2>/dev/null | grep '0.0.0.0'")
+
+    with subtest("Actually not listening on TCP"):
+        unixonly.fail("lsof -i tcp -P | grep ':5432'")
+
+    for machine in machines:
+        machine.shutdown()
+  '';
+}

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -271,6 +271,11 @@ let
           pkgs = self;
           package = this;
         };
+        postgresql-listen-addresses = import ../../../../nixos/tests/postgresql-listen-addresses.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        };
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       } // lib.optionalAttrs jitSupport {
         postgresql-jit = import ../../../../nixos/tests/postgresql-jit.nix {


### PR DESCRIPTION
This is an attempt at fixing https://github.com/NixOS/nixpkgs/issues/346013, started during NixCon 2024 with the help of @jfroche .

---

Setting the option `services.postgresql.enableTCPIP` to `false` did not disable TCP/IP. Instead, this makes PostgreSQL listen on `localhost`.

This was confusing, as a security minded user may want to disable TCP/IP entirely, even for localhost.

It also prevented running multiple instances of PostgreSQL on the same host without manually assigning distinct TCP/IP ports.

This commit adds a new option, `services.postgres.listenAddresses`, that defaults to `localhost`.

The default behaviour of `services.postgresql` is maintained: the service listens on localhost using TCP/IP with the new default `enableTCPIP = null`.

A warning informs users that setting `enableTCPIP = true` now only listens on localhost. Setting `listenAddresses` is now required to listen on all or multiple interfaces. This option follows the upstream PostgreSQL syntax for `liste_addresses`.

New tests validate the new behavior.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
