### PR TITLE
pkgs/by-name/[ab].+: migrate to new apple sdk

### DIFF
--- a/pkgs/by-name/ag/agate/package.nix
+++ b/pkgs/by-name/ag/agate/package.nix
@@ -4,8 +4,6 @@
   nixosTests,
   fetchFromGitHub,
   rustPlatform,
-  libiconv,
-  darwin,
   openssl,
   pkg-config,
   nix-update-script,
@@ -26,12 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [ openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libiconv
-      darwin.apple_sdk.frameworks.Security
-    ];
+  buildInputs = [ openssl ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -2,8 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  stdenv,
-  darwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,9 +16,7 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoPatches = [
-    ./0001-update-time-rs.patch
-  ];
+  cargoPatches = [ ./0001-update-time-rs.patch ];
 
   cargoLock = {
     lockFile = ./Cargo.lock;
@@ -28,11 +24,6 @@ rustPlatform.buildRustPackage rec {
       "serum_dex-0.4.0" = "sha256-Nzhh3OcAFE2LcbUgrA4zE2TnUMfV0dD4iH6fTi48GcI=";
     };
   };
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-    darwin.apple_sdk.frameworks.SystemConfiguration
-  ];
 
   checkFlags = [
     # the following test cases try to access network, skip them

--- a/pkgs/by-name/as/asfa/package.nix
+++ b/pkgs/by-name/as/asfa/package.nix
@@ -3,7 +3,6 @@
   rustPlatform,
   fetchFromGitHub,
   stdenv,
-  darwin,
   help2man,
   openssl,
   pkg-config,
@@ -29,9 +28,7 @@ rustPlatform.buildRustPackage {
     "man"
   ];
 
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
+  buildInputs = [ openssl ];
 
   nativeBuildInputs = [
     help2man

--- a/pkgs/by-name/as/asm-lsp/package.nix
+++ b/pkgs/by-name/as/asm-lsp/package.nix
@@ -5,8 +5,6 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
-  darwin,
-  libiconv,
 }:
 let
   pname = "asm-lsp";
@@ -24,12 +22,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [ openssl ]
-    ++ lib.optionals stdenv.buildPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.SystemConfiguration
-      libiconv
-    ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ openssl ];
 
   cargoHash = "sha256-AtCnYOOtViMpg+rz8miuBZg1pENBPaf9kamSPaVUyiw=";
 

--- a/pkgs/by-name/at/atac/package.nix
+++ b/pkgs/by-name/at/atac/package.nix
@@ -4,8 +4,6 @@
   fetchFromGitHub,
   pkg-config,
   oniguruma,
-  stdenv,
-  darwin,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "atac";
@@ -20,19 +18,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-sNgtqvFiwHSYMDf0379i8Yl9NrkCRVLo/ogjbHFgKBY=";
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [
-      oniguruma
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.AppKit
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
-    ];
+  buildInputs = [ oniguruma ];
 
   env = {
     RUSTONIG_SYSTEM_LIBONIG = true;
@@ -42,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple API client (postman like) in your terminal";
     homepage = "https://github.com/Julien-cpsn/ATAC";
     license = licenses.mit;
-    maintainers = with maintainers; [vinnymeller];
+    maintainers = with maintainers; [ vinnymeller ];
     mainProgram = "atac";
   };
 }

--- a/pkgs/by-name/at/attract-mode/package.nix
+++ b/pkgs/by-name/at/attract-mode/package.nix
@@ -13,7 +13,6 @@
   zlib,
   openal,
   fontconfig,
-  darwin,
 }:
 
 stdenv.mkDerivation {
@@ -43,13 +42,6 @@ stdenv.mkDerivation {
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       openal
       fontconfig
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.Cocoa
-      darwin.apple_sdk.frameworks.Carbon
-      darwin.apple_sdk.frameworks.IOKit
-      darwin.apple_sdk.frameworks.CoreVideo
-      darwin.apple_sdk.frameworks.OpenAL
     ];
 
   makeFlags = [

--- a/pkgs/by-name/av/avbroot/package.nix
+++ b/pkgs/by-name/av/avbroot/package.nix
@@ -6,7 +6,6 @@
   protobuf,
   bzip2,
   stdenv,
-  darwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,9 +32,7 @@ rustPlatform.buildRustPackage rec {
     protobuf
   ];
 
-  buildInputs = [
-    bzip2
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+  buildInputs = [ bzip2 ];
 
   meta = {
     description = "Sign (and root) Android A/B OTAs with custom keys while preserving Android Verified Boot";

--- a/pkgs/by-name/ba/bacon/package.nix
+++ b/pkgs/by-name/ba/bacon/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-  darwin,
   versionCheckHook,
   nix-update-script,
 }:
@@ -21,13 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rlWNrkzUDs3rbQ5ZV4fKU/EKEy4fVbxEP0+wNwXi7Ag=";
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.CoreServices
-  ];
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = [ "--version" ];
   doInstallCheck = true;
 

--- a/pkgs/by-name/bi/biome/package.nix
+++ b/pkgs/by-name/bi/biome/package.nix
@@ -6,8 +6,6 @@
   libgit2,
   rust-jemalloc-sys,
   zlib,
-  stdenv,
-  darwin,
   git,
 }:
 rustPlatform.buildRustPackage rec {
@@ -23,23 +21,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-4vITbsXfgNFoeWMHz7a9Rk7FrsEZRe75nHiyHSMujEQ=";
 
-  nativeBuildInputs = [
-    pkg-config
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libgit2
+    rust-jemalloc-sys
+    zlib
   ];
 
-  buildInputs =
-    [
-      libgit2
-      rust-jemalloc-sys
-      zlib
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.Security
-    ];
-
-  nativeCheckInputs = [
-    git
-  ];
+  nativeCheckInputs = [ git ];
 
   cargoBuildFlags = [ "-p=biome_cli" ];
   cargoTestFlags =

--- a/pkgs/by-name/bu/buckle/package.nix
+++ b/pkgs/by-name/bu/buckle/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   rustPlatform,
-  darwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,18 +16,13 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-eWhcDzw+6I5N0dse5avwhcQ/y6YZ6b3QKyBwWBrA/xo=";
   };
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-    darwin.apple_sdk.frameworks.SystemConfiguration
-  ];
-
   checkFlags = [
     # Both tests access the network.
     "--skip=test_buck2_latest"
     "--skip=test_buck2_specific_version"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Buck2 launcher";
     longDescription = ''
       Buckle is a launcher for [Buck2](https://buck2.build). It manages
@@ -39,8 +32,8 @@ rustPlatform.buildRustPackage rec {
       enforcing the prelude is upgraded in sync.
     '';
     homepage = "https://github.com/benbrittain/buckle";
-    license = licenses.mit;
-    maintainers = with maintainers; [ cbarrete ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cbarrete ];
     mainProgram = "buckle";
   };
 }

--- a/pkgs/by-name/bu/bulloak/package.nix
+++ b/pkgs/by-name/bu/bulloak/package.nix
@@ -1,9 +1,9 @@
-{ lib
-, fetchFromGitHub
-, rustPlatform
-, fetchurl
-, stdenv
-, darwin
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchurl,
+  stdenv,
 }:
 
 let
@@ -42,19 +42,20 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-lj/wmLu4cBjDjzMD8DlIz+6Rnag0h+zWiE7lfcTC7lY=";
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
-
   # tests run in CI on the source repo
   doCheck = false;
 
   # provide the list of solc versions to the `svm-rs-builds` dependency
   SVM_RELEASES_LIST_JSON = solc-versions.${stdenv.hostPlatform.system};
 
-  meta = with lib; {
+  meta = {
     description = "Solidity test generator based on the Branching Tree Technique";
     homepage = "https://github.com/alexfertel/bulloak";
-    license = with licenses; [ mit asl20 ];
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
     mainProgram = "bulloak";
-    maintainers = with maintainers; [ beeb ];
+    maintainers = with lib.maintainers; [ beeb ];
   };
 }


### PR DESCRIPTION
Validating the new apple sdk by migrationg low-risk packages:
- At most 1 downstream dependency
- Only replacing Darwin-specific BuildInputs
- No impact on other platforms

1. Replaced `darwin` dependency with `apple-sdk_11`
2. Replaced all references to darwin.apple_sdk.frameworks.* with single `apple-sdk_11`
3. Reformatted with current nixfmt (rfc style)
4. Minor fixes as needed such as dropping "with lib;"

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
