### PR TITLE
ccze: 0.2.1-2 -> 0.2.1-8, move to by-name

### DIFF
--- a/pkgs/by-name/cc/ccze/package.nix
+++ b/pkgs/by-name/cc/ccze/package.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, ncurses, pcre }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoconf,
+  ncurses,
+  pcre,
+}:
 
 stdenv.mkDerivation rec {
   pname = "ccze";
@@ -13,7 +20,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf ];
 
-  buildInputs = [ ncurses pcre ];
+  buildInputs = [
+    ncurses
+    pcre
+  ];
 
   preConfigure = ''
     autoheader

--- a/pkgs/by-name/cc/ccze/package.nix
+++ b/pkgs/by-name/cc/ccze/package.nix
@@ -1,28 +1,37 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromGitLab,
   autoconf,
   ncurses,
-  pcre,
+  pcre2,
+  quilt,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ccze";
-  version = "0.2.1-2";
+  version = "0.2.1-8";
 
-  src = fetchFromGitHub {
-    owner = "madhouse";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
     repo = "ccze";
-    rev = "ccze-${version}";
-    hash = "sha256-LVwmbrq78mZcAEuAqjXTqLE5we83H9mcMPtxQx2Tn/c=";
+    rev = "debian/${finalAttrs.version}";
+    hash = "sha256-sESbs+HTDRX9w7c+LYnzQoemPIxAtqk27IVSTtiAGEk=";
   };
 
-  nativeBuildInputs = [ autoconf ];
+  postPatch = ''
+    QUILT_PATCHES=debian/patches quilt push -a
+  '';
+
+  nativeBuildInputs = [
+    autoconf
+    quilt
+  ];
 
   buildInputs = [
     ncurses
-    pcre
+    pcre2
   ];
 
   preConfigure = ''
@@ -31,14 +40,19 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    mainProgram = "ccze";
     description = "Fast, modular log colorizer";
+    homepage = "https://salsa.debian.org/debian/ccze";
+    changelog = "https://salsa.debian.org/debian/ccze/-/raw/master/debian/changelog?ref_type=heads";
     longDescription = ''
-      Fast log colorizer written in C, intended to be a drop-in replacement
-      for the Perl colorize tool.  Includes plugins for a variety of log
-      formats (Apache, Postfix, Procmail, etc.).
+      Fast log colorizer written in C, intended to be a drop-in replacement for the Perl colorize tool.
+      Includes plugins for a variety of log formats (Apache, Postfix, Procmail, etc.).
     '';
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ malyn ];
+    maintainers = with maintainers; [
+      malyn
+      philiptaron
+    ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
The only maintained source for this package appears to be Debian.

https://salsa.debian.org/debian/ccze/-/raw/master/debian/changelog?ref_type=heads

I moved it to `pkgs/by-name` in addition to the update, and added myself as a maintainer. cc @malyn.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).