### PR TITLE
etterna: init at 8deab33

### DIFF
--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, writeShellScript
+
+  # dependencies
+, alsa-lib
+, clang
+, cmake
+, curl
+, libGLU
+, libjack2
+, libogg
+, mesa
+, openssl
+, xorg
+
+  # enable crash reporting. makes insecure due to dependency on python2
+  # @TODO: fix crashpad; needs depot_tools
+, enableCrashpad ? false
+, python2
+}:
+let
+  version = "8deab331e6c0e9b34eeeda363863193b26c221a4";
+
+  artifacts =
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "etterna-artifacts";
+      inherit version;
+
+      src = fetchFromGitHub {
+        owner = "etternagame";
+        repo = "etterna";
+        rev = finalAttrs.version;
+        hash = "sha256-LdJDTO8c7kS8G52b0MRO4oFhZZlcsexwJl1deVz9vf0=";
+      };
+
+      nativeBuildInputs = [
+        alsa-lib
+        clang
+        cmake
+        curl
+        libGLU
+        libjack2
+        libogg
+        mesa
+        openssl
+        xorg.libX11
+        xorg.libXext
+        xorg.libXrandr
+      ]
+      # crashpad relies on python2 and depot_tools
+      ++ lib.optionals enableCrashpad [ python2 ];
+
+      cmakeFlags = lib.optionals (!enableCrashpad) [ "-D WITH_CRASHPAD=OFF" ];
+    });
+
+  wrapper = writeShellScript "etterna-wrapper" ''
+    #!/usr/bin/env sh
+
+    export ETTERNA_ROOT_DIR="$HOME/.local/share/etterna"
+    export ETTERNA_ADDITIONAL_ROOT_DIRS="${artifacts}/Etterna"
+
+    exec ${artifacts}/Etterna/Etterna "$@"
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "etterna";
+  inherit version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+
+    # link artifacts
+    ln -s ${artifacts}/Etterna $out/share/etterna
+    ln -s ${wrapper} $out/bin/etterna
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ mib ];
+    mainProgram = "etterna";
+  };
+
+})

--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -1,24 +1,25 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, writeShellScript
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  writeShellScript,
 
   # dependencies
-, alsa-lib
-, clang
-, cmake
-, curl
-, libGLU
-, libjack2
-, libogg
-, mesa
-, openssl
-, xorg
+  alsa-lib,
+  clang,
+  cmake,
+  curl,
+  libGLU,
+  libjack2,
+  libogg,
+  mesa,
+  openssl,
+  xorg,
 
   # enable crash reporting. makes insecure due to dependency on python2
   # @TODO: fix crashpad; needs depot_tools
-, enableCrashpad ? false
-, python2
+  enableCrashpad ? false,
+  python2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,22 +33,23 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-LdJDTO8c7kS8G52b0MRO4oFhZZlcsexwJl1deVz9vf0=";
   };
 
-  nativeBuildInputs = [
-    alsa-lib
-    clang
-    cmake
-    curl
-    libGLU
-    libjack2
-    libogg
-    mesa
-    openssl
-    xorg.libX11
-    xorg.libXext
-    xorg.libXrandr
-  ]
-  # crashpad relies on python2 and depot_tools
-  ++ lib.optionals enableCrashpad [ python2 ];
+  nativeBuildInputs =
+    [
+      alsa-lib
+      clang
+      cmake
+      curl
+      libGLU
+      libjack2
+      libogg
+      mesa
+      openssl
+      xorg.libX11
+      xorg.libXext
+      xorg.libXrandr
+    ]
+    # crashpad relies on python2 and depot_tools
+    ++ lib.optionals enableCrashpad [ python2 ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -71,16 +71,16 @@ stdenv.mkDerivation (finalAttrs: {
 
     # wacky insertion of wrapper directly into phase, so that $out is set
     cat > $out/bin/etterna << EOF
-      #!${stdenv.shell}
+    #!${stdenv.shell}
 
-      export ETTERNA_ROOT_DIR="\$HOME/.local/share/etterna"
-      export ETTERNA_ADDITIONAL_ROOT_DIRS="$out/share/etterna"
+    export ETTERNA_ROOT_DIR="\$HOME/.local/share/etterna"
+    export ETTERNA_ADDITIONAL_ROOT_DIRS="$out/share/etterna"
 
-      echo "HOME: \$HOME"
-      echo "PWD: \$(pwd)"
-      echo "ETTERNA_ADDITIONAL_ROOT_DIRS: \$ETTERNA_ADDITIONAL_ROOT_DIRS"
+    echo "HOME: \$HOME"
+    echo "PWD: \$(pwd)"
+    echo "ETTERNA_ADDITIONAL_ROOT_DIRS: \$ETTERNA_ADDITIONAL_ROOT_DIRS"
 
-      exec $out/bin/etterna-unwrapped "\$@"
+    exec $out/bin/etterna-unwrapped "\$@"
     EOF
 
     chmod +x $out/bin/etterna


### PR DESCRIPTION
This PR is a draft as it's pinned to a non-release version of Etterna, and [the maintainer specifically asked to not package in-development versions](https://github.com/etternagame/etterna/), but they did approve of packaging it without making it generally available - hence this draft PR, which can be used by those who don't want to wait.

## But that is to say; do not report bugs to upstream
unless you're **completely** sure they're actually upstream Etterna bugs, not already tracked, not just a bi-product of whatever is happening in the `develop` branch, and not just the product of the shenanigans this package does to make Etterna work.

## _okay; the normal PR description starts here_

Beta client version of Etterna.

Pinned at the same commit that the beta clients are so that https://github.com/etternagame/etterna/pull/1282 is merged, and packaging is seamless -- it should be updated when the next stable release happens.

Would really like to get the sketchy `installPhase` wrapper fixed, just not sure what the best way would be - I'd definitely prefer to use `makeWrapper`, but am unable to figure out how I'd make it refer to `$HOME` then.

Should probably also try `XDG_DATA_HOME` before defaulting to `$HOME/.local/share`? Again, feedback very much welcome!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
