### PR TITLE
jitterentropy: switch to cmake build, darwin support, `with lib;` cleanup, RFC format

### DIFF
--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -17,12 +17,12 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "fortify" ]; # avoid warnings
 
-  meta = with lib; {
+  meta = {
     description = "Provides a noise source using the CPU execution timing jitter";
     homepage = "https://github.com/smuellerDD/jitterentropy-library";
     changelog = "https://github.com/smuellerDD/jitterentropy-library/raw/v${version}/CHANGES.md";
-    license = with licenses; [ bsd3 /* OR */ gpl2Only ];
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ johnazoidberg c0bw3b ];
+    license = with lib.licenses; [ bsd3 /* OR */ gpl2Only ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ johnazoidberg c0bw3b ];
   };
 }

--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, cmake, fetchFromGitHub }:
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation rec {
   pname = "jitterentropy";
@@ -13,7 +18,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   hardeningDisable = [ "fortify" ]; # avoid warnings
 
@@ -21,8 +29,14 @@ stdenv.mkDerivation rec {
     description = "Provides a noise source using the CPU execution timing jitter";
     homepage = "https://github.com/smuellerDD/jitterentropy-library";
     changelog = "https://github.com/smuellerDD/jitterentropy-library/raw/v${version}/CHANGES.md";
-    license = with lib.licenses; [ bsd3 /* OR */ gpl2Only ];
+    license = with lib.licenses; [
+      bsd3 # OR
+      gpl2Only
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ johnazoidberg c0bw3b ];
+    maintainers = with lib.maintainers; [
+      johnazoidberg
+      c0bw3b
+    ];
   };
 }

--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "jitterentropy";
@@ -11,24 +11,18 @@ stdenv.mkDerivation rec {
     hash = "sha256-CPvgc/W5Z2OfbP9Lp2tQevUQZr+xlh6q5r5Fp2WUHhg=";
   };
 
+  nativeBuildInputs = [ cmake ];
+
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
   hardeningDisable = [ "fortify" ]; # avoid warnings
-
-  # prevent jitterentropy from builtin strip to allow controlling this from the derivation's
-  # settings. Also fixes a strange issue, where this strip may fail when cross-compiling.
-  installFlags = [
-    "INSTALL_STRIP=install"
-    "PREFIX=${placeholder "out"}"
-  ];
 
   meta = with lib; {
     description = "Provides a noise source using the CPU execution timing jitter";
     homepage = "https://github.com/smuellerDD/jitterentropy-library";
     changelog = "https://github.com/smuellerDD/jitterentropy-library/raw/v${version}/CHANGES.md";
     license = with licenses; [ bsd3 /* OR */ gpl2Only ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ johnazoidberg c0bw3b ];
   };
 }


### PR DESCRIPTION
- Moved `jitterentropy` from Makefile-based build to `cmake`, which has better support for Clang.
- `botan3` compiles fine as a result of that

Fixes #354200

Not sure the cross-compilation fixes are still needed, but I'd be grateful if anyone could test it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
