### PR TITLE
python3Packages.django-cms: init at 4.1.3

### DIFF
--- a/pkgs/development/python-modules/django-cms/default.nix
+++ b/pkgs/development/python-modules/django-cms/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  django,
+  pythonOlder,
+  setuptools,
+  django-classy-tags,
+  django-formtools,
+  django-treebeard,
+  django-sekizai,
+  djangocms-admin-style,
+  python,
+  dj-database-url,
+  djangocms-text-ckeditor,
+  fetchpatch,
+  django-cms,
+  gettext,
+  iptools,
+}:
+
+buildPythonPackage rec {
+  pname = "django-cms";
+  version = "4.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "django-cms";
+    repo = "django-cms";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ucGxc6f2UYdmSLuyxVV2nIcl35qoeQMlk1paN6XeBFY=";
+  };
+
+  patches = [
+    # Removed django-app-manage dependency by updating ./manage.py
+    # https://github.com/django-cms/django-cms/pull/8061
+    (fetchpatch {
+      url = "https://github.com/django-cms/django-cms/commit/3270edb72f6a736b5cb448864ce2eaf68f061740.patch";
+      hash = "sha256-DkgAfE/QGAXwKMNvgcYxtO0yAc7oAaAAui2My8ml1Vk=";
+      name = "remove_django_app_manage_dependency.patch";
+    })
+    (fetchpatch {
+      url = "https://github.com/django-cms/django-cms/pull/8061/commits/04005ff693e775db645c62fefbb62367822e66f9.patch";
+      hash = "sha256-4M/VKEv7pnqCk6fDyA6FurSCCu/k9tNnz16wT4Tr0Rw=";
+      name = "manage_py_update_dj_database_url.patch";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    django-classy-tags
+    django-formtools
+    django-treebeard
+    django-sekizai
+    djangocms-admin-style
+  ];
+
+  nativeCheckInputs = [ gettext ];
+
+  checkInputs = [
+    dj-database-url
+    djangocms-text-ckeditor
+    iptools
+  ];
+
+  preCheck = ''
+    # Disable ruff formatter test
+    rm cms/tests/test_static_analysis.py
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} manage.py test
+    runHook postCheck
+  '';
+
+  # Tests depend on djangocms-text-ckeditor and djangocms-admin-style,
+  # which depends on this package.
+  # To avoid infinite recursion, we only enable tests when building passthru.tests.
+  doCheck = false;
+
+  passthru.tests = {
+    runTests = django-cms.overridePythonAttrs (_: {
+      doCheck = true;
+    });
+  };
+
+  pythonImportCheck = [ "cms" ];
+
+  meta = {
+    description = "Lean enterprise content management powered by Django";
+    homepage = "https://django-cms.org";
+    changelog = "https://github.com/django-cms/django-cms/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/development/python-modules/djangocms-admin-style/default.nix
+++ b/pkgs/development/python-modules/djangocms-admin-style/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  django,
+  pythonOlder,
+  pytestCheckHook,
+  setuptools,
+  pytest-django,
+  django-cms,
+  djangocms-admin-style,
+}:
+
+buildPythonPackage rec {
+  pname = "djangocms-admin-style";
+  version = "3.3.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "django-cms";
+    repo = "djangocms-admin-style";
+    rev = "refs/tags/${version}";
+    hash = "sha256-cDbmC7IJTT3NuVXBnbUVqC7dUfusMdntDGu2tSvxIdQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ django ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
+
+  checkInputs = [ django-cms ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE="tests.settings"
+  '';
+
+  disabledTests = [
+    # django.template.exceptions.TemplateDoesNotExist: admin/inc/cms_upgrade_notification.html
+    "test_render_update_notification"
+    # AssertionError: 'my site' != 'example.com'
+    "test_current_site_name"
+    # django.core.exceptions.ImproperlyConfigured: settings.DATABASES is improperly configured
+    "test_render_update_notification"
+    "test_current_site_name"
+    "test_for_missing_migrations"
+  ];
+
+  # Tests depend on django-cms which depends on this package.
+  # To avoid infinite recursion, we only enable tests when building passthru.tests.
+  doCheck = false;
+
+  passthru.tests = {
+    runTests = djangocms-admin-style.overridePythonAttrs (_: {
+      doCheck = true;
+    });
+  };
+
+  pythonImportCheck = [ "djangocms_admin_style" ];
+
+  meta = {
+    description = "Django Theme tailored to the needs of django CMS";
+    homepage = "https://django-cms.org";
+    changelog = "https://github.com/django-cms/djangocms-admin-style/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/development/python-modules/djangocms-text-ckeditor/default.nix
+++ b/pkgs/development/python-modules/djangocms-text-ckeditor/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  pytestCheckHook,
+  setuptools,
+  html5lib,
+  pillow,
+  django-cms,
+  pytest-django,
+}:
+
+buildPythonPackage rec {
+  pname = "djangocms-text-ckeditor";
+  version = "5.1.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "djangocms_text_ckeditor";
+    hash = "sha256-ow2S4FJkO037QUkAf3FheVl2O4BaLw1PSSCVRBhlRX0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django-cms
+    html5lib
+    pillow
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE="tests.settings"
+  '';
+
+  # Tests require module "djangocms-helper" which is not yet packaged
+  doCheck = false;
+
+  pythonImportCheck = [ "djangocms_text_ckeditor" ];
+
+  meta = {
+    description = "Text Plugin for django CMS using CKEditor 4";
+    homepage = "https://github.com/django-cms/djangocms-text-ckeditor";
+    changelog = "https://github.com/django-cms/djangocms-text-ckeditor/blob/${version}/CHANGELOG.rst";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3321,6 +3321,8 @@ self: super: with self; {
 
   djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
 
+  djangocms-text-ckeditor = callPackage ../development/python-modules/djangocms-text-ckeditor { };
+
   django-admin-datta = callPackage ../development/python-modules/django-admin-datta { };
 
   django-admin-sortable2 = callPackage ../development/python-modules/django-admin-sortable2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3367,6 +3367,8 @@ self: super: with self; {
 
   django-cleanup = callPackage ../development/python-modules/django-cleanup { };
 
+  django-cms = callPackage ../development/python-modules/django-cms { };
+
   django-colorful = callPackage ../development/python-modules/django-colorful { };
 
   django-compressor = callPackage ../development/python-modules/django-compressor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3319,6 +3319,8 @@ self: super: with self; {
   # Pre-release
   django_5 = callPackage ../development/python-modules/django/5.nix { };
 
+  djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
+
   django-admin-datta = callPackage ../development/python-modules/django-admin-datta { };
 
   django-admin-sortable2 = callPackage ../development/python-modules/django-admin-sortable2 { };


### PR DESCRIPTION
Adding Python module [django-cms](https://github.com/django-cms/django-cms), „the easy-to-use and developer-friendly enterprise CMS powered by Django“.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
