### PR TITLE
multivnc: init at 2.8.1

### DIFF
--- a/pkgs/by-name/mu/multivnc/nixpkgs.patch
+++ b/pkgs/by-name/mu/multivnc/nixpkgs.patch
@@ -1,0 +1,65 @@
+diff -ruZ source/CMakeLists.txt source2/CMakeLists.txt
+--- source/CMakeLists.txt	1969-12-31 17:00:01.000000000 -0700
++++ source2/CMakeLists.txt	2024-11-03 21:24:22.153712626 -0700
+@@ -12,9 +12,6 @@
+ 
+ set(WXSERVDISC_INSTALL OFF CACHE BOOL "Set to OFF to not include wxservdisc artifacts in install")
+ add_subdirectory(libwxservdisc/src)
+-set(LIBVNCSERVER_INSTALL OFF CACHE BOOL "Set to OFF to not include libvncserver artifacts in install")
+-set(WITH_EXAMPLES OFF CACHE BOOL "Set to OFF to not build libvncserver examples")
+-add_subdirectory(libvncserver)
+ 
+ add_subdirectory(src)
+ 
+diff -ruZ source/src/CMakeLists.txt source2/src/CMakeLists.txt
+--- source/src/CMakeLists.txt	1969-12-31 17:00:01.000000000 -0700
++++ source2/src/CMakeLists.txt	2024-11-03 21:51:56.015301604 -0700
+@@ -1,15 +1,17 @@
+ #
+ # dependencies
+ #
++include(FindPkgConfig)
+ find_package(wxWidgets 3.0 REQUIRED core base net adv qa)
++find_package(LibVNCServer)
++pkg_search_module(GTK3 REQUIRED gtk+-3.0)
+ include(${wxWidgets_USE_FILE})
+ include_directories(
+     ${CMAKE_BINARY_DIR}
+     ${CMAKE_SOURCE_DIR}
+     ${CMAKE_SOURCE_DIR}/src/
+     ${CMAKE_SOURCE_DIR}/libwxservdisc/src
+-    ${CMAKE_SOURCE_DIR}/libvncserver
+-    ${CMAKE_BINARY_DIR}/libvncserver
++    ${GTK3_INCXLUDE_DIRS}
+ )
+ 
+ 
+@@ -39,7 +41,7 @@
+ 
+ add_executable(${executable_name} MACOSX_BUNDLE ${multivnc_SRCS})
+ 
+-target_link_libraries(${executable_name} MultiVNCgui ${wxWidgets_LIBRARIES} wxservdisc vncclient)
++target_link_libraries(${executable_name} MultiVNCgui ${wxWidgets_LIBRARIES} wxservdisc vncclient ${GTK3_LIBRARIES})
+ 
+ if(APPLE AND wxWidgets_VERSION_STRING LESS 3.1)
+     set_target_properties(${executable_name} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in)
+@@ -47,7 +49,6 @@
+ 
+ 
+ 
+-
+ 
+ #original Makefile.am contents follow:
+ 
+diff -ruZ source/src/VNCConn.h source2/src/VNCConn.h
+--- source/src/VNCConn.h	1969-12-31 17:00:01.000000000 -0700
++++ source2/src/VNCConn.h	2024-11-03 21:28:06.620032553 -0700
+@@ -37,7 +37,7 @@
+ #include <wx/secretstore.h>
+ #endif
+ #include <wx/msgqueue.h>
+-#include "rfb/rfbclient.h"
++#include <rfb/rfbclient.h>
+ 
+ 
+ 

--- a/pkgs/by-name/mu/multivnc/package.nix
+++ b/pkgs/by-name/mu/multivnc/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  wxGTK32,
+  gtk3,
+  zlib,
+  libjpeg,
+  libvncserver,
+  cmake,
+  pkg-config,
+  libsysprof-capture,
+  pcre2,
+  util-linux,
+  libselinux,
+  libsepol,
+  libthai,
+  libdatrie,
+  xorg,
+  lerc,
+  libxkbcommon,
+  libepoxy,
+  wrapGAppsHook3,
+}:
+
+let
+  # libvncserver does not support multicast. since multivnc is mostly about multicast, it requires a special branch of libvncserver.
+  libvncserver-patched = libvncserver.overrideAttrs {
+    src = fetchFromGitHub {
+      owner = "LibVNC";
+      repo = "libvncserver";
+      rev = "ef3b57438564f2877148a23055f3f0ffce66df11";
+      hash = "sha256-Cg96tsi6h1DX4VSsq1B8DTn0GxnBfoZK2nuxeT/+ca0=";
+    };
+    patches = [ ];
+  };
+
+in
+stdenv.mkDerivation {
+  pname = "MultiVNC";
+  version = "2.8.1";
+
+  src = fetchFromGitHub {
+    owner = "bk138";
+    repo = "multivnc";
+    rev = "89225243412f43ba2903ffeda98af7fe1f8f4975";
+    hash = "sha256-qdF6nUSGaTphoe6T3gTAJTSQwvu+v/g8xfYobFBmGsI=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # remove part of vendored libraries that can be provided by Nixpkgs
+    ./nixpkgs.patch
+
+    # silences a compiler warning
+    (fetchpatch {
+      url = "https://github.com/bk138/multivnc/commit/002ba7f6b5b88dac3da5c08f99be1f237dcde904.patch";
+      hash = "sha256-Qnk7RrUaw9jsaNTbzYqsH0LU8ivT9xX2jfxrES82ArE=";
+    })
+  ];
+
+  # remove submodules we don't need
+  # some submodules can be provided by nixpkgs
+  postPatch = ''
+    rm -rfv libvncserver libsshtunnel libjpeg-turbo libressl libssh2
+  '';
+
+  buildInputs = [
+    gtk3
+    wxGTK32
+    zlib
+    libjpeg
+    libvncserver-patched
+
+    # transitive dependencies
+    libsysprof-capture
+    pcre2
+    util-linux # mount
+    libselinux
+    libsepol
+    libthai
+    libdatrie
+    lerc
+    libxkbcommon
+    libepoxy
+    xorg.libXdmcp
+    xorg.libXtst
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  meta = {
+    mainProgram = "multivnc";
+    description = "Cross-platform Multicast-enabled VNC viewer based on LibVNCClient";
+    homepage = "https://github.com/bk138/multivnc";
+    maintainers = with lib.maintainers; [ rhelmot ];
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
[MultiVNC](https://github.com/bk138/multivnc) is a mult-platform VNC client. Its claim to fame is that it supports multicast-enabled VNC and also input macro record/replay.

My main concern about this package is that it seemed to require explicitly listing a lot of transitive dependencies, otherwise you get errors from pkg-config. I think there may be some misconfigurations in the dependencies, or perhaps I'm configuring the package wrong...?

Upstream vendors a lot of dependencies as submodules. I was able to remove all of them and replace them with the nixpkgs equivalents (see nixpkgs.patch) except for libwxservdisc, which doesn't seem to have any dependents other than this project.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
