### PR TITLE
treewide: use getLib when accessing clang / libclang / stdenv.cc.cc

### DIFF
--- a/nixos/tests/vscode-remote-ssh.nix
+++ b/nixos/tests/vscode-remote-ssh.nix
@@ -28,7 +28,7 @@ in {
       networking.interfaces.eth1.ipv4.addresses = [ { address = serverAddress; prefixLength = 24; } ];
       services.openssh.enable = true;
       users.users.root.openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-      virtualisation.additionalPaths = with pkgs; [ patchelf bintools stdenv.cc.cc.lib ];
+      virtualisation.additionalPaths = with pkgs; [ patchelf bintools (lib.getLib stdenv.cc.cc) ];
     };
     client = { ... }: {
       imports = [ ./common/x11.nix ./common/user-account.nix ];

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 
   buildInputs = with xorg; [
-    alsa-lib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pulseaudio libjack2 libX11 libglvnd libXcursor stdenv.cc.cc.lib
+    alsa-lib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pulseaudio libjack2 libX11 libglvnd libXcursor (lib.getLib stdenv.cc.cc)
   ];
 
   ldLibraryPath = lib.strings.makeLibraryPath buildInputs;

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     libxkbcommon
     pipewire
     pulseaudio
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     xcbutil
     xcbutilwm
     zlib

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     pango
     pipewire
     pulseaudio
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     vulkan-loader
     xcb-imdkit
     xcbutil

--- a/pkgs/applications/audio/galaxy-buds-client/default.nix
+++ b/pkgs/applications/audio/galaxy-buds-client/default.nix
@@ -30,7 +30,7 @@ buildDotnetModule rec {
     graphicsmagick
   ];
 
-  buildInputs = [ stdenv.cc.cc.lib fontconfig ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) fontconfig ];
 
   runtimeDeps = [
     libglvnd

--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       libXext          # libXext.so.6
       alsa-lib          # libasound.so.2
       freetype         # libfreetype.so.6
-      stdenv.cc.cc.lib # libstdc++.so.6
+      (lib.getLib stdenv.cc.cc) # libstdc++.so.6
     ];
   in ''
     patchelf \

--- a/pkgs/applications/audio/pianoteq/default.nix
+++ b/pkgs/applications/audio/pianoteq/default.nix
@@ -45,7 +45,7 @@ let
       ];
 
       buildInputs = [
-        stdenv.cc.cc.lib
+        (lib.getLib stdenv.cc.cc)
         xorg.libX11 # libX11.so.6
         xorg.libXext # libXext.so.6
         alsa-lib # libasound.so.2

--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin "Reaper.app";
 
   buildInputs = [
-    stdenv.cc.cc.lib # reaper and libSwell need libstdc++.so.6
+    (lib.getLib stdenv.cc.cc) # reaper and libSwell need libstdc++.so.6
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
     gtk3
     alsa-lib
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
     # We opt for wrapping the executable with LD_LIBRARY_PATH prefix.
     # Note that libcurl and libxml2 are needed for ReaPack to run.
     wrapProgram $out/opt/REAPER/reaper \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ curl lame libxml2 ffmpeg vlc xdotool stdenv.cc.cc.lib ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ curl lame libxml2 ffmpeg vlc xdotool stdenv.cc.cc ]}"
 
     mkdir $out/bin
     ln -s $out/opt/REAPER/reaper $out/bin/

--- a/pkgs/applications/audio/redux/default.nix
+++ b/pkgs/applications/audio/redux/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     libX11
     libXext
     alsa-lib
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation rec {
       ln -s $path/lib/*.so* $out/lib/
     done
 
-    ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
+    ln -s ${lib.getLib stdenv.cc.cc}/lib/libstdc++.so.6 $out/lib/
 
     mkdir $out/bin
     ln -s $out/renoise $out/bin/renoise

--- a/pkgs/applications/audio/rymcast/default.nix
+++ b/pkgs/applications/audio/rymcast/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
-  buildInputs = [ alsa-lib curl gtk3 stdenv.cc.cc.lib webkitgtk_4_0 zenity ];
+  buildInputs = [ alsa-lib curl gtk3 (lib.getLib stdenv.cc.cc) webkitgtk_4_0 zenity ];
 
   installPhase = ''
     mkdir -p "$out/bin"

--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     freetype
     libglvnd

--- a/pkgs/applications/audio/tonelib-jam/default.nix
+++ b/pkgs/applications/audio/tonelib-jam/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     freetype
     libglvnd

--- a/pkgs/applications/audio/tonelib-metal/default.nix
+++ b/pkgs/applications/audio/tonelib-metal/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     freetype
     libglvnd

--- a/pkgs/applications/audio/tonelib-noisereducer/default.nix
+++ b/pkgs/applications/audio/tonelib-noisereducer/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     freetype
     libglvnd

--- a/pkgs/applications/audio/tonelib-zoom/default.nix
+++ b/pkgs/applications/audio/tonelib-zoom/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     freetype
     libglvnd

--- a/pkgs/applications/audio/touchosc/default.nix
+++ b/pkgs/applications/audio/touchosc/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
   ];
 

--- a/pkgs/applications/audio/virtual-ans/default.nix
+++ b/pkgs/applications/audio/virtual-ans/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libX11
     libXi
     libGL

--- a/pkgs/applications/audio/vital/default.nix
+++ b/pkgs/applications/audio/vital/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alsa-lib
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libGL
     xorg.libSM
     xorg.libICE

--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -136,7 +136,7 @@ let
   sparrow-modules = stdenvNoCC.mkDerivation {
     pname = "sparrow-modules";
     inherit version src;
-    nativeBuildInputs = [ makeWrapper gzip gnugrep openjdk autoPatchelfHook stdenv.cc.cc.lib zlib ];
+    nativeBuildInputs = [ makeWrapper gzip gnugrep openjdk autoPatchelfHook (lib.getLib stdenv.cc.cc) zlib ];
 
     buildPhase = ''
       # Extract Sparrow's JIMAGE and generate a list of them.

--- a/pkgs/applications/blockchains/terra-station/default.nix
+++ b/pkgs/applications/blockchains/terra-station/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     # patch pre-built node modules
     asar e $out/share/${pname}/resources/app.asar asar-unpacked
     find asar-unpacked -name '*.node' -exec patchelf \
-      --add-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" \
+      --add-rpath "${lib.makeLibraryPath [ stdenv.cc.cc ]}" \
       {} \;
     asar p asar-unpacked $out/share/${pname}/resources/app.asar
 

--- a/pkgs/applications/blockchains/wasabibackend/default.nix
+++ b/pkgs/applications/blockchains/wasabibackend/default.nix
@@ -25,7 +25,7 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_7_0;
   dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
 
-  buildInputs = [stdenv.cc.cc.lib zlib];
+  buildInputs = [(lib.getLib stdenv.cc.cc) zlib];
 
   runtimeDeps = [openssl zlib];
 

--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -16,7 +16,7 @@ let
   runtimeLibs = [
     fontconfig.lib
     openssl
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     xorg.libX11
     xorg.libICE
     xorg.libSM

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -137,7 +137,7 @@ let
           e2fsprogs
 
           # Gradle wants libstdc++.so.6
-          stdenv.cc.cc.lib
+          (lib.getLib stdenv.cc.cc)
           # mksdcard wants 32 bit libstdc++.so.6
           pkgsi686Linux.stdenv.cc.cc.lib
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -153,8 +153,8 @@ let
         # https://github.com/Golevka/emacs-clang-complete-async/issues/90
         auto-complete-clang-async = (addPackageRequires super.auto-complete-clang-async [ self.auto-complete ]).overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
-          CFLAGS = "-I${pkgs.llvmPackages.libclang.lib}/include";
-          LDFLAGS = "-L${pkgs.llvmPackages.libclang.lib}/lib";
+          CFLAGS = "-I${lib.getLib pkgs.llvmPackages.libclang}/include";
+          LDFLAGS = "-L${lib.getLib pkgs.llvmPackages.libclang}/lib";
         });
 
         # part of a larger package

--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -5,17 +5,17 @@
   "631" = {
     # Python
     nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
   };
   "7322" = {
     # Python community edition
     nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
   };
   "8182" = {
     # Rust (deprecated)
     nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
     buildPhase = ''
       runHook preBuild
       chmod +x -R bin
@@ -66,7 +66,7 @@
   "22407" = {
     # Rust
     nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
     buildPhase = ''
       runHook preBuild
       chmod +x -R bin

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -146,8 +146,8 @@ in
         --replace-fail '@node@' ${nodejs}
 
       substituteInPlace src/cpp/core/libclang/LibClang.cpp \
-        --replace-fail '@libclang@' ${llvmPackages.libclang.lib} \
-        --replace-fail '@libclang.so@' ${llvmPackages.libclang.lib}/lib/libclang.so
+        --replace-fail '@libclang@' ${lib.getLib llvmPackages.libclang} \
+        --replace-fail '@libclang.so@' ${lib.getLib llvmPackages.libclang}/lib/libclang.so
 
       substituteInPlace src/cpp/session/CMakeLists.txt \
         --replace-fail '@pandoc@' ${pandoc} \

--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     libPath = lib.makeLibraryPath [
       libsecret
       glib
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
     ];
   in
     ''

--- a/pkgs/applications/editors/sublime/2/default.nix
+++ b/pkgs/applications/editors/sublime/2/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     echo ${libPath}
     patchelf \
       --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
+      --set-rpath ${libPath}:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
       $out/sublime/sublime_text
 
     mkdir -p $out/share/icons

--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -65,7 +65,7 @@ let
       for binary in ${ builtins.concatStringsSep " " binaries }; do
         patchelf \
           --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
+          --set-rpath ${libPath}:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
           $binary
       done
 
@@ -92,7 +92,7 @@ let
 
     postFixup = ''
       wrapProgram $out/sublime_bash \
-        --set LD_PRELOAD "${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"}/libgcc_s.so.1"
+        --set LD_PRELOAD "${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"}/libgcc_s.so.1"
 
       wrapProgram $out/${primaryBinary} \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
@@ -101,7 +101,7 @@ let
         "''${gappsWrapperArgs[@]}"
 
       # Without this, plugin_host crashes, even though it has the rpath
-      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"}/libgcc_s.so.1:${lib.getLib openssl}/lib/libssl.so:${bzip2.out}/lib/libbz2.so
+      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"}/libgcc_s.so.1:${lib.getLib openssl}/lib/libssl.so:${bzip2.out}/lib/libbz2.so
     '';
   };
 in stdenv.mkDerivation (rec {

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -88,7 +88,7 @@ let
       for binary in ${builtins.concatStringsSep " " binaries}; do
         patchelf \
           --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ${lib.makeLibraryPath neededLibraries}:${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
+          --set-rpath ${lib.makeLibraryPath neededLibraries}:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
           $binary
       done
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -293,7 +293,7 @@ in
           --replace "let g:clang_library_path = ''
       + "''"
       + ''
-        " "let g:clang_library_path='${llvmPackages.libclang.lib}/lib/libclang.so'"
+        " "let g:clang_library_path='${lib.getLib llvmPackages.libclang}/lib/libclang.so'"
 
               substituteInPlace "$out"/plugin/libclang.py \
                 --replace "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
@@ -302,7 +302,7 @@ in
 
   clighter8 = super.clighter8.overrideAttrs {
     preFixup = ''
-      sed "/^let g:clighter8_libclang_path/s|')$|${llvmPackages.clang.cc.lib}/lib/libclang.so')|" \
+      sed "/^let g:clighter8_libclang_path/s|')$|${lib.getLib llvmPackages.clang.cc}/lib/libclang.so')|" \
         -i "$out"/plugin/clighter8.vim
     '';
   };

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1072,7 +1072,7 @@ let
           }
           // sources.${stdenv.system};
         nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-        buildInputs = [ stdenv.cc.cc.lib ];
+        buildInputs = [ (lib.getLib stdenv.cc.cc) ];
         meta = {
           description = "Open-source autopilot for software development - bring the power of ChatGPT to your IDE";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=Continue.continue";
@@ -1349,7 +1349,7 @@ let
 
         buildInputs = [
           zlib
-          stdenv.cc.cc.lib
+          (lib.getLib stdenv.cc.cc)
         ];
 
         postInstall = ''
@@ -3245,7 +3245,7 @@ let
           // sources.${stdenv.system};
         nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
         buildInputs = [
-          stdenv.cc.cc.lib
+          (lib.getLib stdenv.cc.cc)
           zlib
         ];
         meta = {

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
@@ -71,7 +71,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     lttng-ust
     libkrb5
     zlib
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   dontAutoPatchelf = isx86Linux;

--- a/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
@@ -23,7 +23,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     zlib
   ];
 

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   libPath = lib.makeLibraryPath (with xorg; [
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
     at-spi2-core.out
     gdk-pixbuf
     glib

--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems unzip ];
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     gstreamer
     gst-plugins-base

--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -37,7 +37,7 @@ let
     xorg.libXrandr
     xorg.libXrender
     xorg.libXtst
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     stdenv.cc.cc
   ];
 

--- a/pkgs/applications/graphics/pixinsight/default.nix
+++ b/pkgs/applications/graphics/pixinsight/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     stdenv.cc
     libGL
     libpulseaudio
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchelf ./installer \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${stdenv.cc.cc.lib}/lib
+      --set-rpath ${lib.getLib stdenv.cc.cc}/lib
   '';
 
   dontConfigure = true;

--- a/pkgs/applications/graphics/sane/backends/dsseries/default.nix
+++ b/pkgs/applications/graphics/sane/backends/dsseries/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     for f in `find $out/lib/sane/ -type f`; do
       # Make it possible to find libstdc++.so.6
-      patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:$out/lib/sane $f
+      patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib:$out/lib/sane $f
 
       # Horrible kludge: The driver hardcodes /usr/lib/sane/ as a dlopen path.
       # We can directly modify the binary to force a relative lookup instead.

--- a/pkgs/applications/kde/kdevelop/kdevelop.nix
+++ b/pkgs/applications/kde/kdevelop/kdevelop.nix
@@ -35,7 +35,7 @@ mkDerivation rec {
   # https://cgit.kde.org/kdevelop.git/commit/?id=716372ae2e8dff9c51e94d33443536786e4bd85b
   # required as nixos seems to be unable to find CLANG_BUILTIN_DIR
   cmakeFlags = [
-    "-DCLANG_BUILTIN_DIR=${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include"
+    "-DCLANG_BUILTIN_DIR=${lib.getLib llvmPackages.libclang}/lib/clang/${lib.getVersion llvmPackages.clang}/include"
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/applications/misc/1password-gui/linux.nix
+++ b/pkgs/applications/misc/1password-gui/linux.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation {
           pango
           systemd
         ]
-        + ":${stdenv.cc.cc.lib}/lib64";
+        + ":${lib.getLib stdenv.cc.cc}/lib64";
     in
     ''
       runHook preInstall

--- a/pkgs/applications/misc/avalonia-ilspy/default.nix
+++ b/pkgs/applications/misc/avalonia-ilspy/default.nix
@@ -44,7 +44,7 @@ buildDotnetModule rec {
 
   buildInputs = [
     # Dependencies of nuget packages w/ native binaries
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     fontconfig
   ];
 

--- a/pkgs/applications/misc/azuredatastudio/default.nix
+++ b/pkgs/applications/misc/azuredatastudio/default.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
       libxkbcommon
       xorg.libxkbfile
       pango
-      stdenv.cc.cc.lib
+      stdenv.cc.cc
       systemd
     ])
     targetPath

--- a/pkgs/applications/misc/bloodhound/default.nix
+++ b/pkgs/applications/misc/bloodhound/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     nss
     pango
     systemd
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     udev
     xorg.libX11
     xorg.libXScrnSaver

--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -10,7 +10,7 @@ let
 
   rpath = lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
-      libXinerama stdenv.cc.cc.lib libnotify glib gtk3 libappindicator-gtk3
+      libXinerama stdenv.cc.cc libnotify glib gtk3 libappindicator-gtk3
       curl libXfixes libXScrnSaver ];
 
 in

--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     find ${src_repo}/resources/fonts -type d -execdir cp -r '{}' $out/lib/koreader/fonts \;
     find $out -xtype l -print -delete
     wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : ${
-      lib.makeLibraryPath [ gtk3-x11 SDL2 glib stdenv.cc.cc.lib ]
+      lib.makeLibraryPath [ gtk3-x11 SDL2 glib stdenv.cc.cc ]
     }
   '';
 

--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -82,7 +82,7 @@
           libxkbcommon
           xorg.libxkbfile
           pango
-          stdenv.cc.cc.lib
+          (lib.getLib stdenv.cc.cc)
           systemd
         ];
       in ''

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -384,7 +384,7 @@ buildStdenv.mkDerivation {
     "--enable-default-toolkit=cairo-gtk3${lib.optionalString waylandSupport "-wayland"}"
     "--enable-system-pixman"
     "--with-distribution-id=org.nixos"
-    "--with-libclang-path=${llvmPackagesBuildBuild.libclang.lib}/lib"
+    "--with-libclang-path=${lib.getLib llvmPackagesBuildBuild.libclang}/lib"
     "--with-system-ffi"
     "--with-system-icu"
     "--with-system-jpeg"

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
     nspr
     nss
     pango
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     qt6.qtbase
   ];
 

--- a/pkgs/applications/networking/browsers/palemoon/bin.nix
+++ b/pkgs/applications/networking/browsers/palemoon/bin.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus-glib
     gtk2-x11
     libXt
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ] ++ lib.optionals withGTK3 [
     gtk3
   ];

--- a/pkgs/applications/networking/browsers/yandex-browser/default.nix
+++ b/pkgs/applications/networking/browsers/yandex-browser/default.nix
@@ -129,7 +129,7 @@ in stdenv.mkDerivation rec {
     nspr
     nss
     pango
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libqt5pas
     qt6.qtbase
   ];

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -45,7 +45,7 @@ let
 
       nativeBuildInputs = [ makeWrapper ]
                           ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-      buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib openssl protobuf zlib snappy libtirpc ];
+      buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ (lib.getLib stdenv.cc.cc) openssl protobuf zlib snappy libtirpc ];
 
       installPhase = ''
         mkdir $out

--- a/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
         freetype
         nspr
         glib
-        stdenv.cc.cc.lib
+        stdenv.cc.cc
         nss
         libX11
         libXrandr

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -69,7 +69,7 @@ in stdenv.mkDerivation (rec {
     expat
     stdenv.cc.cc
   ];
-  runtimeDependencies = [ libglvnd stdenv.cc.cc.lib (lib.getLib udev) libnotify libappindicator-gtk3 ];
+  runtimeDependencies = [ libglvnd (lib.getLib stdenv.cc.cc) (lib.getLib udev) libnotify libappindicator-gtk3 ];
 
   unpackPhase = "dpkg-deb -x $src .";
 

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -138,7 +138,7 @@ let
       xorg.libXtst
       xorg.libxkbfile
       xorg.libxshmfence
-    ] + ":${stdenv.cc.cc.lib}/lib64";
+    ] + ":${lib.getLib stdenv.cc.cc}/lib64";
 
     buildInputs = [
       gtk3 # needed for GSETTINGS_SCHEMAS_PATH

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   NIX_LDFLAGS = ''
-    -L${stdenv.cc.cc.lib}/lib -lX11 -lglib-2.0 -lgtk-x11-2.0
+    -L${lib.getLib stdenv.cc.cc}/lib -lX11 -lglib-2.0 -lgtk-x11-2.0
     -lgdk-x11-2.0 -lgdk_pixbuf-2.0 -lpango-1.0 -latk-1.0 -lcairo
     -lc -lcrypto
   '';

--- a/pkgs/applications/networking/scaleft/default.nix
+++ b/pkgs/applications/networking/scaleft/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   libPath =
     lib.makeLibraryPath
-       [ stdenv.cc stdenv.cc.cc.lib ];
+       [ stdenv.cc stdenv.cc.cc ];
 
   buildCommand = ''
     mkdir -p $out/bin/

--- a/pkgs/applications/office/banana-accounting/default.nix
+++ b/pkgs/applications/office/banana-accounting/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     e2fsprogs
     gmp
     gtk3
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libGL
     libX11
     libgcrypt

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
     libXmu
     libXrandr
     libXrender
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   dontBuild = true;

--- a/pkgs/applications/office/trilium/server.nix
+++ b/pkgs/applications/office/trilium/server.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoPatchelfHook, fetchurl, nixosTests
+{ lib, stdenv, autoPatchelfHook, fetchurl, nixosTests
 , metaCommon }:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   patches = [

--- a/pkgs/applications/radio/sdrplay/default.nix
+++ b/pkgs/applications/radio/sdrplay/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ libusb1 udev stdenv.cc.cc.lib ];
+  buildInputs = [ libusb1 udev (lib.getLib stdenv.cc.cc) ];
 
   unpackPhase = ''
     sh "$src" --noexec --target source

--- a/pkgs/applications/science/biology/quast/default.nix
+++ b/pkgs/applications/science/biology/quast/default.nix
@@ -35,7 +35,7 @@ pythonPackages.buildPythonApplication rec {
    postFixup = ''
    for file in $(find $out -type f -type f -perm /0111); do
        old_rpath=$(patchelf --print-rpath $file) && \
-       patchelf --set-rpath $old_rpath:${stdenv.cc.cc.lib}/lib $file || true
+       patchelf --set-rpath $old_rpath:${lib.getLib stdenv.cc.cc}/lib $file || true
    done
    # Link to the master program
    ln -s $out/bin/quast.py $out/bin/quast

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -47,7 +47,7 @@ let
 
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${libPath}:$out/eagle-${version}/lib:${stdenv.cc.cc.lib}/lib" \
+        --set-rpath "${libPath}:$out/eagle-${version}/lib:${lib.getLib stdenv.cc.cc}/lib" \
         "$out"/eagle-${version}/eagle
 
       mkdir -p "$out"/bin

--- a/pkgs/applications/science/electronics/picoscope/default.nix
+++ b/pkgs/applications/science/electronics/picoscope/default.nix
@@ -28,7 +28,7 @@ let
       inherit (sources.libpicoipp) version;
       src = fetchurl { inherit (sources.libpicoipp) url sha256; };
       nativeBuildInputs = [ dpkg autoPatchelfHook ];
-      buildInputs = [ stdenv.cc.cc.lib ];
+      buildInputs = [ (lib.getLib stdenv.cc.cc) ];
       sourceRoot = ".";
       unpackCmd = "dpkg-deb -x $src .";
       installPhase = ''

--- a/pkgs/applications/science/logic/saw-tools/default.nix
+++ b/pkgs/applications/science/logic/saw-tools/default.nix
@@ -7,7 +7,7 @@ let
       gmp4
       ncurses
       zlib
-    ] + ":${stdenv.cc.cc.lib}/lib64";
+    ] + ":${lib.getLib stdenv.cc.cc}/lib64";
 
   url = "https://github.com/GaloisInc/saw-script/releases/download";
 

--- a/pkgs/applications/science/logic/verifast/default.nix
+++ b/pkgs/applications/science/logic/verifast/default.nix
@@ -6,7 +6,7 @@ let
   libPath = lib.makeLibraryPath
     [ stdenv.cc.libc stdenv.cc.cc gtk2 gdk-pixbuf atk pango glib cairo
       freetype fontconfig libxml2 gnome2.gtksourceview
-    ] + ":${stdenv.cc.cc.lib}/lib64:$out/libexec";
+    ] + ":${lib.getLib stdenv.cc.cc}/lib64:$out/libexec";
 
   patchExe = x: ''
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \

--- a/pkgs/applications/science/math/wolfram-engine/default.nix
+++ b/pkgs/applications/science/math/wolfram-engine/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     ncurses
     opencv4
     openssl
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     unixODBC
     xkeyboard_config
     libxml2
@@ -113,15 +113,15 @@ stdenv.mkDerivation rec {
     # Fix library paths
     cd $out/libexec/${dirName}/Executables
     for path in MathKernel math mcc wolfram; do
-      makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
+      makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${lib.getLib stdenv.cc.cc}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
     done
 
     for path in WolframKernel wolframscript; do
-      makeWrapper $out/libexec/${dirName}/SystemFiles/Kernel/Binaries/Linux-x86-64/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
+      makeWrapper $out/libexec/${dirName}/SystemFiles/Kernel/Binaries/Linux-x86-64/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${lib.getLib stdenv.cc.cc}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
     done
 
     wrapQtApp "$out/libexec/${dirName}/SystemFiles/FrontEnd/Binaries/Linux-x86-64/WolframPlayer" \
-      --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}" \
+      --set LD_LIBRARY_PATH "${zlib}/lib:${lib.getLib stdenv.cc.cc}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}" \
       --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
     if ! isELF "$out/libexec/${dirName}/SystemFiles/FrontEnd/Binaries/Linux-x86-64/WolframPlayer"; then
       substituteInPlace $out/libexec/${dirName}/SystemFiles/FrontEnd/Binaries/Linux-x86-64/WolframPlayer \

--- a/pkgs/applications/version-management/bcompare/default.nix
+++ b/pkgs/applications/version-management/bcompare/default.nix
@@ -51,7 +51,7 @@ let
     nativeBuildInputs = [ autoPatchelfHook ];
 
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       gtk2
       pango
       cairo

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -107,7 +107,7 @@ let
     dontConfigure = true;
 
     libPath = lib.makeLibraryPath [
-      stdenv.cc.cc.lib
+      stdenv.cc.cc
       curlWithGnuTls
       udev
       libX11

--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -85,7 +85,7 @@ let
       for binary in ${builtins.concatStringsSep " " binaries}; do
         patchelf \
           --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ${lib.makeLibraryPath neededLibraries}:${libGL}/lib:${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
+          --set-rpath ${lib.makeLibraryPath neededLibraries}:${libGL}/lib:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
           $binary
       done
 

--- a/pkgs/applications/video/kodi/addons/inputstream-adaptive/default.nix
+++ b/pkgs/applications/video/kodi/addons/inputstream-adaptive/default.nix
@@ -28,7 +28,7 @@ buildKodiBinaryAddon rec {
 
   extraBuildInputs = [ pugixml rapidjson ];
 
-  extraRuntimeDependencies = [ glib nspr nss stdenv.cc.cc.lib ];
+  extraRuntimeDependencies = [ glib nspr nss (lib.getLib stdenv.cc.cc) ];
 
   extraInstallPhase = let n = namespace; in ''
     ln -s $out/lib/addons/${n}/libssd_wv.so $out/${addonDir}/${n}/libssd_wv.so

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -17,7 +17,7 @@
       substitutions = {
         dynamicLinker = "${stdenv.cc}/nix-support/dynamic-linker";
         libPath = lib.makeLibraryPath [
-          stdenv.cc.cc.lib
+          stdenv.cc.cc
           stdenv.cc.libc
           dotnet-sdk.passthru.icu
           zlib

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -42,7 +42,7 @@ else stdenv.mkDerivation rec {
     PATH=${bintools-unwrapped}/bin:${llvmPackages.clang-unwrapped}/bin:$PATH \
       clang -arch x86_64 -arch arm64 -arch arm64e \
       -isystem "$SDKROOT/usr/include" \
-      -isystem ${llvmPackages.libclang.lib}/lib/clang/*/include \
+      -isystem ${lib.getLib llvmPackages.libclang}/lib/clang/*/include \
       "-L$SDKROOT/usr/lib" \
       -Wl,-install_name,$out/lib/$libName \
       -Wall -std=c99 -O3 -fPIC libredirect.c \

--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -232,7 +232,7 @@ in
   nettle-sys = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ nettle clang ];
-    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
   };
 
   openssl = attrs: {

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -92,7 +92,7 @@
     bindgenHook = callPackage ({}: makeSetupHook {
       name = "rust-bindgen-hook";
       substitutions = {
-        libclang = clang.cc.lib;
+        libclang = (lib.getLib clang.cc);
         inherit clang;
       };
     }

--- a/pkgs/by-name/am/am2rlauncher/package.nix
+++ b/pkgs/by-name/am/am2rlauncher/package.nix
@@ -26,7 +26,7 @@ let
     multiArch = true;
 
     multiPkgs = pkgs: with pkgs; [
-        stdenv.cc.cc.lib
+        (lib.getLib stdenv.cc.cc)
         xorg.libX11
         xorg.libXext
         xorg.libXrandr

--- a/pkgs/by-name/am/amdenc/package.nix
+++ b/pkgs/by-name/am/amdenc/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoPatchelfHook
   ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/am/amdvlk/package.nix
+++ b/pkgs/by-name/am/amdvlk/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       libdrm
       openssl
-      stdenv.cc.cc.lib
+      stdenv.cc.cc
       zlib
     ]
     ++ (with xorg; [

--- a/pkgs/by-name/ap/aphorme/package.nix
+++ b/pkgs/by-name/ap/aphorme/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   # No tests exist
   doCheck = false;
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
   nativeBuildInputs = [ autoPatchelfHook ];
 
   runtimeDependencies = [

--- a/pkgs/by-name/aw/aws-workspaces/package.nix
+++ b/pkgs/by-name/aw/aws-workspaces/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontStrip = true;
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libkrb5
     curl
     lttng-ust

--- a/pkgs/by-name/bl/blendfarm/package.nix
+++ b/pkgs/by-name/bl/blendfarm/package.nix
@@ -64,7 +64,7 @@ buildDotnetModule rec {
     ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     fontconfig
     openssl
     libkrb5

--- a/pkgs/by-name/ca/caligula/package.nix
+++ b/pkgs/by-name/ca/caligula/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-ma7JVbWSiKfkCXCDwA8DFm2+KPrWR+8nSdgGSqehNg8=";
 
   env = {
-     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+     LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
    };
 
 

--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       # nix provide lib/clang headers in libclang, not in llvm.
       substituteInPlace casadi/interfaces/clang/CMakeLists.txt --replace-fail \
         '$'{CLANG_LLVM_LIB_DIR} \
-        ${llvmPackages_17.libclang.lib}/lib
+        ${lib.getLib llvmPackages_17.libclang}/lib
 
       # help casadi find its own libs
       substituteInPlace casadi/core/casadi_os.cpp --replace-fail \

--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
           isGNU = unwrappedCC.isGNU or false;
           isCcache = true;
         };
-        inherit (unwrappedCC) lib;
+        lib = lib.getLib unwrappedCC;
         nativeBuildInputs = [ makeWrapper ];
         # Unwrapped clang does not have a targetPrefix because it is multi-target
         # target is decided with argv0.

--- a/pkgs/by-name/ch/chatd/package.nix
+++ b/pkgs/by-name/ch/chatd/package.nix
@@ -37,7 +37,7 @@ buildNpmPackage rec {
   ] ++ lib.optional stdenv.isLinux autoPatchelfHook; # for onnx libs
 
   buildInputs = [
-    stdenv.cc.cc.lib # for libstdc++.so, required by onnxruntime
+    (lib.getLib stdenv.cc.cc) # for libstdc++.so, required by onnxruntime
     vips # or it will try to download from the Internet
   ];
 

--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib # Used by Conga and .NET Bridge
+    (lib.getLib stdenv.cc.cc) # Used by Conga and .NET Bridge
     ncurses5 # Used by the dyalog binary to correctly display in the terminal
   ]
   ++ lib.optionals htmlRendererSupport [

--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -110,7 +110,7 @@ rustPlatform.buildRustPackage rec {
 
   postFixup = ''
     wrapProgram $out/bin/ecc-rs \
-      --prefix LIBCLANG_PATH : ${llvmPackages.libclang.lib}/lib \
+      --prefix LIBCLANG_PATH : ${lib.getLib llvmPackages.libclang}/lib \
       --prefix PATH : ${lib.makeBinPath (with llvmPackages; [clang bintools-unwrapped])}
   '';
 

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libpulseaudio
     pipewire
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   patches =

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   sourceRoot = ".";
 

--- a/pkgs/by-name/fe/fedimint/package.nix
+++ b/pkgs/by-name/fe/fedimint/package.nix
@@ -39,7 +39,7 @@ buildRustPackage rec {
     protobuf
     pkg-config
     clang
-    libclang.lib
+    (lib.getLib libclang)
   ];
 
   buildInputs = [
@@ -79,7 +79,7 @@ buildRustPackage rec {
   PROTOC = "${buildPackages.protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
   OPENSSL_DIR = openssl.dev;
-  LIBCLANG_PATH = "${libclang.lib}/lib";
+  LIBCLANG_PATH = "${lib.getLib libclang}/lib";
 
   FEDIMINT_BUILD_FORCE_GIT_HASH = "0000000000000000000000000000000000000000";
 

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -119,7 +119,7 @@ buildDotnetModule rec {
       darwin.autoSignDarwinBinariesHook
     ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   dotnet-sdk = dotnetCorePackages.sdk_6_0;
   dotnet-runtime = dotnetCorePackages.runtime_6_0;

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libpulseaudio
     pipewire
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   pnpmDeps = pnpm'.fetchDeps {

--- a/pkgs/by-name/gu/guile-lib/package.nix
+++ b/pkgs/by-name/gu/guile-lib/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   preCheck = ''
     # Make `libgcc_s.so' visible for `pthread_cancel'.
     export LD_LIBRARY_PATH=\
-    "$(dirname $(echo ${stdenv.cc.cc.lib}/lib*/libgcc_s.so))''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+    "$(dirname $(echo ${lib.getLib stdenv.cc.cc}/lib*/libgcc_s.so))''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ig/igir/package.nix
+++ b/pkgs/by-name/ig/igir/package.nix
@@ -28,7 +28,7 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   # from lib/node_modules/igir/node_modules/@node-rs/crc32-linux-x64-musl/crc32.linux-x64-musl.node
   # Irrelevant to our use

--- a/pkgs/by-name/in/inko/package.nix
+++ b/pkgs/by-name/in/inko/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     libz
     libxml2
     ncurses
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     let
       libPath = {
         intune = lib.makeLibraryPath [
-          stdenv.cc.cc.lib
+          stdenv.cc.cc
           libuuid
           xorg.libX11
           curlMinimal

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -151,10 +151,10 @@ in stdenv.mkDerivation (finalAttrs: rec {
     done
     patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) contrib/bash_process-*/$arch/bash_process
     for d in contrib/kodkodi-*/jni/$arch; do
-      patchelf --set-rpath "${lib.concatStringsSep ":" [ "${java}/lib/openjdk/lib/server" "${stdenv.cc.cc.lib}/lib" ]}" $d/*.so
+      patchelf --set-rpath "${lib.concatStringsSep ":" [ "${java}/lib/openjdk/lib/server" "${lib.getLib stdenv.cc.cc}/lib" ]}" $d/*.so
     done
   '' + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-    patchelf --set-rpath "${stdenv.cc.cc.lib}/lib" contrib/z3-*/$arch/z3
+    patchelf --set-rpath "${lib.getLib stdenv.cc.cc}/lib" contrib/z3-*/$arch/z3
   '';
 
   buildPhase = ''

--- a/pkgs/by-name/iv/ivm/package.nix
+++ b/pkgs/by-name/iv/ivm/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-EP3fS4lAGOaXJXAM22ZCn4+9Ah8TM1+wvNerKCKByo0=";
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/je/jextract-21/package.nix
+++ b/pkgs/by-name/je/jextract-21/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   ];
 
   gradleFlags = [
-    "-Pllvm_home=${llvmPackages.libclang.lib}"
+    "-Pllvm_home=${lib.getLib llvmPackages.libclang}"
     "-Pjdk21_home=${jdk21}"
   ];
 

--- a/pkgs/by-name/je/jextract/package.nix
+++ b/pkgs/by-name/je/jextract/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   ];
 
   gradleFlags = [
-    "-Pllvm_home=${llvmPackages.libclang.lib}"
+    "-Pllvm_home=${lib.getLib llvmPackages.libclang}"
     "-Pjdk22_home=${jdk23}"
   ];
 

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -41,7 +41,7 @@ in
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ unzip ];
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   dontUnpack = stdenv.hostPlatform.isLinux;
   dontConfigure = true;

--- a/pkgs/by-name/lu/lunarvim/package.nix
+++ b/pkgs/by-name/lu/lunarvim/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm444 utils/desktop/lvim.desktop -t $out/share/applications
 
     wrapProgram $out/bin/lvim --prefix PATH : ${ lib.makeBinPath finalAttrs.runtimeDeps } \
-      --prefix LD_LIBRARY_PATH : ${stdenv.cc.cc.lib} \
+      --prefix LD_LIBRARY_PATH : ${lib.getLib stdenv.cc.cc} \
       --prefix CC : ${stdenv.cc.targetPrefix}cc
   '' + lib.optionalString finalAttrs.nvimAlias ''
     ln -s $out/bin/lvim $out/bin/nvim

--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -39,7 +39,7 @@ let
 
   runtimeLibs = lib.makeLibraryPath [
     libGL
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
   ];
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/mi/mihomo-party/package.nix
+++ b/pkgs/by-name/mi/mihomo-party/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     alsa-lib
     openssl
     webkitgtk_4_0
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   runtimeDependencies = map lib.getLib [

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
           lib.makeLibraryPath [
             jemalloc
             ffmpeg-headless
-            stdenv.cc.cc.lib
+            stdenv.cc.cc
           ]
         }
 

--- a/pkgs/by-name/mo/modrinth-app/package.nix
+++ b/pkgs/by-name/mo/modrinth-app/package.nix
@@ -48,7 +48,7 @@ symlinkJoin rec {
       xorg.libXxf86vm
 
       # lwjgl
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
 
       # narrator support
       flite

--- a/pkgs/by-name/mo/mongodb-ce/package.nix
+++ b/pkgs/by-name/mo/mongodb-ce/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     curl.dev
     openssl.dev
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
+++ b/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/lib
     install -m 755 usr/lib/libmsal_dbus_client.so $out/lib/
-    patchelf --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc.lib sdbus-cpp ]} $out/lib/libmsal_dbus_client.so
+    patchelf --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc sdbus-cpp ]} $out/lib/libmsal_dbus_client.so
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ne/neothesia/package.nix
+++ b/pkgs/by-name/ne/neothesia/package.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage {
   '';
 
   env = {
-    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
   };
 
   meta = {

--- a/pkgs/by-name/nu/nufmt/package.nix
+++ b/pkgs/by-name/nu/nufmt/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage {
     apple-sdk_11
   ];
 
-  env.LIBCLANG_PATH = lib.optionalString stdenv.cc.isClang "${llvmPackages.libclang.lib}/lib";
+  env.LIBCLANG_PATH = lib.optionalString stdenv.cc.isClang "${lib.getLib llvmPackages.libclang}/lib";
 
   cargoHash = "sha256-5DS6pTYGOQ4qay6+YiUstInRX17n3RViNxKXtFZ6J3k=";
 

--- a/pkgs/by-name/pa/passmark-performancetest/package.nix
+++ b/pkgs/by-name/pa/passmark-performancetest/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ unzip autoPatchelfHook makeWrapper ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     curl
     ncurses5
   ];

--- a/pkgs/by-name/ph/pharo/package.nix
+++ b/pkgs/by-name/ph/pharo/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = let
     libPath = lib.makeLibraryPath (finalAttrs.buildInputs ++ [
-      stdenv.cc.cc.lib
+      stdenv.cc.cc
       "$out"
     ]);
   in ''

--- a/pkgs/by-name/ph/photonvision/package.nix
+++ b/pkgs/by-name/ph/photonvision/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     install -D $src $out/lib/photonvision.jar
 
     makeWrapper ${temurin-jre-bin-11}/bin/java $out/bin/photonvision \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc.lib suitesparse ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc suitesparse ]} \
       --prefix PATH : ${lib.makeBinPath [ temurin-jre-bin-11 bash.out ]} \
       --add-flags "-jar $out/lib/photonvision.jar"
 

--- a/pkgs/by-name/pl/plasticity/package.nix
+++ b/pkgs/by-name/pl/plasticity/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec  {
     nss
     openssl
     pango
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     trash-cli
     xdg-utils
   ];

--- a/pkgs/by-name/po/pocl/package.nix
+++ b/pkgs/by-name/po/pocl/package.nix
@@ -30,7 +30,7 @@ let
       rm -f $out/bin/$BASENAME
       makeWrapper ${clang}/bin/$BASENAME $out/bin/$BASENAME \
         --add-flags "-L$LIBGCC_DIR" \
-        --add-flags "-L${stdenv.cc.cc.lib}/lib"
+        --add-flags "-L${lib.getLib stdenv.cc.cc}/lib"
     done
   '';
 in

--- a/pkgs/by-name/po/portablemc/package.nix
+++ b/pkgs/by-name/po/portablemc/package.nix
@@ -35,7 +35,7 @@ let
     libGL
     glfw
     openal
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
 
     # oshi
     udev

--- a/pkgs/by-name/pr/prismlauncher/package.nix
+++ b/pkgs/by-name/pr/prismlauncher/package.nix
@@ -78,7 +78,7 @@ symlinkJoin {
     let
       runtimeLibs =
         [
-          stdenv.cc.cc.lib
+          (lib.getLib stdenv.cc.cc)
           ## native versions
           glfw3-minecraft
           openal

--- a/pkgs/by-name/pu/pulsar/package.nix
+++ b/pkgs/by-name/pu/pulsar/package.nix
@@ -70,7 +70,7 @@ let
     libxkbcommon
     xorg.libxkbfile
     pango
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
     systemd
   ];
 

--- a/pkgs/by-name/pu/pupdate/package.nix
+++ b/pkgs/by-name/pu/pupdate/package.nix
@@ -20,7 +20,7 @@ buildDotnetModule rec {
   };
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     zlib
     openssl
   ];

--- a/pkgs/by-name/ra/rainbowcrack/package.nix
+++ b/pkgs/by-name/ra/rainbowcrack/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
   ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   dontConfigure = true;
 

--- a/pkgs/by-name/se/segger-jlink/qt4-bundled.nix
+++ b/pkgs/by-name/se/segger-jlink/qt4-bundled.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     fontconfig
     xorg.libXrandr
     xorg.libXfixes

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -142,7 +142,7 @@ rustPlatform.buildRustPackage {
       --prefix LD_LIBRARY_PATH : ${runtimePaths}
   '';
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
 
   meta = {
     description = "The embeddable, independent, memory-safe, modular, parallel web rendering engine";

--- a/pkgs/by-name/sk/skypeforlinux/package.nix
+++ b/pkgs/by-name/sk/skypeforlinux/package.nix
@@ -96,7 +96,7 @@ let
       xorg.libXScrnSaver
       xorg.libxcb
     ]
-    + ":${stdenv.cc.cc.lib}/lib64";
+    + ":${lib.getLib stdenv.cc.cc}/lib64";
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then

--- a/pkgs/by-name/sl/slimserver/package.nix
+++ b/pkgs/by-name/sl/slimserver/package.nix
@@ -28,7 +28,7 @@ let
   );
   libPath = lib.makeLibraryPath [
     zlib
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
   ];
 in
 perlPackages.buildPerlPackage rec {

--- a/pkgs/by-name/st/starpls-bin/package.nix
+++ b/pkgs/by-name/st/starpls-bin/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isElf [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/by-name/st/staruml/package.nix
+++ b/pkgs/by-name/st/staruml/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "/opt/StarUML/staruml" "$out/bin/staruml"
 
     mkdir -p $out/lib
-    ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
+    ln -s ${lib.getLib stdenv.cc.cc}/lib/libstdc++.so.6 $out/lib/
     ln -s ${lib.getLib systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
     patchelf \

--- a/pkgs/by-name/st/styluslabs-write-bin/package.nix
+++ b/pkgs/by-name/st/styluslabs-write-bin/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     libPath = lib.makeLibraryPath [
       libsForQt5.qtbase # libQt5PrintSupport.so.5
       libsForQt5.qtsvg  # libQt5Svg.so.5
-      stdenv.cc.cc.lib  # libstdc++.so.6
+      (lib.getLib stdenv.cc.cc)  # libstdc++.so.6
       libglvnd          # libGL.so.1
       libX11            # libX11.so.6
       libXi             # libXi.so.6

--- a/pkgs/by-name/su/surfer/package.nix
+++ b/pkgs/by-name/su/surfer/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
       openssl
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.AppKit ];
 

--- a/pkgs/by-name/sv/svp/package.nix
+++ b/pkgs/by-name/sv/svp/package.nix
@@ -53,7 +53,7 @@ let
     libusb1
     mpvForSVP
     ocl-icd
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     vapoursynth
     xdg-utils
     xorg.libX11

--- a/pkgs/by-name/tp/tplay/package.nix
+++ b/pkgs/by-name/tp/tplay/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     openssl.dev
     alsa-lib.dev
-    libclang.lib
+    (lib.getLib libclang)
     ffmpeg.dev
     opencv
   ];

--- a/pkgs/by-name/tr/tradingview/package.nix
+++ b/pkgs/by-name/tr/tradingview/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     alsa-lib
     atk
     at-spi2-atk

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libpulseaudio
     pipewire
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   patches =

--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -48,7 +48,7 @@ linux = stdenv.mkDerivation (finalAttrs:  {
   buildInputs = [
     curl
     fontconfig
-    stdenv.cc.cc.lib # libstdc++.so libgcc_s.so
+    (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so
     zlib
   ];
 

--- a/pkgs/by-name/wi/windmill/package.nix
+++ b/pkgs/by-name/wi/windmill/package.nix
@@ -144,7 +144,7 @@ rustPlatform.buildRustPackage {
     openssl
     rustfmt
     lld
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [
@@ -170,7 +170,7 @@ rustPlatform.buildRustPackage {
           bash
         ]
       } \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc.lib ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc ]} \
       --set PYTHON_PATH "${pythonEnv}/bin/python3" \
       --set GO_PATH "${go}/bin/go" \
       --set DENO_PATH "${deno}/bin/deno" \

--- a/pkgs/by-name/wl/wl-gammarelay-applet/package.nix
+++ b/pkgs/by-name/wl/wl-gammarelay-applet/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   runtimeDependencies = [

--- a/pkgs/by-name/ya/yarg/package.nix
+++ b/pkgs/by-name/ya/yarg/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
     alsa-lib
     gtk3
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     zlib
 
     # Run-time libraries (loaded with dlopen)

--- a/pkgs/development/compilers/computecpp/default.nix
+++ b/pkgs/development/compilers/computecpp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
-  buildInputs = [ stdenv.cc.cc.lib ocl-icd zlib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ocl-icd zlib ];
   nativeBuildInputs = [ autoPatchelfHook pkg-config installShellFiles ];
 
   installPhase = ''

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   llvmEnv = symlinkJoin {
     name = "emscripten-llvm-${version}";
-    paths = with llvmPackages; [ clang-unwrapped clang-unwrapped.lib lld llvm ];
+    paths = with llvmPackages; [ clang-unwrapped (lib.getLib clang-unwrapped)  lld llvm ];
   };
 
   nodeModules = buildNpmPackage {

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   LCL_PLATFORM = if withQt then "qt5" else "gtk2";
 
   NIX_LDFLAGS = lib.concatStringsSep " " ([
-    "-L${stdenv.cc.cc.lib}/lib"
+    "-L${lib.getLib stdenv.cc.cc}/lib"
     "-lX11"
     "-lXext"
     "-lXi"

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -112,7 +112,7 @@ let
     buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       alsa-lib # libasound.so wanted by lib/libjsound.so
       fontconfig
-      stdenv.cc.cc.lib # libstdc++.so.6
+      (lib.getLib stdenv.cc.cc) # libstdc++.so.6
       xorg.libX11
       xorg.libXext
       xorg.libXi

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation ({
     ++ extraNativeBuildInputs;
 
   buildInputs = [
-    stdenv.cc.cc.lib # libstdc++.so.6
+    (lib.getLib stdenv.cc.cc) # libstdc++.so.6
     zlib
     libxcrypt-legacy # libcrypt.so.1 (default is .2 now)
   ]

--- a/pkgs/development/compilers/inklecate/default.nix
+++ b/pkgs/development/compilers/inklecate/default.nix
@@ -16,7 +16,7 @@ buildDotnetModule rec {
     hash = "sha512-aUjjT5Qf64wrKRn1vkwJadMOBWMkvsXUjtZ7S3/ZWAh1CCDkQNO84mSbtbVc9ny0fKeJEqaDX2tJNwq7pYqAbA==";
   };
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   projectFile = "inklecate/inklecate.csproj";
   nugetDeps = ./deps.nix;

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -199,7 +199,7 @@ let
             ({ substituteAll, libclang }: substituteAll
               {
                 src = ./lldb/resource-dir.patch;
-                clangLibDir = "${libclang.lib}/lib";
+                clangLibDir = "${lib.getLib libclang}/lib";
               })
             { };
         in

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -355,7 +355,7 @@ let
       mkExtraBuildCommands0 = cc: ''
         rsrc="$out/resource-root"
         mkdir "$rsrc"
-        ln -s "${cc.lib}/lib/clang/${clangVersion}/include" "$rsrc"
+        ln -s "${lib.getLib cc}/lib/clang/${clangVersion}/include" "$rsrc"
         echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
       '';
       mkExtraBuildCommandsBasicRt =
@@ -649,7 +649,7 @@ let
                 { substituteAll, libclang }:
                 (substituteAll {
                   src = metadata.getVersionFile "lldb/resource-dir.patch";
-                  clangLibDir = "${libclang.lib}/lib";
+                  clangLibDir = "${lib.getLib libclang}/lib";
                 }).overrideAttrs
                   (_: _: { name = "resource-dir.patch"; })
               ) { };

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation (rec {
   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
   ] ++ lib.optionals (lib.versionAtLeast release_version "17") [
-    "-DCLANG_RESOURCE_DIR=../../../../${libclang.lib}"
+    "-DCLANG_RESOURCE_DIR=../../../../${lib.getLib libclang}"
   ] ++ lib.optionals enableManpages ([
     "-DLLVM_ENABLE_SPHINX=ON"
     "-DSPHINX_OUTPUT_MAN=ON"

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -59,7 +59,7 @@ let
       alsa-lib # libasound.so wanted by lib/libjsound.so
       fontconfig
       freetype
-      stdenv.cc.cc.lib # libstdc++.so.6
+      (lib.getLib stdenv.cc.cc) # libstdc++.so.6
       xorg.libX11
       xorg.libXext
       xorg.libXi

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -215,7 +215,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     # one that is compatible with the rest of nixpkgs, even when
     # nvcc forces us to use an older gcc
     # NB: We don't actually know if this is the right thing to do
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   # Picked up by autoPatchelf

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -31,7 +31,7 @@
 
 let
   gl_rpath = lib.makeLibraryPath [
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
   ];
 
   rpath = lib.makeLibraryPath [

--- a/pkgs/development/libraries/libkrun/default.nix
+++ b/pkgs/development/libraries/libkrun/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withSound pipewire
     ++ lib.optional sevVariant openssl;
 
-  env.LIBCLANG_PATH = "${llvmPackages.clang-unwrapped.lib}/lib/libclang.so";
+  env.LIBCLANG_PATH = "${lib.getLib llvmPackages.clang-unwrapped}/lib/libclang.so";
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -170,7 +170,7 @@ in stdenv.mkDerivation {
 
   # Needed to discover llvm-config for cross
   preConfigure = ''
-    PATH=${llvmPackages.libllvm.dev}/bin:$PATH
+    PATH=${lib.getDev llvmPackages.libllvm}/bin:$PATH
   '';
 
   mesonFlags = [
@@ -204,7 +204,7 @@ in stdenv.mkDerivation {
     # Enable Intel RT stuff when available
     (lib.mesonBool "install-intel-clc" true)
     (lib.mesonEnable "intel-rt" stdenv.hostPlatform.isx86_64)
-    (lib.mesonOption "clang-libdir" "${llvmPackages.clang-unwrapped.lib}/lib")
+    (lib.mesonOption "clang-libdir" "${lib.getLib llvmPackages.clang-unwrapped}/lib")
 
     # Clover, old OpenCL frontend
     (lib.mesonOption "gallium-opencl" "icd")

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DPREFERRED_LLVM_VERSION=${lib.getVersion llvm}"
-    "-DOPENCL_HEADERS_DIR=${libclang.lib}/lib/clang/${lib.getVersion libclang}/include/"
+    "-DOPENCL_HEADERS_DIR=${lib.getLib libclang}/lib/clang/${lib.getVersion libclang}/include/"
 
     "-DLLVMSPIRV_INCLUDED_IN_LLVM=OFF"
     "-DSPIRV_TRANSLATOR_DIR=${spirv-llvm-translator'}"

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -98,7 +98,7 @@ in
 stdenv.mkDerivation {
   inherit pname version srcs;
 
-  buildInputs = [ stdenv.cc.cc.lib ]
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ]
     ++ optional stdenv.hostPlatform.isLinux libaio
     ++ optional odbcSupport unixODBC;
 

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     ls -1 $tools/bin/* | xargs -I{} install_name_tool -change "@rpath/librocksdb.${lib.versions.major finalAttrs.version}.dylib" $out/lib/librocksdb.dylib {}
   '' + lib.optionalString (stdenv.hostPlatform.isLinux && enableShared) ''
-    ls -1 $tools/bin/* | xargs -I{} patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib {}
+    ls -1 $tools/bin/* | xargs -I{} patchelf --set-rpath $out/lib:${lib.getLib stdenv.cc.cc}/lib {}
   '';
 
   # Old version doesn't ship the .pc file, new version puts wrong paths in there.

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -171,7 +171,7 @@ let
     pname = "libasi";
     buildInputs = [
       libusb1
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
     ];
     nativeBuildInputs = [ autoPatchelfHook ];
     meta = with lib; {
@@ -182,7 +182,7 @@ let
 
   libastroasis = buildIndi3rdParty {
     pname = "libastroasis";
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
     nativeBuildInputs = [ autoPatchelfHook ];
     meta = with lib; {
       license = licenses.unfreeRedistributable;
@@ -193,7 +193,7 @@ let
   libatik = buildIndi3rdParty {
     pname = "libatik";
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
       systemd
       libdc1394
@@ -247,7 +247,7 @@ let
   libinovasdk = buildIndi3rdParty {
     pname = "libinovasdk";
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
     ];
     nativeBuildInputs = [ autoPatchelfHook ];
@@ -348,7 +348,7 @@ let
     '';
 
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
       systemd
     ];
@@ -377,7 +377,7 @@ let
     cmakeFlags = [ "-DQHY_FIRMWARE_INSTALL_DIR=\${CMAKE_INSTALL_PREFIX}/lib/firmware/qhy" ];
 
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
     ];
     nativeBuildInputs = [ autoPatchelfHook ];
@@ -404,7 +404,7 @@ let
   libricohcamerasdk = buildIndi3rdParty {
     pname = "libricohcamerasdk";
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
     ];
     nativeBuildInputs = [ autoPatchelfHook ];
@@ -447,7 +447,7 @@ let
   libsvbony = buildIndi3rdParty {
     pname = "libsvbony";
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libusb1
     ];
     nativeBuildInputs = [ autoPatchelfHook ];

--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -23,7 +23,7 @@ let
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";
-  libcxx-for-libtorch = if stdenv.hostPlatform.isDarwin then libcxx else stdenv.cc.cc.lib;
+  libcxx-for-libtorch = if stdenv.hostPlatform.isDarwin then libcxx else (lib.getLib stdenv.cc.cc);
 in stdenv.mkDerivation {
   inherit version;
   pname = "libtorch";
@@ -59,7 +59,7 @@ in stdenv.mkDerivation {
   '';
 
   postFixup = let
-    rpath = lib.makeLibraryPath [ stdenv.cc.cc.lib ];
+    rpath = lib.makeLibraryPath [ stdenv.cc.cc ];
   in lib.optionalString stdenv.hostPlatform.isLinux ''
     find $out/lib -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
       echo "setting rpath for $lib..."

--- a/pkgs/development/misc/juce/default.nix
+++ b/pkgs/development/misc/juce/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     freetype # libfreetype.so
     curl # libcurl.so
-    stdenv.cc.cc.lib # libstdc++.so libgcc_s.so
+    (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so
     pcre # libpcre2.pc
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib # libasound.so

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -12,7 +12,7 @@ deployAndroidPackage rec {
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = [ "*" ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.zlib pkgs.libcxx stdenv.cc.cc.lib ];
+  buildInputs = lib.optionals (os == "linux") [ pkgs.zlib pkgs.libcxx (lib.getLib stdenv.cc.cc) ];
 
   patchElfBnaries = ''
     # Patch the executables of the toolchains, but not the libraries -- they are needed for crosscompiling

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -3,7 +3,7 @@
 deployAndroidPackage {
   inherit package os;
   nativeBuildInputs = lib.optionals (os == "linux") [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.stdenv.cc.cc.lib pkgs.zlib pkgs.ncurses5 ];
+  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc (lib.getLib pkgs.stdenv.cc.cc) pkgs.zlib pkgs.ncurses5 ];
 
   patchInstructions = lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib64

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     # ifcopenshell needs stdc++
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     boost179
     cgal
     eigen

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -189,7 +189,7 @@ buildPythonPackage {
     lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
     ++ lib.optionals cudaSupport [ autoAddDriverRunpath ];
   # Dynamic link dependencies
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   # jaxlib contains shared libraries that open other shared libraries via dlopen
   # and these implicit dependencies are not recognized by ldd or

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # "Couldn't find libclang.dylib You will likely need to add it manually to PATH to ensure the build succeeds."
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    LLVM_INSTALL_DIR = "${llvmPackages.libclang.lib}/lib";
+    LLVM_INSTALL_DIR = "${lib.getLib llvmPackages.libclang}/lib";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./0001-hardcode-path-to-libgomp.patch;
       gomp = "${
-        if stdenv.cc.isClang then openmp else stdenv.cc.cc.lib
+        if stdenv.cc.isClang then openmp else (lib.getLib stdenv.cc.cc)
       }/lib/libgomp${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -154,7 +154,7 @@ buildPythonPackage {
       ];
 
       libpaths = [
-        stdenv.cc.cc.lib
+        (lib.getLib stdenv.cc.cc)
         zlib
       ];
 

--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     xorg.libXrender
     freetype
     jdk17
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     curl
   ];
 

--- a/pkgs/development/tools/azure-static-sites-client/default.nix
+++ b/pkgs/development/tools/azure-static-sites-client/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     libkrb5
     lttng-ust
     openssl
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     zlib
   ];
 

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
   nativeBuildInputs = [ installShellFiles makeWrapper ]
     ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
-  buildInputs = [ stdenv.cc.cc.lib zlib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) zlib ];
   propagatedBuildInputs = [ jre ];
 
   installPhase = ''

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -112,7 +112,7 @@ rec {
         for variant in "" "-ncurses5" "-ncurses6"; do
           autoPatchelfInJar \
             $out/lib/gradle/lib/native-platform-linux-${arch}$variant-''${nativeVersion}.jar \
-            "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ncurses6 ]}"
+            "${lib.getLib stdenv.cc.cc}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ncurses6 ]}"
         done
 
         # The file-events library _seems_ to follow the native-platform version, but
@@ -120,7 +120,7 @@ rec {
         fileEventsVersion="$(extractVersion file-events $out/lib/gradle/lib/file-events-*.jar)"
         autoPatchelfInJar \
           $out/lib/gradle/lib/file-events-linux-${arch}-''${fileEventsVersion}.jar \
-          "${stdenv.cc.cc.lib}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+          "${lib.getLib stdenv.cc.cc}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
 
         # The scanner doesn't pick up the runtime dependency in the jar.
         # Manually add a reference where it will be found.

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -97,7 +97,7 @@ let
     xorg.libxkbfile
     pango
     pciutils
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
     systemd
   ]
     ++ lib.optionals (lib.versionAtLeast version "9.0.0") [ libdrm mesa ]

--- a/pkgs/development/tools/electron/chromedriver/generic.nix
+++ b/pkgs/development/tools/electron/chromedriver/generic.nix
@@ -51,7 +51,7 @@ let
     src = fetcher version (get tags platform) (get hashes platform);
 
     buildInputs = [
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       glib
       xorg.libxcb
       nspr

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -193,7 +193,7 @@ in ((chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
       libPath = lib.makeLibraryPath [
         libnotify
         pipewire
-        stdenv.cc.cc.lib
+        stdenv.cc.cc
         libsecret
         libpulseaudio
         speechd-minimal

--- a/pkgs/development/tools/gauge/plugins/dotnet/default.nix
+++ b/pkgs/development/tools/gauge/plugins/dotnet/default.nix
@@ -12,7 +12,7 @@ makeGaugePlugin {
   releasePrefix = "gauge-dotnet-";
   isCrossArch = true;
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   meta = {
     description = "Gauge plugin that lets you write tests in C#";

--- a/pkgs/development/tools/glamoroustoolkit/default.nix
+++ b/pkgs/development/tools/glamoroustoolkit/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
       harfbuzz        # libWebView.so
       libsoup_3       # libWebView.so
       webkitgtk_4_1   # libWebView.so
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
     ];
     binPath = lib.makeBinPath [
       zenity          # File selection dialog

--- a/pkgs/development/tools/hotdoc/default.nix
+++ b/pkgs/development/tools/hotdoc/default.nix
@@ -101,8 +101,8 @@ buildPythonApplication rec {
     substituteInPlace hotdoc/extensions/c/c_extension.py \
       --replace "shutil.which('llvm-config')" 'True' \
       --replace "subprocess.check_output(['llvm-config', '--version']).strip().decode()" '"${lib.versions.major llvmPackages.libclang.version}"' \
-      --replace "subprocess.check_output(['llvm-config', '--prefix']).strip().decode()" '"${llvmPackages.libclang.lib}"' \
-      --replace "subprocess.check_output(['llvm-config', '--libdir']).strip().decode()" '"${llvmPackages.libclang.lib}/lib"'
+      --replace "subprocess.check_output(['llvm-config', '--prefix']).strip().decode()" '"${lib.getLib llvmPackages.libclang}"' \
+      --replace "subprocess.check_output(['llvm-config', '--libdir']).strip().decode()" '"${lib.getLib llvmPackages.libclang}/lib"'
   '';
 
   # Make pytest run from a temp dir to have it pick up installed package for cmark

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     cp bin/iaca $out/bin/
     cp lib/* $out/lib
   '';
-  preFixup = let libPath = lib.makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
+  preFixup = let libPath = lib.makeLibraryPath [ stdenv.cc.cc gcc ]; in ''
     patchelf \
         --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 \
         --set-rpath $out/lib:"${libPath}" \

--- a/pkgs/development/tools/mblock-mlink/default.nix
+++ b/pkgs/development/tools/mblock-mlink/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -15,7 +15,7 @@
    # $debugdir:$datadir/auto-load are whitelisted by default by GDB
    "$debugdir" "$datadir/auto-load"
    # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
-   targetPackages.stdenv.cc.cc.lib
+   (lib.getLib targetPackages.stdenv.cc.cc)
   ]
 , writeScript
 }:

--- a/pkgs/development/tools/misc/netcoredbg/default.nix
+++ b/pkgs/development/tools/misc/netcoredbg/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
   src = managed;
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ (lib.getLib stdenv.cc.cc) ];
   installPhase = ''
     mkdir -p $out/share/netcoredbg $out/bin
     cp ${unmanaged}/* $out/share/netcoredbg

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -16,7 +16,7 @@ let
 
   libPath = lib.makeLibraryPath [
     glib libSM libICE gtk2 libXext libXft fontconfig libXrender libXfixes libX11
-    libXi libXrandr libXcursor freetype libXinerama libxcb zlib stdenv.cc.cc.lib
+    libXi libXrandr libXcursor freetype libXinerama libxcb zlib stdenv.cc.cc
     dbus libGL
   ];
 
@@ -58,10 +58,10 @@ stdenv.mkDerivation rec {
                "$out/libQt5Gui.so.5"     \
                "$out/libQt5Core.so.5"    \
                "$out/libQt5Network.so.5" ; do
-        patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$bin"
+        patchelf --set-rpath "${lib.getLib stdenv.cc.cc}/lib:${lib.getLib stdenv.cc.cc}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$bin"
     done
 
-    patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64:${libPath}:\$ORIGIN/../" "$out/platforms/libqxcb.so"
+    patchelf --set-rpath "${lib.getLib stdenv.cc.cc}/lib:${lib.getLib stdenv.cc.cc}/lib64:${libPath}:\$ORIGIN/../" "$out/platforms/libqxcb.so"
 
     # Build the LD_PRELOAD library that makes Logic work from a read-only directory
     mkdir -p "$out/lib"

--- a/pkgs/development/tools/misc/segger-ozone/default.nix
+++ b/pkgs/development/tools/misc/segger-ozone/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     libXfixes
     libXrandr
     libXrender
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/development/tools/misc/yakut/default.nix
+++ b/pkgs/development/tools/misc/yakut/default.nix
@@ -24,7 +24,7 @@ buildPythonApplication rec {
   };
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     click
     coloredlogs
     psutil

--- a/pkgs/development/tools/replay-io/default.nix
+++ b/pkgs/development/tools/replay-io/default.nix
@@ -8,7 +8,7 @@ in rec {
     version = builtins.head (builtins.match ".*/linux-recordreplay-(.*).tgz"
       metadata.recordreplay.url);
     nativeBuildInputs = [ autoPatchelfHook ];
-    buildInputs = [ stdenv.cc.cc.lib openssl zlib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) openssl zlib ];
 
     src = (fetchzip metadata.recordreplay);
     dontBuild = true;
@@ -73,7 +73,7 @@ in rec {
     version = builtins.head
       (builtins.match ".*/linux-node-(.*)" metadata.replay-node.url);
     nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
     src = (fetchurl metadata.replay-node);
     dontUnpack = true;
@@ -114,7 +114,7 @@ in rec {
     };
 
     nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ stdenv.cc.cc.lib nodejs ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) nodejs ];
     dontBuild = true;
     installPhase = ''
       runHook preInstall

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,4 +1,4 @@
-{ rust-bindgen-unwrapped, zlib, bash, runCommand, runCommandCC }:
+{ lib, rust-bindgen-unwrapped, zlib, bash, runCommand, runCommandCC }:
 let
   clang = rust-bindgen-unwrapped.clang;
   self = runCommand "rust-bindgen-${rust-bindgen-unwrapped.version}"
@@ -6,7 +6,7 @@ let
       #for substituteAll
       inherit bash;
       unwrapped = rust-bindgen-unwrapped;
-      libclang = clang.cc.lib;
+      libclang = (lib.getLib clang.cc);
       meta = rust-bindgen-unwrapped.meta // {
         longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
           This version of bindgen is wrapped with the required compiler flags

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -15,10 +15,10 @@ in rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UROy/MyPBKJe+EaiUIDbOYKVbge0C9LsmfnsvOLEONE=";
 
-  buildInputs = [ clang.cc.lib ];
+  buildInputs = [ (lib.getLib clang.cc) ];
 
   preConfigure = ''
-    export LIBCLANG_PATH="${clang.cc.lib}/lib"
+    export LIBCLANG_PATH="${lib.getLib clang.cc}/lib"
   '';
 
   doCheck = true;

--- a/pkgs/development/web/postman/linux.nix
+++ b/pkgs/development/web/postman/linux.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     atk
     at-spi2-atk
     at-spi2-core

--- a/pkgs/games/airshipper/default.nix
+++ b/pkgs/games/airshipper/default.nix
@@ -31,7 +31,7 @@ let
     runtimeLibs = [
       udev
       alsa-lib
-      stdenv.cc.cc.lib
+      (lib.getLib stdenv.cc.cc)
       libxkbcommon
       libxcb
       libX11

--- a/pkgs/games/andyetitmoves/default.nix
+++ b/pkgs/games/andyetitmoves/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{opt/andyetitmoves,bin}
     cp -r * $out/opt/andyetitmoves/
 
-    fullPath=${stdenv.cc.cc.lib}/lib64
+    fullPath=${lib.getLib stdenv.cc.cc}/lib64
     for i in $nativeBuildInputs; do
       fullPath=$fullPath''${fullPath:+:}$i/lib
     done

--- a/pkgs/games/arena/default.nix
+++ b/pkgs/games/arena/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   # stdenv.cc.cc.lib is in that list to pick up libstdc++.so. Is there a better way?
-  buildInputs = [gtk2-x11 glib pango cairo atk gdk-pixbuf libX11 stdenv.cc.cc.lib];
+  buildInputs = [gtk2-x11 glib pango cairo atk gdk-pixbuf libX11 (lib.getLib stdenv.cc.cc)];
 
   unpackPhase = ''
     # This is is a tar bomb, i.e. it extract a dozen files and directories to

--- a/pkgs/games/clonehero/default.nix
+++ b/pkgs/games/clonehero/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
     alsa-lib
     gtk3
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     zlib
 
     # Run-time libraries (loaded with dlopen)

--- a/pkgs/games/dwarf-fortress/game.nix
+++ b/pkgs/games/dwarf-fortress/game.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation {
   buildInputs = optionals isAtLeast50 [ SDL2 SDL2_image SDL2_mixer ]
     ++ optional (!isAtLeast50) SDL
     ++ optional enableUnfuck dwarf-fortress-unfuck
-    ++ [ stdenv.cc.cc.lib ];
+    ++ [ (lib.getLib stdenv.cc.cc) ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/games/everspace/default.nix
+++ b/pkgs/games/everspace/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     pango
     gtk2-x11
     openal
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   runtimeDependencies = [

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -26,25 +26,25 @@ stdenv.mkDerivation {
     do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
     done
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
              launcher_$arch
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib\
              libNetwork_$arch.so
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib\
              libQtCoreUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
              libQtGuiUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib\
              libQtNetworkUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXrender fontconfig freetype ]}\
              libQtWebKitUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib\
              libQtXmlUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib\
              libRakNet_$arch.so
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXinerama libXrandr ]}\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXinerama libXrandr ]}\
              libUnigine_$arch.so
-    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXinerama libXrandr ]}\
+    patchelf --set-rpath ${lib.getLib stdenv.cc.cc}/lib64:${makeLibraryPath [ stdenv.cc.cc libX11 libXext libXinerama libXrandr ]}\
              OilRush_$arch
   '';
   installPhase = ''

--- a/pkgs/games/planetaryannihilation/default.nix
+++ b/pkgs/games/planetaryannihilation/default.nix
@@ -23,12 +23,12 @@ stdenv.mkDerivation rec {
     ln -s ${systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/PA"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib xorg.libXdamage xorg.libXfixes gtk2 glib stdenv.cc.libc "$out" xorg.libXext pango udev xorg.libX11 xorg.libXcomposite alsa-lib atk nspr fontconfig cairo pango nss freetype gnome2.GConf gdk-pixbuf xorg.libXrender ]}:{stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" "$out/host/CoherentUI_Host"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc xorg.libXdamage xorg.libXfixes gtk2 glib stdenv.cc.libc "$out" xorg.libXext pango udev xorg.libX11 xorg.libXcomposite alsa-lib atk nspr fontconfig cairo pango nss freetype gnome2.GConf gdk-pixbuf xorg.libXrender ]}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" "$out/host/CoherentUI_Host"
 
-    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.libc xorg.libX11 xorg.libXcursor gtk2 glib curl "$out" ]}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64"
+    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc xorg.libX11 xorg.libXcursor gtk2 glib curl "$out" ]}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64"
 
     for f in $out/lib/*; do
-      patchelf --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib curl xorg.libX11 stdenv.cc.libc xorg.libXcursor "$out" ]}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" $f
+      patchelf --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc curl xorg.libX11 stdenv.cc.libc xorg.libXcursor "$out" ]}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" $f
     done
   '';
 

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ unzip ];
   sourceRoot = pname;
 
-  libPath = lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.libc SDL2 SDL2_mixer
+  libPath = lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc SDL2 SDL2_mixer
     libogg libvorbis ];
 
   unpackPhase = ''

--- a/pkgs/kde/gear/kdevelop/default.nix
+++ b/pkgs/kde/gear/kdevelop/default.nix
@@ -39,7 +39,7 @@ mkKdeDerivation {
   ];
 
   extraCmakeFlags = [
-    "-DCLANG_BUILTIN_DIR=${libclang.lib}/lib/clang/${lib.versions.major libclang.version}/include"
+    "-DCLANG_BUILTIN_DIR=${lib.getLib libclang}/lib/clang/${lib.versions.major libclang.version}/include"
     "-DAPR_CONFIG_PATH=${apr.dev}/bin"
     "-DAPU_CONFIG_PATH=${aprutil.dev}/bin"
   ];

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -147,15 +147,15 @@ stdenv.mkDerivation rec {
       ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so
       ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so.1
 
-      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" libcanonufr2r.so.1.0.0
-      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" libcaepcmufr2.so.1.0
-      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" libColorGearCufr2.so.2.0.0
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64:$out/lib" libcanonufr2r.so.1.0.0
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" libcaepcmufr2.so.1.0
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" libColorGearCufr2.so.2.0.0
     )
 
     (
       cd $out/bin
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64" cnsetuputil2 cnpdfdrv
-      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.libc}/lib64:$out/lib" cnpkbidir cnrsdrvufr2 cnpkmoduleufr2r cnjbigufr2
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" cnsetuputil2 cnpdfdrv
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64:$out/lib" cnpkbidir cnrsdrvufr2 cnpkmoduleufr2r cnjbigufr2
 
       wrapProgram $out/bin/cnrsdrvufr2 \
         --prefix LD_LIBRARY_PATH ":" "$out/lib" \

--- a/pkgs/misc/cups/drivers/samsung/1.00.36/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.36/default.nix
@@ -96,7 +96,7 @@ in stdenv.mkDerivation rec {
     patchelf --set-rpath "$out/lib:${lib.getLib cups}/lib" "$out/lib/libscmssc.so"
     patchelf --set-rpath "$out/lib:${libxml2.out}/lib:${libusb-compat-0_1.out}/lib" "$out/lib/sane/libsane-smfp.so.1.0.1"
 
-    ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
+    ln -s ${lib.getLib stdenv.cc.cc}/lib/libstdc++.so.6 $out/lib/
   '';
 
   # all binaries are already stripped

--- a/pkgs/misc/cups/drivers/samsung/1.00.37.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.37.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
     patchelf --set-rpath "$out/lib:${lib.getLib cups}/lib" "$out/lib/libscmssc.so"
     patchelf --set-rpath "$out/lib:${libxml2.out}/lib:${libusb-compat-0_1.out}/lib" "$out/lib/sane/libsane-smfp.so.1.0.1"
 
-    ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
+    ln -s ${lib.getLib stdenv.cc.cc}/lib/libstdc++.so.6 $out/lib/
   '';
 
   # all binaries are already stripped

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -24,7 +24,7 @@
 let
   installationPath = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64" else "i386";
   appendPath = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "64";
-  libPath = lib.makeLibraryPath [ cups libusb-compat-0_1 ] + ":$out/lib:${stdenv.cc.cc.lib}/lib${appendPath}";
+  libPath = lib.makeLibraryPath [ cups libusb-compat-0_1 ] + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib${appendPath}";
 in stdenv.mkDerivation rec {
   pname = "samsung-UnifiedLinuxDriver";
   version = "4.01.17";

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -385,7 +385,7 @@ let plugins = {
     # for the version, look for the driver of XP-750 in the search page
     version = "2.30.4";
 
-    buildInputs = [ stdenv.cc.cc.lib ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
     nativeBuildInputs = [ autoPatchelfHook ];
 
     src = fetchurl {

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     expat
     zlib
   ];

--- a/pkgs/os-specific/linux/intel-compute-runtime/default.nix
+++ b/pkgs/os-specific/linux/intel-compute-runtime/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    patchelf --set-rpath ${lib.makeLibraryPath [ intel-gmmlib intel-graphics-compiler libva stdenv.cc.cc.lib ]} \
+    patchelf --set-rpath ${lib.makeLibraryPath [ intel-gmmlib intel-graphics-compiler libva stdenv.cc.cc ]} \
       $out/lib/intel-opencl/libigdrcl.so
   '';
 

--- a/pkgs/os-specific/linux/intel-ocl/default.nix
+++ b/pkgs/os-specific/linux/intel-ocl/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   libPath = lib.makeLibraryPath [
-    stdenv.cc.cc.lib
+    stdenv.cc.cc
     ncurses5
     numactl
     zlib

--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -39,7 +39,7 @@ let
             zlib
           ] ++ (args.buildInputs or [ ]);
 
-          env.LIBCLANG_PATH = args.env.LIBCLANG_PATH or "${llvmPackages.libclang.lib}/lib";
+          env.LIBCLANG_PATH = args.env.LIBCLANG_PATH or "${lib.getLib llvmPackages.libclang}/lib";
 
           # Needs to be disabled in BPF builds
           hardeningDisable = [

--- a/pkgs/os-specific/linux/uhk-agent/default.nix
+++ b/pkgs/os-specific/linux/uhk-agent/default.nix
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     libusb1
   ];
 

--- a/pkgs/os-specific/linux/xp-pen-drivers/deco-01-v2/default.nix
+++ b/pkgs/os-specific/linux/xp-pen-drivers/deco-01-v2/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     libXinerama
     glibc
     libGL
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     qtx11extras
   ];
 

--- a/pkgs/os-specific/linux/xp-pen-drivers/g430/default.nix
+++ b/pkgs/os-specific/linux/xp-pen-drivers/g430/default.nix
@@ -19,7 +19,7 @@ mkDerivation rec {
     libXtst
     qtbase
     libglvnd
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -44,7 +44,7 @@ buildGoModule rec {
   tags = [ "rocksdb_7_10" ];
 
   CGO_LDFLAGS = [
-    "-L${stdenv.cc.cc.lib}/lib"
+    "-L${lib.getLib stdenv.cc.cc}/lib"
     "-lrocksdb"
     "-lz"
     "-lbz2"

--- a/pkgs/servers/meteor/default.nix
+++ b/pkgs/servers/meteor/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
     # Patch node.
     patchelf \
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      --set-rpath "$(patchelf --print-rpath $out/dev_bundle/bin/node):${stdenv.cc.cc.lib}/lib" \
+      --set-rpath "$(patchelf --print-rpath $out/dev_bundle/bin/node):${lib.getLib stdenv.cc.cc}/lib" \
       $out/dev_bundle/bin/node
 
     # Patch mongo.
@@ -86,7 +86,7 @@ stdenv.mkDerivation {
     # Patch node dlls.
     for p in $(find $out/packages -name '*.node'); do
       patchelf \
-        --set-rpath "$(patchelf --print-rpath $p):${stdenv.cc.cc.lib}/lib" \
+        --set-rpath "$(patchelf --print-rpath $p):${lib.getLib stdenv.cc.cc}/lib" \
         $p || true
     done
   '';

--- a/pkgs/servers/networkaudiod/default.nix
+++ b/pkgs/servers/networkaudiod/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     alsa-lib
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   dontConfigure = true;

--- a/pkgs/servers/photoprism/libtensorflow.nix
+++ b/pkgs/servers/photoprism/libtensorflow.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   # Patch library to use our libc, libstdc++ and others
   patchPhase =
     let
-      rpath = lib.makeLibraryPath [ stdenv.cc.libc stdenv.cc.cc.lib ];
+      rpath = lib.makeLibraryPath [ stdenv.cc.libc stdenv.cc.cc ];
     in
     ''
       chmod -R +w lib

--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   buildInputs = [
     alsa-lib
     zlib
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     krb5
     libtasn1
     lttng-ust_2_12
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];

--- a/pkgs/servers/search/opensearch/default.nix
+++ b/pkgs/servers/search/opensearch/default.nix
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     wrapProgram $out/bin/opensearch \
       --prefix PATH : "${lib.makeBinPath [ gnugrep coreutils ]}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/plugins/opensearch-knn/lib/" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ]}:$out/plugins/opensearch-knn/lib/" \
       --set JAVA_HOME "${jre_headless}"
 
     wrapProgram $out/bin/opensearch-plugin --set JAVA_HOME "${jre_headless}"

--- a/pkgs/servers/urserver/default.nix
+++ b/pkgs/servers/urserver/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     bluez
     libX11
     libXtst

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -129,7 +129,7 @@ let
 
                 rsrc="$out/resource-root"
                 mkdir "$rsrc"
-                ln -s "$(clangResourceRootIncludePath "${clang-unwrapped.lib}")" "$rsrc"
+                ln -s "$(clangResourceRootIncludePath "${lib.getLib clang-unwrapped}")" "$rsrc"
                 ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
                 ln -s "${compiler-rt.out}/share" "$rsrc/share"
                 echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
@@ -1036,7 +1036,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                       extraBuildCommands = ''
                         rsrc="$out/resource-root"
                         mkdir "$rsrc"
-                        ln -s "${cc.lib}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
+                        ln -s "${lib.getLib cc}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
                         echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
                         ln -s "${prevStage.llvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
                         ln -s "${prevStage.llvmPackages.compiler-rt.out}/share" "$rsrc/share"
@@ -1211,7 +1211,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           ++ (with prevStage.llvmPackages; [
             bintools-unwrapped
             clang-unwrapped
-            clang-unwrapped.lib
+            (lib.getLib clang-unwrapped)
             compiler-rt
             compiler-rt.dev
             libcxx

--- a/pkgs/tools/admin/pulumi-bin/default.nix
+++ b/pkgs/tools/admin/pulumi-bin/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
   installPhase = ''
     install -D -t $out/bin/ *
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
-    wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
+    wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${lib.getLib stdenv.cc.cc}/lib"
   '' + ''
     installShellCompletion --cmd pulumi \
       --bash <($out/bin/pulumi completion bash) \

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -132,7 +132,7 @@ buildGoModule rec {
         mkdir -p $out/bin
         makeWrapper ${pulumi}/bin/pulumi $out/bin/pulumi \
           --suffix PATH : ${lib.makeBinPath (f pulumiPackages)} \
-          --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
+          --set LD_LIBRARY_PATH "${lib.getLib stdenv.cc.cc}/lib"
       '';
   };
 

--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
 
   dontBuild = true;
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ (lib.getLib stdenv.cc.cc) ];
 
   nativeBuildInputs = [ installShellFiles ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];

--- a/pkgs/tools/audio/stt/default.nix
+++ b/pkgs/tools/audio/stt/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     bzip2
     xz
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   installPhase = ''

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -3,13 +3,13 @@
 let
   p = if stdenv.hostPlatform.is64bit then {
       arch = "x86_64";
-      gcclib = "${stdenv.cc.cc.lib}/lib64";
+      gcclib = "${lib.getLib stdenv.cc.cc}/lib64";
       sha256 = "sha256-HH/pLZmDr6m/B3e6MHafDGnNWR83oR2y1ijVMR/LOF0=";
       webarchive = "20220519080155";
     }
     else {
       arch = "i386";
-      gcclib = "${stdenv.cc.cc.lib}/lib";
+      gcclib = "${lib.getLib stdenv.cc.cc}/lib";
       sha256 = "sha256-28dmdnJf+qh9r3F0quwlYXB/UqcOzcHzuzFq8vt2bf0=";
       webarchive = "20220519080430";
     };

--- a/pkgs/tools/games/opentracker/default.nix
+++ b/pkgs/tools/games/opentracker/default.nix
@@ -47,7 +47,7 @@ buildDotnetModule rec {
   ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     fontconfig
     gtk3
     icu

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -102,7 +102,7 @@ python.pkgs.buildPythonApplication rec {
     # inetutils is used in esphome/dashboard/status/ping.py
     "--prefix PATH : ${lib.makeBinPath [ platformio esptool git inetutils ]}"
     "--prefix PYTHONPATH : ${python.pkgs.makePythonPath dependencies}" # will show better error messages
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc ]}"
     "--set ESPHOME_USE_SUBPROCESS ''"
   ];
 

--- a/pkgs/tools/misc/geekbench/5.nix
+++ b/pkgs/tools/misc/geekbench/5.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/misc/geekbench/6.nix
+++ b/pkgs/tools/misc/geekbench/6.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
     ${patchelf}/bin/patchelf \
       --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib64:${stdenv.cc.cc.lib}/lib \
+      --set-rpath ${libPath}:${lib.getLib stdenv.cc.cc}/lib64:${lib.getLib stdenv.cc.cc}/lib \
       $out/opt/MegaRAID/MegaCli/MegaCli64
 
     ln -s $out/opt/MegaRAID/MegaCli/MegaCli64 $out/bin/MegaCli64

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     libpcap
     openssl
     nss
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
   ];
 
   desktopItems = [

--- a/pkgs/tools/networking/mqttmultimeter/default.nix
+++ b/pkgs/tools/networking/mqttmultimeter/default.nix
@@ -32,7 +32,7 @@ buildDotnetModule rec {
     copyDesktopItems
   ];
 
-  buildInputs = [ stdenv.cc.cc.lib ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   postInstall = ''
     rm -rf $out/lib/${lib.toLower pname}/runtimes/{*musl*,win*}

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation {
       rm -f $out/lib/*.a
       ${lib.optionalString stdenv.hostPlatform.isLinux ''
         chmod u+w $out/lib/*.so.*
-        patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+        patchelf --set-rpath $out/lib:${lib.getLib stdenv.cc.cc}/lib $out/lib/libboost_thread.so.*
       ''}
       ${lib.optionalString stdenv.hostPlatform.isDarwin ''
         for LIB in $out/lib/*.dylib; do

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -184,7 +184,7 @@ self = stdenv.mkDerivation {
       rm -f $out/lib/*.a
       ${lib.optionalString stdenv.hostPlatform.isLinux ''
         chmod u+w $out/lib/*.so.*
-        patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+        patchelf --set-rpath $out/lib:${lib.getLib stdenv.cc.cc}/lib $out/lib/libboost_thread.so.*
       ''}
     '' +
     # On all versions before c9f51e87057652db0013289a95deffba495b35e7, which

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   buildInputs = [
-    stdenv.cc.cc.lib
+    (lib.getLib stdenv.cc.cc)
     pam
   ];
 

--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation rec {
   inherit version;
   pname = "dell-command-configure";
 
-  buildInputs = [ openssl stdenv.cc.cc.lib ];
+  buildInputs = [ openssl (lib.getLib stdenv.cc.cc) ];
   nativeBuildInputs = [ autoPatchelfHook ];
   dontConfigure = true;
 


### PR DESCRIPTION
In preparation to eliminate the lib output for the unwrapped clang, use `lib.getLib` to access the `lib` output.

there are only 2 outputs that change:

`vimPluginsUpdater` because it include `./.` and a file in the directory is modified.
`planetary_annihilation` fixed a typeo that `{stdenv.cc.cc.lib}` -> `${lib.getLib stdenv.cc.cc}`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
