### PR TITLE
cunicu: init at 0.5.53

### DIFF
--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  protobuf,
+  protoc-gen-go,
+  protoc-gen-go-grpc,
+}:
+buildGoModule rec {
+  pname = "cunicu";
+  version = "0.5.53";
+
+  src = fetchFromGitHub {
+    owner = "cunicu";
+    repo = "cunicu";
+    rev = "v${version}";
+    hash = "sha256-y8JyXf+LdquhVr9G5wX1LdMF7wpj5PZG3xXGAWoypzA=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    protobuf
+    protoc-gen-go
+    protoc-gen-go-grpc
+  ];
+
+  CGO_ENABLED = 0;
+
+  vendorHash = "sha256-OiLVdEf6fcGHx0k0xC5sZwhnK0FiLgfdkz2zNgBbcgY=";
+
+  # These packages contain networking dependent tests which fail in the sandbox
+  excludedPackages = [
+    "pkg/config"
+    "pkg/selfupdate"
+    "pkg/tty"
+    "scripts"
+  ];
+
+  ldflags = [
+    "-X cunicu.li/cunicu/pkg/buildinfo.Version=${version}"
+    "-X cunicu.li/cunicu/pkg/buildinfo.BuiltBy=Nix"
+  ];
+
+  preBuild = ''
+    go generate ./...
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/cunicu docs --with-frontmatter
+    installManPage ./docs/usage/man/*.1
+    installShellCompletion --cmd cunicu \
+      --bash <($out/bin/cunicu completion bash) \
+      --zsh <($out/bin/cunicu completion zsh) \
+      --fish <($out/bin/cunicu completion fish)
+  '';
+
+  meta = {
+    description = "Zeroconf peer-to-peer mesh VPN using Wireguard® and Interactive Connectivity Establishment (ICE)";
+    homepage = "https://cunicu.li";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ stv0g ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cunicu";
+  };
+}


### PR DESCRIPTION
[cunīcu](https://github.com/cunicu/cunicu) is a user-space daemon managing [WireGuard®](https://wireguard.com/) interfaces to establish a mesh of peer-to-peer VPN connections in harsh network environments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
