### PR TITLE
netbird: rework server and include new component

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -116,6 +116,9 @@
   "module-services-dump1090-fa-configuration": [
     "index.html#module-services-dump1090-fa-configuration"
   ],
+  "module-services-netbird-server-proxy": [
+    "index.html#module-services-netbird-server-proxy"
+  ],
   "preface": [
     "index.html#preface"
   ],

--- a/nixos/modules/services/networking/netbird/dashboard.nix
+++ b/nixos/modules/services/networking/netbird/dashboard.nix
@@ -39,7 +39,7 @@ in
 
     package = mkPackageOption pkgs "netbird-dashboard" { };
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy to serve the dashboard";
+    enableNginx = mkEnableOption "Nginx to serve the dashboard";
 
     domain = mkOption {
       type = str;

--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -61,7 +61,6 @@ let
 
     Signal = {
       Proto = "https";
-      URI = "${cfg.domain}:443";
       Username = "";
       Password = null;
     };
@@ -220,95 +219,92 @@ in
       inherit (settingsFormat) type;
 
       defaultText = literalExpression ''
-        defaultSettings = {
-          Stuns = [
+        Stuns = [
+          {
+            Proto = "udp";
+            URI = "stun:''${cfg.turnDomain}:3478";
+            Username = "";
+            Password = null;
+          }
+        ];
+
+        TURNConfig = {
+          Turns = [
             {
               Proto = "udp";
-              URI = "stun:''${cfg.turnDomain}:3478";
-              Username = "";
-              Password = null;
+              URI = "turn:''${cfg.turnDomain}:3478";
+              Username = "netbird";
+              Password = "netbird";
             }
           ];
 
-          TURNConfig = {
-            Turns = [
-              {
-                Proto = "udp";
-                URI = "turn:''${cfg.turnDomain}:3478";
-                Username = "netbird";
-                Password = "netbird";
-              }
-            ];
+          CredentialsTTL = "12h";
+          Secret = "not-secure-secret";
+          TimeBasedCredentials = false;
+        };
 
-            CredentialsTTL = "12h";
-            Secret = "not-secure-secret";
-            TimeBasedCredentials = false;
+        Signal = {
+          Proto = "https";
+          Username = "";
+          Password = null;
+        };
+
+        ReverseProxy = {
+          TrustedHTTPProxies = [ ];
+          TrustedHTTPProxiesCount = 0;
+          TrustedPeers = [ "0.0.0.0/0" ];
+        };
+
+        Datadir = "${stateDir}/data";
+        DataStoreEncryptionKey = "genEVP6j/Yp2EeVujm0zgqXrRos29dQkpvX0hHdEUlQ=";
+        StoreConfig = { Engine = "sqlite"; };
+
+        HttpConfig = {
+          Address = "127.0.0.1:''${builtins.toString cfg.port}";
+          IdpSignKeyRefreshEnabled = true;
+          OIDCConfigEndpoint = cfg.oidcConfigEndpoint;
+        };
+
+        IdpManagerConfig = {
+          ManagerType = "none";
+          ClientConfig = {
+            Issuer = "";
+            TokenEndpoint = "";
+            ClientID = "netbird";
+            ClientSecret = "";
+            GrantType = "client_credentials";
           };
 
-          Signal = {
-            Proto = "https";
-            URI = "''${cfg.domain}:443";
-            Username = "";
-            Password = null;
+          ExtraConfig = { };
+          Auth0ClientCredentials = null;
+          AzureClientCredentials = null;
+          KeycloakClientCredentials = null;
+          ZitadelClientCredentials = null;
+        };
+
+        DeviceAuthorizationFlow = {
+          Provider = "none";
+          ProviderConfig = {
+            Audience = "netbird";
+            Domain = null;
+            ClientID = "netbird";
+            TokenEndpoint = null;
+            DeviceAuthEndpoint = "";
+            Scope = "openid profile email offline_access api";
+            UseIDToken = false;
           };
+        };
 
-          ReverseProxy = {
-            TrustedHTTPProxies = [ ];
-            TrustedHTTPProxiesCount = 0;
-            TrustedPeers = [ "0.0.0.0/0" ];
-          };
-
-          Datadir = "''${stateDir}/data";
-          DataStoreEncryptionKey = "genEVP6j/Yp2EeVujm0zgqXrRos29dQkpvX0hHdEUlQ=";
-          StoreConfig = { Engine = "sqlite"; };
-
-          HttpConfig = {
-            Address = "127.0.0.1:''${builtins.toString cfg.port}";
-            IdpSignKeyRefreshEnabled = true;
-            OIDCConfigEndpoint = cfg.oidcConfigEndpoint;
-          };
-
-          IdpManagerConfig = {
-            ManagerType = "none";
-            ClientConfig = {
-              Issuer = "";
-              TokenEndpoint = "";
-              ClientID = "netbird";
-              ClientSecret = "";
-              GrantType = "client_credentials";
-            };
-
-            ExtraConfig = { };
-            Auth0ClientCredentials = null;
-            AzureClientCredentials = null;
-            KeycloakClientCredentials = null;
-            ZitadelClientCredentials = null;
-          };
-
-          DeviceAuthorizationFlow = {
-            Provider = "none";
-            ProviderConfig = {
-              Audience = "netbird";
-              Domain = null;
-              ClientID = "netbird";
-              TokenEndpoint = null;
-              DeviceAuthEndpoint = "";
-              Scope = "openid profile email offline_access api";
-              UseIDToken = false;
-            };
-          };
-
-          PKCEAuthorizationFlow = {
-            ProviderConfig = {
-              Audience = "netbird";
-              ClientID = "netbird";
-              ClientSecret = "";
-              AuthorizationEndpoint = "";
-              TokenEndpoint = "";
-              Scope = "openid profile email offline_access api";
-              RedirectURLs = "http://localhost:53000";
-              UseIDToken = false;
-            };
+        PKCEAuthorizationFlow = {
+          ProviderConfig = {
+            Audience = "netbird";
+            ClientID = "netbird";
+            ClientSecret = "";
+            AuthorizationEndpoint = "";
+            TokenEndpoint = "";
+            Scope = "openid profile email offline_access api";
+            RedirectURLs = "http://localhost:53000";
+            UseIDToken = false;
           };
         };
       '';
@@ -340,8 +336,6 @@ in
       default = "INFO";
       description = "Log level of the netbird services.";
     };
-
-    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird management service";
   };
 
   config = mkIf cfg.enable {
@@ -452,27 +446,5 @@ in
       stopIfChanged = false;
     };
 
-    services.nginx = mkIf cfg.enableNginx {
-      enable = true;
-
-      virtualHosts.${cfg.domain} = {
-        locations = {
-          "/api".proxyPass = "http://localhost:${builtins.toString cfg.port}";
-
-          "/management.ManagementService/".extraConfig = ''
-            # This is necessary so that grpc connections do not get closed early
-            # see https://stackoverflow.com/a/67805465
-            client_body_timeout 1d;
-
-            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            grpc_pass grpc://localhost:${builtins.toString cfg.port};
-            grpc_read_timeout 1d;
-            grpc_send_timeout 1d;
-            grpc_socket_keepalive on;
-          '';
-        };
-      };
-    };
   };
 }

--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -58,6 +58,9 @@ let
       Secret = "not-secure-secret";
       TimeBasedCredentials = false;
     };
+    Relay = {
+      CredentialsTTL = "24h";
+    };
 
     Signal = {
       Proto = "https";

--- a/nixos/modules/services/networking/netbird/proxy.nix
+++ b/nixos/modules/services/networking/netbird/proxy.nix
@@ -1,0 +1,94 @@
+{ lib, config, ... }:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkDefault
+    ;
+  inherit (lib.types) str nullOr;
+  cfg = config.services.netbird.server.proxy;
+in
+{
+  options.services.netbird.server.proxy = {
+
+    enableNginx = mkEnableOption "the nginx reverse proxy as a complete, singular frontend for the server components of the Netbird overlay network";
+
+    signalAddress = mkOption {
+      type = str;
+      description = "Address to reach the signal service.";
+      example = "1.2.3.4:1764";
+    };
+
+    managementAddress = mkOption {
+      type = str;
+      description = "Address to reach the management api.";
+      example = "1.2.3.4:1766";
+    };
+
+    dashboardAddress = mkOption {
+      type = nullOr str;
+      default = null;
+      description = ''
+        Address to reach the dashboard.
+        If set to null, the default, it will not forward the dashboard,
+        use this if you want to host the proxy on the same host as the dasboard.
+      '';
+      example = "1.2.3.4:1767";
+    };
+
+    domain = mkOption {
+      type = str;
+      description = "Domain that hosts the proxy";
+      example = "netbird.selfhosted";
+    };
+  };
+  config = {
+    services.nginx = mkIf cfg.enableNginx {
+      enable = true;
+
+      virtualHosts.${cfg.domain} = {
+        forceSSL = mkDefault true;
+        extraConfig = ''
+          proxy_set_header        X-Real-IP $remote_addr;
+          proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header        X-Scheme $scheme;
+          proxy_set_header        X-Forwarded-Proto https;
+          proxy_set_header        X-Forwarded-Host $host;
+          grpc_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
+        '';
+        locations = {
+          "/" = mkIf (cfg.dashboardAddress != null) {
+            proxyPass = "http://${cfg.dashboardAddress}";
+            proxyWebsockets = true;
+          };
+          "/api".proxyPass = "http://${cfg.managementAddress}";
+
+          "/management.ManagementService/".extraConfig = ''
+            # This is necessary so that grpc connections do not get closed early
+            # see https://stackoverflow.com/a/67805465
+            client_body_timeout 1d;
+
+            grpc_pass grpc://${cfg.managementAddress};
+            grpc_read_timeout 1d;
+            grpc_send_timeout 1d;
+            grpc_socket_keepalive on;
+          '';
+        };
+        locations."/signalexchange.SignalExchange/".extraConfig = ''
+          # This is necessary so that grpc connections do not get closed early
+          # see https://stackoverflow.com/a/67805465
+          client_body_timeout 1d;
+
+          grpc_pass grpc://${cfg.signalAddress};
+          grpc_read_timeout 1d;
+          grpc_send_timeout 1d;
+          grpc_socket_keepalive on;
+        '';
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    patrickdag
+  ];
+}

--- a/nixos/modules/services/networking/netbird/relay.nix
+++ b/nixos/modules/services/networking/netbird/relay.nix
@@ -1,0 +1,123 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe'
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    mkOption
+    mkDefault
+    ;
+
+  inherit (lib.types)
+    port
+    str
+    attrsOf
+    bool
+    either
+    submodule
+    path
+    ;
+
+  cfg = config.services.netbird.server.relay;
+in
+
+{
+  options.services.netbird.server.relay = {
+    enable = mkEnableOption "Netbird's Relay Service";
+
+    package = mkPackageOption pkgs "netbird-relay" { };
+
+    port = mkOption {
+      type = port;
+      default = 33080;
+      description = "Internal port of the relay server.";
+    };
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = attrsOf (either str bool);
+        options.NB_EXPOSED_ADDRESS = mkOption {
+          type = str;
+          description = ''
+            The public address of this peer, to be distribute as part of relay operations.
+          '';
+        };
+      };
+
+      defaultText = ''
+        {
+          NB_LISTEN_ADDRESS = ":''${builtins.toString cfg.port}";
+          NB_METRICS_PORT = "9092";
+        }
+      '';
+
+      description = ''
+        An attribute set that will be set as the environment for the process.
+        Used for runtime configuration.
+        The exact values sadly aren't documented anywhere.
+        A starting point when searching for valid values is this [source file](https://github.com/netbirdio/netbird/blob/main/relay/cmd/root.go).
+      '';
+    };
+
+    authSecretFile = mkOption {
+      type = path;
+      description = ''
+        The path to a file containing the auth-secret used by netbird to connect to the relay server.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    services.netbird.server.relay.settings = {
+      NB_LISTEN_ADDRESS = mkDefault ":${builtins.toString cfg.port}";
+      NB_METRICS_PORT = mkDefault "9092"; # Upstream default is 9090 but this would clash for nixos where all services run on the same host
+    };
+    systemd.services.netbird-relay = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+
+      script = ''
+        export NB_AUTH_SECRET="$(<${cfg.authSecretFile})"
+        ${getExe' cfg.package "netbird-relay"}
+      '';
+      serviceConfig = {
+
+        Restart = "always";
+        RuntimeDirectory = "netbird-mgmt";
+        StateDirectory = "netbird-mgmt";
+        WorkingDirectory = "/var/lib/netbird-mgmt";
+
+        # hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = true;
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+
+      stopIfChanged = false;
+    };
+  };
+}

--- a/nixos/modules/services/networking/netbird/server.md
+++ b/nixos/modules/services/networking/netbird/server.md
@@ -4,41 +4,62 @@ NetBird is a VPN built on top of WireGuard® making it easy to create secure pri
 
 ## Quickstart {#module-services-netbird-server-quickstart}
 
-To fully setup Netbird as a self-hosted server, we need both a Coturn server and an identity provider, the list of supported SSOs and their setup are available [on Netbird's documentation](https://docs.netbird.io/selfhosted/selfhosted-guide#step-3-configure-identity-provider-idp).
+To fully setup Netbird as a self-hosted server, you need a Coturn or relay server, a netbird-signal server, an identity provider, and
+a netbird management instance.
+A list of supported SSOs and their setup are available [on Netbird's documentation](https://docs.netbird.io/selfhosted/selfhosted-guide#step-3-configure-identity-provider-idp).
 
-There are quite a few settings that need to be passed to Netbird for it to function, and a minimal config looks like :
+There are quite a few settings that need to be passed to Netbird for it to function, and a minimal config might look like :
+
+::: {.example}
+
+# Netbird minmal Configuration
 
 ```nix
 {
   services.netbird.server = {
-    enable = true;
-
+    # Publicly exposed domain
     domain = "netbird.example.selfhosted";
 
-    enableNginx = true;
-
-    coturn = {
-      enable = true;
-
-      passwordFile = "/path/to/a/secret/password";
+    # website for administration
+    dashboard = {
+      enableNginx = true;
+      settings.AUTH_AUTHORITY = "https://sso.example.selfhosted/oauth2/openid/netbird";
     };
 
+    # Netbirds own relay implementation
+    relay.authSecretFile = pkgs.writeText "secret-file" "very secure secret";
+
+    # Relay using coturn
+    coturn = {
+      enable = true;
+      passwordFile = pkgs.writeText "password-file" "very secure password";
+    };
+
+    # Backend management api
     management = {
       oidcConfigEndpoint = "https://sso.example.selfhosted/oauth2/openid/netbird/.well-known/openid-configuration";
-
-      settings = {
-        TURNConfig = {
-          Turns = [
-            {
-              Proto = "udp";
-              URI = "turn:netbird.example.selfhosted:3478";
-              Username = "netbird";
-              Password._secret = "/path/to/a/secret/password";
-            }
-          ];
-        };
-      };
+      settings.Signal.URI = "publicly reachable signal endpoint";
+      DataStoreEncryptionKey._secret = pkgs.writeText "encryption-key" "another very secure secret";
     };
   };
 }
 ```
+
+:::
+
+## Proxy {#module-services-netbird-server-proxy}
+
+The proxy module sets up a unified nginx proxy in front of your netbird instance.
+
+::: {.warning}
+The proxy module is completely independent from netbird upstream.
+If you have any problems with it DO NOT open an issue in any `netbirdio` repositories. Instead open them in [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs/issues) and ping the proxy maintainers.
+:::
+
+The proxy assumes being hosted over https.
+
+When using the proxy remember to set all public address options to use the proxy host instead of the instance itself. These include:
+
+- {option}`server.domain`
+- {option}`management.settings.Signal.URI`
+- {option}`relay.setting.NB_EXPOSED_ADDRESS`

--- a/nixos/modules/services/networking/netbird/server.md
+++ b/nixos/modules/services/networking/netbird/server.md
@@ -15,8 +15,11 @@ There are quite a few settings that need to be passed to Netbird for it to funct
 # Netbird minmal Configuration
 
 ```nix
+{ pkgs, ... }:
 {
   services.netbird.server = {
+    enable = true;
+
     # Publicly exposed domain
     domain = "netbird.example.selfhosted";
 

--- a/nixos/modules/services/networking/netbird/server.nix
+++ b/nixos/modules/services/networking/netbird/server.nix
@@ -7,6 +7,7 @@ let
     mkIf
     mkOption
     optionalAttrs
+    mkMerge
     ;
 
   inherit (lib.types) str;
@@ -49,30 +50,32 @@ in
         managementServer = "https://${cfg.domain}";
       };
 
-      management = {
-        domain = mkDefault cfg.domain;
-        enable = mkDefault cfg.enable;
-        enableNginx = mkDefault cfg.enableNginx;
-      }
-      // (optionalAttrs cfg.coturn.enable rec {
-        turnDomain = cfg.domain;
-        turnPort = config.services.coturn.tls-listening-port;
-        # We cannot merge a list of attrsets so we have to redefine the whole list
-        settings = {
-          TURNConfig.Turns = mkDefault [
-            {
-              Proto = "udp";
-              URI = "turn:${turnDomain}:${builtins.toString turnPort}";
-              Username = "netbird";
-              Password =
-                if (cfg.coturn.password != null) then
-                  cfg.coturn.password
-                else
-                  { _secret = cfg.coturn.passwordFile; };
-            }
-          ];
-        };
-      });
+      management = mkMerge [
+        {
+          domain = mkDefault cfg.domain;
+          enable = mkDefault cfg.enable;
+          enableNginx = mkDefault cfg.enableNginx;
+        }
+        (mkIf cfg.coturn.enable rec {
+          turnDomain = cfg.domain;
+          turnPort = config.services.coturn.tls-listening-port;
+          # We cannot merge a list of attrsets so we have to redefine the whole list
+          settings = {
+            TURNConfig.Turns = mkDefault [
+              {
+                Proto = "udp";
+                URI = "turn:${turnDomain}:${builtins.toString turnPort}";
+                Username = "netbird";
+                Password =
+                  if (cfg.coturn.password != null) then
+                    cfg.coturn.password
+                  else
+                    { _secret = cfg.coturn.passwordFile; };
+              }
+            ];
+          };
+        })
+      ];
 
       signal = {
         domain = mkDefault cfg.domain;

--- a/nixos/modules/services/networking/netbird/signal.nix
+++ b/nixos/modules/services/networking/netbird/signal.nix
@@ -33,13 +33,6 @@ in
 
     package = mkPackageOption pkgs "netbird-signal" { };
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird signal service";
-
-    domain = mkOption {
-      type = str;
-      description = "The domain name for the signal service.";
-    };
-
     port = mkOption {
       type = port;
       default = 8012;
@@ -134,23 +127,5 @@ in
       stopIfChanged = false;
     };
 
-    services.nginx = mkIf cfg.enableNginx {
-      enable = true;
-
-      virtualHosts.${cfg.domain} = {
-        locations."/signalexchange.SignalExchange/".extraConfig = ''
-          # This is necessary so that grpc connections do not get closed early
-          # see https://stackoverflow.com/a/67805465
-          client_body_timeout 1d;
-
-          grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-          grpc_pass grpc://localhost:${builtins.toString cfg.port};
-          grpc_read_timeout 1d;
-          grpc_send_timeout 1d;
-          grpc_socket_keepalive on;
-        '';
-      };
-    };
   };
 }

--- a/nixos/tests/netbird.nix
+++ b/nixos/tests/netbird.nix
@@ -22,7 +22,7 @@ in
       services.kanidm = {
         # needed since default for nixos 24.11
         # is kanidm 1.4.6 which is insecure
-        package = pkgs.kanidm_1_5;
+        package = pkgs.kanidm_1_7;
         enableServer = true;
         serverSettings = {
           inherit tls_key tls_chain;
@@ -44,6 +44,7 @@ in
           domain = "nixos-test.internal";
           dashboard.settings.AUTH_AUTHORITY = "https://kanidm/oauth2/openid/netbird";
           management.oidcConfigEndpoint = "https://kanidm:8443/oauth2/openid/netbird/.well-known/openid-configuration";
+          relay.authSecretFile = (pkgs.writeText "secure-secret" "secret-value");
         };
       };
   };
@@ -127,6 +128,7 @@ in
     with subtest("server starting"):
       server.wait_for_unit("netbird-management.service")
       server.wait_for_unit("netbird-signal.service")
+      server.wait_for_unit("netbird-relay.service")
   ''
   # The status used to turn into `NeedsLogin`, but recently started crashing instead.
   # leaving the snippets in here, in case some update goes back to the old behavior and can be tested again

--- a/pkgs/by-name/ne/netbird/package.nix
+++ b/pkgs/by-name/ne/netbird/package.nix
@@ -168,6 +168,6 @@ buildGoModule (finalAttrs: {
       loc
       patrickdag
     ];
-     mainProgram = component.binaryName;
+    mainProgram = component.binaryName;
   };
 })

--- a/pkgs/by-name/ne/netbird/package.nix
+++ b/pkgs/by-name/ne/netbird/package.nix
@@ -166,7 +166,8 @@ buildGoModule (finalAttrs: {
       nazarewk
       saturn745
       loc
+      patrickdag
     ];
-    mainProgram = component.binaryName;
+     mainProgram = component.binaryName;
   };
 })


### PR DESCRIPTION
This is a pretty hefty rework of the nixos netbird modules.

First of all I split the package into three because currently you cannot have the client installed without the server components coming with it, now it's three packages, a client, a client with gui and a server.
You still have the option to build a package containing everything but I don't think most people need that.

Secondly I wrote a basic test for the server, now we at least know if it starts, which it currently doesn't cause upstream introduced clashing ports for all server, that cannot be disabled.
I would love further testing but I think that would need actually logging in into the kanidm instance inside the testing framework, which is something for another day.
The test also currently depend on #353681.

Netbird is currently switching away from coturn in favour of their own relay implementation, which this pull adds.
Their communication towards whether coturn will be needed going forward is a bit confusing, but I'm pretty sure right now you need both their relay and coturn, maybe in a few updates we can remove coturn.

Lastly I reworked the nginx setup, realizing you don't necesarrily need it, apart from serving the dashboard.
I removed it from all services and the default setup should now work without it, but you have to forward and open all relevant ports, for the management, signal, coturn, dashboard and relay.

To make it easier for people using nginx as a reverse proxy I've added the proxy, module which is written and maintained completely by myself and has no affiliation to upstream netbird. I do plan on using this and think it's valuable to have even just as a documentation of nginx options to use with netbird, but I am scared that people have problems with this module and complain to upstream netbird. Don't really know what to do whether to include or not, feedback appreciated.

In general this isn't extensively tested yet, but I would be very happy if people help me test it.
It has to wait for branch off anyway because it contains a bunch of breaking changes.

Also should probably write more documentation especially regarding the proxy module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
