### PR TITLE
mautrix-signal: fix build with goolm, enable checks & version test

### DIFF
--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -48,7 +48,20 @@ buildGoModule rec {
 
   vendorHash = "sha256-bKQKO5RqgMrWq7NyNF1rj2CLp5SeBP80HWxF8MWnZ1U=";
 
-  doCheck = false;
+  doCheck = true;
+  preCheck =
+    ''
+      # Needed by the tests to be able to find libstdc++
+      export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+    ''
+    + (lib.optionalString (!withGoolm) ''
+      # When using libolm, the tests need explicit linking to libstdc++
+      export CGO_LDFLAGS="-lstdc++"
+    '');
+
+  postCheck = ''
+    unset LD_LIBRARY_PATH
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mautrix/signal";

--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -6,6 +6,7 @@
   fetchpatch,
   olm,
   libsignal-ffi,
+  versionCheckHook,
   # This option enables the use of an experimental pure-Go implementation of
   # the Olm protocol instead of libolm for end-to-end encryption. Using goolm
   # is not recommended by the mautrix developers, but they are interested in
@@ -62,6 +63,10 @@ buildGoModule rec {
   postCheck = ''
     unset LD_LIBRARY_PATH
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
 
   meta = with lib; {
     homepage = "https://github.com/mautrix/signal";

--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   fetchpatch,
@@ -32,12 +33,18 @@ buildGoModule rec {
     })
   ];
 
-  buildInputs = (lib.optional (!withGoolm) olm) ++ [
-    # must match the version used in https://github.com/mautrix/signal/tree/main/pkg/libsignalgo
-    # see https://github.com/mautrix/signal/issues/401
-    libsignal-ffi
-  ];
+  buildInputs =
+    (lib.optional (!withGoolm) olm)
+    ++ (lib.optional withGoolm stdenv.cc.cc.lib)
+    ++ [
+      # must match the version used in https://github.com/mautrix/signal/tree/main/pkg/libsignalgo
+      # see https://github.com/mautrix/signal/issues/401
+      libsignal-ffi
+    ];
+
   tags = lib.optional withGoolm "goolm";
+
+  CGO_LDFLAGS = lib.optional withGoolm [ "-lstdc++" ];
 
   vendorHash = "sha256-bKQKO5RqgMrWq7NyNF1rj2CLp5SeBP80HWxF8MWnZ1U=";
 


### PR DESCRIPTION
On current `master`, building mautrix-signal is broken when using `witGoolm = true`, as it needs to explicitly link to `libstdc++` (which is transitivly required).

Further, enable checks on the package, which only need a small workaround for properly finding `libstdc++` in the check phase -- hopefully that is acceptable, but maybe there is a better solution to this.

Finally, add a basic version test for the resulting binary with `testers.testVersion`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
