### PR TITLE
cargo-llvm-cov: fix build, 0.6.12 -> 0.6.14

### DIFF
--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -24,7 +24,7 @@
 
 let
   pname = "cargo-llvm-cov";
-  version = "0.6.12";
+  version = "0.6.14";
 
   owner = "taiki-e";
   homepage = "https://github.com/${owner}/${pname}";
@@ -35,7 +35,7 @@ let
   cargoLock = fetchurl {
     name = "Cargo.lock";
     url = "https://crates.io/api/v1/crates/${pname}/${version}/download";
-    sha256 = "sha256-QMO5J5c8MQr84w6X74oQrHV99cjSUVfpC8Ub1csQ0gI=";
+    sha256 = "sha256-f0xO+UxB9f6q6q8QyjtP+z+U146+8GLmLKgGmAs/YYA=";
     downloadToTemp = true;
     postFetch = ''
       tar xzf $downloadedFile ${pname}-${version}/Cargo.lock
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage {
     inherit owner;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-BlXgbCWjGya/I94nqfjBqQPSWnVhyhNn0oSRL9xiS6k=";
+    sha256 = "sha256-iJrnNDSMich5OzEbPgnQWLVz6Zj/MUIzEsaBzqVdoDg=";
   };
 
   # Upstream doesn't include the lockfile so we need to add it back
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage {
     cp ${cargoLock} source/Cargo.lock
   '';
 
-  cargoHash = "sha256-nabO19JePQRuhxsbm5wVIU4+5si6p0VgqR2QLmLeivU=";
+  cargoHash = "sha256-kYKQ7ddgoSvarF0HG/yESu5cU87DUgYm9tDkem5a/gw=";
 
   # `cargo-llvm-cov` reads these environment variables to find these binaries,
   # which are needed to run the tests

--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -1,9 +1,7 @@
 # If the tests are broken, it's probably for one of two reasons:
 #
 # 1. The version of llvm used doesn't match the expectations of rustc and/or
-#    cargo-llvm-cov. This is relatively unlikely because we pull llvm out of
-#    rustc's attrset, so it *should* be the right version as long as this is the
-#    case.
+#    cargo-llvm-cov.
 # 2. Nixpkgs has changed its rust infrastructure in a way that causes
 #    cargo-llvm-cov to misbehave under test. It's likely that even though the
 #    tests are failing, cargo-llvm-cov will still function properly in actual
@@ -20,7 +18,7 @@
 , fetchurl
 , fetchFromGitHub
 , rustPlatform
-, rustc
+, llvmPackages_19
 , git
 }:
 
@@ -31,7 +29,7 @@ let
   owner = "taiki-e";
   homepage = "https://github.com/${owner}/${pname}";
 
-  llvm = rustc.llvmPackages.llvm;
+  inherit (llvmPackages_19) llvm;
 
   # Download `Cargo.lock` from crates.io so we don't clutter up Nixpkgs
   cargoLock = fetchurl {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The tests were previously failing with error messages like:

> warning: /build/.tmpbQtXl2/target/llvm-cov-target/.tmpbQtXl2-2369-155103972593717385_0.profraw: raw profile version mismatch: Profile uses raw profile format version = 10; expected version = 9
> PLEASE update this tool to version in the raw profile, or regenerate raw profile with expected version.

which are fixed by switching to LLVM 19. Not sure why `rust.llvmPackages.llvm` stopped being the right version though, or if anything needs to be done about that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
