### PR TITLE
phash: compilation fixes

### DIFF
--- a/pkgs/by-name/ph/phash/0001-proper-pthread-return-value.patch
+++ b/pkgs/by-name/ph/phash/0001-proper-pthread-return-value.patch
@@ -1,0 +1,40 @@
+From 6ac2f207e8d8e1d16ee73198abccc64d20c5f608 Mon Sep 17 00:00:00 2001
+From: benaryorg <binary@benary.org>
+Date: Thu, 7 Nov 2024 03:27:52 +0000
+Subject: [PATCH 1/2] proper pthread return value
+
+*pthread_create(3)* states that the ways for a pthread to exit includes:
+
+> It returns from start_routine().  This is equivalent to calling pthread_exit(3) with the value supplied in the return statement.
+
+This "retval" is a void pointer which can be anything.
+In this case, since all threads are always joined with a parameter of NULL for the `void**` to store the retval this isn't really relevant for providing a meaningful return value.
+However a `void*` function must return a `void*`, otherwise compilers will complain:
+
+> pHash.cpp:416:1: warning: no return statement in function returning non-void [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type-Wreturn-type8;;]
+
+Therefore returning NULL seems reasonable.
+As for the choice of NULL vs. nullptr or any other value, NULL is already widely used in the file.
+
+Long story short: this fixes a compiler warning/error.
+
+Signed-off-by: benaryorg <binary@benary.org>
+---
+ src/pHash.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/pHash.cpp b/src/pHash.cpp
+index 07b03ad..23bbbf3 100644
+--- a/src/pHash.cpp
++++ b/src/pHash.cpp
+@@ -417,6 +417,7 @@ void *ph_image_thread(void *p)
+ 		memcpy(dp->hash, &hash, sizeof(hash));
+                 dp->hash_length = 1;
+         }
++        return NULL;
+ }
+ 
+ DP** ph_dct_image_hashes(char *files[], int count, int threads)
+-- 
+2.44.1
+

--- a/pkgs/by-name/ph/phash/package.nix
+++ b/pkgs/by-name/ph/phash/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cimg, imagemagick }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, cimg, imagemagick }:
 
 stdenv.mkDerivation rec {
   pname = "pHash";
@@ -23,6 +23,13 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-frISiZ89ei7XfI5F2nJJehfQZsk0Mlb4n91q/AiZ2vA=";
   };
+
+  NIX_LDFLAGS = "-lfftw3_threads";
+
+  patches = [
+    # proper pthread return value (https://github.com/clearscene/pHash/pull/20)
+    ./0001-proper-pthread-return-value.patch
+  ];
 
   meta = with lib; {
     description = "Compute the perceptual hash of an image";


### PR DESCRIPTION
This includes a patch already sent upstream that fixes compilation with Werror due to a lacking return, as well as adding a linker flag to include a threaded version of a library. The fftw3_threads part stems from cimg requiring this apparently when linking the examples:

> test_texthash.cpp:(.text.startup+0x1c1): undefined reference to `fftw_init_threads'

I wouldn't know how to patch this upstream, however other packages in nixpkgs seem to provide the LDFLAGS too.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #352882
Hydra log: https://hydra.nixos.org/build/276602092/nixlog/2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
