### PR TITLE
tamatool: fix darwin builds

### DIFF
--- a/pkgs/applications/emulators/tamatool/default.nix
+++ b/pkgs/applications/emulators/tamatool/default.nix
@@ -6,7 +6,6 @@
 , libpng
 , SDL2
 , SDL2_image
-, darwin
 
 # Optionally bundle a ROM file
 , rom ? null
@@ -43,8 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     SDL2
     SDL2_image
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.CoreFoundation
   ];
 
   makeFlags = [
@@ -55,6 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
     "DIST_PATH=$(out)"
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-framework CoreFoundation";
+  };
 
   desktopItems = [ "linux/tamatool.desktop" ];
 

--- a/pkgs/applications/emulators/tamatool/default.nix
+++ b/pkgs/applications/emulators/tamatool/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, zip
-, copyDesktopItems
-, libpng
-, SDL2
-, SDL2_image
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zip,
+  copyDesktopItems,
+  libpng,
+  SDL2,
+  SDL2_image,
 
-# Optionally bundle a ROM file
-, rom ? null
+  # Optionally bundle a ROM file
+  rom ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
https://hydra.nixos.org/build/276155325/nixlog/1/tail

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
