### PR TITLE
deepin: don't inherit libsForQt5 scope

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-album/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-album/default.nix
@@ -4,18 +4,15 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   dtkdeclarative,
   qt5integration,
   qt5platform-plugins,
-  qtbase,
-  qtsvg,
   udisks2-qt5,
   gio-qt,
   freeimage,
-  ffmpeg,
+  ffmpeg_6,
   ffmpegthumbnailer,
 }:
 
@@ -33,8 +30,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -42,12 +39,12 @@ stdenv.mkDerivation rec {
     dtkdeclarative
     qt5integration
     qt5platform-plugins
-    qtbase
-    qtsvg
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     udisks2-qt5
     gio-qt
     freeimage
-    ffmpeg
+    ffmpeg_6
     ffmpegthumbnailer
   ];
 

--- a/pkgs/desktops/deepin/apps/deepin-calculator/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-calculator/default.nix
@@ -5,13 +5,10 @@
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
-  qtbase,
-  qtsvg,
+  libsForQt5,
   dde-qt-dbus-factory,
   cmake,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
   gtest,
 }:
 
@@ -28,17 +25,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     dtkwidget
     qt5integration
     qt5platform-plugins
-    qtbase
-    qtsvg
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     dde-qt-dbus-factory
     gtest
   ];

--- a/pkgs/desktops/deepin/apps/deepin-camera/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-camera/default.nix
@@ -4,17 +4,14 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   wayland,
   dwayland,
   qt5integration,
   qt5platform-plugins,
   image-editor,
-  qtbase,
-  qtmultimedia,
-  ffmpeg,
+  ffmpeg_6,
   ffmpegthumbnailer,
   libusb1,
   libpciaccess,
@@ -43,15 +40,15 @@ stdenv.mkDerivation rec {
       --replace "/usr/share/libimagevisualresult" "${image-editor}/share/libimagevisualresult" \
       --replace "/usr/include/libusb-1.0" "${lib.getDev libusb1}/include/libusb-1.0"
     substituteInPlace src/com.deepin.Camera.service \
-      --replace "/usr/bin/qdbus" "${lib.getBin qttools}/bin/qdbus" \
+      --replace "/usr/bin/qdbus" "${lib.getBin libsForQt5.qttools}/bin/qdbus" \
       --replace "/usr/share" "$out/share"
   '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs =
@@ -62,9 +59,9 @@ stdenv.mkDerivation rec {
       qt5integration
       qt5platform-plugins
       image-editor
-      qtbase
-      qtmultimedia
-      ffmpeg
+      libsForQt5.qtbase
+      libsForQt5.qtmultimedia
+      ffmpeg_6
       ffmpegthumbnailer
       libusb1
       libpciaccess
@@ -88,7 +85,7 @@ stdenv.mkDerivation rec {
   qtWrapperArgs = [
     "--prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath [
-        ffmpeg
+        ffmpeg_6
         ffmpegthumbnailer
         gst_all_1.gstreamer
         gst_all_1.gst-plugins-base

--- a/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
@@ -7,12 +7,8 @@
   qt5platform-plugins,
   udisks2-qt5,
   cmake,
-  qtbase,
-  qttools,
   pkg-config,
-  kcodecs,
-  karchive,
-  wrapQtAppsHook,
+  libsForQt5,
   minizip,
   libzip,
   libuuid,
@@ -39,9 +35,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -49,8 +45,8 @@ stdenv.mkDerivation rec {
     qt5integration
     qt5platform-plugins
     udisks2-qt5
-    kcodecs
-    karchive
+    libsForQt5.kcodecs
+    libsForQt5.karchive
     minizip
     libzip
     libuuid
@@ -61,9 +57,6 @@ stdenv.mkDerivation rec {
     "-DVERSION=${version}"
     "-DUSE_TEST=OFF"
   ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [ "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}" ];
 
   strictDeps = true;
 

--- a/pkgs/desktops/deepin/apps/deepin-draw/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-draw/default.nix
@@ -3,11 +3,8 @@
   lib,
   fetchFromGitHub,
   cmake,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
-  qtbase,
-  qtsvg,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
@@ -31,15 +28,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     qt5integration
-    qtsvg
+    libsForQt5.qtsvg
     dtkwidget
     qt5platform-plugins
   ];

--- a/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
@@ -5,8 +5,7 @@
   fetchpatch,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   qt5platform-plugins,
   dtkwidget,
   dtkdeclarative,
@@ -37,8 +36,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/apps/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-movie-reborn/default.nix
@@ -4,15 +4,10 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
-  qttools,
-  qtx11extras,
-  qtmultimedia,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
-  qtmpris,
-  qtdbusextended,
   gsettings-qt,
   elfutils,
   ffmpeg_6,
@@ -52,8 +47,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs =
@@ -61,10 +56,10 @@ stdenv.mkDerivation rec {
       dtkwidget
       qt5integration
       qt5platform-plugins
-      qtx11extras
-      qtmultimedia
-      qtdbusextended
-      qtmpris
+      libsForQt5.qtx11extras
+      libsForQt5.qtmultimedia
+      libsForQt5.qtdbusextended
+      libsForQt5.qtmpris
       gsettings-qt
       elfutils
       ffmpeg_6
@@ -88,8 +83,8 @@ stdenv.mkDerivation rec {
     ]);
 
   propagatedBuildInputs = [
-    qtmultimedia
-    qtx11extras
+    libsForQt5.qtmultimedia
+    libsForQt5.qtx11extras
     ffmpegthumbnailer
   ];
 

--- a/pkgs/desktops/deepin/apps/deepin-picker/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-picker/default.nix
@@ -2,13 +2,9 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
-  qtbase,
-  qtsvg,
   xorg,
 }:
 
@@ -24,16 +20,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    libsForQt5.qmake
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     dtkwidget
-    qtsvg
+    libsForQt5.qtsvg
     xorg.libXtst
   ];
 

--- a/pkgs/desktops/deepin/apps/deepin-reader/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-reader/default.nix
@@ -2,16 +2,12 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
   dde-qt-dbus-factory,
-  qtwebengine,
-  karchive,
   poppler,
   libchardet,
   libspectre,
@@ -42,10 +38,10 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    qmake
+    libsForQt5.qmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -53,8 +49,8 @@ stdenv.mkDerivation rec {
     qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
-    qtwebengine
-    karchive
+    libsForQt5.qtwebengine
+    libsForQt5.karchive
     poppler
     libchardet
     libspectre

--- a/pkgs/desktops/deepin/apps/deepin-screen-recorder/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-screen-recorder/default.nix
@@ -2,16 +2,11 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   dde-qt-dbus-factory,
-  qtbase,
-  qtmultimedia,
-  qtx11extras,
   image-editor,
   gsettings-qt,
   xorg,
@@ -20,7 +15,7 @@
   ffmpeg,
   ffmpegthumbnailer,
   portaudio,
-  kwayland,
+  dwayland,
   udev,
   gst_all_1,
 }:
@@ -50,19 +45,20 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    qmake
+    libsForQt5.qmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs =
     [
       dtkwidget
       dde-qt-dbus-factory
-      qtbase
-      qtmultimedia
-      qtx11extras
+      qt5integration
+      libsForQt5.qtbase
+      libsForQt5.qtmultimedia
+      libsForQt5.qtx11extras
       image-editor
       gsettings-qt
       xorg.libXdmcp
@@ -73,7 +69,7 @@ stdenv.mkDerivation rec {
       ffmpeg
       ffmpegthumbnailer
       portaudio
-      kwayland
+      dwayland
       udev
     ]
     ++ (with gst_all_1; [
@@ -82,9 +78,7 @@ stdenv.mkDerivation rec {
       gst-plugins-good
     ]);
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
   qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
     "--prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath [
         udev
@@ -106,5 +100,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = lib.teams.deepin.members;
+    broken = true;
   };
 }

--- a/pkgs/desktops/deepin/apps/deepin-screensaver/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-screensaver/default.nix
@@ -2,13 +2,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
-  qtbase,
-  qtx11extras,
-  qtdeclarative,
+  libsForQt5,
   dtkwidget,
   dde-qt-dbus-factory,
   xorg,
@@ -39,16 +34,16 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    libsForQt5.qmake
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
-    qtx11extras
-    qtdeclarative
+    libsForQt5.qtbase
+    libsForQt5.qtx11extras
+    libsForQt5.qtdeclarative
     dtkwidget
     dde-qt-dbus-factory
     xorg.libXScrnSaver

--- a/pkgs/desktops/deepin/apps/deepin-shortcut-viewer/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-shortcut-viewer/default.nix
@@ -5,11 +5,8 @@
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
-  qmake,
-  qtbase,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,14 +21,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    libsForQt5.qmake
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     dtkwidget
     qt5integration
     qt5platform-plugins

--- a/pkgs/desktops/deepin/apps/deepin-system-monitor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-system-monitor/default.nix
@@ -4,19 +4,14 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
   deepin-gettext-tools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
-  qtbase,
-  qtsvg,
-  qtx11extras,
   dde-qt-dbus-factory,
   dde-tray-loader,
   gsettings-qt,
-  polkit-qt,
   procps,
   libpcap,
   libnl,
@@ -60,22 +55,22 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
+    libsForQt5.qttools
     deepin-gettext-tools
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     dtkwidget
     qt5integration
     qt5platform-plugins
-    qtbase
-    qtsvg
-    qtx11extras
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
+    libsForQt5.qtx11extras
     dde-qt-dbus-factory
     dde-tray-loader
     gsettings-qt
-    polkit-qt
+    libsForQt5.polkit-qt
     procps
     libpcap
     libnl

--- a/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
@@ -7,12 +7,8 @@
   qt5integration,
   qt5platform-plugins,
   cmake,
-  qtbase,
-  qtsvg,
-  qttools,
-  qtx11extras,
+  libsForQt5,
   pkg-config,
-  wrapQtAppsHook,
   libsecret,
   chrpath,
   lxqt,
@@ -33,19 +29,19 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
     lxqt.lxqt-build-tools_0_13
   ];
 
   buildInputs = [
     qt5integration
     qt5platform-plugins
-    qtbase
-    qtsvg
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     dtkwidget
-    qtx11extras
+    libsForQt5.qtx11extras
     libsecret
     chrpath
   ];

--- a/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-voice-note/default.nix
@@ -4,17 +4,12 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
-  qtbase,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
-  qtsvg,
   dde-qt-dbus-factory,
   deepin-movie-reborn,
-  qtmultimedia,
-  qtwebengine,
   libvlc,
   gst_all_1,
   gtest,
@@ -43,20 +38,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs =
     [
-      qtbase
-      qtsvg
+      libsForQt5.qtbase
+      libsForQt5.qtsvg
       dtkwidget
+      qt5integration
       qt5platform-plugins
       dde-qt-dbus-factory
       deepin-movie-reborn
-      qtmultimedia
-      qtwebengine
+      libsForQt5.qtmultimedia
+      libsForQt5.qtwebengine
       libvlc
       gtest
     ]
@@ -69,9 +65,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
   qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
     "--prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath [
         gst_all_1.gstreamer

--- a/pkgs/desktops/deepin/artwork/deepin-desktop-theme/default.nix
+++ b/pkgs/desktops/deepin/artwork/deepin-desktop-theme/default.nix
@@ -6,7 +6,7 @@
   gtk3,
   xcursorgen,
   papirus-icon-theme,
-  breeze-icons,
+  libsForQt5,
   hicolor-icon-theme,
   deepin-icon-theme,
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    breeze-icons
+    libsForQt5.breeze-icons
     papirus-icon-theme
     hicolor-icon-theme
     deepin-icon-theme

--- a/pkgs/desktops/deepin/core/dde-app-services/default.nix
+++ b/pkgs/desktops/deepin/core/dde-app-services/default.nix
@@ -6,9 +6,7 @@
   qt5integration,
   qt5platform-plugins,
   cmake,
-  wrapQtAppsHook,
-  qtbase,
-  qttools,
+  libsForQt5,
   doxygen,
 }:
 
@@ -39,9 +37,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     doxygen
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -53,13 +51,13 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DDVERSION=${version}"
     "-DDSG_DATA_DIR=/run/current-system/sw/share/dsg"
-    "-DQCH_INSTALL_DESTINATION=${placeholder "out"}/${qtbase.qtDocPrefix}"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "out"}/${libsForQt5.qtbase.qtDocPrefix}"
   ];
 
   preConfigure = ''
     # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
     # A workaround is to set QT_PLUGIN_PATH explicitly
-    export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
+    export QT_PLUGIN_PATH=${libsForQt5.qtbase.bin}/${libsForQt5.qtbase.qtPluginPrefix}
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/deepin/core/dde-appearance/default.nix
+++ b/pkgs/desktops/deepin/core/dde-appearance/default.nix
@@ -4,13 +4,10 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkgui,
   gsettings-qt,
   gtk3,
-  kconfig,
-  kwindowsystem,
-  kglobalaccel,
   xorg,
   iconv,
 }:
@@ -50,16 +47,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     dtkgui
     gsettings-qt
     gtk3
-    kconfig
-    kwindowsystem
-    kglobalaccel
+    libsForQt5.kconfig
+    libsForQt5.kwindowsystem
+    libsForQt5.kglobalaccel
     xorg.libXcursor
     xorg.xcbutilcursor
   ];

--- a/pkgs/desktops/deepin/core/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/core/dde-calendar/default.nix
@@ -3,15 +3,12 @@
   lib,
   fetchFromGitHub,
   cmake,
-  qttools,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
   dde-qt-dbus-factory,
-  qtbase,
-  qtsvg,
   libical,
   sqlite,
   runtimeShell,
@@ -38,17 +35,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     qt5integration
     qt5platform-plugins
     dtkwidget
-    qtbase
-    qtsvg
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     dde-qt-dbus-factory
     libical
     sqlite

--- a/pkgs/desktops/deepin/core/dde-clipboard/default.nix
+++ b/pkgs/desktops/deepin/core/dde-clipboard/default.nix
@@ -6,12 +6,10 @@
   gio-qt,
   cmake,
   extra-cmake-modules,
-  qttools,
+  libsForQt5,
   wayland,
-  kwayland,
   dwayland,
   pkg-config,
-  wrapQtAppsHook,
   glibmm,
   gtest,
 }:
@@ -31,15 +29,14 @@ stdenv.mkDerivation rec {
     cmake
     extra-cmake-modules
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     dtkwidget
     gio-qt
     wayland
-    kwayland
     dwayland
     glibmm
     gtest

--- a/pkgs/desktops/deepin/core/dde-file-manager/default.nix
+++ b/pkgs/desktops/deepin/core/dde-file-manager/default.nix
@@ -11,10 +11,7 @@
   docparser,
   dde-tray-loader,
   cmake,
-  qttools,
-  qtx11extras,
-  qtmultimedia,
-  kcodecs,
+  libsForQt5,
   pkg-config,
   ffmpegthumbnailer,
   libsecret,
@@ -22,16 +19,13 @@
   mediainfo,
   libzen,
   poppler,
-  polkit-qt,
   polkit,
-  wrapQtAppsHook,
   wrapGAppsHook3,
   lucenepp,
   boost,
   taglib,
   cryptsetup,
   glib,
-  qtbase,
   util-dfm,
   deepin-pdfium,
   libuuid,
@@ -56,9 +50,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
     wrapGAppsHook3
   ];
   dontWrapGApps = true;
@@ -109,6 +103,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     deepin-pdfium
     util-dfm
@@ -116,15 +111,15 @@ stdenv.mkDerivation rec {
     glibmm
     docparser
     dde-tray-loader
-    qtx11extras
-    qtmultimedia
-    kcodecs
+    libsForQt5.qtx11extras
+    libsForQt5.qtmultimedia
+    libsForQt5.kcodecs
     ffmpegthumbnailer
     libsecret
     libmediainfo
     mediainfo
     poppler
-    polkit-qt
+    libsForQt5.polkit-qt
     polkit
     lucenepp
     boost
@@ -145,9 +140,6 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [ "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}" ];
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")

--- a/pkgs/desktops/deepin/core/dde-grand-search/default.nix
+++ b/pkgs/desktops/deepin/core/dde-grand-search/default.nix
@@ -3,9 +3,8 @@
   lib,
   fetchFromGitHub,
   cmake,
-  qttools,
+  libsForQt5,
   pkg-config,
-  wrapQtAppsHook,
   dtkwidget,
   dde-qt-dbus-factory,
   dde-tray-loader,
@@ -33,9 +32,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/core/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/core/dde-polkit-agent/default.nix
@@ -8,10 +8,7 @@
   dde-qt-dbus-factory,
   pkg-config,
   cmake,
-  qttools,
-  wrapQtAppsHook,
-  polkit-qt,
-  qtbase,
+  libsForQt5,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,19 +25,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     dtkwidget
+    qt5integration
     qt5platform-plugins
     dde-qt-dbus-factory
-    polkit-qt
+    libsForQt5.polkit-qt
   ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [ "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}" ];
 
   postFixup = ''
     wrapQtApp $out/lib/polkit-1-dde/dde-polkit-agent

--- a/pkgs/desktops/deepin/core/dde-session-shell/default.nix
+++ b/pkgs/desktops/deepin/core/dde-session-shell/default.nix
@@ -5,17 +5,14 @@
   linkFarm,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   wrapGAppsHook3,
-  qtbase,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
   deepin-pw-check,
   gsettings-qt,
   lightdm_qt,
-  qtx11extras,
   linux-pam,
   xorg,
   gtest,
@@ -64,20 +61,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
     wrapGAppsHook3
   ];
   dontWrapGApps = true;
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     dtkwidget
+    qt5integration
     qt5platform-plugins
     deepin-pw-check
     gsettings-qt
     lightdm_qt
-    qtx11extras
+    libsForQt5.qtx11extras
     linux-pam
     xorg.libXcursor
     xorg.libXtst
@@ -90,9 +88,6 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
   ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [ "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}" ];
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")

--- a/pkgs/desktops/deepin/core/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/core/dde-session-ui/default.nix
@@ -4,15 +4,12 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
-  qtbase,
+  libsForQt5,
   dtkwidget,
   qt5integration,
   qt5platform-plugins,
   dde-tray-loader,
   gsettings-qt,
-  qtx11extras,
   gtest,
 }:
 
@@ -42,28 +39,22 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     dtkwidget
     qt5platform-plugins
+    qt5integration
     dde-tray-loader
     gsettings-qt
-    qtx11extras
+    libsForQt5.qtx11extras
     gtest
   ];
 
   cmakeFlags = [ "-DDISABLE_SYS_UPDATE=ON" ];
-
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [ "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}" ];
-
-  preFixup = ''
-    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
 
   postFixup = ''
     for binary in $out/lib/deepin-daemon/*; do

--- a/pkgs/desktops/deepin/core/dde-session/default.nix
+++ b/pkgs/desktops/deepin/core/dde-session/default.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
-  qtbase,
+  libsForQt5,
   dtkcore,
   gsettings-qt,
   libsecret,
@@ -48,11 +47,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     dtkcore
     gsettings-qt
     libsecret

--- a/pkgs/desktops/deepin/core/dde-shell/default.nix
+++ b/pkgs/desktops/deepin/core/dde-shell/default.nix
@@ -5,7 +5,6 @@
   cmake,
   extra-cmake-modules,
   pkg-config,
-  wrapQtAppsHook,
   wayland-scanner,
   dtk6declarative,
   dtk6widget,

--- a/pkgs/desktops/deepin/core/dde-widgets/default.nix
+++ b/pkgs/desktops/deepin/core/dde-widgets/default.nix
@@ -5,10 +5,8 @@
   cmake,
   pkg-config,
   dde-qt-dbus-factory,
-  wrapQtAppsHook,
-  qtbase,
-  qtx11extras,
   dtkwidget,
+  libsForQt5,
   qt5integration,
   gtest,
 }:
@@ -28,12 +26,12 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     dde-qt-dbus-factory
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
-    qtx11extras
+    libsForQt5.qtbase
+    libsForQt5.qtx11extras
     dtkwidget
     qt5integration
     gtest

--- a/pkgs/desktops/deepin/core/deepin-kwin/default.nix
+++ b/pkgs/desktops/deepin/core/deepin-kwin/default.nix
@@ -6,29 +6,10 @@
   pkg-config,
   wayland,
   dwayland,
-  qtbase,
-  qttools,
-  qtx11extras,
-  wrapQtAppsHook,
+  libsForQt5,
   extra-cmake-modules,
   gsettings-qt,
   libepoxy,
-  kconfig,
-  kconfigwidgets,
-  kcoreaddons,
-  kcrash,
-  kdbusaddons,
-  kiconthemes,
-  kglobalaccel,
-  kidletime,
-  knotifications,
-  kpackage,
-  plasma-framework,
-  kcmutils,
-  knewstuff,
-  kdecoration,
-  kscreenlocker,
-  breeze-qt5,
   libinput,
   mesa,
   lcms2,
@@ -58,47 +39,48 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     extra-cmake-modules
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qttools
   ];
 
-  buildInputs = [
-    qtbase
-    qttools
-    qtx11extras
-    wayland
-    dwayland
-    libepoxy
-    gsettings-qt
+  buildInputs =
+    [
+      wayland
+      dwayland
+      libepoxy
+      gsettings-qt
 
-    kconfig
-    kconfigwidgets
-    kcoreaddons
-    kcrash
-    kdbusaddons
-    kiconthemes
+      libinput
+      mesa
+      lcms2
 
-    kglobalaccel
-    kidletime
-    knotifications
-    kpackage
-    plasma-framework
-    kcmutils
-    knewstuff
-    kdecoration
-    kscreenlocker
-
-    breeze-qt5
-    libinput
-    mesa
-    lcms2
-
-    xorg.libxcb
-    xorg.libXdmcp
-    xorg.libXcursor
-    xorg.xcbutilcursor
-    xorg.libXtst
-    xorg.libXScrnSaver
-  ];
+      xorg.libxcb
+      xorg.libXdmcp
+      xorg.libXcursor
+      xorg.xcbutilcursor
+      xorg.libXtst
+      xorg.libXScrnSaver
+    ]
+    ++ (with libsForQt5; [
+      qtbase
+      qtx11extras
+      kconfig
+      kconfigwidgets
+      kcoreaddons
+      kcrash
+      kdbusaddons
+      kiconthemes
+      kglobalaccel
+      kidletime
+      knotifications
+      kpackage
+      plasma-framework
+      kcmutils
+      knewstuff
+      kdecoration
+      kscreenlocker
+      breeze-qt5
+    ]);
 
   cmakeFlags = [ "-DKWIN_BUILD_RUNNERS=OFF" ];
 
@@ -107,11 +89,11 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Fork of kwin, an easy to use, but flexible, composited Window Manager";
     homepage = "https://github.com/linuxdeepin/deepin-kwin";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    maintainers = teams.deepin.members;
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
   };
 }

--- a/pkgs/desktops/deepin/core/deepin-service-manager/default.nix
+++ b/pkgs/desktops/deepin/core/deepin-service-manager/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/deepin/core/dpa-ext-gnomekeyring/default.nix
+++ b/pkgs/desktops/deepin/core/dpa-ext-gnomekeyring/default.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
   dde-polkit-agent,
   qt5integration,
@@ -31,8 +30,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   config,
-  libsForQt5,
+  pkgs,
 }:
 let
   packages =
@@ -117,4 +117,4 @@ let
       go-dbus-factory = throw "Then 'deepin.go-dbus-factory' package was removed, use 'go mod' to manage it"; # added 2024-05-31
     };
 in
-lib.makeScope libsForQt5.newScope packages
+lib.makeScope pkgs.newScope packages

--- a/pkgs/desktops/deepin/go-package/dde-api/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-api/default.nix
@@ -4,7 +4,6 @@
   buildGoModule,
   pkg-config,
   deepin-gettext-tools,
-  wrapQtAppsHook,
   wrapGAppsHook3,
   alsa-lib,
   gtk3,
@@ -56,10 +55,8 @@ buildGoModule rec {
   nativeBuildInputs = [
     pkg-config
     deepin-gettext-tools
-    wrapQtAppsHook
     wrapGAppsHook3
   ];
-  dontWrapGApps = true;
 
   buildInputs = [
     alsa-lib
@@ -86,13 +83,9 @@ buildGoModule rec {
     runHook postInstall
   '';
 
-  preFixup = ''
-    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
-
   postFixup = ''
     for binary in $out/lib/deepin-api/*; do
-      wrapProgram $binary "''${qtWrapperArgs[@]}"
+      wrapProgram $binary "''${gappsWrapperArgs[@]}"
     done
   '';
 

--- a/pkgs/desktops/deepin/library/deepin-ocr-plugin-manager/default.nix
+++ b/pkgs/desktops/deepin/library/deepin-ocr-plugin-manager/default.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   cmake,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   ncnn,
   opencv,
   vulkan-headers,
@@ -32,9 +31,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    qttools
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/library/deepin-pdfium/default.nix
+++ b/pkgs/desktops/deepin/library/deepin-pdfium/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
+  libsForQt5,
   pkg-config,
   libchardet,
   lcms2,
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
+    libsForQt5.qmake
     pkg-config
   ];
 

--- a/pkgs/desktops/deepin/library/disomaster/default.nix
+++ b/pkgs/desktops/deepin/library/disomaster/default.nix
@@ -3,9 +3,7 @@
   lib,
   fetchFromGitHub,
   pkg-config,
-  qmake,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   libisoburn,
 }:
 
@@ -21,10 +19,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    libsForQt5.qmake
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [ libisoburn ];

--- a/pkgs/desktops/deepin/library/docparser/default.nix
+++ b/pkgs/desktops/deepin/library/docparser/default.nix
@@ -3,9 +3,7 @@
   lib,
   fetchFromGitHub,
   pkg-config,
-  qmake,
-  qttools,
-  wrapQtAppsHook,
+  libsForQt5,
   poppler,
   pugixml,
   libzip,
@@ -25,10 +23,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    libsForQt5.qmake
+    libsForQt5.qttools
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/library/dwayland/default.nix
+++ b/pkgs/desktops/deepin/library/dwayland/default.nix
@@ -3,14 +3,12 @@
   lib,
   fetchFromGitHub,
   cmake,
-  qtbase,
-  qtwayland,
+  libsForQt5,
   wayland,
   wayland-protocols,
   wayland-scanner,
   extra-cmake-modules,
   deepin-wayland-protocols,
-  qttools,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,13 +25,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    qttools
+    libsForQt5.qttools
     wayland-scanner
   ];
 
   buildInputs = [
-    qtbase
-    qtwayland
+    libsForQt5.qtbase
+    libsForQt5.qtwayland
     wayland
     wayland-protocols
     deepin-wayland-protocols

--- a/pkgs/desktops/deepin/library/gio-qt/default.nix
+++ b/pkgs/desktops/deepin/library/gio-qt/default.nix
@@ -4,11 +4,9 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   glibmm,
   doxygen,
-  qttools,
-  qtbase,
   buildDocs ? true,
 }:
 
@@ -34,11 +32,11 @@ stdenv.mkDerivation rec {
     [
       cmake
       pkg-config
-      wrapQtAppsHook
+      libsForQt5.wrapQtAppsHook
     ]
     ++ lib.optionals buildDocs [
       doxygen
-      qttools.dev
+      libsForQt5.qttools
     ];
 
   cmakeFlags = [
@@ -51,7 +49,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
     # A workaround is to set QT_PLUGIN_PATH explicitly
-    export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
+    export QT_PLUGIN_PATH=${libsForQt5.qtbase.bin}/${libsForQt5.qtbase.qtPluginPrefix}
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/deepin/library/image-editor/default.nix
+++ b/pkgs/desktops/deepin/library/image-editor/default.nix
@@ -4,9 +4,8 @@
   fetchFromGitHub,
   dtkwidget,
   cmake,
-  qttools,
+  libsForQt5,
   pkg-config,
-  wrapQtAppsHook,
   opencv,
   freeimage,
   libmediainfo,
@@ -33,8 +32,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/library/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/library/udisks2-qt5/default.nix
@@ -2,9 +2,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
+  libsForQt5,
   pkg-config,
-  wrapQtAppsHook,
   udisks,
 }:
 
@@ -20,9 +19,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
+    libsForQt5.qmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [ udisks ];

--- a/pkgs/desktops/deepin/library/util-dfm/default.nix
+++ b/pkgs/desktops/deepin/library/util-dfm/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qtbase,
+  libsForQt5,
   libmediainfo,
   libsecret,
   libisoburn,
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   buildInputs = [
-    qtbase
+    libsForQt5.qtbase
     libmediainfo
     libsecret
     libuuid

--- a/pkgs/desktops/deepin/misc/deepin-turbo/default.nix
+++ b/pkgs/desktops/deepin/misc/deepin-turbo/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   dtkwidget,
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [ dtkwidget ];

--- a/pkgs/desktops/deepin/tools/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/tools/deepin-anything/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
+  libsForQt5,
   udisks2-qt5,
   util-linux,
   libnl,
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
The deepin desktop environment requires both qt5 and qt6, deepin scope should not inherit from qt5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
