### PR TITLE
freebsd.mkimg: support openbsd partitions guids

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/mkimg-openbsd.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/mkimg-openbsd.patch
@@ -1,0 +1,44 @@
+diff --git a/usr.bin/mkimg/gpt.c b/usr.bin/mkimg/gpt.c
+index ed3f008c394f..b4fb98682a4c 100644
+--- a/usr.bin/mkimg/gpt.c
++++ b/usr.bin/mkimg/gpt.c
+@@ -50,6 +50,7 @@ static mkimg_uuid_t gpt_uuid_freebsd_zfs = GPT_ENT_TYPE_FREEBSD_ZFS;
+ static mkimg_uuid_t gpt_uuid_mbr = GPT_ENT_TYPE_MBR;
+ static mkimg_uuid_t gpt_uuid_ms_basic_data = GPT_ENT_TYPE_MS_BASIC_DATA;
+ static mkimg_uuid_t gpt_uuid_prep_boot = GPT_ENT_TYPE_PREP_BOOT;
++static mkimg_uuid_t gpt_uuid_openbsd_ufs = GPT_ENT_TYPE_OPENBSD_DATA;
+ 
+ static struct mkimg_alias gpt_aliases[] = {
+     {	ALIAS_EFI, ALIAS_PTR2TYPE(&gpt_uuid_efi) },
+@@ -63,6 +64,7 @@ static struct mkimg_alias gpt_aliases[] = {
+     {	ALIAS_MBR, ALIAS_PTR2TYPE(&gpt_uuid_mbr) },
+     {	ALIAS_NTFS, ALIAS_PTR2TYPE(&gpt_uuid_ms_basic_data) },
+     {	ALIAS_PPCBOOT, ALIAS_PTR2TYPE(&gpt_uuid_prep_boot) },
++    {	ALIAS_OPENBSD_UFS, ALIAS_PTR2TYPE(&gpt_uuid_openbsd_ufs) },
+     {	ALIAS_NONE, 0 }		/* Keep last! */
+ };
+ 
+diff --git a/usr.bin/mkimg/scheme.c b/usr.bin/mkimg/scheme.c
+index 85ed94013e8d..00a3432c5328 100644
+--- a/usr.bin/mkimg/scheme.c
++++ b/usr.bin/mkimg/scheme.c
+@@ -56,6 +56,7 @@ static struct {
+ 	{ "mbr", ALIAS_MBR },
+ 	{ "ntfs", ALIAS_NTFS },
+ 	{ "prepboot", ALIAS_PPCBOOT },
++	{ "openbsd-ufs", ALIAS_OPENBSD_UFS },
+ 	{ NULL, ALIAS_NONE }		/* Keep last! */
+ };
+ 
+diff --git a/usr.bin/mkimg/scheme.h b/usr.bin/mkimg/scheme.h
+index 52614255595f..0c44f8653af2 100644
+--- a/usr.bin/mkimg/scheme.h
++++ b/usr.bin/mkimg/scheme.h
+@@ -45,6 +45,7 @@ enum alias {
+ 	ALIAS_MBR,
+ 	ALIAS_NTFS,
+ 	ALIAS_PPCBOOT,
++	ALIAS_OPENBSD_UFS,
+ 	/* end */
+ 	ALIAS_COUNT		/* Keep last! */
+ };


### PR DESCRIPTION
OpenBSD does not have a tool comparable to FreeBSD's `mkimg`, but we still need one to create OpenBSD install and VM images.

FreeBSD's mkimg already does what we need except setting the correct partition ID, so add a new `openbsd-ufs` type.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
