### PR TITLE
bambu-studio: fix build deps

### DIFF
--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -28,7 +28,6 @@
   mesa,
   mpfr,
   nlopt,
-  slic3r,
   opencascade-occt_7_6,
   openvdb,
   opencv,

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -6,7 +6,7 @@
   cmake,
   pkg-config,
   wrapGAppsHook3,
-  boost179,
+  boost180,
   cereal,
   cgal_5,
   curl,
@@ -28,6 +28,7 @@
   mesa,
   mpfr,
   nlopt,
+  slic3r,
   opencascade-occt_7_6,
   openvdb,
   opencv,
@@ -72,7 +73,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     binutils
-    boost179
+    boost180
     cereal
     cgal_5
     curl


### PR DESCRIPTION
Fix bambu-studio build dependencies:
- Upgrade `boost v1.79 -> v1.80
- ~Add `slic3r`~

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
