### PR TITLE
nixos/test-driver: add `elapsed_sec` to `JunitXMLLogger`

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -59,6 +59,8 @@ class JunitXMLLogger(AbstractLogger):
             self.stdout = ""
             self.stderr = ""
             self.failure = False
+            self.total_secs = None
+            self.nested_secs = 0
 
     def __init__(self, outfile: Path) -> None:
         self.tests: dict[str, JunitXMLLogger.TestCaseState] = {
@@ -78,9 +80,14 @@ class JunitXMLLogger(AbstractLogger):
         self.tests.setdefault(name, self.TestCaseState())
         self.currentSubtest = name
 
+        tic = time.monotonic()
         yield
+        toc = time.monotonic()
 
+        time_difference = toc - tic
+        self.tests[self.currentSubtest].total_secs = time_difference
         self.currentSubtest = old_test
+        self.tests[self.currentSubtest].nested_secs += time_difference
 
     @contextmanager
     def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
@@ -112,6 +119,7 @@ class JunitXMLLogger(AbstractLogger):
             for name, test_case_state in self.tests.items():
                 tc = TestCase(
                     name,
+                    elapsed_sec=test_case_state.total_secs - test_case_state.nested_secs,
                     stdout=test_case_state.stdout,
                     stderr=test_case_state.stderr,
                 )


### PR DESCRIPTION
Without this commit, all junit.xml generated for nixos-tests do not have a time set/time is set to `0`. This PR measures the time of a subtest and adds this measurement to `<testcase …>`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~~[ ] Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - ~~[ ] (Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~[ ] (Module updates) Added a release notes entry if the change is significant~~
  - ~~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
