### PR TITLE
openbsd.sys (OpenBSD kernel): init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/boot-config.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/boot-config.nix
@@ -1,0 +1,32 @@
+{
+  mkDerivation,
+  lib,
+  flex,
+  byacc,
+  compatHook,
+}:
+mkDerivation {
+  path = "usr.sbin/config";
+
+  extraNativeBuildInputs = [
+    flex
+    byacc
+    compatHook
+  ];
+
+  postPatch = ''
+    rm $BSDSRCDIR/usr.sbin/config/ukc.c
+    rm $BSDSRCDIR/usr.sbin/config/ukcutil.c
+    rm $BSDSRCDIR/usr.sbin/config/cmd.c
+    rm $BSDSRCDIR/usr.sbin/config/exec_elf.c
+  '';
+
+  buildPhase = ''
+    for f in *.l; do flex $f; done
+    for f in *.y; do yacc -H ''${f%.y}.h $f; done
+    for f in *.c; do $CC -I$TMP/include -DMAKE_BOOTSTRAP -c $f; done
+    $CC *.o -o config
+  '';
+
+  meta.platforms = lib.platforms.linux;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/boot-ctags.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/boot-ctags.nix
@@ -1,0 +1,25 @@
+{
+  mkDerivation,
+  lib,
+  flex,
+  byacc,
+  compatHook,
+}:
+mkDerivation {
+  path = "usr.bin/ctags";
+
+  extraNativeBuildInputs = [
+    flex
+    byacc
+    compatHook
+  ];
+
+  buildPhase = ''
+    for f in *.l; do flex $f; done
+    for f in *.y; do yacc -H ''${f%.y}.h $f; done
+    for f in *.c; do $CC -I$TMP/include -DMAKE_BOOTSTRAP -c $f; done
+    $CC *.o -o ctags
+  '';
+
+  meta.platforms = lib.platforms.linux;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/err.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/err.h
@@ -1,0 +1,30 @@
+#pragma once
+#include_next <err.h>
+
+#include <errno.h>
+#include <stdarg.h>
+static inline void __attribute__((__format__(printf, 3, 4)))
+errc(int eval, int code, const char *fmt, ...) {
+  // verr uses the error code from errno
+  // No need to keep the old value since this is noreturn anyway
+  errno = code;
+
+  va_list args;
+  va_start(args, fmt);
+  verr(eval, fmt, args);
+  va_end(args);
+}
+
+static inline void __attribute__((__format__(printf, 2, 3)))
+warnc(int code, const char *fmt, ...) {
+  // verr uses the error code from errno
+  int old_errno = errno;
+  errno = code;
+
+  va_list args;
+  va_start(args, fmt);
+  vwarn(fmt, args);
+  va_end(args);
+
+  errno = old_errno;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/fcntl.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/fcntl.h
@@ -1,0 +1,6 @@
+#pragma once
+#include_next <fcntl.h>
+
+// Linux doesn't let you lock during open, make these do nothing
+#define O_EXLOCK 0
+#define O_SHLOCK 0

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/cdefs.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/cdefs.h
@@ -1,0 +1,4 @@
+#include_next <sys/cdefs.h>
+
+#define __packed __attribute__((__packed__))
+#define __aligned(x) __attribute__((__aligned__(x)))

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/dirent.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/dirent.h
@@ -1,0 +1,1 @@
+#include <dirent.h>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/endian.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/endian.h
@@ -1,0 +1,2 @@
+// Seems to be the only header for htonl
+#include <netinet/in.h>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/types.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/sys/types.h
@@ -1,0 +1,10 @@
+#include_next <sys/types.h>
+
+// for makedev, major, minor
+#include <sys/sysmacros.h>
+
+// For htonl, htons, etc.
+#include <arpa/inet.h>
+
+// for uint32_t etc.
+#include <stdint.h>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/unistd.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/unistd.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include_next <unistd.h>
+
+// Reimplementing pledge and unvail with seccomp would be a pain,
+// so do nothing but claim they succeeded
+static int pledge(const char *, const char *) { return 0; }
+static int unveil(const char *, const char *) { return 0; }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/util.h
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/include/util.h
@@ -1,0 +1,1 @@
+#include <sys/types.h>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compat/package.nix
@@ -1,0 +1,16 @@
+{ runCommand, lib }:
+
+runCommand "openbsd-compat"
+  {
+    include = ./include;
+
+    meta = with lib; {
+      description = "A header-only library for running OpenBSD software on Linux";
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ artemist ];
+    };
+  }
+  ''
+    mkdir -p $out
+    cp -R $include $out/include
+  ''

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compatHook/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compatHook/package.nix
@@ -1,0 +1,13 @@
+{
+  stdenv,
+  makeSetupHook,
+  compat,
+}:
+
+makeSetupHook {
+  name = "openbsd-compat-hook";
+  substitutions = {
+    inherit compat;
+    inherit (stdenv.cc) suffixSalt;
+  };
+} ./setup-hook.sh

--- a/pkgs/os-specific/bsd/openbsd/pkgs/compatHook/setup-hook.sh
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/compatHook/setup-hook.sh
@@ -1,0 +1,5 @@
+useOpenBSDCompat () {
+  export NIX_CFLAGS_COMPILE_@suffixSalt@+="-I@compat@/include"
+}
+
+postHooks+=(useOpenBSDCompat)

--- a/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
@@ -34,6 +34,8 @@ mkDerivation {
     sed -i -E \
       -e 's|/usr/lib|\$\{LIBDIR\}|' \
       share/mk/bsd.prog.mk
+
+    substituteInPlace share/mk/bsd.obj.mk --replace-fail /bin/pwd pwd
   '';
 
   installPhase = ''

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -53,7 +53,7 @@ lib.makeOverridable (
         install
         tsort
         lorder
-      ];
+      ] ++ (attrs.extraNativeBuildInputs or [ ]);
 
       HOST_SH = stdenv'.shell;
 
@@ -93,6 +93,6 @@ lib.makeOverridable (
       dontBuild = true;
     }
     // lib.optionalAttrs stdenv'.hostPlatform.isStatic { NOLIBSHARED = true; }
-    // attrs
+    // (builtins.removeAttrs attrs [ "extraNativeBuildInputs" ])
   )
 )

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys.nix
@@ -1,0 +1,66 @@
+{
+  mkDerivation,
+  boot-config,
+  pkgsBuildTarget,
+  baseConfig ? "GENERIC",
+}:
+mkDerivation {
+  path = "sys/arch/amd64";
+  pname = "sys";
+  extraPaths = [ "sys" ];
+  noLibc = true;
+
+  extraNativeBuildInputs = [
+    boot-config
+  ];
+
+  postPatch =
+    # The in-kernel debugger (DDB) requires compiler flags not supported by clang, disable it
+    ''
+      sed -E -i -e '/DDB/d' $BSDSRCDIR/sys/conf/GENERIC
+      sed -E -i -e '/pseudo-device\tdt/d' $BSDSRCDIR/sys/arch/amd64/conf/GENERIC
+    ''
+    +
+      # Clang flags compatibility
+      ''
+        find $BSDSRCDIR -name 'Makefile*' -exec sed -E -i -e 's/-fno-ret-protector/-fno-stack-protector/g' -e 's/-nopie/-no-pie/g' {} +
+        sed -E -i -e 's_^\tinstall.*$_\tinstall bsd ''${out}/bsd_' -e s/update-link// $BSDSRCDIR/sys/arch/*/conf/Makefile.*
+      ''
+    +
+      # Remove randomness in build
+      ''
+        sed -E -i -e 's/^PAGE_SIZE=.*$/PAGE_SIZE=4096/g' -e '/^random_uniform/a echo 0; return 0;' $BSDSRCDIR/sys/conf/makegap.sh
+        sed -E -i -e 's/^v=.*$/v=0 u=nixpkgs h=nixpkgs t=`date -d @1`/g' $BSDSRCDIR/sys/conf/newvers.sh
+      '';
+
+  postConfigure = ''
+    export BSDOBJDIR=$TMP/obj
+    mkdir $BSDOBJDIR
+    make obj
+
+    cd conf
+    config ${baseConfig}
+    cd -
+  '';
+
+  preBuild =
+    # A lot of files insist on calling unprefixed GNU `ld` and `objdump`.
+    # It's easier to add them to PATH than patch and substitute.
+    ''
+      mkdir $TMP/bin
+      export PATH=$TMP/bin:$PATH
+      ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}objdump $TMP/bin/objdump
+      ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}ld $TMP/bin/ld
+    ''
+    +
+      # The Makefile claims it needs includes, but it really doesn't.
+      # Tell it includes aren't real and can't hurt it.
+      ''
+        cd compile/${baseConfig}/obj
+        echo 'includes:' >>Makefile
+      '';
+
+  # stand is in a separate package
+  env.SKIPDIR = "stand";
+  env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument -Wno-visibility";
+}


### PR DESCRIPTION
Add the OpenBSD kernel and several build tools used in its build process.

OpenBSD is really not designed for cross compiling, so we had to split out some tools into separate packages. We have not tested native compilation on OpenBSD as there is no sandbox, only cross builds from Linux.

If you want to build this, try `pkgsCross.x86_64-openbsd.openbsd.sys`. There will only be one file in the output directory: `sys` (the kernel). OpenBSD does not have loadable kernel modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
