### PR TITLE
nixos/ids: explain *why* uids/gids shouldn't be above "399"

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -356,7 +356,24 @@ in
       localtimed = 325;
       automatic-timezoned = 326;
 
-      # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
+      # When adding a uid, make sure it doesn't match an existing gid.
+      #
+      # !!! Don't use uids above "399"! !!!
+      #
+      # The reason behind this restriction is that, NixOS by default allocates
+      # system user UIDs/GIDs in the range of `400..999`. System users/groups
+      # created using command like `useradd` will have UID and GID in this range[1].
+      #
+      # If a newly added ID goes beyond "399", it may conflict with existing
+      # system user or group of the same id in someone else's NixOS.
+      # This could break their system and make that person upset for a whole day.
+      #
+      # Sidenote: the default is defined in `shadow` module[2], and the relavent change
+      # was made way back in 2014[3].
+      #
+      # [1]: https://man7.org/linux/man-pages/man5/login.defs.5.html#:~:text=SYS_UID_MAX%20(number)%2C%20SYS_UID_MIN%20(number)
+      # [2]: <nixos/modules/programs/shadow.nix>
+      # [3]: https://github.com/NixOS/nixpkgs/commit/0e23a175de3687df8232fe118cbe87f04228ff28
 
       nixbld = 30000; # start of range of uids
       nobody = 65534;
@@ -669,7 +686,24 @@ in
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal
-      # uids and gids. Also, don't use gids above 399!
+      # uids and gids.
+      #
+      # !!! Don't use gids above "399"! !!!
+      #
+      # The reason behind this restriction is that, NixOS by default allocates
+      # system user UIDs/GIDs in the range of `400..999`. System users/groups
+      # created using command like `useradd` will have UID and GID in this range[1].
+      #
+      # If a newly added ID goes beyond "399", it may conflict with existing
+      # system user or group of the same id in someone else's NixOS.
+      # This could break their system and make that person upset for a whole day.
+      #
+      # Sidenote: the default is defined in `shadow` module[2], and the relavent change
+      # was made way back in 2014[3].
+      #
+      # [1]: https://man7.org/linux/man-pages/man5/login.defs.5.html#:~:text=SYS_UID_MAX%20(number)%2C%20SYS_UID_MIN%20(number)
+      # [2]: <nixos/modules/programs/shadow.nix>
+      # [3]: https://github.com/NixOS/nixpkgs/commit/0e23a175de3687df8232fe118cbe87f04228ff28
 
       # For exceptional cases where you really need a gid above 399, leave a
       # comment stating why.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Motivation

I was curious about why [ids shouldn't be above 399](https://github.com/NixOS/nixpkgs/blob/4aa36568d413aca0ea84a1684d2d46f55dbabad7/nixos/modules/misc/ids.nix#L359). The truth was buried in git history, but git blame helped a lot here.

I think it's always good to explain why the restriction is here, rather than letting contributors plainly accept it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
