### PR TITLE
etherpad-lite: init at 2.2.6

### DIFF
--- a/pkgs/by-name/et/etherpad-lite/dont-fail-on-plugins-json.patch
+++ b/pkgs/by-name/et/etherpad-lite/dont-fail-on-plugins-json.patch
@@ -1,0 +1,19 @@
+diff --git a/src/static/js/pluginfw/installer.ts b/src/static/js/pluginfw/installer.ts
+index c605378e1..27e3e487b 100644
+--- a/src/static/js/pluginfw/installer.ts
++++ b/src/static/js/pluginfw/installer.ts
+@@ -83,7 +83,13 @@ export const checkForMigration = async () => {
+   try {
+     await fs.access(installedPluginsPath, fs.constants.F_OK);
+   } catch (err) {
+-    await migratePluginsFromNodeModules();
++    logger.info(`${installedPluginsPath} not found, creating using current node modules`);
++    try {
++      await migratePluginsFromNodeModules();
++    } catch (err2) {
++      logger.warn(`unable to create ${installedPluginsPath}, skipping plugin migrations`);
++      return;
++    }
+   }
+ 
+   /*

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  gitUpdater,
+  pnpm,
+  makeWrapper,
+  nodejs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "etherpad-lite";
+  version = "2.2.6";
+
+  src = fetchFromGitHub {
+    owner = "ether";
+    repo = "etherpad-lite";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-B//EwfXS0BXxkksvB1EZZaZuPuruTZ3FySj9B5y0iBw=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "use-tmp-dir-esbuild.patch";
+      url = "https://github.com/ether/etherpad-lite/commit/e881a383b38d4d80ee28c17a14b5de58889245de.patch";
+      hash = "sha256-svRkaW2nqLLAmWtEgaur5BORUNvRnDYLHM1FD7b1cFU=";
+    })
+
+    # etherpad expects to read and write $out/lib/var/installed_plugins.json
+    # FIXME: this patch disables plugin support
+    ./dont-fail-on-plugins-json.patch
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-IdnlJmjgOMR04WwAEabepD4DWJyXii7XzS5v27Y1LHY=";
+  };
+
+  nativeBuildInputs = [
+    pnpm.configHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    NODE_ENV="production" pnpm run build:etherpad
+    runHook postBuild
+  '';
+
+  # Upstream scripts uses `pnpm run prod` which is equivalent to
+  # `cross-env NODE_ENV=production node --require tsx/cjs node/server.ts`
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{lib,bin}
+    cp -r node_modules ui src doc admin $out/lib
+    makeWrapper ${lib.getExe nodejs} $out/bin/etherpad-lite \
+      --inherit-argv0 \
+      --add-flags "--require tsx/cjs $out/lib/node_modules/ep_etherpad-lite/node/server.ts" \
+      --suffix PATH : "${lib.makeBinPath [ pnpm ]}" \
+      --set NODE_PATH "$out/lib/node_modules:$out/lib/node_modules/ep_etherpad-lite/node_modules" \
+      --set-default NODE_ENV production
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Modern really-real-time collaborative document editor";
+    longDescription = ''
+      Etherpad is a real-time collaborative editor scalable to thousands of simultaneous real time users.
+      It provides full data export capabilities, and runs on your server, under your control.
+    '';
+    homepage = "https://etherpad.org/";
+    changelog = "https://github.com/ether/etherpad-lite/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    maintainers = with maintainers; [ erdnaxe ];
+    license = licenses.asl20;
+    mainProgram = "etherpad-lite";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/117608

When starting `etherpad-lite`, you need to provide some arguments:
- `--settings` with an absolute path to [settings.json](https://github.com/ether/etherpad-lite/blob/056e777539dc9b5ef7db965740965b0f49ac388e/settings.json.template)
- `--credentials` with an absolute path to `credentials.json` (which will be created),
- `--sessionkey` with an absolute path to `SESSIONKEY.txt` (which will be created).

else etherpad-lite will try to write into the Nix store and fail.

`settings.json` also needs to reference a database outside of the nix store.

Note: we will need to contribute an option upstream later for plugins support, as Etherpad hardcodes the path to `<etherpad_root>/var/installed_plugins.json`: https://github.com/ether/etherpad-lite/blob/056e777539dc9b5ef7db965740965b0f49ac388e/bin/plugins.ts#L68

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
