### PR TITLE
telepathy-glib: fix gcc14 build

### DIFF
--- a/pkgs/development/libraries/telepathy/glib/default.nix
+++ b/pkgs/development/libraries/telepathy/glib/default.nix
@@ -1,21 +1,25 @@
-{ lib
-, stdenv
-, fetchurl
-, dbus-glib
-, glib
-, python3
-, pkg-config
-, libxslt
-, gobject-introspection
-, vala
-, glibcLocales
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dbus-glib,
+  glib,
+  python3,
+  pkg-config,
+  libxslt,
+  gobject-introspection,
+  vala,
+  glibcLocales,
 }:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-glib";
   version = "0.24.2";
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   src = fetchurl {
     url = "${meta.homepage}/releases/telepathy-glib/${pname}-${version}.tar.gz";
@@ -55,6 +59,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://telepathy.freedesktop.org";
     platforms = platforms.unix;
-    license = with licenses; [ bsd2 bsd3 lgpl21Plus ];
+    license = with licenses; [
+      bsd2
+      bsd3
+      lgpl21Plus
+    ];
   };
 }

--- a/pkgs/development/libraries/telepathy/glib/default.nix
+++ b/pkgs/development/libraries/telepathy/glib/default.nix
@@ -10,6 +10,7 @@
   gobject-introspection,
   vala,
   glibcLocales,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -55,6 +56,15 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace telepathy-glib/telepathy-glib.pc.in --replace Requires.private Requires
   '';
+
+  patches = [
+    # Upstream unreleased patch for gcc14 error
+    (fetchpatch {
+      name = "fix-incompatible-pointer-types.patch";
+      url = "https://github.com/TelepathyIM/telepathy-glib/commit/72412c944b771f3214ddc40fa9dea82cea3a5651.patch";
+      hash = "sha256-NXQel0eS7zK6FRbJcPsPXCQxos0xT8EN102vX94M5Vo=";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://telepathy.freedesktop.org";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
ZHF: #352882
https://hydra.nixos.org/build/274108110/nixlog/6

Upstream has a commit that fixes our build issue, already.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
