### PR TITLE
python312Packages.oddsprout: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/development/python-modules/oddsprout/default.nix
+++ b/pkgs/development/python-modules/oddsprout/default.nix
@@ -3,24 +3,37 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
+  pytestCheckHook,
+  pythonOlder,
   dahlia,
-  ixia
+  ixia,
 }:
 
 buildPythonPackage rec {
   pname = "oddsprout";
-  version = "0.1.0";
+  version = "0.1.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "trag1c";
     repo = "oddsprout";
     rev = "refs/tags/v${version}";
-    hash = "sha256-k5/mBoW4PxGUbkwaZyHgS3MGI4533V/nNoGqEg+VXpM=";
+    hash = "sha256-BOUYq4yny3ScgzCzx2cpeK4e7nxxwTj8mJ42nr59mFA=";
   };
 
   build-system = [ poetry-core ];
-  dependencies = [ dahlia ixia ];
+
+  dependencies = [
+    dahlia
+    ixia
+  ];
+
+  # has one test `test_main_recursion_error`
+  # that has a very low (~1%) but nonzero chance to fail,
+  # this is known upstream (https://github.com/trag1c/oddsprout/issues/5)
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "oddsprout" ];
 

--- a/pkgs/development/python-modules/oddsprout/default.nix
+++ b/pkgs/development/python-modules/oddsprout/default.nix
@@ -42,6 +42,9 @@ buildPythonPackage rec {
     description = "Generate random JSON with no schemas involved";
     license = licenses.mit;
     homepage = "https://trag1c.github.io/oddsprout";
-    maintainers = with maintainers; [ sigmanificient ];
+    maintainers = with maintainers; [
+      itepastra
+      sigmanificient
+    ];
   };
 }


### PR DESCRIPTION
Relax the dependency on `dahlia`, but this broke the import since

`dahlia` became `Dahlia`, so I made a patch to fix it.

Tested whether the binary didn't give errors.

ZHF: #352882

am waiting on https://github.com/trag1c/oddsprout/pull/4 to finish this
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
