### PR TITLE
rip2: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14244,6 +14244,12 @@
     githubId = 38543128;
     name = "Miles Breslin";
   };
+  milescranmer = {
+    email = "miles.cranmer@gmail.com";
+    github = "MilesCranmer";
+    githubId = 7593028;
+    name = "Miles Cranmer";
+  };
   milibopp = {
     email = "contact@ebopp.de";
     github = "milibopp";

--- a/pkgs/by-name/ri/rip2/package.nix
+++ b/pkgs/by-name/ri/rip2/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rip2";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "MilesCranmer";
+    repo = "rip2";
+    rev = "v${version}";
+    hash = "sha256-9leLWfPilDQHzQRzTUjAFt9olTPEL4GcQgYFWZu3dug=";
+  };
+
+  cargoHash = "sha256-l6rbeiyIsr1csBcp+428TpQYSs9RvfJutGoL/wtSGR8=";
+
+  # TODO: Unsure why this test fails, but not a major issue so
+  #       skipping for now.
+  checkFlags = [ "--skip=test_filetypes::file_type_3___fifo__" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/rip";
+
+  meta = {
+    description = "Safe and ergonomic alternative to rm";
+    homepage = "https://github.com/MilesCranmer/rip2";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ milescranmer ];
+    mainProgram = "rip";
+  };
+}


### PR DESCRIPTION
rip2 (https://github.com/MilesCranmer/rip2) is a safer and ergonomic alternative to rm implemented in Rust. This is the first Nixpkgs packaging of rip2. rip2 is a fork of the original `rip` which is now unmaintained.

rip2 is also packaged on Homebrew, Termux, AUR, and OpenSUSE. I also have flake support on the GitHub. So I would like to add a nixpkgs version for it. I will be the maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable: package tests
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
