### PR TITLE
ncmpc: 0.49 -> 0.51

### DIFF
--- a/pkgs/by-name/nc/ncmpc/package.nix
+++ b/pkgs/by-name/nc/ncmpc/package.nix
@@ -9,6 +9,7 @@
 , libmpdclient
 , gettext
 , boost
+, fmt
 , pcreSupport ? false, pcre ? null
 }:
 
@@ -16,16 +17,16 @@ assert pcreSupport -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "ncmpc";
-  version = "0.49";
+  version = "0.51";
 
   src = fetchFromGitHub {
     owner  = "MusicPlayerDaemon";
     repo   = "ncmpc";
     rev    = "v${version}";
-    sha256 = "sha256-rqIlQQ9RhFrhPwUd9dZmMZiqwFinNoV46VaJ3pbyUI8=";
+    sha256 = "sha256-mFZ8szJT7eTPHQHxjpP5pThCcY0YERGkGR8528Xu9MA=";
   };
 
-  buildInputs = [ glib ncurses libmpdclient boost ]
+  buildInputs = [ glib ncurses libmpdclient boost fmt ]
     ++ lib.optional pcreSupport pcre;
   nativeBuildInputs = [ meson ninja pkg-config gettext ];
 

--- a/pkgs/by-name/nc/ncmpc/package.nix
+++ b/pkgs/by-name/nc/ncmpc/package.nix
@@ -5,17 +5,15 @@
   meson,
   ninja,
   pkg-config,
+  sphinx,
   glib,
   ncurses,
   libmpdclient,
   gettext,
   boost,
   fmt,
-  pcreSupport ? false,
-  pcre ? null,
+  pcre2,
 }:
-
-assert pcreSupport -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "ncmpc";
@@ -34,19 +32,25 @@ stdenv.mkDerivation rec {
     libmpdclient
     boost
     fmt
-  ] ++ lib.optional pcreSupport pcre;
+    pcre2
+  ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
     gettext
+    sphinx
   ];
 
   mesonFlags = [
-    "-Dlirc=disabled"
-    "-Ddocumentation=disabled"
-  ] ++ lib.optional (!pcreSupport) "-Dregex=disabled";
+    (lib.mesonEnable "lirc" false)
+  ];
+
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   meta = with lib; {
     description = "Curses-based interface for MPD (music player daemon)";

--- a/pkgs/by-name/nc/ncmpc/package.nix
+++ b/pkgs/by-name/nc/ncmpc/package.nix
@@ -56,7 +56,8 @@ stdenv.mkDerivation rec {
     description = "Curses-based interface for MPD (music player daemon)";
     homepage = "https://www.musicpd.org/clients/ncmpc/";
     license = licenses.gpl2Plus;
-    platforms = platforms.all;
+    platforms = platforms.unix;
+    badPlatforms = platforms.darwin;
     maintainers = with maintainers; [ fpletz ];
     mainProgram = "ncmpc";
   };

--- a/pkgs/by-name/nc/ncmpc/package.nix
+++ b/pkgs/by-name/nc/ncmpc/package.nix
@@ -1,16 +1,18 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, meson
-, ninja
-, pkg-config
-, glib
-, ncurses
-, libmpdclient
-, gettext
-, boost
-, fmt
-, pcreSupport ? false, pcre ? null
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  ncurses,
+  libmpdclient,
+  gettext,
+  boost,
+  fmt,
+  pcreSupport ? false,
+  pcre ? null,
 }:
 
 assert pcreSupport -> pcre != null;
@@ -20,15 +22,26 @@ stdenv.mkDerivation rec {
   version = "0.51";
 
   src = fetchFromGitHub {
-    owner  = "MusicPlayerDaemon";
-    repo   = "ncmpc";
-    rev    = "v${version}";
+    owner = "MusicPlayerDaemon";
+    repo = "ncmpc";
+    rev = "v${version}";
     sha256 = "sha256-mFZ8szJT7eTPHQHxjpP5pThCcY0YERGkGR8528Xu9MA=";
   };
 
-  buildInputs = [ glib ncurses libmpdclient boost fmt ]
-    ++ lib.optional pcreSupport pcre;
-  nativeBuildInputs = [ meson ninja pkg-config gettext ];
+  buildInputs = [
+    glib
+    ncurses
+    libmpdclient
+    boost
+    fmt
+  ] ++ lib.optional pcreSupport pcre;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+  ];
 
   mesonFlags = [
     "-Dlirc=disabled"
@@ -37,9 +50,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Curses-based interface for MPD (music player daemon)";
-    homepage    = "https://www.musicpd.org/clients/ncmpc/";
-    license     = licenses.gpl2Plus;
-    platforms   = platforms.all;
+    homepage = "https://www.musicpd.org/clients/ncmpc/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
     maintainers = with maintainers; [ fpletz ];
     mainProgram = "ncmpc";
   };


### PR DESCRIPTION
Some maintenance tasks and version bump: https://raw.githubusercontent.com/MusicPlayerDaemon/ncmpc/v0.51/NEWS

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
