### PR TITLE
nixos/syncthing: declare ignore patterns (resolves #268282)

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -117,6 +117,7 @@ let
             override = cfg.overrideFolders;
             conf = folders;
             baseAddress = curlAddressArgs "/rest/config/folders";
+            ignoreAddress = curlAddressArgs "/rest/db/ignores";
           };
         }
         [
@@ -142,7 +143,8 @@ let
                 let
                   jsonPreSecretsFile = pkgs.writeTextFile {
                     name = "${conf_type}-${new_cfg.id}-conf-pre-secrets.json";
-                    text = builtins.toJSON new_cfg;
+                    # Remove the ignorePatterns attribute, it is handled separately
+                    text = builtins.toJSON (builtins.removeAttrs new_cfg [ "ignorePatterns" ]);
                   };
                   injectSecretsJqCmd =
                     {
@@ -208,6 +210,13 @@ let
                 in
                 ''
                   ${injectSecretsJqCmd} ${jsonPreSecretsFile} | curl --json @- -X POST ${s.baseAddress}
+                ''
+                /*
+                  Check if we are configuring a folder which has ignore patterns.
+                  If it does, write the ignore patterns to the rest API.
+                */
+                + lib.optionalString ((conf_type == "dirs") && (new_cfg.ignorePatterns != null)) ''
+                  curl -d '{"ignore": ${builtins.toJSON new_cfg.ignorePatterns}}' -X POST ${s.ignoreAddress}?folder=${new_cfg.id}
                 ''
               ))
               (lib.concatStringsSep "\n")
@@ -648,6 +657,26 @@ in
                           On Unix systems, tries to copy file/folder ownership from the parent directory (the directory it’s located in).
                           Requires running Syncthing as a privileged user, or granting it additional capabilities (e.g. CAP_CHOWN on Linux).
                         '';
+                      };
+
+                      ignorePatterns = mkOption {
+                        type = types.nullOr (types.listOf types.str);
+                        default = null;
+                        description = ''
+                          Syncthing can be configured to ignore certain files in a folder using ignore patterns.
+                          Enter them as a list of strings, one string per line.
+                          See the Syncthing documentation for syntax: <https://docs.syncthing.net/users/ignoring.html>
+                          Patterns set using the WebUI will be overridden if you define this option.
+                          If you want to override the ignore patterns to be empty, use `ignorePatterns = []`.
+                          Deleting the `ignorePatterns` option will not remove the patterns from Syncthing automatically
+                          because patterns are only handled by the module if this option is defined. Either use
+                          `ignorePatterns = []` before deleting the option or remove the patterns afterwards using the WebUI.
+                        '';
+                        example = [
+                          "// This is a comment"
+                          "*.part // Firefox downloads and other things"
+                          "*.crdownload // Chrom(ium|e) downloads"
+                        ];
                       };
                     };
                   }

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -42,6 +42,14 @@ in
                 }
               ];
             };
+            folders.baz = {
+              path = "/var/lib/syncthing/baz";
+              devices = [
+                "b"
+                "c"
+              ];
+              ignorePatterns = [ ];
+            };
           };
         };
       };
@@ -70,6 +78,16 @@ in
                 }
               ];
             };
+            folders.baz = {
+              path = "/var/lib/syncthing/baz";
+              devices = [
+                "a"
+                "c"
+              ];
+              ignorePatterns = [
+                "notB"
+              ];
+            };
           };
         };
       };
@@ -89,6 +107,16 @@ in
               "b"
             ];
             type = "receiveencrypted";
+          };
+          folders.baz = {
+            path = "/var/lib/syncthing/baz";
+            devices = [
+              "a"
+              "b"
+            ];
+            ignorePatterns = [
+              "notC"
+            ];
           };
         };
       };
@@ -131,5 +159,29 @@ in
 
     # Bar on C is untrusted, check that content is not in cleartext
     c.fail("grep -R plaincontent /var/lib/syncthing/bar")
+
+    # Test baz
+
+    a.wait_for_file("/var/lib/syncthing/baz")
+    b.wait_for_file("/var/lib/syncthing/baz")
+    c.wait_for_file("/var/lib/syncthing/baz")
+
+    # A creates the file notB, C should get it, B should ignore it
+    a.succeed("echo notB > /var/lib/syncthing/baz/notB")
+    a.succeed("echo controlA > /var/lib/syncthing/baz/controlA")
+    c.wait_for_file("/var/lib/syncthing/baz/notB")
+    c.wait_for_file("/var/lib/syncthing/baz/controlA")
+    b.wait_for_file("/var/lib/syncthing/baz/controlA")
+
+    # B creates the file notC, A should get it, C should ignore it
+    b.succeed("echo notC > /var/lib/syncthing/baz/notC")
+    b.succeed("echo controlB > /var/lib/syncthing/baz/controlB")
+    a.wait_for_file("/var/lib/syncthing/baz/notC")
+    a.wait_for_file("/var/lib/syncthing/baz/controlB")
+    c.wait_for_file("/var/lib/syncthing/baz/controlB")
+
+    # Check that files have been correctly ignored
+    b.fail("cat /var/lib/syncthing/baz/notB")
+    c.fail("cat /var/lib/syncthing/baz/notC")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds an option to declaratively add ignore patterns to a syncthing folder. Patterns are added as a list of strings which is send to the syncthing service via the rest api. 

This resolves #268282.

## Things done

I've been using this for a few months now and it works with no issues.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
