### PR TITLE
python312Packages.markdownify: fix build

### DIFF
--- a/pkgs/development/python-modules/markdownify/default.nix
+++ b/pkgs/development/python-modules/markdownify/default.nix
@@ -2,7 +2,7 @@
   lib,
   beautifulsoup4,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -17,9 +17,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-qyV/nmvUB1EYgoooydAvikv+t0IfVYg0qnmy3+syoJg=";
+  src = fetchFromGitHub {
+    owner = "matthewwithanm";
+    repo = "python-markdownify";
+    rev = "refs/tags/${version}";
+    hash = "sha256-EqQ4DKIGaMNivw9cWCSP/Mh+1YxyTaHGPYRjGxPFOnA=";
   };
 
   build-system = [


### PR DESCRIPTION
The tests are not present in the PyPI release.

Regression from c7e08603a5d5459c22890d98dcf4456a840eb292 / #345326 probably

Fixes #353855

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).