### PR TITLE
lunatic: fix build by patching in updated Cargo.lock

### DIFF
--- a/pkgs/development/interpreters/lunatic/0001-update-dependencies-cargo-lock.patch
+++ b/pkgs/development/interpreters/lunatic/0001-update-dependencies-cargo-lock.patch
@@ -1,0 +1,3984 @@
+tree 0613b25263f9140973d14f4e31eea7b61966bd56
+parent 0b325fb264f005b0a35648e142637e4fb14ad387
+author Noa Aarts <noa@voorwaarts.nl> Tue Nov 5 14:30:05 2024 +0100
+committer Noa Aarts <noa@voorwaarts.nl> Tue Nov 5 14:30:05 2024 +0100
+
+update cargo lock
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 8f1ae47..6eaf7b6 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -8,14 +8,29 @@ version = "0.19.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+ dependencies = [
+- "gimli",
++ "gimli 0.27.3",
+ ]
+ 
++[[package]]
++name = "addr2line"
++version = "0.24.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
++dependencies = [
++ "gimli 0.31.1",
++]
++
++[[package]]
++name = "adler2"
++version = "2.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
++
+ [[package]]
+ name = "ahash"
+-version = "0.7.6"
++version = "0.7.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
++checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+ dependencies = [
+  "getrandom",
+  "once_cell",
+@@ -24,20 +39,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.8.3"
++version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
++checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+ dependencies = [
+  "cfg-if",
+  "once_cell",
+  "version_check",
++ "zerocopy",
+ ]
+ 
+ [[package]]
+ name = "aho-corasick"
+-version = "1.0.1"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
++checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+ dependencies = [
+  "memchr",
+ ]
+@@ -48,6 +64,12 @@ version = "0.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+ 
++[[package]]
++name = "android-tzdata"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
++
+ [[package]]
+ name = "android_system_properties"
+ version = "0.1.5"
+@@ -65,58 +87,58 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+ 
+ [[package]]
+ name = "anstream"
+-version = "0.3.2"
++version = "0.6.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
++checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+ dependencies = [
+  "anstyle",
+  "anstyle-parse",
+  "anstyle-query",
+  "anstyle-wincon",
+  "colorchoice",
+- "is-terminal",
++ "is_terminal_polyfill",
+  "utf8parse",
+ ]
+ 
+ [[package]]
+ name = "anstyle"
+-version = "1.0.0"
++version = "1.0.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
++checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+ 
+ [[package]]
+ name = "anstyle-parse"
+-version = "0.2.0"
++version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
++checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+ dependencies = [
+  "utf8parse",
+ ]
+ 
+ [[package]]
+ name = "anstyle-query"
+-version = "1.0.0"
++version = "1.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
++checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+ dependencies = [
+- "windows-sys 0.48.0",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+ name = "anstyle-wincon"
+-version = "1.0.1"
++version = "3.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
++checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+ dependencies = [
+  "anstyle",
+- "windows-sys 0.48.0",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+ name = "anyhow"
+-version = "1.0.71"
++version = "1.0.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
++checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+ 
+ [[package]]
+ name = "asn1-rs"
+@@ -143,7 +165,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "syn 1.0.109",
+- "synstructure",
++ "synstructure 0.12.6",
+ ]
+ 
+ [[package]]
+@@ -168,13 +190,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-trait"
+-version = "0.1.68"
++version = "0.1.83"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
++checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+@@ -196,20 +218,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "autocfg"
+-version = "1.1.0"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
++checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+ 
+ [[package]]
+ name = "axum"
+-version = "0.6.18"
++version = "0.6.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
++checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+ dependencies = [
+  "async-trait",
+  "axum-core",
+  "axum-macros",
+- "bitflags",
++ "bitflags 1.3.2",
+  "bytes",
+  "futures-util",
+  "http",
+@@ -252,14 +274,29 @@ dependencies = [
+ 
+ [[package]]
+ name = "axum-macros"
+-version = "0.3.7"
++version = "0.3.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2bb524613be645939e280b7279f7b017f98cf7f5ef084ec374df373530e73277"
++checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+ dependencies = [
+- "heck",
++ "heck 0.4.1",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
++]
++
++[[package]]
++name = "backtrace"
++version = "0.3.74"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
++dependencies = [
++ "addr2line 0.24.2",
++ "cfg-if",
++ "libc",
++ "miniz_oxide",
++ "object 0.36.5",
++ "rustc-demangle",
++ "windows-targets 0.52.6",
+ ]
+ 
+ [[package]]
+@@ -270,17 +307,17 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+ 
+ [[package]]
+ name = "base64"
+-version = "0.21.0"
++version = "0.21.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
++checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+ 
+ [[package]]
+ name = "base64-url"
+-version = "2.0.0"
++version = "2.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9c5b0a88aa36e9f095ee2e2b13fb8c5e4313e022783aedacc123328c0084916d"
++checksum = "fb9fb9fb058cc3063b5fc88d9a21eefa2735871498a04e1650da76ed511c8569"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.21.7",
+ ]
+ 
+ [[package]]
+@@ -298,6 +335,12 @@ version = "1.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
++[[package]]
++name = "bitflags"
++version = "2.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
++
+ [[package]]
+ name = "block-buffer"
+ version = "0.10.4"
+@@ -309,56 +352,56 @@ dependencies = [
+ 
+ [[package]]
+ name = "bumpalo"
+-version = "3.12.1"
++version = "3.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
++checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+ 
+ [[package]]
+ name = "byteorder"
+-version = "1.4.3"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
++checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+ 
+ [[package]]
+ name = "bytes"
+-version = "1.4.0"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
++checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+ 
+ [[package]]
+ name = "cap-fs-ext"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e1742f5106155d46a41eac5f730ee189bf92fde6ae109fbf2cdb67176726ca5d"
++checksum = "58bc48200a1a0fa6fba138b1802ad7def18ec1cdd92f7b2a04e21f1bd887f7b9"
+ dependencies = [
+  "cap-primitives",
+  "cap-std",
+- "io-lifetimes",
++ "io-lifetimes 1.0.11",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "cap-primitives"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "42068f579028e856717d61423645c85d2d216dde8eff62c9b30140e725c79177"
++checksum = "a4b6df5b295dca8d56f35560be8c391d59f0420f72e546997154e24e765e6451"
+ dependencies = [
+  "ambient-authority",
+- "fs-set-times 0.19.1",
++ "fs-set-times 0.19.2",
+  "io-extras",
+- "io-lifetimes",
++ "io-lifetimes 1.0.11",
+  "ipnet",
+  "maybe-owned",
+- "rustix 0.37.18",
++ "rustix 0.37.27",
+  "windows-sys 0.48.0",
+- "winx",
++ "winx 0.35.1",
+ ]
+ 
+ [[package]]
+ name = "cap-rand"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d3be2ededc13f42a5921c08e565b854cb5ff9b88753e2c6ec12c58a24e7e8d4e"
++checksum = "4d25555efacb0b5244cf1d35833d55d21abc916fff0eaad254b8e2453ea9b8ab"
+ dependencies = [
+  "ambient-authority",
+  "rand",
+@@ -366,26 +409,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "cap-std"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "559ad6fab5fedcc9bd5877160e1433fcd481f8af615068d6ca49472b1201cc6c"
++checksum = "3373a62accd150b4fcba056d4c5f3b552127f0ec86d3c8c102d60b978174a012"
+ dependencies = [
+  "cap-primitives",
+  "io-extras",
+- "io-lifetimes",
+- "rustix 0.37.18",
++ "io-lifetimes 1.0.11",
++ "rustix 0.37.27",
+ ]
+ 
+ [[package]]
+ name = "cap-time-ext"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a74e04cd32787bfa3a911af745b0fd5d99d4c3fc16c64449e1622c06fa27c8e"
++checksum = "e95002993b7baee6b66c8950470e59e5226a23b3af39fc59c47fe416dd39821a"
+ dependencies = [
+  "cap-primitives",
+  "once_cell",
+- "rustix 0.37.18",
+- "winx",
++ "rustix 0.37.27",
++ "winx 0.35.1",
+ ]
+ 
+ [[package]]
+@@ -396,11 +439,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.79"
++version = "1.1.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
++checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+ dependencies = [
+  "jobserver",
++ "libc",
++ "shlex",
+ ]
+ 
+ [[package]]
+@@ -409,23 +454,29 @@ version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+ 
++[[package]]
++name = "cfg_aliases"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
++
+ [[package]]
+ name = "chrono"
+-version = "0.4.24"
++version = "0.4.38"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
++checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+ dependencies = [
++ "android-tzdata",
+  "iana-time-zone",
+- "num-integer",
+  "num-traits",
+- "winapi",
++ "windows-targets 0.52.6",
+ ]
+ 
+ [[package]]
+ name = "ciborium"
+-version = "0.2.0"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
++checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+ dependencies = [
+  "ciborium-io",
+  "ciborium-ll",
+@@ -434,15 +485,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "ciborium-io"
+-version = "0.2.0"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
++checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+ 
+ [[package]]
+ name = "ciborium-ll"
+-version = "0.2.0"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
++checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+ dependencies = [
+  "ciborium-io",
+  "half",
+@@ -454,47 +505,44 @@ version = "3.2.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+  "clap_lex 0.2.4",
+- "indexmap",
++ "indexmap 1.9.3",
+  "textwrap",
+ ]
+ 
+ [[package]]
+ name = "clap"
+-version = "4.2.7"
++version = "4.5.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
++checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+- "once_cell",
+ ]
+ 
+ [[package]]
+ name = "clap_builder"
+-version = "4.2.7"
++version = "4.5.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
++checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+ dependencies = [
+  "anstream",
+  "anstyle",
+- "bitflags",
+- "clap_lex 0.4.1",
+- "once_cell",
++ "clap_lex 0.7.2",
+  "strsim",
+ ]
+ 
+ [[package]]
+ name = "clap_derive"
+-version = "4.2.0"
++version = "4.5.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
++checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+ dependencies = [
+- "heck",
++ "heck 0.5.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+@@ -508,31 +556,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_lex"
+-version = "0.4.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+-
+-[[package]]
+-name = "codespan-reporting"
+-version = "0.11.1"
++version = "0.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+-dependencies = [
+- "termcolor",
+- "unicode-width",
+-]
++checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+ 
+ [[package]]
+ name = "colorchoice"
+-version = "1.0.0"
++version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
++checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+ 
+ [[package]]
+ name = "core-foundation"
+-version = "0.9.3"
++version = "0.9.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
++checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+ dependencies = [
+  "core-foundation-sys",
+  "libc",
+@@ -540,9 +578,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "core-foundation-sys"
+-version = "0.8.4"
++version = "0.8.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
++checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+ 
+ [[package]]
+ name = "cpp_demangle"
+@@ -555,9 +593,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cpufeatures"
+-version = "0.2.7"
++version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
++checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+ dependencies = [
+  "libc",
+ ]
+@@ -583,7 +621,7 @@ dependencies = [
+  "cranelift-codegen-shared",
+  "cranelift-entity",
+  "cranelift-isle",
+- "gimli",
++ "gimli 0.27.3",
+  "hashbrown 0.13.2",
+  "log",
+  "regalloc2",
+@@ -656,15 +694,15 @@ dependencies = [
+  "itertools",
+  "log",
+  "smallvec",
+- "wasmparser",
++ "wasmparser 0.102.0",
+  "wasmtime-types",
+ ]
+ 
+ [[package]]
+ name = "crc32fast"
+-version = "1.3.2"
++version = "1.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
++checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -707,48 +745,36 @@ dependencies = [
+  "itertools",
+ ]
+ 
+-[[package]]
+-name = "crossbeam-channel"
+-version = "0.5.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+-dependencies = [
+- "cfg-if",
+- "crossbeam-utils",
+-]
+-
+ [[package]]
+ name = "crossbeam-deque"
+-version = "0.8.3"
++version = "0.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
++checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+ dependencies = [
+- "cfg-if",
+  "crossbeam-epoch",
+  "crossbeam-utils",
+ ]
+ 
+ [[package]]
+ name = "crossbeam-epoch"
+-version = "0.9.14"
++version = "0.9.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
++checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+ dependencies = [
+- "autocfg",
+- "cfg-if",
+  "crossbeam-utils",
+- "memoffset",
+- "scopeguard",
+ ]
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.15"
++version = "0.8.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+-dependencies = [
+- "cfg-if",
+-]
++checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
++
++[[package]]
++name = "crunchy"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+ 
+ [[package]]
+ name = "crypto-common"
+@@ -762,66 +788,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "ctrlc"
+-version = "3.2.5"
++version = "3.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
++checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+ dependencies = [
+  "nix",
+- "windows-sys 0.45.0",
+-]
+-
+-[[package]]
+-name = "cxx"
+-version = "1.0.94"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+-dependencies = [
+- "cc",
+- "cxxbridge-flags",
+- "cxxbridge-macro",
+- "link-cplusplus",
+-]
+-
+-[[package]]
+-name = "cxx-build"
+-version = "1.0.94"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+-dependencies = [
+- "cc",
+- "codespan-reporting",
+- "once_cell",
+- "proc-macro2",
+- "quote",
+- "scratch",
+- "syn 2.0.15",
+-]
+-
+-[[package]]
+-name = "cxxbridge-flags"
+-version = "1.0.94"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+-
+-[[package]]
+-name = "cxxbridge-macro"
+-version = "1.0.94"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.15",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+ name = "dashmap"
+-version = "5.4.0"
++version = "5.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
++checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+ dependencies = [
+  "cfg-if",
+- "hashbrown 0.12.3",
++ "hashbrown 0.14.5",
+  "lock_api",
+  "once_cell",
+  "parking_lot_core",
+@@ -829,9 +811,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "data-encoding"
+-version = "2.3.3"
++version = "2.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
++checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+ 
+ [[package]]
+ name = "der-parser"
+@@ -847,11 +829,20 @@ dependencies = [
+  "rusticata-macros",
+ ]
+ 
++[[package]]
++name = "deranged"
++version = "0.3.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
++dependencies = [
++ "powerfmt",
++]
++
+ [[package]]
+ name = "digest"
+-version = "0.10.6"
++version = "0.10.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
++checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+ dependencies = [
+  "block-buffer",
+  "crypto-common",
+@@ -900,26 +891,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "displaydoc"
+-version = "0.2.3"
++version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
++checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+ name = "either"
+-version = "1.8.1"
++version = "1.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
++checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+ 
+ [[package]]
+ name = "encoding_rs"
+-version = "0.8.32"
++version = "0.8.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
++checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -939,9 +930,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "env_logger"
+-version = "0.10.0"
++version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
++checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+ dependencies = [
+  "humantime",
+  "is-terminal",
+@@ -951,24 +942,19 @@ dependencies = [
+ ]
+ 
+ [[package]]
+-name = "errno"
+-version = "0.3.1"
++name = "equivalent"
++version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+-dependencies = [
+- "errno-dragonfly",
+- "libc",
+- "windows-sys 0.48.0",
+-]
++checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+ 
+ [[package]]
+-name = "errno-dragonfly"
+-version = "0.1.2"
++name = "errno"
++version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
++checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+ dependencies = [
+- "cc",
+  "libc",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -979,22 +965,19 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+ 
+ [[package]]
+ name = "fastrand"
+-version = "1.9.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+-dependencies = [
+- "instant",
+-]
++checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+ 
+ [[package]]
+ name = "fd-lock"
+-version = "3.0.12"
++version = "4.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
++checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+ dependencies = [
+  "cfg-if",
+- "rustix 0.37.18",
+- "windows-sys 0.48.0",
++ "rustix 0.38.39",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -1003,7 +986,7 @@ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
+ dependencies = [
+- "env_logger 0.10.0",
++ "env_logger 0.10.2",
+  "log",
+ ]
+ 
+@@ -1030,9 +1013,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+ 
+ [[package]]
+ name = "form_urlencoded"
+-version = "1.1.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
++checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+ dependencies = [
+  "percent-encoding",
+ ]
+@@ -1043,27 +1026,27 @@ version = "0.18.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "857cf27edcb26c2a36d84b2954019573d335bb289876113aceacacdca47a4fd4"
+ dependencies = [
+- "io-lifetimes",
+- "rustix 0.36.13",
++ "io-lifetimes 1.0.11",
++ "rustix 0.36.17",
+  "windows-sys 0.45.0",
+ ]
+ 
+ [[package]]
+ name = "fs-set-times"
+-version = "0.19.1"
++version = "0.19.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7833d0f115a013d51c55950a3b09d30e4b057be9961b709acb9b5b17a1108861"
++checksum = "6d167b646a876ba8fda6b50ac645cfd96242553cbaf0ca4fccaa39afcbf0801f"
+ dependencies = [
+- "io-lifetimes",
+- "rustix 0.37.18",
++ "io-lifetimes 1.0.11",
++ "rustix 0.38.39",
+  "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+ name = "futures"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
++checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+ dependencies = [
+  "futures-channel",
+  "futures-core",
+@@ -1075,9 +1058,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-channel"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
++checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+ dependencies = [
+  "futures-core",
+  "futures-sink",
+@@ -1085,33 +1068,33 @@ dependencies = [
+ 
+ [[package]]
+ name = "futures-core"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
++checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+ 
+ [[package]]
+ name = "futures-io"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
++checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+ 
+ [[package]]
+ name = "futures-sink"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
++checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+ 
+ [[package]]
+ name = "futures-task"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
++checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+ 
+ [[package]]
+ name = "futures-util"
+-version = "0.3.28"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
++checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+ dependencies = [
+  "futures-core",
+  "futures-sink",
+@@ -1141,9 +1124,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.9"
++version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
++checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+ dependencies = [
+  "cfg-if",
+  "libc",
+@@ -1152,20 +1135,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "gimli"
+-version = "0.27.2"
++version = "0.27.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
++checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+ dependencies = [
+  "fallible-iterator",
+- "indexmap",
++ "indexmap 1.9.3",
+  "stable_deref_trait",
+ ]
+ 
++[[package]]
++name = "gimli"
++version = "0.31.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
++
+ [[package]]
+ name = "h2"
+-version = "0.3.18"
++version = "0.3.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
++checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -1173,7 +1162,7 @@ dependencies = [
+  "futures-sink",
+  "futures-util",
+  "http",
+- "indexmap",
++ "indexmap 2.6.0",
+  "slab",
+  "tokio",
+  "tokio-util",
+@@ -1182,9 +1171,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "half"
+-version = "1.8.2"
++version = "2.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
++checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
++dependencies = [
++ "cfg-if",
++ "crunchy",
++]
+ 
+ [[package]]
+ name = "hash-map-id"
+@@ -1196,7 +1189,7 @@ version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+ dependencies = [
+- "ahash 0.7.6",
++ "ahash 0.7.8",
+ ]
+ 
+ [[package]]
+@@ -1205,15 +1198,33 @@ version = "0.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+ dependencies = [
+- "ahash 0.8.3",
++ "ahash 0.8.11",
+ ]
+ 
++[[package]]
++name = "hashbrown"
++version = "0.14.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
++
++[[package]]
++name = "hashbrown"
++version = "0.15.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
++
+ [[package]]
+ name = "heck"
+ version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+ 
++[[package]]
++name = "heck"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
++
+ [[package]]
+ name = "hermit-abi"
+ version = "0.1.19"
+@@ -1225,24 +1236,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.2.6"
++version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+-dependencies = [
+- "libc",
+-]
++checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.3.1"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
++checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+ 
+ [[package]]
+ name = "http"
+-version = "0.2.9"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
++checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -1251,9 +1259,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "http-body"
+-version = "0.4.5"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
++checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+ dependencies = [
+  "bytes",
+  "http",
+@@ -1262,21 +1270,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "http-range-header"
+-version = "0.3.0"
++version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
++checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+ 
+ [[package]]
+ name = "httparse"
+-version = "1.8.0"
++version = "1.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
++checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+ 
+ [[package]]
+ name = "httpdate"
+-version = "1.0.2"
++version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
++checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+ 
+ [[package]]
+ name = "humantime"
+@@ -1286,9 +1294,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+ 
+ [[package]]
+ name = "hyper"
+-version = "0.14.26"
++version = "0.14.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
++checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+ dependencies = [
+  "bytes",
+  "futures-channel",
+@@ -1301,7 +1309,7 @@ dependencies = [
+  "httpdate",
+  "itoa",
+  "pin-project-lite",
+- "socket2",
++ "socket2 0.5.7",
+  "tokio",
+  "tower-service",
+  "tracing",
+@@ -1323,161 +1331,301 @@ dependencies = [
+ 
+ [[package]]
+ name = "iana-time-zone"
+-version = "0.1.56"
++version = "0.1.61"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
++checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+ dependencies = [
+  "android_system_properties",
+  "core-foundation-sys",
+  "iana-time-zone-haiku",
+  "js-sys",
+  "wasm-bindgen",
+- "windows",
++ "windows-core",
+ ]
+ 
+ [[package]]
+ name = "iana-time-zone-haiku"
+-version = "0.1.1"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
++checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+ dependencies = [
+- "cxx",
+- "cxx-build",
++ "cc",
+ ]
+ 
+ [[package]]
+-name = "id-arena"
+-version = "2.2.1"
++name = "icu_collections"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
++checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
++dependencies = [
++ "displaydoc",
++ "yoke",
++ "zerofrom",
++ "zerovec",
++]
+ 
+ [[package]]
+-name = "idna"
+-version = "0.3.0"
++name = "icu_locid"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
++checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+ dependencies = [
+- "unicode-bidi",
+- "unicode-normalization",
++ "displaydoc",
++ "litemap",
++ "tinystr",
++ "writeable",
++ "zerovec",
+ ]
+ 
+ [[package]]
+-name = "indexmap"
+-version = "1.9.3"
++name = "icu_locid_transform"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
++checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+ dependencies = [
+- "autocfg",
+- "hashbrown 0.12.3",
+- "serde",
++ "displaydoc",
++ "icu_locid",
++ "icu_locid_transform_data",
++ "icu_provider",
++ "tinystr",
++ "zerovec",
+ ]
+ 
+ [[package]]
+-name = "instant"
+-version = "0.1.12"
++name = "icu_locid_transform_data"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+-dependencies = [
+- "cfg-if",
+-]
++checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+ 
+ [[package]]
+-name = "io-extras"
+-version = "0.17.4"
++name = "icu_normalizer"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fde93d48f0d9277f977a333eca8313695ddd5301dc96f7e02aeddcb0dd99096f"
++checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+ dependencies = [
+- "io-lifetimes",
+- "windows-sys 0.48.0",
++ "displaydoc",
++ "icu_collections",
++ "icu_normalizer_data",
++ "icu_properties",
++ "icu_provider",
++ "smallvec",
++ "utf16_iter",
++ "utf8_iter",
++ "write16",
++ "zerovec",
+ ]
+ 
+ [[package]]
+-name = "io-lifetimes"
+-version = "1.0.10"
++name = "icu_normalizer_data"
++version = "1.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
++
++[[package]]
++name = "icu_properties"
++version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
++checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+ dependencies = [
+- "hermit-abi 0.3.1",
+- "libc",
+- "windows-sys 0.48.0",
++ "displaydoc",
++ "icu_collections",
++ "icu_locid_transform",
++ "icu_properties_data",
++ "icu_provider",
++ "tinystr",
++ "zerovec",
+ ]
+ 
+ [[package]]
+-name = "ipnet"
+-version = "2.7.2"
++name = "icu_properties_data"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
++checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+ 
+ [[package]]
+-name = "is-terminal"
+-version = "0.4.7"
++name = "icu_provider"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
++checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+ dependencies = [
+- "hermit-abi 0.3.1",
+- "io-lifetimes",
+- "rustix 0.37.18",
+- "windows-sys 0.48.0",
++ "displaydoc",
++ "icu_locid",
++ "icu_provider_macros",
++ "stable_deref_trait",
++ "tinystr",
++ "writeable",
++ "yoke",
++ "zerofrom",
++ "zerovec",
+ ]
+ 
+ [[package]]
+-name = "itertools"
+-version = "0.10.5"
++name = "icu_provider_macros"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
++checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+ dependencies = [
+- "either",
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+-name = "itoa"
+-version = "1.0.6"
++name = "id-arena"
++version = "2.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
++checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+ 
+ [[package]]
+-name = "ittapi"
+-version = "0.3.3"
++name = "idna"
++version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e648c437172ce7d3ac35ca11a068755072054826fa455a916b43524fa4a62a7"
++checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+ dependencies = [
+- "anyhow",
+- "ittapi-sys",
+- "log",
++ "idna_adapter",
++ "smallvec",
++ "utf8_iter",
+ ]
+ 
+ [[package]]
+-name = "ittapi-sys"
+-version = "0.3.3"
++name = "idna_adapter"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a9b32a4d23f72548178dde54f3c12c6b6a08598e25575c0d0fa5bd861e0dc1a5"
++checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+ dependencies = [
+- "cc",
++ "icu_normalizer",
++ "icu_properties",
+ ]
+ 
+ [[package]]
+-name = "jobserver"
+-version = "0.1.26"
++name = "indexmap"
++version = "1.9.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
++checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+ dependencies = [
+- "libc",
++ "autocfg",
++ "hashbrown 0.12.3",
++ "serde",
+ ]
+ 
+ [[package]]
+-name = "js-sys"
+-version = "0.3.61"
++name = "indexmap"
++version = "2.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
++dependencies = [
++ "equivalent",
++ "hashbrown 0.15.1",
++]
++
++[[package]]
++name = "io-extras"
++version = "0.17.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fde93d48f0d9277f977a333eca8313695ddd5301dc96f7e02aeddcb0dd99096f"
++dependencies = [
++ "io-lifetimes 1.0.11",
++ "windows-sys 0.48.0",
++]
++
++[[package]]
++name = "io-lifetimes"
++version = "1.0.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
++dependencies = [
++ "hermit-abi 0.3.9",
++ "libc",
++ "windows-sys 0.48.0",
++]
++
++[[package]]
++name = "io-lifetimes"
++version = "2.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
++
++[[package]]
++name = "ipnet"
++version = "2.10.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
++
++[[package]]
++name = "is-terminal"
++version = "0.4.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
++dependencies = [
++ "hermit-abi 0.4.0",
++ "libc",
++ "windows-sys 0.52.0",
++]
++
++[[package]]
++name = "is_terminal_polyfill"
++version = "1.70.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
++
++[[package]]
++name = "itertools"
++version = "0.10.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
++dependencies = [
++ "either",
++]
++
++[[package]]
++name = "itoa"
++version = "1.0.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
++
++[[package]]
++name = "ittapi"
++version = "0.3.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "25a5c0b993601cad796222ea076565c5d9f337d35592f8622c753724f06d7271"
++dependencies = [
++ "anyhow",
++ "ittapi-sys",
++ "log",
++]
++
++[[package]]
++name = "ittapi-sys"
++version = "0.3.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cb7b5e473765060536a660eed127f758cf1a810c73e49063264959c60d1727d9"
++dependencies = [
++ "cc",
++]
++
++[[package]]
++name = "jobserver"
++version = "0.1.32"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
++dependencies = [
++ "libc",
++]
++
++[[package]]
++name = "js-sys"
++version = "0.3.72"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
++checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+ dependencies = [
+  "wasm-bindgen",
+ ]
+ 
+ [[package]]
+ name = "lazy_static"
+-version = "1.4.0"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
++checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ 
+ [[package]]
+ name = "leb128"
+@@ -1487,17 +1635,18 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.142"
++version = "0.2.161"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
++checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+ 
+ [[package]]
+-name = "link-cplusplus"
+-version = "1.0.8"
++name = "libredox"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
++checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+ dependencies = [
+- "cc",
++ "bitflags 2.6.0",
++ "libc",
+ ]
+ 
+ [[package]]
+@@ -1508,15 +1657,27 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+ 
+ [[package]]
+ name = "linux-raw-sys"
+-version = "0.3.6"
++version = "0.3.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
++
++[[package]]
++name = "linux-raw-sys"
++version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
++checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
++
++[[package]]
++name = "litemap"
++version = "0.7.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+ 
+ [[package]]
+ name = "lock_api"
+-version = "0.4.9"
++version = "0.4.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
++checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+ dependencies = [
+  "autocfg",
+  "scopeguard",
+@@ -1524,12 +1685,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "log"
+-version = "0.4.17"
++version = "0.4.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+-dependencies = [
+- "cfg-if",
+-]
++checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+ 
+ [[package]]
+ name = "lunatic-common-api"
+@@ -1712,7 +1870,7 @@ version = "0.13.2"
+ dependencies = [
+  "anyhow",
+  "async-ctrlc",
+- "clap 4.2.7",
++ "clap 4.5.20",
+  "criterion",
+  "dashmap",
+  "env_logger 0.9.3",
+@@ -1825,9 +1983,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "matchit"
+-version = "0.7.0"
++version = "0.7.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
++checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+ 
+ [[package]]
+ name = "maybe-owned"
+@@ -1837,17 +1995,17 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+ 
+ [[package]]
+ name = "memchr"
+-version = "2.5.0"
++version = "2.7.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
++checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+ 
+ [[package]]
+ name = "memfd"
+-version = "0.6.3"
++version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
++checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+ dependencies = [
+- "rustix 0.37.18",
++ "rustix 0.38.39",
+ ]
+ 
+ [[package]]
+@@ -1865,9 +2023,9 @@ version = "0.20.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+ dependencies = [
+- "ahash 0.7.6",
++ "ahash 0.7.8",
+  "metrics-macros",
+- "portable-atomic",
++ "portable-atomic 0.3.20",
+ ]
+ 
+ [[package]]
+@@ -1877,12 +2035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+ dependencies = [
+  "hyper",
+- "indexmap",
++ "indexmap 1.9.3",
+  "ipnet",
+  "metrics",
+  "metrics-util",
+  "parking_lot",
+- "portable-atomic",
++ "portable-atomic 0.3.20",
+  "quanta",
+  "thiserror",
+  "tokio",
+@@ -1912,7 +2070,7 @@ dependencies = [
+  "metrics",
+  "num_cpus",
+  "parking_lot",
+- "portable-atomic",
++ "portable-atomic 0.3.20",
+  "quanta",
+  "sketches-ddsketch",
+ ]
+@@ -1929,25 +2087,33 @@ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+ 
++[[package]]
++name = "miniz_oxide"
++version = "0.8.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
++dependencies = [
++ "adler2",
++]
++
+ [[package]]
+ name = "mio"
+-version = "0.8.6"
++version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
++checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+ dependencies = [
++ "hermit-abi 0.3.9",
+  "libc",
+- "log",
+  "wasi 0.11.0+wasi-snapshot-preview1",
+- "windows-sys 0.45.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+ name = "native-tls"
+-version = "0.2.11"
++version = "0.2.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
++checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+ dependencies = [
+- "lazy_static",
+  "libc",
+  "log",
+  "openssl",
+@@ -1961,14 +2127,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "nix"
+-version = "0.26.2"
++version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
++checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+ dependencies = [
+- "bitflags",
++ "bitflags 2.6.0",
+  "cfg-if",
++ "cfg_aliases",
+  "libc",
+- "static_assertions",
+ ]
+ 
+ [[package]]
+@@ -1983,53 +2149,66 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-bigint"
+-version = "0.4.3"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
++checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+ dependencies = [
+- "autocfg",
+  "num-integer",
+  "num-traits",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-integer"
+-version = "0.1.45"
++version = "0.1.46"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
++checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+ dependencies = [
+- "autocfg",
+  "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-traits"
+-version = "0.2.15"
++version = "0.2.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
++checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+ dependencies = [
+  "autocfg",
+ ]
+ 
+ [[package]]
+ name = "num_cpus"
+-version = "1.15.0"
++version = "1.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
++checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+ dependencies = [
+- "hermit-abi 0.2.6",
++ "hermit-abi 0.3.9",
+  "libc",
+ ]
+ 
+ [[package]]
+ name = "object"
+-version = "0.30.3"
++version = "0.30.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
++checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+ dependencies = [
+  "crc32fast",
+  "hashbrown 0.13.2",
+- "indexmap",
++ "indexmap 1.9.3",
++ "memchr",
++]
++
++[[package]]
++name = "object"
++version = "0.36.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
++dependencies = [
+  "memchr",
+ ]
+ 
+@@ -2044,23 +2223,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "once_cell"
+-version = "1.17.1"
++version = "1.20.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
++checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+ 
+ [[package]]
+ name = "oorandom"
+-version = "11.1.3"
++version = "11.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
++checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.52"
++version = "0.10.68"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
++checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+ dependencies = [
+- "bitflags",
++ "bitflags 2.6.0",
+  "cfg-if",
+  "foreign-types",
+  "libc",
+@@ -2077,7 +2256,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+@@ -2088,9 +2267,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.87"
++version = "0.9.104"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
++checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -2100,15 +2279,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "os_str_bytes"
+-version = "6.5.0"
++version = "6.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
++checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+ 
+ [[package]]
+ name = "parking_lot"
+-version = "0.12.1"
++version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
++checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+ dependencies = [
+  "lock_api",
+  "parking_lot_core",
+@@ -2116,22 +2295,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "parking_lot_core"
+-version = "0.9.7"
++version = "0.9.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
++checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+ dependencies = [
+  "cfg-if",
+  "libc",
+- "redox_syscall 0.2.16",
++ "redox_syscall",
+  "smallvec",
+- "windows-sys 0.45.0",
++ "windows-targets 0.52.6",
+ ]
+ 
+ [[package]]
+ name = "paste"
+-version = "1.0.12"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
++checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+ 
+ [[package]]
+ name = "pem"
+@@ -2144,35 +2323,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "percent-encoding"
+-version = "2.2.0"
++version = "2.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
++checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+ 
+ [[package]]
+ name = "pin-project"
+-version = "1.0.12"
++version = "1.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
++checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+ dependencies = [
+  "pin-project-internal",
+ ]
+ 
+ [[package]]
+ name = "pin-project-internal"
+-version = "1.0.12"
++version = "1.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
++checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+ name = "pin-project-lite"
+-version = "0.2.9"
++version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
++checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+ 
+ [[package]]
+ name = "pin-utils"
+@@ -2182,15 +2361,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+ 
+ [[package]]
+ name = "pkg-config"
+-version = "0.3.27"
++version = "0.3.31"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
++checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+ 
+ [[package]]
+ name = "plotters"
+-version = "0.3.4"
++version = "0.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
++checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+ dependencies = [
+  "num-traits",
+  "plotters-backend",
+@@ -2201,45 +2380,63 @@ dependencies = [
+ 
+ [[package]]
+ name = "plotters-backend"
+-version = "0.3.4"
++version = "0.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
++checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+ 
+ [[package]]
+ name = "plotters-svg"
+-version = "0.3.3"
++version = "0.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
++checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+ dependencies = [
+  "plotters-backend",
+ ]
+ 
+ [[package]]
+ name = "portable-atomic"
+-version = "0.3.19"
++version = "0.3.20"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
++dependencies = [
++ "portable-atomic 1.9.0",
++]
++
++[[package]]
++name = "portable-atomic"
++version = "1.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
++
++[[package]]
++name = "powerfmt"
++version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+ 
+ [[package]]
+ name = "ppv-lite86"
+-version = "0.2.17"
++version = "0.2.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
++checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
++dependencies = [
++ "zerocopy",
++]
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.56"
++version = "1.0.89"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
++checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+ dependencies = [
+  "unicode-ident",
+ ]
+ 
+ [[package]]
+ name = "psm"
+-version = "0.1.21"
++version = "0.1.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
++checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
+ dependencies = [
+  "cc",
+ ]
+@@ -2250,7 +2447,7 @@ version = "0.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+  "memchr",
+  "unicase",
+ ]
+@@ -2273,9 +2470,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "quinn"
+-version = "0.9.3"
++version = "0.9.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
++checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
+ dependencies = [
+  "bytes",
+  "pin-project-lite",
+@@ -2291,13 +2488,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "quinn-proto"
+-version = "0.9.3"
++version = "0.9.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
++checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
+ dependencies = [
+  "bytes",
+  "rand",
+- "ring",
++ "ring 0.16.20",
+  "rustc-hash",
+  "rustls",
+  "rustls-native-certs",
+@@ -2316,16 +2513,16 @@ checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+ dependencies = [
+  "libc",
+  "quinn-proto",
+- "socket2",
++ "socket2 0.4.10",
+  "tracing",
+  "windows-sys 0.42.0",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.26"
++version = "1.0.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
++checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -2366,14 +2563,14 @@ version = "10.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+ ]
+ 
+ [[package]]
+ name = "rayon"
+-version = "1.7.0"
++version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
++checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+ dependencies = [
+  "either",
+  "rayon-core",
+@@ -2381,14 +2578,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "rayon-core"
+-version = "1.11.0"
++version = "1.12.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
++checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+ dependencies = [
+- "crossbeam-channel",
+  "crossbeam-deque",
+  "crossbeam-utils",
+- "num_cpus",
+ ]
+ 
+ [[package]]
+@@ -2398,7 +2593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+ dependencies = [
+  "pem",
+- "ring",
++ "ring 0.16.20",
+  "time",
+  "x509-parser",
+  "yasna",
+@@ -2406,30 +2601,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "redox_syscall"
+-version = "0.2.16"
++version = "0.5.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
++checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+ dependencies = [
+- "bitflags",
+-]
+-
+-[[package]]
+-name = "redox_syscall"
+-version = "0.3.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+-dependencies = [
+- "bitflags",
++ "bitflags 2.6.0",
+ ]
+ 
+ [[package]]
+ name = "redox_users"
+-version = "0.4.3"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
++checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+ dependencies = [
+  "getrandom",
+- "redox_syscall 0.2.16",
++ "libredox",
+  "thiserror",
+ ]
+ 
+@@ -2447,9 +2633,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex"
+-version = "1.8.1"
++version = "1.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
++dependencies = [
++ "aho-corasick",
++ "memchr",
++ "regex-automata",
++ "regex-syntax",
++]
++
++[[package]]
++name = "regex-automata"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
++checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -2458,17 +2656,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-syntax"
+-version = "0.7.1"
++version = "0.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
++checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.11.17"
++version = "0.11.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
++checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.21.7",
+  "bytes",
+  "encoding_rs",
+  "futures-core",
+@@ -2486,9 +2684,12 @@ dependencies = [
+  "once_cell",
+  "percent-encoding",
+  "pin-project-lite",
++ "rustls-pemfile",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
++ "sync_wrapper",
++ "system-configuration",
+  "tokio",
+  "tokio-native-tls",
+  "tower-service",
+@@ -2508,17 +2709,32 @@ dependencies = [
+  "cc",
+  "libc",
+  "once_cell",
+- "spin",
+- "untrusted",
++ "spin 0.5.2",
++ "untrusted 0.7.1",
+  "web-sys",
+  "winapi",
+ ]
+ 
++[[package]]
++name = "ring"
++version = "0.17.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
++dependencies = [
++ "cc",
++ "cfg-if",
++ "getrandom",
++ "libc",
++ "spin 0.9.8",
++ "untrusted 0.9.0",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "rmp"
+-version = "0.8.11"
++version = "0.8.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
++checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+ dependencies = [
+  "byteorder",
+  "num-traits",
+@@ -2527,9 +2743,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rmp-serde"
+-version = "1.1.1"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
++checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+ dependencies = [
+  "byteorder",
+  "rmp",
+@@ -2538,9 +2754,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustc-demangle"
+-version = "0.1.23"
++version = "0.1.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
++checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+ 
+ [[package]]
+ name = "rustc-hash"
+@@ -2559,13 +2775,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.36.13"
++version = "0.36.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
++checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+  "errno",
+- "io-lifetimes",
++ "io-lifetimes 1.0.11",
+  "libc",
+  "linux-raw-sys 0.1.4",
+  "windows-sys 0.45.0",
+@@ -2573,37 +2789,50 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.37.18"
++version = "0.37.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
++checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+  "errno",
+- "io-lifetimes",
++ "io-lifetimes 1.0.11",
+  "itoa",
+  "libc",
+- "linux-raw-sys 0.3.6",
++ "linux-raw-sys 0.3.8",
+  "once_cell",
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "rustix"
++version = "0.38.39"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
++dependencies = [
++ "bitflags 2.6.0",
++ "errno",
++ "libc",
++ "linux-raw-sys 0.4.14",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "rustls"
+-version = "0.20.8"
++version = "0.20.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
++checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+ dependencies = [
+  "log",
+- "ring",
++ "ring 0.16.20",
+  "sct",
+  "webpki",
+ ]
+ 
+ [[package]]
+ name = "rustls-native-certs"
+-version = "0.6.2"
++version = "0.6.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
++checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+ dependencies = [
+  "openssl-probe",
+  "rustls-pemfile",
+@@ -2613,24 +2842,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-pemfile"
+-version = "1.0.2"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
++checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+ dependencies = [
+- "base64 0.21.0",
++ "base64 0.21.7",
+ ]
+ 
+ [[package]]
+ name = "rustversion"
+-version = "1.0.12"
++version = "1.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
++checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+ 
+ [[package]]
+ name = "ryu"
+-version = "1.0.13"
++version = "1.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
++checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+ 
+ [[package]]
+ name = "same-file"
+@@ -2643,42 +2872,36 @@ dependencies = [
+ 
+ [[package]]
+ name = "schannel"
+-version = "0.1.21"
++version = "0.1.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
++checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+ dependencies = [
+- "windows-sys 0.42.0",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+ name = "scopeguard"
+-version = "1.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+-
+-[[package]]
+-name = "scratch"
+-version = "1.0.5"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
++checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+ 
+ [[package]]
+ name = "sct"
+-version = "0.7.0"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
++checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+ dependencies = [
+- "ring",
+- "untrusted",
++ "ring 0.17.8",
++ "untrusted 0.9.0",
+ ]
+ 
+ [[package]]
+ name = "security-framework"
+-version = "2.8.2"
++version = "2.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
++checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+ dependencies = [
+- "bitflags",
++ "bitflags 2.6.0",
+  "core-foundation",
+  "core-foundation-sys",
+  "libc",
+@@ -2687,9 +2910,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "security-framework-sys"
+-version = "2.8.0"
++version = "2.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
++checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+ dependencies = [
+  "core-foundation-sys",
+  "libc",
+@@ -2697,41 +2920,43 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.160"
++version = "1.0.214"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
++checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+ dependencies = [
+  "serde_derive",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.160"
++version = "1.0.214"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
++checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.96"
++version = "1.0.132"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
++checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+ dependencies = [
+  "itoa",
++ "memchr",
+  "ryu",
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "serde_path_to_error"
+-version = "0.1.11"
++version = "0.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
++checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+ dependencies = [
++ "itoa",
+  "serde",
+ ]
+ 
+@@ -2749,9 +2974,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sha2"
+-version = "0.10.6"
++version = "0.10.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
++checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+ dependencies = [
+  "cfg-if",
+  "cpufeatures",
+@@ -2767,17 +2992,23 @@ dependencies = [
+  "dirs",
+ ]
+ 
++[[package]]
++name = "shlex"
++version = "1.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
++
+ [[package]]
+ name = "sketches-ddsketch"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
++checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+ 
+ [[package]]
+ name = "slab"
+-version = "0.4.8"
++version = "0.4.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
++checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+ dependencies = [
+  "autocfg",
+ ]
+@@ -2790,26 +3021,42 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.10.0"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.4.9"
++version = "0.4.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
++checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+ dependencies = [
+  "libc",
+  "winapi",
+ ]
+ 
++[[package]]
++name = "socket2"
++version = "0.5.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
++dependencies = [
++ "libc",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "spin"
+ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+ 
++[[package]]
++name = "spin"
++version = "0.9.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
++
+ [[package]]
+ name = "sqlite-bindings-lunatic"
+ version = "0.30.4"
+@@ -2846,17 +3093,11 @@ version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+ 
+-[[package]]
+-name = "static_assertions"
+-version = "1.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+-
+ [[package]]
+ name = "strsim"
+-version = "0.10.0"
++version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
++checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+ 
+ [[package]]
+ name = "syn"
+@@ -2871,9 +3112,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.15"
++version = "2.0.87"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
++checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2898,83 +3139,118 @@ dependencies = [
+  "unicode-xid",
+ ]
+ 
++[[package]]
++name = "synstructure"
++version = "0.13.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++]
++
++[[package]]
++name = "system-configuration"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
++dependencies = [
++ "bitflags 1.3.2",
++ "core-foundation",
++ "system-configuration-sys",
++]
++
++[[package]]
++name = "system-configuration-sys"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
++dependencies = [
++ "core-foundation-sys",
++ "libc",
++]
++
+ [[package]]
+ name = "system-interface"
+-version = "0.25.7"
++version = "0.25.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "928ebd55ab758962e230f51ca63735c5b283f26292297c81404289cda5d78631"
++checksum = "10081a99cbecbc363d381b9503563785f0b02735fccbb0d4c1a2cb3d39f7e7fe"
+ dependencies = [
+- "bitflags",
++ "bitflags 2.6.0",
+  "cap-fs-ext",
+  "cap-std",
+  "fd-lock",
+- "io-lifetimes",
+- "rustix 0.37.18",
++ "io-lifetimes 2.0.3",
++ "rustix 0.38.39",
+  "windows-sys 0.48.0",
+- "winx",
++ "winx 0.36.3",
+ ]
+ 
+ [[package]]
+ name = "target-lexicon"
+-version = "0.12.7"
++version = "0.12.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
++checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+ 
+ [[package]]
+ name = "tempfile"
+-version = "3.5.0"
++version = "3.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
++checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+ dependencies = [
+  "cfg-if",
+  "fastrand",
+- "redox_syscall 0.3.5",
+- "rustix 0.37.18",
+- "windows-sys 0.45.0",
++ "once_cell",
++ "rustix 0.38.39",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+ name = "termcolor"
+-version = "1.2.0"
++version = "1.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
++checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+ dependencies = [
+  "winapi-util",
+ ]
+ 
+ [[package]]
+ name = "textwrap"
+-version = "0.16.0"
++version = "0.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
++checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+ 
+ [[package]]
+ name = "thiserror"
+-version = "1.0.40"
++version = "1.0.68"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
++checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+ dependencies = [
+  "thiserror-impl",
+ ]
+ 
+ [[package]]
+ name = "thiserror-impl"
+-version = "1.0.40"
++version = "1.0.68"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
++checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.20"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
++ "deranged",
+  "itoa",
++ "num-conv",
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -2982,19 +3258,30 @@ dependencies = [
+ 
+ [[package]]
+ name = "time-core"
+-version = "0.1.0"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
++checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.8"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 
++[[package]]
++name = "tinystr"
++version = "0.7.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
++dependencies = [
++ "displaydoc",
++ "zerovec",
++]
++
+ [[package]]
+ name = "tinytemplate"
+ version = "1.2.1"
+@@ -3007,9 +3294,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tinyvec"
+-version = "1.6.0"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
++checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+ dependencies = [
+  "tinyvec_macros",
+ ]
+@@ -3022,30 +3309,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+ 
+ [[package]]
+ name = "tokio"
+-version = "1.28.0"
++version = "1.41.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
++checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+ dependencies = [
+- "autocfg",
++ "backtrace",
+  "bytes",
+  "libc",
+  "mio",
+- "num_cpus",
+  "pin-project-lite",
+- "socket2",
++ "socket2 0.5.7",
+  "tokio-macros",
+- "windows-sys 0.48.0",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+ name = "tokio-macros"
+-version = "2.1.0"
++version = "2.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
++checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+@@ -3071,16 +3357,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-util"
+-version = "0.7.8"
++version = "0.7.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
++checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+ dependencies = [
+  "bytes",
+  "futures-core",
+  "futures-sink",
+  "pin-project-lite",
+  "tokio",
+- "tracing",
+ ]
+ 
+ [[package]]
+@@ -3114,7 +3399,7 @@ version = "0.3.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+  "bytes",
+  "futures-core",
+  "futures-util",
+@@ -3128,23 +3413,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "tower-layer"
+-version = "0.3.2"
++version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
++checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+ 
+ [[package]]
+ name = "tower-service"
+-version = "0.3.2"
++version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
++checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+ 
+ [[package]]
+ name = "tracing"
+-version = "0.1.37"
++version = "0.1.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
++checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+ dependencies = [
+- "cfg-if",
+  "log",
+  "pin-project-lite",
+  "tracing-attributes",
+@@ -3153,77 +3437,59 @@ dependencies = [
+ 
+ [[package]]
+ name = "tracing-attributes"
+-version = "0.1.24"
++version = "0.1.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
++checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.87",
+ ]
+ 
+ [[package]]
+ name = "tracing-core"
+-version = "0.1.30"
++version = "0.1.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
++checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+ dependencies = [
+  "once_cell",
+ ]
+ 
+ [[package]]
+ name = "try-lock"
+-version = "0.2.4"
++version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
++checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+ 
+ [[package]]
+ name = "typenum"
+-version = "1.16.0"
++version = "1.17.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
++checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+ 
+ [[package]]
+ name = "unicase"
+-version = "2.6.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+-dependencies = [
+- "version_check",
+-]
+-
+-[[package]]
+-name = "unicode-bidi"
+-version = "0.3.13"
++version = "2.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
++checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+ 
+ [[package]]
+ name = "unicode-ident"
+-version = "1.0.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+-
+-[[package]]
+-name = "unicode-normalization"
+-version = "0.1.22"
++version = "1.0.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+-dependencies = [
+- "tinyvec",
+-]
++checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+ 
+ [[package]]
+ name = "unicode-width"
+-version = "0.1.10"
++version = "0.1.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
++checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+ 
+ [[package]]
+ name = "unicode-xid"
+-version = "0.2.4"
++version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
++checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+ 
+ [[package]]
+ name = "untrusted"
+@@ -3231,28 +3497,46 @@ version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+ 
++[[package]]
++name = "untrusted"
++version = "0.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
++
+ [[package]]
+ name = "url"
+-version = "2.3.1"
++version = "2.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
++checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+ dependencies = [
+  "form_urlencoded",
+  "idna",
+  "percent-encoding",
+ ]
+ 
++[[package]]
++name = "utf16_iter"
++version = "1.0.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
++
++[[package]]
++name = "utf8_iter"
++version = "1.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
++
+ [[package]]
+ name = "utf8parse"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
++checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+ 
+ [[package]]
+ name = "uuid"
+-version = "1.3.2"
++version = "1.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
++checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+ dependencies = [
+  "getrandom",
+  "serde",
+@@ -3266,15 +3550,15 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+ 
+ [[package]]
+ name = "version_check"
+-version = "0.9.4"
++version = "0.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
++checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+ 
+ [[package]]
+ name = "walkdir"
+-version = "2.3.3"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
++checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+ dependencies = [
+  "same-file",
+  "winapi-util",
+@@ -3282,11 +3566,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "want"
+-version = "0.3.0"
++version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
++checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+ dependencies = [
+- "log",
+  "try-lock",
+ ]
+ 
+@@ -3316,10 +3599,10 @@ dependencies = [
+  "cap-time-ext",
+  "fs-set-times 0.18.1",
+  "io-extras",
+- "io-lifetimes",
++ "io-lifetimes 1.0.11",
+  "is-terminal",
+  "once_cell",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+  "system-interface",
+  "tracing",
+  "wasi-common",
+@@ -3333,12 +3616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "008136464e438c5049a614b6ea1bae9f6c4d354ce9ee2b4d9a1ac6e73f31aafc"
+ dependencies = [
+  "anyhow",
+- "bitflags",
++ "bitflags 1.3.2",
+  "cap-rand",
+  "cap-std",
+  "io-extras",
+  "log",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+  "thiserror",
+  "tracing",
+  "wasmtime",
+@@ -3348,34 +3631,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.84"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
++checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+ dependencies = [
+  "cfg-if",
++ "once_cell",
+  "wasm-bindgen-macro",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-backend"
+-version = "0.2.84"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
++checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+ dependencies = [
+  "bumpalo",
+  "log",
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.87",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-futures"
+-version = "0.4.34"
++version = "0.4.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
++checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -3385,9 +3669,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.84"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
++checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -3395,30 +3679,31 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.84"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
++checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.109",
++ "syn 2.0.87",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.84"
++version = "0.2.95"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
++checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+ 
+ [[package]]
+ name = "wasm-encoder"
+-version = "0.26.0"
++version = "0.219.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d05d0b6fcd0aeb98adf16e7975331b3c17222aa815148f5b976370ce589d80ef"
++checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
+ dependencies = [
+  "leb128",
++ "wasmparser 0.219.1",
+ ]
+ 
+ [[package]]
+@@ -3427,10 +3712,20 @@ version = "0.102.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
+ dependencies = [
+- "indexmap",
++ "indexmap 1.9.3",
+  "url",
+ ]
+ 
++[[package]]
++name = "wasmparser"
++version = "0.219.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
++dependencies = [
++ "bitflags 2.6.0",
++ "indexmap 2.6.0",
++]
++
+ [[package]]
+ name = "wasmtime"
+ version = "8.0.1"
+@@ -3441,17 +3736,17 @@ dependencies = [
+  "async-trait",
+  "bincode",
+  "cfg-if",
+- "indexmap",
++ "indexmap 1.9.3",
+  "libc",
+  "log",
+- "object",
++ "object 0.30.4",
+  "once_cell",
+  "paste",
+  "psm",
+  "rayon",
+  "serde",
+  "target-lexicon",
+- "wasmparser",
++ "wasmparser 0.102.0",
+  "wasmtime-cache",
+  "wasmtime-component-macro",
+  "wasmtime-cranelift",
+@@ -3479,12 +3774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c86437fa68626fe896e5afc69234bb2b5894949083586535f200385adfd71213"
+ dependencies = [
+  "anyhow",
+- "base64 0.21.0",
++ "base64 0.21.7",
+  "bincode",
+  "directories-next",
+  "file-per-thread-logger",
+  "log",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+  "serde",
+  "sha2",
+  "toml",
+@@ -3525,12 +3820,12 @@ dependencies = [
+  "cranelift-frontend",
+  "cranelift-native",
+  "cranelift-wasm",
+- "gimli",
++ "gimli 0.27.3",
+  "log",
+- "object",
++ "object 0.30.4",
+  "target-lexicon",
+  "thiserror",
+- "wasmparser",
++ "wasmparser 0.102.0",
+  "wasmtime-cranelift-shared",
+  "wasmtime-environ",
+ ]
+@@ -3544,8 +3839,8 @@ dependencies = [
+  "anyhow",
+  "cranelift-codegen",
+  "cranelift-native",
+- "gimli",
+- "object",
++ "gimli 0.27.3",
++ "object 0.30.4",
+  "target-lexicon",
+  "wasmtime-environ",
+ ]
+@@ -3558,14 +3853,14 @@ checksum = "a990198cee4197423045235bf89d3359e69bd2ea031005f4c2d901125955c949"
+ dependencies = [
+  "anyhow",
+  "cranelift-entity",
+- "gimli",
+- "indexmap",
++ "gimli 0.27.3",
++ "indexmap 1.9.3",
+  "log",
+- "object",
++ "object 0.30.4",
+  "serde",
+  "target-lexicon",
+  "thiserror",
+- "wasmparser",
++ "wasmparser 0.102.0",
+  "wasmtime-types",
+ ]
+ 
+@@ -3577,7 +3872,7 @@ checksum = "7ab182d5ab6273a133ab88db94d8ca86dc3e57e43d70baaa4d98f94ddbd7d10a"
+ dependencies = [
+  "cc",
+  "cfg-if",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+  "wasmtime-asm-macros",
+  "windows-sys 0.45.0",
+ ]
+@@ -3588,15 +3883,15 @@ version = "8.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0de48df552cfca1c9b750002d3e07b45772dd033b0b206d5c0968496abf31244"
+ dependencies = [
+- "addr2line",
++ "addr2line 0.19.0",
+  "anyhow",
+  "bincode",
+  "cfg-if",
+  "cpp_demangle",
+- "gimli",
++ "gimli 0.27.3",
+  "ittapi",
+  "log",
+- "object",
++ "object 0.30.4",
+  "rustc-demangle",
+  "serde",
+  "target-lexicon",
+@@ -3613,9 +3908,9 @@ version = "8.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6e0554b84c15a27d76281d06838aed94e13a77d7bf604bbbaf548aa20eb93846"
+ dependencies = [
+- "object",
++ "object 0.30.4",
+  "once_cell",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+ ]
+ 
+ [[package]]
+@@ -3638,7 +3933,7 @@ dependencies = [
+  "anyhow",
+  "cc",
+  "cfg-if",
+- "indexmap",
++ "indexmap 1.9.3",
+  "libc",
+  "log",
+  "mach",
+@@ -3646,7 +3941,7 @@ dependencies = [
+  "memoffset",
+  "paste",
+  "rand",
+- "rustix 0.36.13",
++ "rustix 0.36.17",
+  "wasmtime-asm-macros",
+  "wasmtime-environ",
+  "wasmtime-fiber",
+@@ -3663,7 +3958,7 @@ dependencies = [
+  "cranelift-entity",
+  "serde",
+  "thiserror",
+- "wasmparser",
++ "wasmparser 0.102.0",
+ ]
+ 
+ [[package]]
+@@ -3687,7 +3982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "983db9cc294d1adaa892a53ff6a0dc6605fc0ab1a4da5d8a2d2d4bde871ff7dd"
+ dependencies = [
+  "anyhow",
+- "heck",
++ "heck 0.4.1",
+  "wit-parser",
+ ]
+ 
+@@ -3702,10 +3997,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "wast"
+-version = "57.0.0"
++version = "219.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6eb0f5ed17ac4421193c7477da05892c2edafd67f9639e3c11a82086416662dc"
++checksum = "4f79a9d9df79986a68689a6b40bcc8d5d40d807487b235bebc2ac69a242b54a1"
+ dependencies = [
++ "bumpalo",
+  "leb128",
+  "memchr",
+  "unicode-width",
+@@ -3714,18 +4010,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "wat"
+-version = "1.0.63"
++version = "1.219.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab9ab0d87337c3be2bb6fc5cd331c4ba9fd6bcb4ee85048a0dd59ed9ecf92e53"
++checksum = "8bc3cf014fb336883a411cd662f987abf6a1d2a27f2f0008616a0070bbf6bd0d"
+ dependencies = [
+- "wast 57.0.0",
++ "wast 219.0.1",
+ ]
+ 
+ [[package]]
+ name = "web-sys"
+-version = "0.3.61"
++version = "0.3.72"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
++checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+ dependencies = [
+  "js-sys",
+  "wasm-bindgen",
+@@ -3733,12 +4029,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "webpki"
+-version = "0.22.0"
++version = "0.22.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
++checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+ dependencies = [
+- "ring",
+- "untrusted",
++ "ring 0.17.8",
++ "untrusted 0.9.0",
+ ]
+ 
+ [[package]]
+@@ -3758,7 +4054,7 @@ checksum = "6b16a7462893c46c6d3dd2a1f99925953bdbb921080606e1a4c9344864492fa4"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+- "bitflags",
++ "bitflags 1.3.2",
+  "thiserror",
+  "tracing",
+  "wasmtime",
+@@ -3773,7 +4069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "489499e186ab24c8ac6d89e9934c54ced6f19bd473730e6a74f533bd67ecd905"
+ dependencies = [
+  "anyhow",
+- "heck",
++ "heck 0.4.1",
+  "proc-macro2",
+  "quote",
+  "shellexpand",
+@@ -3811,11 +4107,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ 
+ [[package]]
+ name = "winapi-util"
+-version = "0.1.5"
++version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
++checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+ dependencies = [
+- "winapi",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+@@ -3825,12 +4121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+-name = "windows"
+-version = "0.48.0"
++name = "windows-core"
++version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
++checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+ dependencies = [
+- "windows-targets 0.48.0",
++ "windows-targets 0.52.6",
+ ]
+ 
+ [[package]]
+@@ -3863,7 +4159,25 @@ version = "0.48.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+ dependencies = [
+- "windows-targets 0.48.0",
++ "windows-targets 0.48.5",
++]
++
++[[package]]
++name = "windows-sys"
++version = "0.52.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
++dependencies = [
++ "windows-targets 0.52.6",
++]
++
++[[package]]
++name = "windows-sys"
++version = "0.59.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
++dependencies = [
++ "windows-targets 0.52.6",
+ ]
+ 
+ [[package]]
+@@ -3883,17 +4197,33 @@ dependencies = [
+ 
+ [[package]]
+ name = "windows-targets"
+-version = "0.48.0"
++version = "0.48.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
++dependencies = [
++ "windows_aarch64_gnullvm 0.48.5",
++ "windows_aarch64_msvc 0.48.5",
++ "windows_i686_gnu 0.48.5",
++ "windows_i686_msvc 0.48.5",
++ "windows_x86_64_gnu 0.48.5",
++ "windows_x86_64_gnullvm 0.48.5",
++ "windows_x86_64_msvc 0.48.5",
++]
++
++[[package]]
++name = "windows-targets"
++version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
++checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.48.0",
+- "windows_aarch64_msvc 0.48.0",
+- "windows_i686_gnu 0.48.0",
+- "windows_i686_msvc 0.48.0",
+- "windows_x86_64_gnu 0.48.0",
+- "windows_x86_64_gnullvm 0.48.0",
+- "windows_x86_64_msvc 0.48.0",
++ "windows_aarch64_gnullvm 0.52.6",
++ "windows_aarch64_msvc 0.52.6",
++ "windows_i686_gnu 0.52.6",
++ "windows_i686_gnullvm",
++ "windows_i686_msvc 0.52.6",
++ "windows_x86_64_gnu 0.52.6",
++ "windows_x86_64_gnullvm 0.52.6",
++ "windows_x86_64_msvc 0.52.6",
+ ]
+ 
+ [[package]]
+@@ -3904,9 +4234,15 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+ 
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+-version = "0.48.0"
++version = "0.48.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
++checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
++
++[[package]]
++name = "windows_aarch64_gnullvm"
++version = "0.52.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+@@ -3916,9 +4252,15 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+ 
+ [[package]]
+ name = "windows_aarch64_msvc"
+-version = "0.48.0"
++version = "0.48.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
++
++[[package]]
++name = "windows_aarch64_msvc"
++version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
++checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+@@ -3928,9 +4270,21 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+ 
+ [[package]]
+ name = "windows_i686_gnu"
+-version = "0.48.0"
++version = "0.48.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
++
++[[package]]
++name = "windows_i686_gnu"
++version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
++checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
++
++[[package]]
++name = "windows_i686_gnullvm"
++version = "0.52.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+@@ -3940,9 +4294,15 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+ 
+ [[package]]
+ name = "windows_i686_msvc"
+-version = "0.48.0"
++version = "0.48.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
++checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
++
++[[package]]
++name = "windows_i686_msvc"
++version = "0.52.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+@@ -3952,9 +4312,15 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+ 
+ [[package]]
+ name = "windows_x86_64_gnu"
+-version = "0.48.0"
++version = "0.48.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
++
++[[package]]
++name = "windows_x86_64_gnu"
++version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
++checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+@@ -3964,9 +4330,15 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+ 
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+-version = "0.48.0"
++version = "0.48.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
++checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
++
++[[package]]
++name = "windows_x86_64_gnullvm"
++version = "0.52.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+@@ -3976,17 +4348,24 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+ 
+ [[package]]
+ name = "windows_x86_64_msvc"
+-version = "0.48.0"
++version = "0.48.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
++checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
++
++[[package]]
++name = "windows_x86_64_msvc"
++version = "0.52.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+ 
+ [[package]]
+ name = "winreg"
+-version = "0.10.1"
++version = "0.50.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
++checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+ dependencies = [
+- "winapi",
++ "cfg-if",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+@@ -3995,11 +4374,21 @@ version = "0.35.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1c52a121f0fbf9320d5f2a9a5d82f6cb7557eda5e8b47fc3e7f359ec866ae960"
+ dependencies = [
+- "bitflags",
+- "io-lifetimes",
++ "bitflags 1.3.2",
++ "io-lifetimes 1.0.11",
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "winx"
++version = "0.36.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
++dependencies = [
++ "bitflags 2.6.0",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "wit-parser"
+ version = "0.6.4"
+@@ -4008,7 +4397,7 @@ checksum = "f887c3da527a51b321076ebe6a7513026a4757b6d4d144259946552d6fc728b3"
+ dependencies = [
+  "anyhow",
+  "id-arena",
+- "indexmap",
++ "indexmap 1.9.3",
+  "log",
+  "pulldown-cmark",
+  "unicode-xid",
+@@ -4027,6 +4416,18 @@ dependencies = [
+  "wast 35.0.2",
+ ]
+ 
++[[package]]
++name = "write16"
++version = "1.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
++
++[[package]]
++name = "writeable"
++version = "0.5.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
++
+ [[package]]
+ name = "x509-parser"
+ version = "0.14.0"
+@@ -4040,7 +4441,7 @@ dependencies = [
+  "lazy_static",
+  "nom",
+  "oid-registry",
+- "ring",
++ "ring 0.16.20",
+  "rusticata-macros",
+  "thiserror",
+  "time",
+@@ -4055,6 +4456,94 @@ dependencies = [
+  "time",
+ ]
+ 
++[[package]]
++name = "yoke"
++version = "0.7.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
++dependencies = [
++ "serde",
++ "stable_deref_trait",
++ "yoke-derive",
++ "zerofrom",
++]
++
++[[package]]
++name = "yoke-derive"
++version = "0.7.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++ "synstructure 0.13.1",
++]
++
++[[package]]
++name = "zerocopy"
++version = "0.7.35"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
++dependencies = [
++ "byteorder",
++ "zerocopy-derive",
++]
++
++[[package]]
++name = "zerocopy-derive"
++version = "0.7.35"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++]
++
++[[package]]
++name = "zerofrom"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
++dependencies = [
++ "zerofrom-derive",
++]
++
++[[package]]
++name = "zerofrom-derive"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++ "synstructure 0.13.1",
++]
++
++[[package]]
++name = "zerovec"
++version = "0.10.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
++dependencies = [
++ "yoke",
++ "zerofrom",
++ "zerovec-derive",
++]
++
++[[package]]
++name = "zerovec-derive"
++version = "0.10.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++]
++
+ [[package]]
+ name = "zstd"
+ version = "0.11.2+zstd.1.5.2"
+@@ -4076,11 +4565,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "zstd-sys"
+-version = "2.0.8+zstd.1.5.5"
++version = "2.0.13+zstd.1.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
++checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+ dependencies = [
+  "cc",
+- "libc",
+  "pkg-config",
+ ]

--- a/pkgs/development/interpreters/lunatic/default.nix
+++ b/pkgs/development/interpreters/lunatic/default.nix
@@ -43,14 +43,14 @@ rustPlatform.buildRustPackage rec {
     "--skip=state::tests::import_filter_signature_matches"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Erlang inspired runtime for WebAssembly";
     homepage = "https://lunatic.solutions";
     changelog = "https://github.com/lunatic-solutions/lunatic/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/development/interpreters/lunatic/default.nix
+++ b/pkgs/development/interpreters/lunatic/default.nix
@@ -1,10 +1,11 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, openssl
-, stdenv
-, darwin
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  stdenv,
+  darwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -13,22 +14,29 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "lunatic-solutions";
-    repo = pname;
+    repo = "lunatic";
     rev = "v${version}";
     hash = "sha256-uMMssZaPDZn3bOtQIho+GvUCPmzRllv7eJ+SJuKaYtg=";
   };
 
-  cargoHash = "sha256-ALjlQsxmZVREyi3ZGMJMv/38kkMjYh+hTSr/0avYJVs=";
+  cargoPatches = [
+    # the `time` dependency was out of date and that broke the build
+    ./0001-update-dependencies-cargo-lock.patch
+  ];
+
+  cargoHash = "sha256-yGeCpzpeoVjTioGEL3yBJ4tDveJnoy+6UMfog84yahY=";
 
   nativeBuildInputs = [
     pkg-config
   ];
 
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ];
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+    ];
 
   checkFlags = [
     # requires simd support which is not always available on hydra
@@ -39,7 +47,10 @@ rustPlatform.buildRustPackage rec {
     description = "Erlang inspired runtime for WebAssembly";
     homepage = "https://lunatic.solutions";
     changelog = "https://github.com/lunatic-solutions/lunatic/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [ mit /* or */ asl20 ];
+    license = with licenses; [
+      mit # or
+      asl20
+    ];
     maintainers = with maintainers; [ figsoda ];
   };
 }


### PR DESCRIPTION
Lunatic depended on an old version of the `time` crate, updated the lock file to use the version that works with `rustc >= 1.80`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
