### PR TITLE
nixosTests.retroarch: fix test by changing window title

### DIFF
--- a/nixos/tests/retroarch.nix
+++ b/nixos/tests/retroarch.nix
@@ -1,10 +1,14 @@
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix (
+  { pkgs, ... }:
 
   {
     name = "retroarch";
-    meta = with pkgs.lib; { maintainers = teams.libretro.members ++ [ maintainers.j0hax ]; };
+    meta = with pkgs.lib; {
+      maintainers = teams.libretro.members ++ [ maintainers.j0hax ];
+    };
 
-    nodes.machine = { ... }:
+    nodes.machine =
+      { ... }:
 
       {
         imports = [ ./common/user-account.nix ];
@@ -23,11 +27,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
         };
       };
 
-    testScript = { nodes, ... }:
+    testScript =
+      { nodes, ... }:
       let
         user = nodes.machine.config.users.users.alice;
         xdo = "${pkgs.xdotool}/bin/xdotool";
-      in ''
+      in
+      ''
         with subtest("Wait for login"):
             start_all()
             machine.wait_for_file("/tmp/xauth_*")
@@ -46,4 +52,5 @@ import ./make-test-python.nix ({ pkgs, ... }:
             )
             machine.screenshot("screen")
       '';
-  })
+  }
+)

--- a/nixos/tests/retroarch.nix
+++ b/nixos/tests/retroarch.nix
@@ -41,7 +41,7 @@ import ./make-test-python.nix (
 
         with subtest("Check RetroArch started"):
             machine.wait_until_succeeds("pgrep retroarch")
-            machine.wait_for_window("^RetroArch ")
+            machine.wait_for_window("^RetroArch")
 
         with subtest("Check configuration created"):
             machine.wait_for_file("${user.home}/.config/retroarch/retroarch.cfg")


### PR DESCRIPTION
Format the test for retroarch and change `"^RetroArch "` to `"^RetroArch"` to fix the test

ZHF: #352882
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
