### PR TITLE
darwin.libffi: init at 35

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  autoreconfHook,
+  dejagnu,
+  mkAppleDerivation,
+  stdenv,
+  testers,
+  texinfo,
+
+  # test suite depends on dejagnu which cannot be used during bootstrapping
+  # dejagnu also requires tcl which can't be built statically at the moment
+  doCheck ? !(stdenv.hostPlatform.isStatic),
+}:
+
+mkAppleDerivation (finalAttrs: {
+  releaseName = "libffi";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "info"
+  ];
+
+  patches = [
+    # Clang 18 requires that no non-private symbols by defined after cfi_startproc. Apply the upstream libffi fix.
+    ./patches/llvm-18-compatibility.patch
+  ];
+
+  # Make sure libffi is using the trampolines dylib in this package not the system one.
+  postPatch = ''
+    substituteInPlace src/closures.c --replace-fail /usr/lib "$out/lib"
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    texinfo
+  ];
+
+  configurePlatforms = [
+    "build"
+    "host"
+  ];
+
+  configureFlags = [
+    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--enable-pax_emutramp"
+  ];
+
+  # Make sure aarch64-darwin is using the trampoline dylib.
+  postConfigure = lib.optionalString stdenv.hostPlatform.isAarch64 ''
+    echo '#define FFI_TRAMPOLINE_WHOLE_DYLIB 1' >> aarch64-apple-darwin/fficonfig.h
+  '';
+
+  postBuild = lib.optionalString stdenv.hostPlatform.isAarch64 ''
+    $CC src/aarch64/trampoline.S -dynamiclib -o libffi-trampolines.dylib \
+      -Iinclude -Iaarch64-apple-darwin -Iaarch64-apple-darwin/include \
+      -install_name "$out/lib/libffi-trampoline.dylib" -Wl,-compatibility_version,1 -Wl,-current_version,1
+  '';
+
+  postInstall =
+    # The Darwin SDK puts the headers in `include/ffi`. Add a symlink for compatibility.
+    ''
+      ln -s "$dev/include" "$dev/include/ffi"
+    ''
+    # Install the trampoline dylib since it is build manually.
+    + lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      cp libffi-trampolines.dylib "$out/lib/libffi-trampolines.dylib"
+    '';
+
+  preCheck = ''
+    # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify3/}
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
+  '';
+
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+
+  inherit doCheck;
+
+  nativeCheckInputs = [ dejagnu ];
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
+
+  meta = {
+    description = "Foreign function call interface library";
+    longDescription = ''
+      The libffi library provides a portable, high level programming
+      interface to various calling conventions.  This allows a
+      programmer to call any function specified by a call interface
+      description at run-time.
+
+      FFI stands for Foreign Function Interface.  A foreign function
+      interface is the popular name for the interface that allows code
+      written in one language to call code written in another
+      language.  The libffi library really only provides the lowest,
+      machine dependent layer of a fully featured foreign function
+      interface.  A layer must exist above libffi that handles type
+      conversions for values passed between the two languages.
+    '';
+    homepage = "https://github.com/apple-oss-distributions/libffi/";
+    license = lib.licenses.mit;
+    pkgConfigModules = [ "libffi" ];
+  };
+})

--- a/pkgs/os-specific/darwin/apple-source-releases/libffi/patches/llvm-18-compatibility.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/libffi/patches/llvm-18-compatibility.patch
@@ -1,0 +1,34 @@
+diff --git a/src/aarch64/sysv.S b/src/aarch64/sysv.S
+index eeaf3f8..329889c 100644
+--- a/src/aarch64/sysv.S
++++ b/src/aarch64/sysv.S
+@@ -76,8 +76,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+    x5 closure
+ */
+ 
+-	cfi_startproc
+ CNAME(ffi_call_SYSV):
++	cfi_startproc
+ 	/* Sign the lr with x1 since that is where it will be stored */
+ 	SIGN_LR_WITH_REG(x1)
+ 
+@@ -268,8 +268,8 @@ CNAME(ffi_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_closure_SYSV):
++	cfi_startproc
+ 	SIGN_LR
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+@@ -500,8 +500,8 @@ CNAME(ffi_go_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_go_closure_SYSV):
++	cfi_startproc
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+ 	cfi_rel_offset (x29, 0)

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -51,6 +51,10 @@
     "hash": "sha256-/79jS//IBZiQBumGA60lKDmddQCzl/r8QnviD6lGXNg=",
     "version": "448.0.3"
   },
+  "libffi": {
+    "hash": "sha256-tQJdKCz2OIwVtorHQapq9Xs2e1Ac96lGEzIWUXmsasY=",
+    "version": "35"
+  },
   "libiconv": {
     "hash": "sha256-4I70hci8SUQ5QERbImP3htjYCGXdZZ0a6RM7ggUnVa4=",
     "version": "107"


### PR DESCRIPTION
Apple’s version of libffi is required by PyObjC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
