### PR TITLE
libfprint-focaltech-2808-a658: init at 1.94.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9405,6 +9405,12 @@
     githubId = 36996706;
     name = "Philip Rying";
   };
+  imsick = {
+    email = "lent-lather-excuse@duck.com";
+    github = "dvishal485";
+    githubId = 26341736;
+    name = "Vishal Das";
+  };
   imuli = {
     email = "i@imu.li";
     github = "imuli";

--- a/pkgs/by-name/li/libfprint-focaltech-2808-a658/package.nix
+++ b/pkgs/by-name/li/libfprint-focaltech-2808-a658/package.nix
@@ -1,0 +1,104 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  rpm,
+  cpio,
+  glib,
+  gusb,
+  pixman,
+  libgudev,
+  nss,
+  libfprint,
+  cairo,
+  pkg-config,
+  autoPatchelfHook,
+  makePkgconfigItem,
+  copyPkgconfigItems,
+}:
+
+# https://discourse.nixos.org/t/request-for-libfprint-port-for-2808-a658/55474
+let
+  # The provided `.so`'s name in the binary package we fetch and unpack
+  libso = "libfprint-2.so.2.0.0";
+in
+stdenv.mkDerivation rec {
+  pname = "libfprint-focaltech-2808-a658";
+  version = "1.94.4";
+  # https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/413#note_2476573
+  src = fetchurl {
+    url = "https://github.com/ftfpteams/RTS5811-FT9366-fingerprint-linux-driver-with-VID-2808-and-PID-a658/raw/b040ccd953c27e26c1285c456b4264e70b36bc3f/libfprint-2-2-${version}+tod1-FT9366_20240627.x86_64.rpm";
+    hash = "sha256-MRWHwBievAfTfQqjs1WGKBnht9cIDj9aYiT3YJ0/CUM=";
+  };
+
+  nativeBuildInputs = [
+    rpm
+    cpio
+    pkg-config
+    autoPatchelfHook
+    copyPkgconfigItems
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    glib
+    gusb
+    pixman
+    nss
+    libgudev
+    libfprint
+    cairo
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    rpm2cpio $src | cpio -idmv
+
+    runHook postUnpack
+  '';
+
+  # custom pkg-config based on libfprint's pkg-config
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "libfprint-2";
+      inherit version;
+      inherit (meta) description;
+      cflags = [ "-I${variables.includedir}/libfprint-2" ];
+      libs = [
+        "-L${variables.libdir}"
+        "-lfprint-2"
+      ];
+      variables = rec {
+        prefix = "${placeholder "out"}";
+        includedir = "${prefix}/include";
+        libdir = "${prefix}/lib";
+      };
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 usr/lib64/${libso} -t $out/lib
+
+    # create this symlink as it was there in libfprint
+    ln -s -T $out/lib/${libso} $out/lib/libfprint-2.so
+    ln -s -T $out/lib/${libso} $out/lib/libfprint-2.so.2
+
+    # get files from libfprint required to build the package
+    cp -r ${libfprint}/lib/girepository-1.0 $out/lib
+    cp -r ${libfprint}/include $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Focaltech Fingerprint driver for focaltech 0x2808:0xa658";
+    homepage = "https://github.com/ftfpteams/RTS5811-FT9366-fingerprint-linux-driver-with-VID-2808-and-PID-a658";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.imsick ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added fingerprint sensor support for focaltech fingerprint scanner 2808:a658.

Discourse discussion: https://discourse.nixos.org/t/request-for-libfprint-port-for-2808-a658/55474/30?u=imsick
Discussion on source: https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/413 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
