### PR TITLE
apfsprogs: 0-unstable-2024-09-27 -> 0.2.0

### DIFF
--- a/pkgs/by-name/ap/apfsprogs/package.nix
+++ b/pkgs/by-name/ap/apfsprogs/package.nix
@@ -1,7 +1,8 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, nixosTests
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,15 +16,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+c+wU52XKNOTxSpSrkrNWoGEYw6Zo4CGEOyKMvkXEa0=";
   };
 
-  postPatch = let
-    shortRev = builtins.substring 0 9 finalAttrs.src.rev;
-  in ''
-    substituteInPlace \
-      apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile apfs-label/Makefile \
-      --replace-fail \
-        '$(shell git describe --always HEAD | tail -c 9)' \
-        '${shortRev}'
-  '';
+  postPatch =
+    let
+      shortRev = builtins.substring 0 9 finalAttrs.src.rev;
+    in
+    ''
+      substituteInPlace \
+        apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile apfs-label/Makefile \
+        --replace-fail \
+          '$(shell git describe --always HEAD | tail -c 9)' \
+          '${shortRev}'
+    '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ap/apfsprogs/package.nix
+++ b/pkgs/by-name/ap/apfsprogs/package.nix
@@ -3,30 +3,34 @@
   stdenv,
   fetchFromGitHub,
   nixosTests,
+  testers,
 }:
-
+let
+  tools = [
+    "apfsck"
+    "apfs-label"
+    "apfs-snap"
+    "mkapfs"
+  ];
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "apfsprogs";
-  version = "0-unstable-2024-09-27";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "apfsprogs";
-    rev = "f31d7c2d69d212ce381399d2bb1e91410f592484";
-    hash = "sha256-+c+wU52XKNOTxSpSrkrNWoGEYw6Zo4CGEOyKMvkXEa0=";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-rolbBLdE98jqlKC06fTo6eJU3abKzgB3QIlaw4bza9U=";
   };
 
-  postPatch =
-    let
-      shortRev = builtins.substring 0 9 finalAttrs.src.rev;
-    in
-    ''
-      substituteInPlace \
-        apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile apfs-label/Makefile \
-        --replace-fail \
-          '$(shell git describe --always HEAD | tail -c 9)' \
-          '${shortRev}'
-    '';
+  postPatch = ''
+    substituteInPlace \
+      apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile apfs-label/Makefile \
+      --replace-fail \
+        '$(shell git describe --always HEAD | tail -c 9)' \
+        'v${finalAttrs.version}'
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -46,15 +50,30 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    apfs = nixosTests.apfs;
-  };
+  passthru.tests =
+    let
+      mkVersionTest = tool: {
+        "version-${tool}" = testers.testVersion {
+          package = finalAttrs.finalPackage;
+          command = "${tool} -v";
+          version = "v${finalAttrs.version}";
+        };
+      };
+      versionTestList = builtins.map mkVersionTest tools;
+
+      versionTests = lib.mergeAttrsList versionTestList;
+    in
+    {
+      apfs = nixosTests.apfs;
+    }
+    // versionTests;
 
   strictDeps = true;
 
   meta = with lib; {
     description = "Experimental APFS tools for linux";
     homepage = "https://github.com/linux-apfs/apfsprogs";
+    changelog = "https://github.com/linux-apfs/apfsprogs/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ Luflosi ];


### PR DESCRIPTION
https://github.com/linux-apfs/apfsprogs/releases/tag/v0.2.0

Also format with nixfmt-rfc-style

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
