### PR TITLE
yabridge: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -72,14 +72,14 @@ let
 in
 multiStdenv.mkDerivation (finalAttrs: {
   pname = "yabridge";
-  version = "5.1.0";
+  version = "5.1.1";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = "yabridge";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-vnSdGedpiit8nym26i1QFiNnATk0Bymm7e5Ha2H41/M=";
+    hash = "sha256-4eA3vQFklIWkhtbd3Nw39bnJT6gPcni79ZyQVqU4+GQ=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
+++ b/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index c602c5ad..a52e20a1 100644
+index 9e69128d..8c53ac88 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -226,7 +226,7 @@ if is_64bit_system
@@ -12,7 +12,7 @@ index c602c5ad..a52e20a1 100644
  
  # These are all headers-only libraries, and thus won't require separate 32-bit
 diff --git a/src/common/notifications.cpp b/src/common/notifications.cpp
-index 66e08527..685c54af 100644
+index 654b6c83..78ba2fe7 100644
 --- a/src/common/notifications.cpp
 +++ b/src/common/notifications.cpp
 @@ -29,8 +29,8 @@
@@ -27,7 +27,7 @@ index 66e08527..685c54af 100644
  std::atomic<void*> libdbus_handle = nullptr;
  std::mutex libdbus_mutex;
 diff --git a/src/plugin/utils.cpp b/src/plugin/utils.cpp
-index 82db99a5..491f005d 100644
+index 441345c6..f3e51cff 100644
 --- a/src/plugin/utils.cpp
 +++ b/src/plugin/utils.cpp
 @@ -103,7 +103,7 @@ std::string PluginInfo::wine_version() const {

--- a/pkgs/tools/audio/yabridge/libyabridge-from-nix-profiles.patch
+++ b/pkgs/tools/audio/yabridge/libyabridge-from-nix-profiles.patch
@@ -1,5 +1,5 @@
 diff --git a/src/chainloader/utils.cpp b/src/chainloader/utils.cpp
-index c43e5693..b8352adf 100644
+index fa90b8f7..bd44d0ea 100644
 --- a/src/chainloader/utils.cpp
 +++ b/src/chainloader/utils.cpp
 @@ -29,8 +29,10 @@

--- a/pkgs/tools/audio/yabridgectl/Cargo.lock
+++ b/pkgs/tools/audio/yabridgectl/Cargo.lock
@@ -914,7 +914,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yabridgectl"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/pkgs/tools/audio/yabridgectl/chainloader-from-nix-profiles.patch
+++ b/pkgs/tools/audio/yabridgectl/chainloader-from-nix-profiles.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/yabridgectl/src/config.rs b/tools/yabridgectl/src/config.rs
-index da5f4ff5..c220d62d 100644
+index d948beff..9b3f9ffb 100644
 --- a/tools/yabridgectl/src/config.rs
 +++ b/tools/yabridgectl/src/config.rs
 @@ -22,6 +22,7 @@ use serde_derive::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ index da5f4ff5..c220d62d 100644
                          ));
                      }
 diff --git a/tools/yabridgectl/src/main.rs b/tools/yabridgectl/src/main.rs
-index 0a29d431..479eaef0 100644
+index e66ef0da..bfe9c8bf 100644
 --- a/tools/yabridgectl/src/main.rs
 +++ b/tools/yabridgectl/src/main.rs
 @@ -134,7 +134,7 @@ fn main() -> Result<()> {

--- a/pkgs/tools/audio/yabridgectl/remove-dependency-verification.patch
+++ b/pkgs/tools/audio/yabridgectl/remove-dependency-verification.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/yabridgectl/src/actions.rs b/tools/yabridgectl/src/actions.rs
-index a0d9b98e..2819f017 100644
+index 6a8be858..5ce5e460 100644
 --- a/tools/yabridgectl/src/actions.rs
 +++ b/tools/yabridgectl/src/actions.rs
 @@ -847,14 +847,6 @@ pub fn do_sync(config: &mut Config, options: &SyncOptions) -> Result<()> {


### PR DESCRIPTION
https://github.com/robbert-vdh/yabridge/blob/5.1.1/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
