### PR TITLE
dyndnsc: 0.6.1 -> 0.6.1-unstable

### DIFF
--- a/pkgs/by-name/dy/dyndnsc/package.nix
+++ b/pkgs/by-name/dy/dyndnsc/package.nix
@@ -1,18 +1,19 @@
 {
   lib,
-  stdenv,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "dyndnsc";
-  version = "0.6.1";
+  version = "0.6.1-unstable-2024-02-25";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-EweNKe6i+aTKAfBWdsMwnq1eNB2rBH4NUcRvI9S3+7Q=";
+  src = fetchFromGitHub {
+    owner = "infothrill";
+    repo = "python-dyndnsc";
+    rev = "75f82ce64a91b9fd25cd362d295095be4dab72b5";
+    hash = "sha256-2SWtYQ3TaFbuHxABBUeXSqgfCA/T8lCAB+9mAIyjySU=";
   };
 
   postPatch = ''
@@ -20,10 +21,7 @@ python3Packages.buildPythonApplication rec {
       --replace-fail '"pytest-runner"' ""
   '';
 
-  pythonRelaxDeps = [ "bottle" ];
-
   build-system = with python3Packages; [ setuptools ];
-
 
   dependencies = with python3Packages; [
     daemonocle
@@ -32,31 +30,21 @@ python3Packages.buildPythonApplication rec {
     netifaces
     requests
     setuptools
+    responses
   ];
 
   nativeCheckInputs = with python3Packages; [
-    bottle
     pytest-console-scripts
     pytestCheckHook
   ];
 
-  disabledTests =
-    [
-      # dnswanip connects to an external server to discover the
-      # machine's IP address.
-      "dnswanip"
-      # AssertionError
-      "test_null_dummy"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # The tests that spawn a server using Bottle cannot be run on
-      # macOS or Windows as the default multiprocessing start method
-      # on those platforms is 'spawn', which requires the code to be
-      # run to be picklable, which this code isn't.
-      # Additionaly, other start methods are unsafe and prone to failure
-      # on macOS; see https://bugs.python.org/issue33725.
-      "BottleServer"
-    ];
+  disabledTests = [
+    # dnswanip connects to an external server to discover the
+    # machine's IP address.
+    "dnswanip"
+    # AssertionError
+    "test_null_dummy"
+  ];
   # Allow tests that bind or connect to localhost on macOS.
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Switch to newest branch. Fixes the build errors and gets rid of bootle dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

ZHF: #352882