### PR TITLE
testkube: init at 2.1.56

### DIFF
--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -26,11 +26,11 @@ buildGoModule rec {
   doCheck = false;
   subPackages = [ "cmd/kubectl-testkube" ];
 
-  meta = with lib; {
+  meta = {
     description = "Kubernetes-native framework for test definition and execution";
     homepage = "https://github.com/kubeshop/testkube/";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "kubectl-testkube";
-    maintainers = with maintainers; [ ];
+    maintainers = with lib.maintainers; [ mathstlouis ];
   };
 }

--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "testkube";
+  version = "2.1.56";
+
+  src = fetchFromGitHub {
+    owner = "kubeshop";
+    repo = "testkube";
+    rev = "v${version}";
+    sha256 = "sha256-P+A9lUMzQ3M0SEVZBMDSMj8S0uCsEhadv5vDRxbQORA=";
+  };
+
+  vendorHash = "sha256-44aIwddMH6CMfTno90xGkHgna4DO2Ii3KhpMwv6Zjmo=";
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.builtBy=nixpkgs"
+    "-X main.commit=v${version}"
+    "-X main.date=1970-01-01-00:00:01"
+  ];
+
+  doCheck = false;
+  subPackages = [ "cmd/kubectl-testkube" ];
+
+  meta = with lib; {
+    description = "Kubernetes-native framework for test definition and execution";
+    homepage = "https://github.com/kubeshop/testkube/";
+    license = licenses.mit;
+    mainProgram = "kubectl-testkube";
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "kubeshop";
     repo = "testkube";
     rev = "v${version}";
-    sha256 = "sha256-P+A9lUMzQ3M0SEVZBMDSMj8S0uCsEhadv5vDRxbQORA=";
+    hash = "sha256-P+A9lUMzQ3M0SEVZBMDSMj8S0uCsEhadv5vDRxbQORA=";
   };
 
   vendorHash = "sha256-44aIwddMH6CMfTno90xGkHgna4DO2Ii3KhpMwv6Zjmo=";

--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -23,7 +23,6 @@ buildGoModule rec {
     "-X main.date=1970-01-01-00:00:01"
   ];
 
-  doCheck = false;
   subPackages = [ "cmd/kubectl-testkube" ];
 
   meta = {


### PR DESCRIPTION
Added Testkube CLI at version 2.1.56

> Testkube is a kubernetes-native framework for test definition and execution.
> The Testkube CLI allows you to both manage your Testkube installation and interact with your Testkube resources

refs.:
https://docs.testkube.io/articles/install/cli
https://github.com/kubeshop/testkube

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
