### PR TITLE
tulip: fix build

### DIFF
--- a/pkgs/applications/science/misc/tulip/default.nix
+++ b/pkgs/applications/science/misc/tulip/default.nix
@@ -47,12 +47,15 @@ stdenv.mkDerivation rec {
 
   qtWrapperArgs = [ ''--prefix PATH : ${lib.makeBinPath [ python3 ]}'' ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
-    # fatal error: 'Python.h' file not found
-    "-I${python3}/include/${python3.libPrefix}"
-    # error: format string is not a string literal (potentially insecure)
-    "-Wno-format-security"
-  ]);
+  env.NIX_CFLAGS_COMPILE =
+    # error: invalid conversion from 'unsigned char*' to 'char*'
+    "-fpermissive "
+    + (lib.optionalString stdenv.hostPlatform.isDarwin (toString [
+      # fatal error: 'Python.h' file not found
+      "-I${python3}/include/${python3.libPrefix}"
+      # error: format string is not a string literal (potentially insecure)
+      "-Wno-format-security"
+    ]));
 
   # FIXME: "make check" needs Docbook's DTD 4.4, among other things.
   doCheck = false;

--- a/pkgs/applications/science/misc/tulip/default.nix
+++ b/pkgs/applications/science/misc/tulip/default.nix
@@ -1,6 +1,20 @@
-{ lib, stdenv, fetchurl, libxml2, freetype, libGLU, libGL, glew
-, qtbase, wrapQtAppsHook, autoPatchelfHook, python3
-, cmake, libjpeg, llvmPackages }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  libxml2,
+  freetype,
+  libGLU,
+  libGL,
+  glew,
+  qtbase,
+  wrapQtAppsHook,
+  autoPatchelfHook,
+  python3,
+  cmake,
+  libjpeg,
+  llvmPackages,
+}:
 
 stdenv.mkDerivation rec {
   pname = "tulip";
@@ -11,12 +25,25 @@ stdenv.mkDerivation rec {
     hash = "sha256-7z21WkPi1v2AGishDmXZPAedMjgXPRnpUiHTzEnc5LY=";
   };
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = [ libxml2 freetype glew libjpeg qtbase python3 ]
+  buildInputs =
+    [
+      libxml2
+      freetype
+      glew
+      libjpeg
+      qtbase
+      python3
+    ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ libGLU libGL ];
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libGLU
+      libGL
+    ];
 
   qtWrapperArgs = [ ''--prefix PATH : ${lib.makeBinPath [ python3 ]}'' ];
 


### PR DESCRIPTION
- **tulip: format using nixfmt**
- **tulip: fix compilation by adding the `-fpermissive` flag**

A typecast from unsigned char* to char* in the source broke the build so I added -fpermissive to make the build function again

ZHF: #352882 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
