### PR TITLE
libamplsolver: mark cross-compile as broken

### DIFF
--- a/pkgs/development/libraries/science/math/libamplsolver/default.nix
+++ b/pkgs/development/libraries/science/math/libamplsolver/default.nix
@@ -35,5 +35,7 @@ stdenv.mkDerivation rec {
     license = [ licenses.mit ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ aanderse ];
+    # generates header at compile time
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
The build system generates `arith.h` by executing a small C "script".

## Things done

- Did not build on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).