### PR TITLE
angular-language-server: remove overjealous templating

### DIFF
--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -12,16 +12,12 @@
   unzip,
 }:
 
-let
-  owner = "angular";
-  repo = "vscode-ng-language-service";
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "angular-language-server";
   version = "18.2.0";
   src = fetchurl {
-    name = "${finalAttrs.pname}-${finalAttrs.version}.zip";
-    url = "https://github.com/${owner}/${repo}/releases/download/v${finalAttrs.version}/ng-template.vsix";
+    name = "angular-language-server-${finalAttrs.version}.zip";
+    url = "https://github.com/angular/vscode-ng-language-service/releases/download/v${finalAttrs.version}/ng-template.vsix";
     hash = "sha256-rl04nqSSBMjZfPW8Y+UtFLFLDFd5FSxJs3S937mhDWE=";
   };
 
@@ -56,7 +52,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
 
     updateScript = lib.getExe (writeShellApplication {
-      name = "update-${finalAttrs.pname}";
+      name = "update-angular-language-server";
       runtimeInputs = [
         curl
         common-updater-scripts
@@ -68,9 +64,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
         LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" \
             ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
-          -Lsf https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+          -Lsf https://api.github.com/repos/angular/vscode-ng-language-service/releases/latest | \
           jq -r .tag_name | cut -c 2-)
-        update-source-version ${finalAttrs.pname} "$LATEST_VERSION"
+        update-source-version angular-language-server "$LATEST_VERSION"
       '';
     });
   };


### PR DESCRIPTION
Templating owner/repo just decreases readability; the pname in the update script just matches by accident, we really need the attr of the package here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
