### PR TITLE
streamlink: 6.11.0 -> 7.0.0

### DIFF
--- a/pkgs/by-name/st/streamlink/ffmpeg-path.patch
+++ b/pkgs/by-name/st/streamlink/ffmpeg-path.patch
@@ -1,13 +1,13 @@
 diff --git a/src/streamlink/stream/ffmpegmux.py b/src/streamlink/stream/ffmpegmux.py
-index 258b314a..c493e010 100644
+index 136c0b81..2dd00a20 100644
 --- a/src/streamlink/stream/ffmpegmux.py
 +++ b/src/streamlink/stream/ffmpegmux.py
-@@ -80,7 +80,7 @@ class MuxedStream(Stream, Generic[TSubstreams]):
+@@ -83,7 +83,7 @@ class MuxedStream(Stream, Generic[TSubstreams]):
  
  
  class FFMPEGMuxer(StreamIO):
--    __commands__: ClassVar[List[str]] = ["ffmpeg"]
-+    __commands__: ClassVar[List[str]] = ["@ffmpeg@"]
+-    __commands__: ClassVar[list[str]] = ["ffmpeg"]
++    __commands__: ClassVar[list[str]] = ["@ffmpeg@"]
  
+     DEFAULT_LOGLEVEL = "info"
      DEFAULT_OUTPUT_FORMAT = "matroska"
-     DEFAULT_VIDEO_CODEC = "copy"

--- a/pkgs/by-name/st/streamlink/package.nix
+++ b/pkgs/by-name/st/streamlink/package.nix
@@ -7,12 +7,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "streamlink";
-  version = "6.11.0";
+  version = "7.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Vi5ddTyhCeGVYgfeSsJ8M3zmuZ++ftcgO5RRBe1bL4Y=";
+    hash = "sha256-UaQGKGLmeV1pQEbKbnBUnW0TWDxkDRUFlmgEsOA/7/I=";
   };
 
   patches = [
@@ -55,7 +55,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   meta = {
-    changelog = "https://github.com/streamlink/streamlink/raw/${version}/CHANGELOG.md";
+    changelog = "https://streamlink.github.io/changelog.html";
     description = "CLI for extracting streams from various websites to video player of your choosing";
     homepage = "https://streamlink.github.io/";
     longDescription = ''


### PR DESCRIPTION
Changes: https://github.com/streamlink/streamlink/releases/tag/7.0.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
