### PR TITLE
pkgs: add Motorcomm YT6801 out of tree kernel module

### DIFF
--- a/pkgs/os-specific/linux/yt6801/default.nix
+++ b/pkgs/os-specific/linux/yt6801/default.nix
@@ -1,4 +1,10 @@
-{ kernel, stdenv, lib, fetchzip, bc }:
+{
+  kernel,
+  stdenv,
+  lib,
+  fetchzip,
+  bc,
+}:
 
 stdenv.mkDerivation rec {
   pname = "yt6801";
@@ -9,7 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-oz6CeOUN6QWKXxe3WUZljhGDTFArsknjzBuQ4IchGeU=";
   };
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}";
   nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
 
@@ -17,15 +26,17 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "modules" ];
 
-  makeFlags = [
-    "ARCH=${stdenv.hostPlatform.linuxArch}"
-    "KSRC_BASE=${KERNELDIR}"
-    "KSRC=${KERNELDIR}/build"
-    "KDST=kernel/drivers/net/ethernet/motorcomm"
-    "INSTALL_MOD_PATH=${placeholder "out"}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-  ];
+  makeFlags =
+    [
+      "ARCH=${stdenv.hostPlatform.linuxArch}"
+      "KSRC_BASE=${KERNELDIR}"
+      "KSRC=${KERNELDIR}/build"
+      "KDST=kernel/drivers/net/ethernet/motorcomm"
+      "INSTALL_MOD_PATH=${placeholder "out"}"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ];
 
   installPhase = ''
     mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/motorcomm
@@ -37,8 +48,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Motorcomm yt6801 Network Interface Card driver";
     homepage = "https://www.motor-comm.com/product/ethernet-control-chip";
-    license = with licenses; [ gpl2Plus gpl2Only ];
+    license = with licenses; [
+      gpl2Plus
+      gpl2Only
+    ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bartvdbraak ];
   };
 }

--- a/pkgs/os-specific/linux/yt6801/default.nix
+++ b/pkgs/os-specific/linux/yt6801/default.nix
@@ -1,0 +1,44 @@
+{ kernel, stdenv, lib, fetchzip, bc }:
+
+stdenv.mkDerivation rec {
+  pname = "yt6801";
+  version = "1.0.29";
+
+  src = fetchzip {
+    url = "https://www.motor-comm.com/Public/Uploads/uploadfile/files/20240812/yt6801-linux-driver-1.0.29.zip";
+    sha256 = "sha256-oz6CeOUN6QWKXxe3WUZljhGDTFArsknjzBuQ4IchGeU=";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}";
+  nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
+
+  configurePhase = "true";
+
+  buildFlags = [ "modules" ];
+
+  makeFlags = [
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+    "KSRC_BASE=${KERNELDIR}"
+    "KSRC=${KERNELDIR}/build"
+    "KDST=kernel/drivers/net/ethernet/motorcomm"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/motorcomm
+    find . -name "*.ko" -exec cp {} $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/motorcomm/ \;
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Motorcomm yt6801 Network Interface Card driver";
+    homepage = "https://www.motor-comm.com/product/ethernet-control-chip";
+    license = with licenses; [ gpl2Plus gpl2Only ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bartvdbraak ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -558,6 +558,8 @@ in {
 
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 
+    yt6801 = callPackage ../os-specific/linux/yt6801 { };
+
     ithc = callPackage ../os-specific/linux/ithc { };
 
     ryzen-smu = callPackage ../os-specific/linux/ryzen-smu { };


### PR DESCRIPTION
This package provides an out of tree kernel module for the Motorcomm YT6801 network interface.

Sources:
- 🇯🇵 https://www.motor-comm.com/product/ethernet-control-chip
- 🇺🇸 https://en.motor-comm.com/product/ethernet-control-chip

Used in:
- [TongFang GX4HRXL](https://laptopparts4less.frl/laptop-samenstellen/AMD-Ryzen-AI-laptop-samenstellen/TongFang-GX4HRXL-AMD-R7-8845HS-laptop-samenstellen)
- [TUXEDO InfinityBook Pro 14 - Gen9 - AMD](https://www.tuxedocomputers.com/en/TUXEDO-InfinityBook-Pro-14-Gen9-AMD#gallery)
- [SKIKK GREEN 6](https://www.skikk.eu/nl/laptops/green)
- [WootBook Y14](https://www.wootware.co.za/wootbook-y14-amd-ryzen-7-8845hs-5-10ghz-boost-8-core-14-2-8k-2880x1800-120hz-grey-laptop.html?srsltid=AfmBOoo-DEJkgRE9VpwDMccXLpBA-tOxc_A87b8O0mjfDDIihQCZQ3wS)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
