### PR TITLE
treewide: fix build by pinning Go 1.22 for now

### DIFF
--- a/pkgs/applications/networking/peroxide/default.nix
+++ b/pkgs/applications/networking/peroxide/default.nix
@@ -1,10 +1,10 @@
 { lib
-, buildGoModule
+, buildGo122Module
 , fetchFromGitHub
 , nixosTests
 }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "peroxide";
   version = "0.5.0";
 

--- a/pkgs/by-name/de/devdash/package.nix
+++ b/pkgs/by-name/de/devdash/package.nix
@@ -1,12 +1,12 @@
 {
   lib
-, buildGoModule
+, buildGo122Module
 , fetchFromGitHub
 , nix-update-script
 , coreutils
 }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "devdash";
   version = "0.5.0";
 

--- a/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
@@ -1,6 +1,6 @@
-{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+{ lib, buildGo122Module, fetchFromGitHub, nixosTests }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "dnsmasq_exporter";
   version = "0.3.0";
 

--- a/pkgs/tools/networking/ali/default.nix
+++ b/pkgs/tools/networking/ali/default.nix
@@ -1,9 +1,9 @@
 { lib
-, buildGoModule
+, buildGo122Module
 , fetchFromGitHub
 }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "ali";
   version = "0.7.5";
 

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, buildGoModule
+, buildGo122Module
 , fetchFromGitHub
 , pkg-config
 , libpcap
@@ -8,7 +8,7 @@
 , libusb1
 }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "bettercap";
   version = "2.32.0";
 

--- a/pkgs/tools/security/honeytrap/default.nix
+++ b/pkgs/tools/security/honeytrap/default.nix
@@ -1,8 +1,8 @@
 { lib
-, buildGoModule
+, buildGo122Module
 , fetchFromGitHub
 }:
-buildGoModule {
+buildGo122Module {
   pname = "honeytrap";
   version = "unstable-2021-12-20";
 


### PR DESCRIPTION
After #342429, lots of packages failing with this error:

```
link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg
```

Ultimately `golang.org/x/net` needs to be upgraded in the project to support Go 1.23, but 1.22 can be used to unbreak these packages for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
