### PR TITLE
unison: 2.53.5 -> 2.53.7

### DIFF
--- a/pkgs/by-name/un/unison/package.nix
+++ b/pkgs/by-name/un/unison/package.nix
@@ -11,21 +11,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unison";
-  version = "2.53.5";
+  version = "2.53.7";
 
   src = fetchFromGitHub {
     owner = "bcpierce00";
     repo = "unison";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XCdK38jG7tRI+/Zk72JVY8a/pPJF6KVaf8l2s3hgxLs=";
+    hash = "sha256-QmYcxzsnbRDQdqkLh82OLWrLF6v3qzf1aOIcnz0kwEk=";
   };
 
   strictDeps = true;
-
-  # uimac requires xcode
-  postPatch = ''
-    sed -i -e 's/ macuimaybe//' src/Makefile
-  '';
 
   nativeBuildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib ]
     ++ lib.optionals enableX11 [ copyDesktopItems wrapGAppsHook3 ];

--- a/pkgs/by-name/un/unison/package.nix
+++ b/pkgs/by-name/un/unison/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, ocamlPackages
-, copyDesktopItems
-, makeDesktopItem
-, wrapGAppsHook3
-, gsettings-desktop-schemas
-, enableX11 ? !stdenv.hostPlatform.isDarwin
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ocamlPackages,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook3,
+  gsettings-desktop-schemas,
+  enableX11 ? !stdenv.hostPlatform.isDarwin,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,12 +23,23 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib ]
-    ++ lib.optionals enableX11 [ copyDesktopItems wrapGAppsHook3 ];
-  buildInputs = lib.optionals enableX11 [ gsettings-desktop-schemas ocamlPackages.lablgtk3 ];
+  nativeBuildInputs =
+    [
+      ocamlPackages.ocaml
+      ocamlPackages.findlib
+    ]
+    ++ lib.optionals enableX11 [
+      copyDesktopItems
+      wrapGAppsHook3
+    ];
+  buildInputs = lib.optionals enableX11 [
+    gsettings-desktop-schemas
+    ocamlPackages.lablgtk3
+  ];
 
-  makeFlags = [ "PREFIX=$(out)" ]
-    ++ lib.optionals (!ocamlPackages.ocaml.nativeCompilers) [ "NATIVE=false" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+  ] ++ lib.optionals (!ocamlPackages.ocaml.nativeCompilers) [ "NATIVE=false" ];
 
   postInstall = lib.optionalString enableX11 ''
     install -D $src/icons/U.svg $out/share/icons/hicolor/scalable/apps/unison.svg
@@ -42,7 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
     genericName = "File synchronization tool";
     exec = "unison-gui";
     icon = "unison";
-    categories = [ "Utility" "FileTools" "GTK" ];
+    categories = [
+      "Utility"
+      "FileTools"
+      "GTK"
+    ];
     startupNotify = true;
     startupWMClass = "Unison";
   });

--- a/pkgs/by-name/un/unison/package.nix
+++ b/pkgs/by-name/un/unison/package.nix
@@ -47,12 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
     startupWMClass = "Unison";
   });
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.cis.upenn.edu/~bcpierce/unison/";
     description = "Bidirectional file synchronizer";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ nevivurn ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ nevivurn ];
+    platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin && enableX11; # unison-gui and uimac are broken on darwin
     mainProgram = if enableX11 then "unison-gui" else "unison";
   };


### PR DESCRIPTION
- Diff: https://github.com/bcpierce00/unison/compare/v2.53.5...v2.53.7
- Patch to disable macui is no longer needed, upstream detects environments that can't build it.
- Reduce `with lib`.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>unison</li>
    <li>usync</li>
  </ul>
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
