### PR TITLE
[llvm-19] rust: use LLVM 19

### DIFF
--- a/pkgs/development/compilers/rust/1_82.nix
+++ b/pkgs/development/compilers/rust/1_82.nix
@@ -24,8 +24,8 @@
   pkgsTargetTarget,
   makeRustPlatform,
   wrapRustcWith,
-  llvmPackages_18,
-  llvm_18,
+  llvmPackages_19,
+  llvm_19,
   wrapCCWith,
   overrideCC,
   fetchpatch,
@@ -33,7 +33,7 @@
 let
   llvmSharedFor =
     pkgSet:
-    pkgSet.llvmPackages_18.libllvm.override (
+    pkgSet.llvmPackages_19.libllvm.override (
       {
         enableSharedLibraries = true;
       }
@@ -41,7 +41,7 @@ let
         # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
         stdenv = pkgSet.stdenv.override {
           allowedRequisites = null;
-          cc = pkgSet.pkgsBuildHost.llvmPackages_18.clangUseLLVM;
+          cc = pkgSet.pkgsBuildHost.llvmPackages_19.clangUseLLVM;
         };
       }
     );
@@ -68,14 +68,14 @@ import ./default.nix
             bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
           }:
           let
-            llvmPackages = llvmPackages_18;
+            llvmPackages = llvmPackages_19;
 
             setStdenv =
               pkg:
               pkg.override {
                 stdenv = stdenv.override {
                   allowedRequisites = null;
-                  cc = pkgsBuildHost.llvmPackages_18.clangUseLLVM;
+                  cc = pkgsBuildHost.llvmPackages_19.clangUseLLVM;
                 };
               };
           in
@@ -88,7 +88,7 @@ import ./default.nix
             libcxx = llvmPackages.libcxx.override {
               stdenv = stdenv.override {
                 allowedRequisites = null;
-                cc = pkgsBuildHost.llvmPackages_18.clangNoLibcxx;
+                cc = pkgsBuildHost.llvmPackages_19.clangNoLibcxx;
                 hostPlatform = stdenv.hostPlatform // {
                   useLLVM = !stdenv.hostPlatform.isDarwin;
                 };
@@ -102,7 +102,7 @@ import ./default.nix
           }
         ) { }
       else
-        llvmPackages_18;
+        llvmPackages_19;
 
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
@@ -139,8 +139,8 @@ import ./default.nix
 
   (
     builtins.removeAttrs args [
-      "llvmPackages_18"
-      "llvm_18"
+      "llvmPackages_19"
+      "llvm_19"
       "wrapCCWith"
       "overrideCC"
       "fetchpatch"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15296,7 +15296,7 @@ with pkgs;
 
   rust_1_82 = callPackage ../development/compilers/rust/1_82.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
-    llvm_18 = llvmPackages_18.libllvm;
+    llvm_19 = llvmPackages_19.libllvm;
   };
   rust = rust_1_82;
 


### PR DESCRIPTION
Possibly this should just be unversioned `llvmPackages` now that we’ve formulated something like a plan to keep our LLVMs in sync? But this is the conservative thing that lets us test the branch.

See: https://github.com/NixOS/nixpkgs/pull/354107
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
