### PR TITLE
dependabot-cli improvements

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -1,12 +1,12 @@
 {
   buildGoModule,
   dependabot-cli,
+  dockerTools,
   fetchFromGitHub,
   installShellFiles,
   lib,
-  testers,
-  dockerTools,
   makeWrapper,
+  testers,
 }:
 let
   pname = "dependabot-cli";

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -6,6 +6,7 @@
   installShellFiles,
   lib,
   makeWrapper,
+  symlinkJoin,
   testers,
 }:
 let
@@ -65,13 +66,6 @@ buildGoModule {
       --bash <($out/bin/dependabot completion bash) \
       --fish <($out/bin/dependabot completion fish) \
       --zsh <($out/bin/dependabot completion zsh)
-
-    # Create a wrapper that pins the docker images that are depended upon
-    makeWrapper $out/bin/dependabot $out/bin/dependabot-pinned \
-      --run "docker load --input ${updateJobProxy}" \
-      --add-flags "--proxy-image=dependabot-update-job-proxy:${tag}" \
-      --run "docker load --input ${updaterGitHubActions}" \
-      --add-flags "--updater-image=dependabot-updater-github-actions:${tag}"
   '';
 
   checkFlags = [
@@ -82,6 +76,20 @@ buildGoModule {
   installCheckPhase = ''
     $out/bin/dependabot --help
   '';
+
+  passthru.withDockerImages = symlinkJoin {
+    name = "dependabot-cli-with-docker-images";
+    paths = [ dependabot-cli ];
+    buildInputs = [ makeWrapper ];
+    postBuild = ''
+      # Create a wrapper that pins the docker images that are depended upon
+      wrapProgram $out/bin/dependabot \
+        --run "docker load --input ${updateJobProxy} >&2" \
+        --add-flags "--proxy-image=dependabot-update-job-proxy:${tag}" \
+        --run "docker load --input ${updaterGitHubActions} >&2" \
+        --add-flags "--updater-image=dependabot-updater-github-actions:${tag}"
+    '';
+  };
 
   passthru.tests.version = testers.testVersion {
     package = dependabot-cli;


### PR DESCRIPTION
As asked for by @l0b0 in https://github.com/NixOS/nixpkgs/pull/352866, ping @philiptaron 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
