### PR TITLE
ghstack: init at 0.9.4

### DIFF
--- a/pkgs/by-name/gh/ghstack/package.nix
+++ b/pkgs/by-name/gh/ghstack/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "ghstack";
+  version = "0.9.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-DgJOju8y66CXB1rn28fcrCIhRZiLlqPEw8S4+aO/8ss=";
+  };
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    click
+    flake8
+    requests
+    typing-extensions
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Conveniently submit stacks of diffs to GitHub as separate pull requests";
+    homepage = "https://pypi.org/project/ghstack";
+    license = licenses.mit;
+    sourceProvenance = [ sourceTypes.fromSource ];
+    maintainers = with maintainers; [ aftix ];
+    mainProgram = "ghstack";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Added package for [ghstack](https://pypi.org/project/ghstack/). Not sure if I'm using `meta.sourceProvenance` correctly.

Closes #341572

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
