### PR TITLE
gssdp: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/gssdp/1.6.nix
+++ b/pkgs/development/libraries/gssdp/1.6.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     sha256 = "L+21r9sizxTVSYo5p3PKiXiKJQ/PcBGHg9+CHh8/NEY=";
   };
 
+  patches = [ ./fix-cross-1.6.patch ];
+
+  strictDeps = true;
+
   depsBuildBuild = [
     pkg-config
   ];

--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     sha256 = "VySWVDV9PVGxQDFRaaJMBnHeeqUsb3XIxcmr1Ao1JSk=";
   };
 
+  patches  = [ ./fix-cross.patch ];
+
   strictDeps = true;
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gssdp/fix-cross-1.6.patch
+++ b/pkgs/development/libraries/gssdp/fix-cross-1.6.patch
@@ -1,0 +1,16 @@
+diff -Naur a/meson.build b/meson.build
+--- a/meson.build	2023-11-02 22:19:05.000000000 +0000
++++ b/meson.build	2024-11-06 21:03:00.492857007 +0000
+@@ -92,12 +92,6 @@
+ endif
+ 
+ 
+-gidocgen_dep = dependency('gi-docgen', version: '>= 2021.1',
+-                          fallback: ['gi-docgen', 'dummy_dep'],
+-                          native: true,
+-                          required: get_option('gtk_doc') and get_option('introspection')
+-                      )
+-
+ subdir('doc')
+ 
+ if get_option('examples')

--- a/pkgs/development/libraries/gssdp/fix-cross.patch
+++ b/pkgs/development/libraries/gssdp/fix-cross.patch
@@ -1,0 +1,15 @@
+diff -Naur a/meson.build b/meson.build
+--- a/meson.build	2022-11-09 11:07:58.000000000 +0000
++++ b/meson.build	2024-11-06 20:56:42.381398948 +0000
+@@ -89,11 +89,6 @@
+ endif
+ 
+ 
+-gidocgen_dep = dependency('gi-docgen', version: '>= 2021.1',
+-                          fallback: ['gi-docgen', 'dummy_dep'],
+-                          required: get_option('gtk_doc') and get_option('introspection')
+-                      )
+-
+ if get_option('gtk_doc')
+   subdir('doc')
+ endif


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

gssdp's meson.build contains an unused dependency, whose presence breaks cross compilation.

This fix allows for building more ambitious packages (e.g. `pkgsCross.aarch64-multiplatform.epiphany` now builds successfully)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
