### PR TITLE
cargo-lambda: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-lambda/default.nix
+++ b/pkgs/development/tools/rust/cargo-lambda/default.nix
@@ -16,16 +16,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-lambda";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-QTFIFD04pAcNgj+ktY8WP0ScDmSy6mNlhfiXAabMlGE=";
+    hash = "sha256-58kVtwBZEAlv9eVesqmWMZ+KxAwEiGMm8mCf9X5tPMI=";
   };
 
-  cargoHash = "sha256-1/+bkxEpIvaJBJatqpX186MHKOdLO8Jiw8NEnyr9ctg=";
+  cargoHash = "sha256-DoMIVpYtEHvYSW2THpZFdhoFI0zjC70hYnwnzGwkJ4Q=";
 
   nativeCheckInputs = [ cacert ];
 
@@ -43,36 +43,16 @@ rustPlatform.buildRustPackage rec {
     ];
 
   checkFlags = [
-    # Disabled because they access the network.
-    "--skip=test_build_basic_extension"
-    "--skip=test_build_basic_function"
-    "--skip=test_build_basic_zip_extension"
-    "--skip=test_build_basic_zip_function"
-    "--skip=test_build_event_type_function"
-    "--skip=test_build_http_feature_function"
-    "--skip=test_build_http_function"
-    "--skip=test_build_internal_zip_extension"
-    "--skip=test_build_logs_extension"
-    "--skip=test_build_telemetry_extension"
-    "--skip=test_build_zip_workspace"
+    # Tests disabled because they access the network.
     "--skip=test_download_example"
-    "--skip=test_init_subcommand"
-    "--skip=test_init_subcommand_without_override"
-    "--skip=test_build_example"
-    "--skip=test_deploy_workspace"
-    "--skip=test_add_files"
-    "--skip=test_consistent_hash"
-    "--skip=test_create_binary_archive_from_target"
-    "--skip=test_create_binary_archive_with_base_path"
-    "--skip=test_zip_extension"
-    "--skip=test_zip_funcion"
-    "--skip=test_zip_funcion_with_files"
-    "--skip=test_zip_internal_extension"
   ];
 
-  # remove date from version output to make reproducible
+  # Remove files that don't make builds reproducible:
+  # - Remove build.rs file that adds the build date to the version.
+  # - Remove cargo_lambda.rs that contains tests that reach the network.
   postPatch = ''
     rm crates/cargo-lambda-cli/build.rs
+    rm crates/cargo-lambda-cli/tests/cargo_lambda.rs
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update Cargo Lambda to version 1.5.0: https://github.com/cargo-lambda/cargo-lambda/releases/tag/v1.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
