### PR TITLE
openjdk: Fix cross for most versions

### DIFF
--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -7,6 +7,7 @@
   fetchurl,
   fetchpatch,
 
+  buildPackages,
   pkg-config,
   autoconf,
   lndir,
@@ -77,11 +78,11 @@
   temurin-bin-23,
   jdk-bootstrap ?
     {
-      "8" = temurin-bin-8;
-      "11" = temurin-bin-11;
-      "17" = temurin-bin-17;
-      "21" = temurin-bin-21;
-      "23" = temurin-bin-23;
+      "8" = temurin-bin-8.__spliced.buildBuild or temurin-bin-8;
+      "11" = temurin-bin-11.__spliced.buildBuild or temurin-bin-11;
+      "17" = temurin-bin-17.__spliced.buildBuild or temurin-bin-17;
+      "21" = temurin-bin-21.__spliced.buildBuild or temurin-bin-21;
+      "23" = temurin-bin-23.__spliced.buildBuild or temurin-bin-23;
     }
     .${featureVersion},
 }:
@@ -241,6 +242,10 @@ stdenv.mkDerivation (finalAttrs: {
       )
     ];
 
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   nativeBuildInputs =
     [
       pkg-config
@@ -250,9 +255,15 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals (!atLeast11) [
       lndir
+      # Certificates generated using perl in `installPhase`
+      perl
     ]
     ++ [
       unzip
+      zip
+      which
+      # Probably for BUILD_CC but not sure, not in closure.
+      zlib
     ]
     ++ lib.optionals atLeast21 [
       ensureNewerSourcesForZipFilesHook
@@ -262,11 +273,8 @@ stdenv.mkDerivation (finalAttrs: {
     [
       # TODO: Many of these should likely be in `nativeBuildInputs`.
       cpio
+      # `-lmagic` in NIX_LDFLAGS
       file
-      which
-      zip
-      perl
-      zlib
       cups
       freetype
     ]
@@ -305,7 +313,6 @@ stdenv.mkDerivation (finalAttrs: {
       libXcursor
       libXrandr
       fontconfig
-      jdk-bootstrap'
     ]
     ++ lib.optionals (!headless && enableGtk) [
       (if atLeast11 then gtk3 else gtk2)
@@ -330,6 +337,14 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags =
     [
       "--with-boot-jdk=${jdk-bootstrap'.home}"
+      # https://github.com/openjdk/jdk/blob/471f112bca715d04304cbe35c6ed63df8c7b7fee/make/autoconf/util_paths.m4#L315
+      # Ignoring value of READELF from the environment. Use command line variables instead.
+      "READELF=${stdenv.cc.targetPrefix}readelf"
+      "AR=${stdenv.cc.targetPrefix}ar"
+      "STRIP=${stdenv.cc.targetPrefix}strip"
+      "NM=${stdenv.cc.targetPrefix}nm"
+      "OBJDUMP=${stdenv.cc.targetPrefix}objdump"
+      "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
     ]
     ++ (
       if atLeast23 then


### PR DESCRIPTION
Using `__spliced.depsBuildBuild` to reduce rebuilds/space usage because it does not seem to matter if it's that or `buildHost`

`depsBuildBuild` `configure: error: Could not find required tool for BUILD_CC`

`zlib`

```
/build/source/src/java.base/share/native/libzip/Adler32.c:33:10: fatal error: zlib.h: No such file or directory
   33 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
make[4]: *** [lib/CoreLibraries.gmk:88: /build/source/build/linux-aarch64-server-release/buildjdk/support/native/java.base/libzip/Adler32.o] Error 1
make[4]: *** Waiting for unfinished jobs....
/build/source/src/java.base/share/native/libzip/CRC32.c:32:10: fatal error: zlib.h: No such file or directory
   32 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
/build/source/src/java.base/share/native/libzip/Deflater.c:35:10: fatal error: zlib.h: No such file or directory
   35 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
make[4]: *** [lib/CoreLibraries.gmk:88: /build/source/build/linux-aarch64-server-release/buildjdk/support/native/java.base/libzip/CRC32.o] Error 1
make[4]: *** [lib/CoreLibraries.gmk:88: /build/source/build/linux-aarch64-server-release/buildjdk/support/native/java.base/libzip/Deflater.o] Error 1
make[3]: *** [Main.gmk:191: java.base-libs] Error 2
make[2]: *** [make/Main.gmk:589: create-buildjdk-interim-image] Error 2
make[2]: *** Waiting for unfinished jobs....
ERROR: Build failed for target 'images' in configuration 'linux-aarch64-server-release' (exit code 2)
Stopping javac server
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
