### PR TITLE
nixos/keepassxc: fix test

### DIFF
--- a/nixos/tests/keepassxc.nix
+++ b/nixos/tests/keepassxc.nix
@@ -17,6 +17,11 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
     services.xserver.enable = true;
 
+    # for better OCR
+    environment.etc."icewm/prefoverride".text = ''
+      ColorActiveTitleBar = "rgb:FF/FF/FF"
+    '';
+
     # Regression test for https://github.com/NixOS/nixpkgs/issues/163482
     qt = {
       enable = true;

--- a/nixos/tests/keepassxc.nix
+++ b/nixos/tests/keepassxc.nix
@@ -67,10 +67,21 @@ import ./make-test-python.nix ({ pkgs, ...} :
         # Wait for the enter password screen to appear.
         machine.wait_for_text("/home/alice/foo.kdbx")
 
-        # Click on "Browse" button to select keyfile
+        # Click on "I have key file" button to open keyfile dialog
         machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("ret")
+
+        # Select keyfile
+        machine.wait_for_text("Select key file")
         machine.send_chars("/home/alice/foo.keyfile")
         machine.send_key("ret")
+
+        # Open database
+        machine.wait_for_text("foo.kdbx \\[Locked] - KeePassXC")
+        machine.send_key("ret")
+
         # Database is unlocked (doesn't have "[Locked]" in the title anymore)
         machine.wait_for_text("foo.kdbx - KeePassXC")
   '';

--- a/nixos/tests/keepassxc.nix
+++ b/nixos/tests/keepassxc.nix
@@ -46,7 +46,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
         machine.wait_for_x()
 
     with subtest("Can create database and entry with CLI"):
-        ${aliceDo "keepassxc-cli db-create -k foo.keyfile foo.kdbx"}
+        ${aliceDo "keepassxc-cli db-create --set-key-file foo.keyfile foo.kdbx"}
         ${aliceDo "keepassxc-cli add --no-password -k foo.keyfile foo.kdbx bar"}
 
     with subtest("Ensure KeePassXC starts"):

--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , qttools
 
@@ -61,6 +62,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./darwin.patch
+
+    # https://github.com/keepassxreboot/keepassxc/issues/10391
+    (fetchpatch {
+      url = "https://github.com/keepassxreboot/keepassxc/commit/6a9ed210792ac60d9ed35cc702500e5ebbb95622.patch";
+      hash = "sha256-CyaVMfJ0O+5vgvmwI6rYbf0G7ryKFcLv3p4b/D6Pzw8=";
+    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
This fixes three independent issues with the NixOS KeePassXC test, see the first three commit messages.

https://hydra.nixos.org/build/277283418

ZHF: #352882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
