### PR TITLE
swift: Workaround Hydra darwin build problem

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -6,7 +6,7 @@
 , coreutils
 , gnugrep
 , perl
-, ninja
+, ninja_1_11
 , pkg-config
 , clang
 , bintools
@@ -189,6 +189,14 @@ let
         $out/lib/swift/
     '';
   };
+
+  # https://github.com/NixOS/nixpkgs/issues/327836
+  # Fail to build with ninja 1.12 when NIX_BUILD_CORES is low (Hydra or Github Actions).
+  # Can reproduce using `nix --option cores 2 build -f . swiftPackages.swift-unwrapped`.
+  # Until we find out the exact cause, follow [swift upstream][1], pin ninja to version
+  # 1.11.1.
+  # [1]: https://github.com/swiftlang/swift/pull/72989
+  ninja = ninja_1_11;
 
 in stdenv.mkDerivation {
   pname = "swift";


### PR DESCRIPTION
When the host platform is darwin, building swift on Hydra and Github Actions with ninja 1.12 will both give the same error:

```
ld: warning: directory not found for option '-L/nix/store/g9rbp9m6vs1xj4jl6b6vjb6bm8kgr107-SDKs/MacOSX10.15.sdk/usr/lib/swift'
...
ld: warning: Could not find or use auto-linked library 'swiftCompatibility56'
Undefined symbols for architecture arm64:
  "__swift_FORCE_LOAD_$_swiftCompatibility56", referenced from:
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_Optimizer in libswiftCompilerModules-bootstrapping1.a(Optimizer.o)
  ...
```

~~Beware the failure does not happen on developers' local machines.~~

Edit: You can reproduce the problem using `nix --option cores 2 -L build -f . swiftPackages.swift-unwrapped`.

Until we find out the exact cause, pin ninja to version 1.11 to workaround the problem.

I have verified `nix build github:azuwis/nixpkgs/push-yzpukurnozzk#swiftPackages.swift-unwrapped` works on Github Actions macos-latest (aarch64-darwin) with `sandbox = relaxed` in `/etc/nix/nix.conf`.

This will hopefully also fix build problem in Hydra https://github.com/NixOS/nixpkgs/issues/327836, https://hydra.nixos.org/build/276929157

ZHF: #352882

---

A bit more about the build failure, compare the [last successful build log][1] and [first broken build log][2] with `grep swiftCompatibility56`.

Last successful build log:
```
[16/1354] Building CXX object stdlib/toolchain/Compatibility56/CMakeFiles/swiftCompatibility56-macosx-arm64.dir/Concurrency/MutexPThread.cpp.o
[17/1354] Building CXX object stdlib/toolchain/Compatibility56/CMakeFiles/swiftCompatibility56-macosx-arm64.dir/Concurrency/TaskAlloc.cpp.o
[18/1354] Building CXX object stdlib/toolchain/Compatibility56/CMakeFiles/swiftCompatibility56-macosx-arm64.dir/Runtime/Exclusivity.cpp.o
[28/1354] Linking CXX static library lib/swift/macosx/arm64/libswiftCompatibility56.a
[29/1354] Generating ../../../lib/swift/macosx/libswiftCompatibility56.a
-- Installing: /nix/store/3qk45k9hgr68psf072x4zfwsyva17hpy-swift-5.8/lib/lldb//swift/macosx/libswiftCompatibility56.a
-- Installing: /nix/store/3qk45k9hgr68psf072x4zfwsyva17hpy-swift-5.8/lib/lldb//swift/macosx/arm64/libswiftCompatibility56.a
-- Installing: /nix/store/3qk45k9hgr68psf072x4zfwsyva17hpy-swift-5.8/lib/swift/macosx/libswiftCompatibility56.a
```

First broken build log:
```
[886/1354] Building CXX object stdlib/toolchain/Compatibility56/CMakeFiles/swiftCompatibility56-macosx-arm64.dir/Concurrency/MutexPThread.cpp.o
[887/1354] Building CXX object stdlib/toolchain/Compatibility56/CMakeFiles/swiftCompatibility56-macosx-arm64.dir/Runtime/Exclusivity.cpp.o
[925/1354] Linking CXX static library lib/swift/macosx/arm64/libswiftCompatibility56.a
ld: warning: Could not find or use auto-linked library 'swiftCompatibility56'
  "__swift_FORCE_LOAD_$_swiftCompatibility56", referenced from:
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_Optimizer in libswiftCompilerModules-bootstrapping1.a(Optimizer.o)
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_SIL in libswiftCompilerModules-bootstrapping1.a(SIL.o)
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_Basic in libswiftCompilerModules-bootstrapping1.a(Basic.o)
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_Parse in libswiftCompilerModules-bootstrapping1.a(Parse.o)
      __swift_FORCE_LOAD_$_swiftCompatibility56_$__CompilerRegexParser in libswiftCompilerModules-bootstrapping1.a(_CompilerRegexParser.o)
      __swift_FORCE_LOAD_$_swiftCompatibility56_$_AST in libswiftCompilerModules-bootstrapping1.a(AST.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCompatibility56_$__CompilerRegexParser, __swift_FORCE_LOAD_$_swiftCompatibility56_$_SIL , __swift_FORCE_LOAD_$_swiftCompatibility56_$_Parse , __swift_FORCE_LOAD_$_swiftCompatibility56_$_Basic , __swift_FORCE_LOAD_$_swiftCompatibility56_$_Optimizer , __swift_FORCE_LOAD_$_swiftCompatibility56_$_AST )
```

The broken build log lacks this line `Generating ../../../lib/swift/macosx/libswiftCompatibility56.a`, it seems `libswiftCompatibility56.a` is not generated in the first place, hence the final ld error.

And with `grep ninja`.

Last successful build log:

```
-- CMake Make Program (/nix/store/cisdzsmkr9rk82npn4w2ln295abdy83w-ninja-1.11.1/bin/ninja) Version: 1.11.1
-- CMake Make Program (/nix/store/cisdzsmkr9rk82npn4w2ln295abdy83w-ninja-1.11.1/bin/ninja) Version: 1.11.1
```

First broken build log:

```
-- CMake Make Program (/nix/store/zzcj2g6a7znzbr5h26nh5hss9crh5n28-ninja-1.12.1/bin/ninja) Version: 1.12.1
ninja: build stopped: subcommand failed.
```


[1]: https://hydra.nixos.org/build/260349303
[2]: https://hydra.nixos.org/build/262769164


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
