### PR TITLE
emacsPackages.org-xlatex: fix xwidgets dependency

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1381,6 +1381,22 @@ let
         # TODO report to upstream
         org-kindle = addPackageRequires super.org-kindle [ self.dash ];
 
+        # Requires xwidgets compiled into emacs and so fails with the
+        # default, non-GTK package. Override the package to ensure
+        # that xwidgets are available and the package can build.
+        org-xlatex = let
+          org-xlatex = super.org-xlatex.overrideAttrs (old: {
+            nativeBuildInputs = builtins.map
+              (p: if p.pname == "emacs" then pkgs.emacs-gtk else p)
+              old.nativeBuildInputs;
+          });
+          in
+          # Similarly, we can't build in xwidgets on Darwin, so mark
+          # it broken in that case.
+          if pkgs.stdenv.hostPlatform.isDarwin
+          then markBroken org-xlatex
+          else org-xlatex;
+
         org-special-block-extras = ignoreCompilationError super.org-special-block-extras; # elisp error
 
         org-trello = ignoreCompilationError super.org-trello; # elisp error


### PR DESCRIPTION
I came across the call for help with ZHF and took a look at failing builds without owners. I'm not well-versed with the nix emacs infrastructure, but I thought that any sort of build failure help would be a small drop of assistance into the vast ZHF bucket given that I'm a nixos+emacs user.

The `org-xlatex` package is failing on all systems because the package requires emacs with xwidgets support. Changing the default emacs package to a GUI-enabled one definitely seems too heavy a hammer; so this change overrides the package to swap in a GTK-enabled emacs in place of the default emacs package. I noted in the `Xwidgets` argument to `make-emacs.nix` that xwidgets support won't work in some other cases (like Darwin) so I tried to translate that into the `markBroken` predicate so it'll be skipped appropriately where it isn't compatible.

Please do correct me if I'm doing anything seriously anti-pattern-ish here.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
