### PR TITLE
git-warp-time: init at 0.8.4

### DIFF
--- a/pkgs/by-name/gi/git-warp-time/package.nix
+++ b/pkgs/by-name/gi/git-warp-time/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  # nativeBuildInputs
+  zstd,
+  pkg-config,
+  jq,
+  cargo,
+  rustc,
+  rustPlatform,
+
+  # buildInputs
+  libgit2,
+  typos,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "git-warp-time";
+  version = "0.8.4";
+
+  src = fetchurl {
+    url = "https://github.com/alerque/git-warp-time/releases/download/v${finalAttrs.version}/git-warp-time-${finalAttrs.version}.tar.zst";
+    sha256 = "sha256-Xh30nA77cJ7+UfKlIslnyD+93AtnQ+8P3sCFsG0DAUk=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) src;
+    nativeBuildInputs = [ zstd ];
+    dontConfigure = true;
+    hash = "sha256-ozy8Mfl5fTJL2Sr22tCSnK30SOKaC9cL+g4lX6ivi9Q=";
+  };
+
+  nativeBuildInputs = [
+    zstd
+    pkg-config
+    jq
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    libgit2
+    typos
+  ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = "1";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+    "man"
+    "dev"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Utility to reset filesystem timestamps based on Git history";
+    longDescription = ''
+      A CLI utility that resets the timestamps of files in a Git repository
+      working directory to the exact timestamp of the last commit which
+      modified each file.
+    '';
+    homepage = "https://github.com/alerque/git-warp-time";
+    changelog = "https://github.com/alerque/git-warp-time/raw/v${finalAttrs.version}/CHANGELOG.md";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alerque
+    ];
+    license = lib.licenses.gpl3Only;
+    mainProgram = "git-warp-time";
+  };
+})

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -1,9 +1,10 @@
 {
   lib,
   stdenv,
-  fetchzip,
+  fetchurl,
 
   # nativeBuildInputs
+  zstd,
   pkg-config,
   jq,
   cargo,
@@ -32,18 +33,20 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sile";
   version = "0.15.5";
 
-  src = fetchzip {
-    url = "https://github.com/sile-typesetter/sile/releases/download/v${finalAttrs.version}/sile-${finalAttrs.version}.zip";
-    sha256 = "sha256-zP+MGCXGEg19U6tMrHIdgAAfKQT21vFtmoEROXgxUB0=";
+  src = fetchurl {
+    url = "https://github.com/sile-typesetter/sile/releases/download/v${finalAttrs.version}/sile-${finalAttrs.version}.tar.zst";
+    sha256 = "sha256-0gE3sC0WMC0odnD9KFrSisO406+RZGCqa8jL/5Mhufk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit (finalAttrs) src;
+    nativeBuildInputs = [ zstd ];
     dontConfigure = true;
     hash = "sha256-hmgDG29C5JfQX2acMr8c3lmswa1u5XHauRWFd4QGmOo=";
   };
 
   nativeBuildInputs = [
+    zstd
     pkg-config
     jq
     cargo


### PR DESCRIPTION
New packaging for https://github.com/alerque/git-warp-time

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
