### PR TITLE
theseus-ship: init at 6.2.0, como: init at 0.3.0, wrapland: init at 0.602.0

### DIFF
--- a/pkgs/by-name/co/como/package.nix
+++ b/pkgs/by-name/co/como/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  python3,
+  kdePackages,
+
+  libepoxy,
+  libinput,
+  wayland,
+  pixman,
+  wlroots,
+  freetype,
+  fontconfig,
+  wrapland,
+  xwayland,
+  microsoft-gsl,
+  libdrm,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "como";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "winft";
+    repo = "como";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-cXCGlrxnJgblDZRfUGIbBHQ1H9L1DYlVypCX7mb76TY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = with kdePackages; [
+    # Core
+    kauth
+    kcolorscheme
+    kconfig
+    kcoreaddons
+    kcrash
+    kglobalaccel
+    ki18n
+    kidletime
+    knotifications
+    kpackage
+    ksvg
+    kwidgetsaddons
+    kwindowsystem
+
+    # Config modules
+    kcmutils
+    knewstuff
+    kservice
+    kxmlgui
+
+    # Wayland binary
+    kdbusaddons
+
+    # Optional
+    kdoctools
+
+    kirigami
+    kdecoration
+    kscreenlocker
+    breeze
+
+    qt5compat
+    qtbase
+    qttools
+
+    libepoxy
+    libinput
+    wayland
+    pixman
+    wlroots
+    freetype
+    fontconfig
+    wrapland
+    xwayland
+    # qaccessibilityclient
+    microsoft-gsl
+    libdrm
+  ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  # It wants <drm_fourcc.h> and not <libdrm/drm_fourcc.h>
+  env.NIX_CFLAGS_COMPILE = "-isystem ${lib.getDev libdrm}/include/libdrm";
+
+  meta = {
+    description = "Robust and versatile set of libraries to create compositors for the Wayland and X11 windowing systems";
+    homepage = "https://github.com/winft/como";
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/th/theseus-ship/package.nix
+++ b/pkgs/by-name/th/theseus-ship/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  kdePackages,
+
+  libepoxy,
+  libinput,
+  libcap,
+  como,
+  wrapland,
+  microsoft-gsl,
+  pixman,
+  wayland,
+  wlroots,
+  libdrm,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "theseus-ship";
+  version = "6.2.0";
+
+  src = fetchFromGitHub {
+    owner = "winft";
+    repo = "theseus-ship";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-8KTTkOkYcltcYZ+arvhRQSrHiZDX6F3JwoXVXa8NFKU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+    libcap
+  ];
+
+  buildInputs = with kdePackages; [
+    kcrash
+    kdbusaddons
+    kwidgetsaddons
+    kirigami
+    kscreenlocker
+    breeze
+    wayland
+    qtbase
+    qttools
+
+    libepoxy
+    libinput
+    como
+    wrapland
+    microsoft-gsl
+    pixman
+    wayland
+    wlroots
+    libdrm
+  ];
+
+  # It wants <drm_fourcc.h> and not <libdrm/drm_fourcc.h>
+  env.NIX_CFLAGS_COMPILE = "-isystem ${lib.getDev libdrm}/include/libdrm";
+
+  cmakeFlags = [
+    # Otherwise the kcoreaddon plugin macro would try to write them to
+    # /plasma (yes, top level). How fun!
+    (lib.cmakeFeature "CMAKE_LIBRARY_OUTPUT_DIRECTORY" "${placeholder "out"}/lib")
+  ];
+
+  meta = {
+    description = "Wayland and X11 Compositor for the KDE Plasma desktop";
+    homepage = "https://github.com/winft/theseus-ship";
+    license = with lib.licenses; [ gpl2Only ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+})

--- a/pkgs/by-name/wr/wrapland/package.nix
+++ b/pkgs/by-name/wr/wrapland/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  kdePackages,
+
+  wayland,
+  microsoft-gsl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wrapland";
+  version = "0.602.0";
+
+  src = fetchFromGitHub {
+    owner = "winft";
+    repo = "wrapland";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-1e756nGuUwq96WCLHS/BB/dG2cYcFjpEOWKmSw1PAPk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    wayland-scanner
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = with kdePackages; [
+    qtbase
+    wayland-protocols
+    wayland
+    microsoft-gsl
+  ];
+
+  meta = {
+    description = "Qt/C++ library wrapping libwayland";
+    homepage = "https://github.com/winft/wrapland";
+    license = with lib.licenses; [ lgpl2Only ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Fixes #353807 — though I am not exactly sure how to add the NixOS modules and successfully replace KWin with it

- **wrapland: init at 0.602.0**
- **como: init at 0.3.0**
- **theseus-ship: init at 6.2.0**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
