### PR TITLE
lemurs: fix build error caused by rust-lang/rust/issues/115010

### DIFF
--- a/pkgs/applications/display-managers/lemurs/0001-fix-static-lifetime-string.patch
+++ b/pkgs/applications/display-managers/lemurs/0001-fix-static-lifetime-string.patch
@@ -1,0 +1,22 @@
+tree 18207ad257a4c0a9ffc4fd250360a91d0b5240cb
+parent 37963b8ff6945ae8bdbabee658e5e36d0f67b84a
+author Noa Aarts <noa@voorwaarts.nl> Tue Nov 5 13:49:49 2024 +0100
+committer Noa Aarts <noa@voorwaarts.nl> Tue Nov 5 13:49:49 2024 +0100
+
+fix static lifetime for string
+
+This fixes a compiler error without changing functionality
+
+diff --git a/src/config.rs b/src/config.rs
+index f4bca31..a4fc6bf 100644
+--- a/src/config.rs
++++ b/src/config.rs
+@@ -645,7 +645,7 @@ struct Variable<'a> {
+ }
+ 
+ impl<'a> Variable<'a> {
+-    const START_SYMBOL: &str = "$";
++    const START_SYMBOL: &'static str = "$";
+ 
+     fn span(&self) -> std::ops::Range<usize> {
+         self.start..self.start + Self::START_SYMBOL.len() + self.ident.len()

--- a/pkgs/applications/display-managers/lemurs/default.nix
+++ b/pkgs/applications/display-managers/lemurs/default.nix
@@ -17,6 +17,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-YDopY+wdWlVL2X+/wc1tLSSqFclAkt++JXMK3VodD4s=";
   };
 
+  patches = [
+    # part of https://github.com/coastalwhite/lemurs/commit/09003a830400250ec7745939399fc942c505e6c6, but including the rest of the commit may be breaking
+    ./0001-fix-static-lifetime-string.patch
+  ];
+
   cargoHash = "sha256-uuHPJe+1VsnLRGbHtgTMrib6Tk359cwTDVfvtHnDToo=";
 
   buildInputs = [
@@ -30,8 +35,11 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Customizable TUI display/login manager written in Rust";
     homepage = "https://github.com/coastalwhite/lemurs";
-    license = with licenses; [asl20 mit];
-    maintainers = with maintainers; [jeremiahs];
+    license = with licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with maintainers; [ jeremiahs ];
     mainProgram = "lemurs";
   };
 }


### PR DESCRIPTION
Lemurs had a string that was used as having 'static lifetime, but it wasn't marked.

As explained in https://github.com/rust-lang/rust/issues/115010 this became an error,
so I patched it to fix the build problem since there was no new release yet.

ZHF: #352882
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
