### PR TITLE
[Backport release-24.05] nixos/swapspace: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15389,6 +15389,13 @@
     githubId = 101753;
     keys = [ { fingerprint = "5D69 CF04 B7BC 2BC1 A567  9267 00BC F29B 3208 0700"; } ];
   };
+  phanirithvij = {
+    name = "Phani Rithvij";
+    email = "phanirithvij2000@gmail.com";
+    github = "phanirithvij";
+    githubId = 29627898;
+    matrix = "@phanirithvij:matrix.org";
+  };
   phdcybersec = {
     name = "Léo Lavaur";
     email = "phdcybersec@pm.me";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -192,6 +192,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Suwayomi Server](https://github.com/Suwayomi/Suwayomi-Server), a free and open source manga reader server that runs extensions built for [Tachiyomi](https://tachiyomi.org). Available as [services.suwayomi-server](#opt-services.suwayomi-server.enable).
 
+- [Swapspace](https://github.com/Tookmund/Swapspace), a dynamic swap space manager, turns your unused free space into swap automatically. Available as [services.swapspace](#opt-services.swapspace.enable).
+
 - [TigerBeetle](https://tigerbeetle.com/), a distributed financial accounting database designed for mission critical safety and performance. Available as [services.tigerbeetle](#opt-services.tigerbeetle.enable).
 
 - [transfer-sh](https://github.com/dutchcoders/transfer.sh), a tool that supports easy and fast file sharing from the command-line. Available as [services.transfer-sh](#opt-services.transfer-sh.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1306,6 +1306,7 @@
   ./services/system/nscd.nix
   ./services/system/saslauthd.nix
   ./services/system/self-deploy.nix
+  ./services/system/swapspace.nix
   ./services/system/systembus-notify.nix
   ./services/system/systemd-lock-handler.nix
   ./services/system/uptimed.nix

--- a/nixos/modules/services/system/swapspace.nix
+++ b/nixos/modules/services/system/swapspace.nix
@@ -1,0 +1,120 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.swapspace;
+  inherit (lib)
+    types
+    mkOption
+    mkPackageOption
+    mkEnableOption
+    ;
+  configFile = pkgs.writeText "swapspace.conf" (lib.generators.toKeyValue { } cfg.settings);
+in
+{
+  options.services.swapspace = {
+    enable = mkEnableOption "Swapspace, a dynamic swap space manager";
+    package = mkPackageOption pkgs "swapspace" { };
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "-P"
+        "-v"
+      ];
+      description = "Any extra arguments to pass to swapspace";
+    };
+    settings = mkOption {
+      type = types.submodule {
+        options = {
+          swappath = mkOption {
+            type = types.str;
+            default = "/var/lib/swapspace";
+            description = "Location where swapspace may create and delete swapfiles";
+          };
+          lower_freelimit = mkOption {
+            type = types.ints.between 0 99;
+            default = 20;
+            description = "Lower free-space threshold: if the percentage of free space drops below this number, additional swapspace is allocated";
+          };
+          upper_freelimit = mkOption {
+            type = types.ints.between 0 100;
+            default = 60;
+            description = "Upper free-space threshold: if the percentage of free space exceeds this number, swapspace will attempt to free up swapspace";
+          };
+          freetarget = mkOption {
+            type = types.ints.between 2 99;
+            default = 30;
+            description = ''
+              Percentage of free space swapspace should aim for when adding swapspace.
+              This should fall somewhere between lower_freelimit and upper_freelimit.
+            '';
+          };
+          min_swapsize = mkOption {
+            type = types.str;
+            default = "4m";
+            description = "Smallest allowed size for individual swapfiles";
+          };
+          max_swapsize = mkOption {
+            type = types.str;
+            default = "2t";
+            description = "Greatest allowed size for individual swapfiles";
+          };
+          cooldown = mkOption {
+            type = types.ints.unsigned;
+            default = 600;
+            description = ''
+              Duration (roughly in seconds) of the moratorium on swap allocation that is instated if disk space runs out, or the cooldown time after a new swapfile is successfully allocated before swapspace will consider deallocating swap space again.
+              The default cooldown period is about 10 minutes.
+            '';
+          };
+          buffer_elasticity = mkOption {
+            type = types.ints.between 0 100;
+            default = 30;
+            description = ''Percentage of buffer space considered to be "free"'';
+          };
+          cache_elasticity = mkOption {
+            type = types.ints.between 0 100;
+            default = 80;
+            description = ''Percentage of cache space considered to be "free"'';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Config file for swapspace.
+        See the options here: <https://github.com/Tookmund/Swapspace/blob/master/swapspace.conf>
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    systemd.services.swapspace = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = [
+          ""
+          "${lib.getExe cfg.package} -c ${configFile} ${utils.escapeSystemdExecArgs cfg.extraArgs}"
+        ];
+      };
+    };
+    systemd.tmpfiles.settings.swapspace = {
+      ${cfg.settings.swappath}.d = {
+        mode = "0700";
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      Luflosi
+      phanirithvij
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -885,6 +885,7 @@ in {
   swap-file-btrfs = handleTest ./swap-file-btrfs.nix {};
   swap-partition = handleTest ./swap-partition.nix {};
   swap-random-encryption = handleTest ./swap-random-encryption.nix {};
+  swapspace = handleTestOn ["aarch64-linux" "x86_64-linux"] ./swapspace.nix {};
   sway = handleTest ./sway.nix {};
   swayfx = handleTest ./swayfx.nix {};
   switchTest = handleTest ./switch-test.nix { ng = false; };

--- a/nixos/tests/swapspace.nix
+++ b/nixos/tests/swapspace.nix
@@ -1,0 +1,69 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  {
+    name = "swapspace";
+
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [
+        Luflosi
+        phanirithvij
+      ];
+    };
+
+    nodes.machine = {
+      virtualisation.memorySize = 512;
+
+      services.swapspace = {
+        enable = true;
+        extraArgs = [ "-v" ];
+        settings = {
+          # test outside /var/lib/swapspace
+          swappath = "/swamp";
+          cooldown = 1;
+        };
+      };
+
+      swapDevices = lib.mkOverride 0 [
+        {
+          size = 127;
+          device = "/root/swapfile";
+        }
+      ];
+      boot.kernel.sysctl."vm.swappiness" = 60;
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("swapspace.service")
+      machine.wait_for_unit("root-swapfile.swap")
+
+      swamp = False
+      with subtest("swapspace works"):
+        machine.execute("mkdir /root/memfs")
+        machine.execute("mount -o size=2G -t tmpfs none /root/memfs")
+        i = 0
+        while i < 14:
+          print(machine.succeed("free -h"))
+          out = machine.succeed("sh -c 'swapon --show --noheadings --raw --bytes | grep /root/swapfile'")
+          row = out.split(' ')
+          # leave 1MB free to not get killed by oom
+          freebytes=int(row[2]) - int(row[3]) - 1*1024*1024
+          machine.succeed(f"dd if=/dev/random of=/root/memfs/{i} bs={freebytes} count=1")
+          machine.sleep(1)
+          out = machine.succeed("swapon --show")
+          print(out)
+          swamp = "/swamp" in out
+          if not swamp:
+            i += 1
+          else:
+            print("*"*10, "SWAPED", "*"*10)
+            machine.succeed("rm -f /root/memfs/*")
+            break
+
+      print(machine.succeed("swapspace -e -s /swamp"))
+      assert "/swamp" not in machine.execute("swapon --show")
+      assert swamp
+    '';
+  }
+)

--- a/pkgs/tools/admin/swapspace/default.nix
+++ b/pkgs/tools/admin/swapspace/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, installShellFiles, util-linux }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  installShellFiles,
+  util-linux,
+  nixosTests,
+}:
 
 stdenv.mkDerivation rec {
   pname = "swapspace";
@@ -34,6 +42,10 @@ stdenv.mkDerivation rec {
     installManPage doc/swapspace.8
     install --mode=444 -D 'swapspace.service' "$out/etc/systemd/system/swapspace.service"
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) swapspace;
+  };
 
   meta = with lib; {
     description = "Dynamic swap manager for Linux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of #348588 (and the add-maintainer commit from #332765).

Ran the test, seems to be working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
