### PR TITLE
nixos/environment: make {sessionV,v}ariables items nullable

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -34,14 +34,18 @@ in
       description = ''
         A set of environment variables used in the global environment.
         These variables will be set on shell initialisation (e.g. in /etc/profile).
+
         The value of each variable can be either a string or a list of
         strings.  The latter is concatenated, interspersed with colon
         characters.
+
+        Setting a variable to `null` does nothing. You can override a
+        variable set by another module to `null` to unset it.
       '';
-      type = with lib.types; attrsOf (oneOf [ (listOf (oneOf [ int str path ])) int str path ]);
+      type = with lib.types; attrsOf (nullOr (oneOf [ (listOf (oneOf [ int str path ])) int str path ]));
       apply = let
         toStr = v: if lib.isPath v then "${v}" else toString v;
-      in lib.mapAttrs (n: v: if lib.isList v then lib.concatMapStringsSep ":" toStr v else toStr v);
+      in attrs: lib.mapAttrs (n: v: if lib.isList v then lib.concatMapStringsSep ":" toStr v else toStr v) (lib.filterAttrs (n: v: v != null) attrs);
     };
 
     environment.profiles = lib.mkOption {

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -21,6 +21,9 @@ in
         list of strings. The latter is concatenated, interspersed with
         colon characters.
 
+        Setting a variable to `null` does nothing. You can override a
+        variable set by another module to `null` to unset it.
+
         Note, due to limitations in the PAM format values may not
         contain the `"` character.
 

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     maintainers = [ nequissimus ];
   };
 
-  nodes.machine = { pkgs, ... }:
+  nodes.machine = { pkgs, lib, ... }: lib.mkMerge [
     {
       boot.kernelPackages = pkgs.linuxPackages;
       environment.etc.plainFile.text = ''
@@ -17,8 +17,15 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       environment.sessionVariables = {
         TERMINFO_DIRS = "/run/current-system/sw/share/terminfo";
         NIXCON = "awesome";
+        SHOULD_NOT_BE_SET = "oops";
       };
-    };
+    }
+    {
+      environment.sessionVariables = {
+        SHOULD_NOT_BE_SET = lib.mkForce null;
+      };
+    }
+  ];
 
   testScript = ''
     machine.succeed('[ -L "/etc/plainFile" ]')
@@ -32,5 +39,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         "echo ''${TERMINFO_DIRS}"
     )
     assert "awesome" in machine.succeed("echo ''${NIXCON}")
+    machine.fail("printenv SHOULD_NOT_BE_SET")
   '';
 })


### PR DESCRIPTION
Allow users to unset a variable set by another module by overriding it to `null`.

```nix
{
  environment.sessionVariables.SHOULD_NOT_BE_SET = lib.mkForce null;
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
