### PR TITLE
qualisys-cpp-sdk: init at 2024.2

### DIFF
--- a/pkgs/by-name/qu/qualisys-cpp-sdk/package.nix
+++ b/pkgs/by-name/qu/qualisys-cpp-sdk/package.nix
@@ -1,0 +1,42 @@
+{
+  cmake,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "qualisys-cpp-sdk";
+  version = "2024.2";
+
+  src = fetchFromGitHub {
+    owner = "qualisys";
+    repo = "qualisys_cpp_sdk";
+    rev = "refs/tags/rt_protocol_1.25";
+    hash = "sha256-BeG6LF1a8m9BSoILsD9EppywXlCSheKGm0fBoLR1cak=";
+  };
+
+  patches = [
+    # Fix include dir in CMake export
+    (fetchpatch {
+      url = "https://github.com/qualisys/qualisys_cpp_sdk/pull/32/commits/db5e22662b7f417b317571a7488b6dcbb82b7538.patch";
+      hash = "sha256-q7sNT/kQ9xlRPYKfmhiKg+UaYUsZJ4J2xMyQQNSTgxQ=";
+    })
+    # don't concatenate CMAKE_INSTALL_PREFIX and absolute CMAKE_INSTALL_INCLUDEDIR
+    (fetchpatch {
+      url = "https://github.com/nim65s/qualisys_cpp_sdk/commit/1ba8cdb9a8e3583b68d93a553a6f59ea7ee24876.patch";
+      hash = "sha256-5CWBvvnlXlh3UkU3S+LVG2rWC8VZ7+EVo+YFKHk6KuY=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C++ sdk for talking to Qualisys Track Manager software";
+    homepage = "https://github.com/qualisys/qualisys_cpp_sdk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This add https://github.com/qualisys/qualisys_cpp_sdk, to retrieve data from the https://www.qualisys.com/ motion capture system

## Things  done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
