### PR TITLE
wpsoffice{-cn}: 11.1.0.11723 -> 12.1.0.17900

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -1,37 +1,49 @@
-{ lib
-, stdenv
-, dpkg
-, autoPatchelfHook
-, alsa-lib
-, at-spi2-core
-, libtool
-, libxkbcommon
-, nspr
-, mesa
-, libtiff
-, udev
-, gtk3
-, qtbase
-, xorg
-, cups
-, pango
-, runCommandLocal
-, curl
-, coreutils
-, cacert
-, libjpeg
-, useChineseVersion ? false
+{
+  lib,
+  stdenv,
+  dpkg,
+  autoPatchelfHook,
+  alsa-lib,
+  at-spi2-core,
+  libtool,
+  libxkbcommon,
+  nspr,
+  mesa,
+  libtiff,
+  udev,
+  gtk3,
+  libsForQt5,
+  xorg,
+  cups,
+  pango,
+  libjpeg,
+  gtk2,
+  gdk-pixbuf,
+  libpulseaudio,
+  libbsd,
+  libusb1,
+  libmysqlclient,
+  llvmPackages,
+  dbus,
+  gcc-unwrapped,
+  freetype,
+  curl,
+  makeWrapper,
+  runCommandLocal,
+  cacert,
+  coreutils,
+  useChineseVersion ? false,
 }:
 let
-  pkgVersion = "11.1.0.11723";
+  pkgVersion = "12.1.0.17900";
   url =
     if useChineseVersion then
-      "https://wps-linux-personal.wpscdn.cn/wps/download/ep/Linux2019/${lib.last (lib.splitVersion pkgVersion)}/wps-office_${pkgVersion}_amd64.deb"
+      "https://wps-linux-personal.wpscdn.cn/wps/download/ep/Linux2023/${lib.last (lib.splitVersion pkgVersion)}/wps-office_${pkgVersion}_amd64.deb"
     else
       "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/${lib.last (lib.splitVersion pkgVersion)}/wps-office_${pkgVersion}.XA_amd64.deb";
   hash =
     if useChineseVersion then
-      "sha256-vpXK8YyjqhFdmtajO6ZotYACpe5thMct9hwUT3advUM="
+      "sha256-i2EVCmDLE2gx7l2aAo+fW8onP/z+xlPIbQYwKhQ46+o="
     else
       "sha256-o8njvwE/UsQpPuLyChxGAZ4euvwfuaHxs5pfUvcM7kI=";
   uri = builtins.replaceStrings [ "https://wps-linux-personal.wpscdn.cn" ] [ "" ] url;
@@ -41,25 +53,36 @@ stdenv.mkDerivation rec {
   pname = "wpsoffice";
   version = pkgVersion;
 
-  src = runCommandLocal (if useChineseVersion then "wps-office_${version}_amd64.deb" else "wps-office_${version}.XA_amd64.deb")
-    {
-      outputHashMode = "recursive";
-      outputHashAlgo = "sha256";
-      outputHash = hash;
+  src =
+    runCommandLocal
+      (
+        if useChineseVersion then
+          "wps-office_${version}_amd64.deb"
+        else
+          "wps-office_${version}.XA_amd64.deb"
+      )
+      {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = hash;
 
-      nativeBuildInputs = [ curl coreutils ];
+        nativeBuildInputs = [
+          curl
+          coreutils
+        ];
 
-      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
-      SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-    } ''
-    timestamp10=$(date '+%s')
-    md5hash=($(echo -n "${securityKey}${uri}$timestamp10" | md5sum))
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      }
+      ''
+        timestamp10=$(date '+%s')
+        md5hash=($(echo -n "${securityKey}${uri}$timestamp10" | md5sum))
 
-    curl \
-    --retry 3 --retry-delay 3 \
-    "${url}?t=$timestamp10&k=$md5hash" \
-    > $out
-  '';
+        curl \
+        --retry 3 --retry-delay 3 \
+        "${url}?t=$timestamp10&k=$md5hash" \
+        > $out
+      '';
 
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";
@@ -67,6 +90,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -80,10 +104,21 @@ stdenv.mkDerivation rec {
     libtiff
     udev
     gtk3
-    qtbase
+    libsForQt5.qt5.qtbase
     xorg.libXdamage
     xorg.libXtst
     xorg.libXv
+    gtk2
+    gdk-pixbuf
+    libpulseaudio
+    xorg.libXScrnSaver
+    xorg.libXxf86vm
+    libbsd
+    libusb1
+    libmysqlclient
+    llvmPackages.openmp
+    dbus
+    libsForQt5.fcitx5-qt
   ];
 
   dontWrapQtApps = true;
@@ -91,6 +126,8 @@ stdenv.mkDerivation rec {
   runtimeDependencies = map lib.getLib [
     cups
     pango
+    freetype
+    gcc-unwrapped.lib
   ];
 
   autoPatchelfIgnoreMissingDeps = [
@@ -100,6 +137,12 @@ stdenv.mkDerivation rec {
     "libQtCore.so.4"
     "libQtNetwork.so.4"
     "libQtXml.so.4"
+    # file manager integration. Not needed
+    "libnautilus-extension.so.1"
+    "libcaja-extension.so.1"
+    "libpeony.so.3"
+    # libuof.so is a exclusive library in WPS. No need to repatch it
+    "libuof.so"
   ];
 
   installPhase = ''
@@ -116,12 +159,19 @@ stdenv.mkDerivation rec {
       substituteInPlace $i \
         --replace /usr/bin $out/bin
     done
+    # need system freetype and gcc lib to run properly
+    for i in wps wpp et wpspdf wpsoffice; do
+      wrapProgram $out/opt/kingsoft/wps-office/office6/$i \
+        --set LD_PRELOAD "${freetype}/lib/libfreetype.so" \
+        --set LD_LIBRARY_PATH "${lib.makeLibraryPath [ gcc-unwrapped.lib ]}"
+    done
     runHook postInstall
   '';
 
   preFixup = ''
     # The following libraries need libtiff.so.5, but nixpkgs provides libtiff.so.6
     patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so,addons/pdfbatchcompression/libpdfbatchcompressionapp.so}
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/addons/ksplitmerge/libksplitmergeapp.so
     patchelf --add-needed libtiff.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
     # Fix: Wrong JPEG library version: library is 62, caller expects 80
     patchelf --add-needed libjpeg.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
@@ -136,6 +186,11 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     hydraPlatforms = [ ];
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ mlatus th0rgal rewine pokon548 ];
+    maintainers = with maintainers; [
+      mlatus
+      th0rgal
+      rewine
+      pokon548
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

DO NOT MERGE! This PR is still work-in-progress.
Update `wpsoffice{-cn}` to `12.1.17900`. 

Currently, `wpsoffice-cn` is fully functional. The major block for this PR is `wpsoffice` upstream, which is still at `11`.

Close https://github.com/NixOS/nixpkgs/issues/342772

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
