### PR TITLE
apidog: init at 2.6.30

### DIFF
--- a/pkgs/by-name/ap/apidog/package.nix
+++ b/pkgs/by-name/ap/apidog/package.nix
@@ -1,0 +1,69 @@
+{
+  pkgs,
+  fetchzip,
+  appimageTools,
+  makeWrapper,
+  imagemagick,
+  lib,
+  ...
+}:
+let
+  pname = "apidog";
+  version = "2.6.30";
+  name = "${pname}-${version}";
+
+  zipFile = fetchzip {
+    url = "https://web.archive.org/web/20241114142057if_/https://file-assets.apidog.com/download/Apidog-linux-latest.zip";
+    sha256 = "sha256-tkGL4+Ol/9H92vemJIe5riyg+l6mGHWK5q5Mz6gK5no=";
+    stripRoot = false;
+  };
+
+  # Extract AppImage to a new derivation
+  src = pkgs.runCommand "apidog-appimage" { } ''
+    cp ${zipFile}/Apidog.AppImage $out
+    chmod +x $out
+  '';
+
+  appimageContents = pkgs.appimageTools.extractType2 { inherit name src; };
+in
+appimageTools.wrapType2 rec {
+  inherit name;
+  inherit src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/${pname} \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --use-gl=desktop}}"
+
+    # Check for required desktop file
+    if [ ! -f ${appimageContents}/apidog.desktop ]; then
+      echo "Error: Missing .desktop file in ${appimageContents}"
+      exit 1
+    else
+      # Install and modify the desktop file
+      install -m 444 -D ${appimageContents}/apidog.desktop $out/share/applications/${pname}.desktop
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace 'Exec=Apidog' 'Exec=${pname}'
+    fi
+
+    # Check for required icon file
+    if [ ! -f ${appimageContents}/apidog.png ]; then
+      echo "Error: Missing icon file in ${appimageContents}"
+      exit 1
+    else
+      # Resize and install the icon
+      ${imagemagick}/bin/magick ${appimageContents}/apidog.png -resize 512x512 ${pname}_512.png
+      install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${pname}.png
+    fi
+  '';
+
+  meta = {
+    description = "Platform for building, testing, and documenting APIs";
+    homepage = "https://apidog.com/";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "apidog";
+  };
+}


### PR DESCRIPTION
This PR aims to add [Apidog](https://apidog.com/) for x86_64-linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
