### PR TITLE
tyson: 0.1.1 -> 0.1.1-unstable-2024-04-10

### DIFF
--- a/pkgs/development/tools/misc/tyson/default.nix
+++ b/pkgs/development/tools/misc/tyson/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, installShellFiles
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
 }:
 
 buildGoModule rec {
@@ -21,7 +22,10 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s"
+    "-w"
+  ];
 
   postInstall = ''
     installShellCompletion --cmd tyson \

--- a/pkgs/development/tools/misc/tyson/default.nix
+++ b/pkgs/development/tools/misc/tyson/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "tyson";
-  version = "0.1.1";
+  version = "0.1.1-unstable-2024-04-10";
 
   src = fetchFromGitHub {
     owner = "jetpack-io";
     repo = "tyson";
-    rev = "v${version}";
-    hash = "sha256-c4ROLn+BSX7v/4C9/IeU6HiE2YvnqDuXXGp2iZhAVk4=";
+    rev = "d6b38819db9b260928b29f4d39bf4c72841c6a01";
+    hash = "sha256-NoQJBEedV3NDNQ4PVvvjjsO7N+rq40LWKp962P+naEY=";
   };
 
-  vendorHash = "sha256-NhDv7oH8LK/vebwjs55tsCCWVhbZZd15z5ewOF5z9+Y=";
+  vendorHash = "sha256-kJIfKgVaHuCYvvTZXyuZ/Hg8z1BlW4oW6+5s1inFizg=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/development/tools/misc/tyson/default.nix
+++ b/pkgs/development/tools/misc/tyson/default.nix
@@ -37,8 +37,8 @@ buildGoModule rec {
   meta = with lib; {
     description = "TypeScript as a configuration language";
     mainProgram = "tyson";
-    homepage = "https://github.com/jetpack-io/tyson";
-    changelog = "https://github.com/jetpack-io/tyson/releases/tag/${src.rev}";
+    homepage = "https://github.com/jetify-com/tyson";
+    changelog = "https://github.com/jetify-com/tyson/releases/tag/${src.rev}";
     license = licenses.asl20;
     maintainers = with maintainers; [ figsoda ];
   };


### PR DESCRIPTION
- **tyson: 0.1.1 -> 0.1.1-unstable-2024-04-10**
- **tyson: format using nixfmt**
- **tyson: change homepage to new name**

Update tyson to newer commit since it was calling a removed go function.

The repository owner also had a github rename so I changed the homepage and changelog urls to match.

ZHF: #352882 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
