### PR TITLE
[24.05] ytmdesktop: init at 2.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3642,6 +3642,12 @@
     githubId = 136485;
     name = "Chad Jablonski";
   };
+  cjshearer = {
+    email = "cjshearer@live.com";
+    github = "cjshearer";
+    githubId = 7173077;
+    name = "Cody Shearer";
+  };
   ck3d = {
     email = "ck3d@gmx.de";
     github = "ck3d";

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   desktopItems = [
     (makeDesktopItem {
-      desktopName = "Youtube Music Desktop App";
+      desktopName = "YouTube Music Desktop App";
       exec = "ytmdesktop";
       icon = "ytmdesktop";
       name = "ytmdesktop";
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
         "Audio"
       ];
       startupNotify = true;
+      startupWMClass = "YouTube Music Desktop App";
     })
   ];
 

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -3,7 +3,7 @@
   asar,
   commandLineArgs ? "",
   copyDesktopItems,
-  electron_30,
+  electron_33,
   fetchurl,
   makeDesktopItem,
   makeWrapper,
@@ -12,7 +12,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ytmdesktop";
-  version = "2.0.5";
+  version = "2.0.6";
 
   desktopItems = [
     (makeDesktopItem {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/ytmdesktop/ytmdesktop/releases/download/v${finalAttrs.version}/youtube-music-desktop-app_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-0j8HVmkFyTk/Jpq9dfQXFxd2jnLwzfEiqCgRHuc5g9o=";
+    hash = "sha256-uLTnVA9ooGlbtmUGoYtrT9IlOhTAJpEXMr1GSs3ae/8=";
   };
 
   unpackPhase = ''
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   fixupPhase = ''
     runHook preFixup
 
-    makeWrapper ${lib.getExe electron_30} $out/bin/ytmdesktop \
+    makeWrapper ${lib.getExe electron_33} $out/bin/ytmdesktop \
       --add-flags $out/lib/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = finalAttrs.pname;
     maintainers = [ lib.maintainers.cjshearer ];
-    inherit (electron_30.meta) platforms;
+    inherit (electron_33.meta) platforms;
     # While the files we extract from the .deb are cross-platform (javascript), the installation
     # process for darwin is different, and I don't have a test device. PRs are welcome if you can
     # add the correct installation steps. I would suggest looking at the following:

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -1,14 +1,12 @@
 {
   lib,
   asar,
-  binutils,
   commandLineArgs ? "",
   copyDesktopItems,
   electron_30,
   fetchurl,
   makeDesktopItem,
   makeWrapper,
-  nix-update-script,
   stdenv,
   zstd,
 }:
@@ -16,19 +14,21 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "ytmdesktop";
   version = "2.0.5";
 
-  desktopItem = makeDesktopItem {
-    desktopName = "Youtube Music Desktop App";
-    exec = "ytmdesktop";
-    icon = "ytmdesktop";
-    name = "ytmdesktop";
-    genericName = finalAttrs.meta.description;
-    mimeTypes = [ "x-scheme-handler/ytmd" ];
-    categories = [
-      "AudioVideo"
-      "Audio"
-    ];
-    startupNotify = true;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Youtube Music Desktop App";
+      exec = "ytmdesktop";
+      icon = "ytmdesktop";
+      name = "ytmdesktop";
+      genericName = finalAttrs.meta.description;
+      mimeTypes = [ "x-scheme-handler/ytmd" ];
+      categories = [
+        "AudioVideo"
+        "Audio"
+      ];
+      startupNotify = true;
+    })
+  ];
 
   nativeBuildInputs = [
     asar

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  asar,
+  binutils,
+  commandLineArgs ? "",
+  copyDesktopItems,
+  electron_30,
+  fetchurl,
+  makeDesktopItem,
+  makeWrapper,
+  nix-update-script,
+  stdenv,
+  zstd,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ytmdesktop";
+  version = "2.0.5";
+
+  desktopItem = makeDesktopItem {
+    desktopName = "Youtube Music Desktop App";
+    exec = "ytmdesktop";
+    icon = "ytmdesktop";
+    name = "ytmdesktop";
+    genericName = finalAttrs.meta.description;
+    mimeTypes = [ "x-scheme-handler/ytmd" ];
+    categories = [
+      "AudioVideo"
+      "Audio"
+    ];
+    startupNotify = true;
+  };
+
+  nativeBuildInputs = [
+    asar
+    copyDesktopItems
+    makeWrapper
+    zstd
+  ];
+
+  src = fetchurl {
+    url = "https://github.com/ytmdesktop/ytmdesktop/releases/download/v${finalAttrs.version}/youtube-music-desktop-app_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-0j8HVmkFyTk/Jpq9dfQXFxd2jnLwzfEiqCgRHuc5g9o=";
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    ar x $src data.tar.zst
+    tar xf data.tar.zst
+
+    runHook preUnpack
+  '';
+
+  postPatch = ''
+    pushd usr/lib/youtube-music-desktop-app
+
+    asar extract resources/app.asar patched-asar
+
+    # workaround for https://github.com/electron/electron/issues/31121
+    substituteInPlace patched-asar/.webpack/main/index.js \
+      --replace-fail "process.resourcesPath" "'$out/lib/resources'"
+
+    asar pack patched-asar resources/app.asar
+
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,share/pixmaps}
+
+    cp -r usr/lib/youtube-music-desktop-app/{locales,resources{,.pak}} $out/lib
+    cp usr/share/pixmaps/youtube-music-desktop-app.png $out/share/pixmaps/ytmdesktop.png
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    makeWrapper ${lib.getExe electron_30} $out/bin/ytmdesktop \
+      --add-flags $out/lib/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    runHook preFixup
+  '';
+
+  meta = {
+    changelog = "https://github.com/ytmdesktop/ytmdesktop/tag/v${finalAttrs.version}";
+    description = "A Desktop App for YouTube Music";
+    downloadPage = "https://github.com/ytmdesktop/ytmdesktop/releases";
+    homepage = "https://ytmdesktop.app/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = finalAttrs.pname;
+    maintainers = [ lib.maintainers.cjshearer ];
+    inherit (electron_30.meta) platforms;
+    # While the files we extract from the .deb are cross-platform (javascript), the installation
+    # process for darwin is different, and I don't have a test device. PRs are welcome if you can
+    # add the correct installation steps. I would suggest looking at the following:
+    # https://www.electronjs.org/docs/latest/tutorial/application-distribution#manual-packaging
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1403,7 +1403,6 @@ mapAliases ({
   yacc = bison; # moved from top-level 2021-03-14
   yafaray-core = libyafaray; # Added 2022-09-23
   yarn2nix-moretea-openssl_1_1 = throw "'yarn2nix-moretea-openssl_1_1' has been removed."; # Added 2023-02-04
-  ytmdesktop = throw "ytmdesktop was removed because upstream vanished"; # added 2024-03-24
   yubikey-manager4 = throw "yubikey-manager4 has been removed, since it is no longer required by yubikey-manager-qt. Please update to yubikey-manager."; # Added 2024-01-14
   yuzu-ea = throw "yuzu-ea has been removed from nixpkgs, as it has been taken down upstream"; # Added 2024-03-04
   yuzu-early-access = throw "yuzu-early-access has been removed from nixpkgs, as it has been taken down upstream"; # Added 2024-03-04


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Depends on: https://github.com/NixOS/nixpkgs/pull/352693 (which got merged).

Manual backports of 
- https://github.com/NixOS/nixpkgs/pull/317309
- https://github.com/NixOS/nixpkgs/pull/326284
- https://github.com/NixOS/nixpkgs/pull/333742
- https://github.com/NixOS/nixpkgs/pull/351671

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
