### PR TITLE
igraph: 0.10.13 -> 0.10.15

### DIFF
--- a/pkgs/by-name/ig/igraph/package.nix
+++ b/pkgs/by-name/ig/igraph/package.nix
@@ -26,13 +26,13 @@ assert (blas.isILP64 == lapack.isILP64 &&
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "igraph";
-  version = "0.10.13";
+  version = "0.10.15";
 
   src = fetchFromGitHub {
     owner = "igraph";
     repo = "igraph";
     rev = finalAttrs.version;
-    hash = "sha256-c5yZI5AfaO/NFyy88efu1COb+T2r1LpHhUTfilw2H1U=";
+    hash = "sha256-TSAVRLeOWh3IQ9X0Zr4CQS+h1vTeUZnzMp/IYujGMn0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -7,7 +7,6 @@
   scikit-build-core,
   pybind11,
   ninja,
-  ruff,
   cmake,
   pytestCheckHook,
   setuptools,
@@ -20,31 +19,27 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
-    rev = version;
+    repo = "explorerscript";
+    rev = "refs/tags/${version}";
     hash = "sha256-cKEceWr7XmZbuomPOmjQ32ptAjz3LZDQBWAgZEFadDY=";
     # Include a pinned antlr4 fork used as a C++ library
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     scikit-build-core
     ninja
     cmake
-    ruff
+    pybind11
   ];
 
   # The source include some auto-generated ANTLR code that could be recompiled, but trying that resulted in a crash while decompiling unionall.ssb.
   # We thus do not rebuild them.
 
   postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail ./generate_parser_bindings.py "python3 ./generate_parser_bindings.py"
-
-    # Doesn’t detect that package for some reason
     substituteInPlace pyproject.toml \
-      --replace-fail "\"scikit-build-core<=0.9.8\"," ""
+      --replace-fail "scikit-build-core<=0.9.8" scikit-build-core
   '';
 
   dontUseCmakeConfigure = true;
@@ -53,9 +48,8 @@ buildPythonPackage rec {
     "igraph"
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     igraph
-    pybind11
   ];
 
   optional-dependencies.pygments = [ pygments ];
@@ -64,10 +58,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "explorerscript" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/SkyTemple/explorerscript";
     description = "Programming language + compiler/decompiler for creating scripts for Pokémon Mystery Dungeon Explorers of Sky";
-    license = licenses.mit;
-    maintainers = with maintainers; [ marius851000 ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marius851000 ];
   };
 }

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -49,6 +49,10 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
+  pythonRelaxDeps = [
+    "igraph"
+  ];
+
   propagatedBuildInputs = [
     igraph
     pybind11

--- a/pkgs/development/python-modules/igraph/default.nix
+++ b/pkgs/development/python-modules/igraph/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "igraph";
-  version = "0.11.6";
+  version = "0.11.8";
 
   disabled = pythonOlder "3.8";
 
@@ -29,11 +29,15 @@ buildPythonPackage rec {
       # export-subst prevents reproducability
       rm $out/.git_archival.json
     '';
-    hash = "sha256-DXYNFSvmKiulMnWL8w5l9lWGtS9Sff/Hn4x538nrvzo=";
+    hash = "sha256-FEp9kwUAPSAnGcAuxApAq1AXiT0klXuXE2M6xNVilRg=";
   };
 
   postPatch = ''
     rm -r vendor
+
+    # TODO remove starting with 0.11.9
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=64,<72.2.0" setuptools
   '';
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Diff: https://github.com/igraph/igraph/compare/0.10.13...0.10.15

Changelog: https://github.com/igraph/igraph/blob/0.10.15/CHANGELOG.md
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
cc @marius851000 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
