### PR TITLE
ninja_1_11: init at 1.11.1

### DIFF
--- a/pkgs/by-name/ni/ninja/package.nix
+++ b/pkgs/by-name/ni/ninja/package.nix
@@ -11,18 +11,29 @@
 , buildPackages
 , buildDocs ? true
 , nix-update-script
+, ninjaRelease ? "latest"
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ninja";
-  version = "1.12.1";
+  version = lib.removePrefix "v" finalAttrs.src.rev;
 
-  src = fetchFromGitHub {
-    owner = "ninja-build";
-    repo = "ninja";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-RT5u+TDvWxG5EVQEYj931EZyrHUSAqK73OKDAascAwA=";
-  };
+  src = {
+    # TODO: Remove Ninja 1.11 as soon as possible.
+    "1.11" = fetchFromGitHub {
+      owner = "ninja-build";
+      repo = "ninja";
+      rev = "v1.11.1";
+      hash = "sha256-LvV/Fi2ARXBkfyA1paCRmLUwCh/rTyz+tGMg2/qEepI=";
+    };
+
+    latest = fetchFromGitHub {
+      owner = "ninja-build";
+      repo = "ninja";
+      rev = "v1.12.1";
+      hash = "sha256-RT5u+TDvWxG5EVQEYj931EZyrHUSAqK73OKDAascAwA=";
+    };
+  }.${ninjaRelease} or (throw "Unsupported Ninja release: ${ninjaRelease}");
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30944,6 +30944,8 @@ with pkgs;
 
   node-problem-detector = callPackage ../applications/networking/cluster/node-problem-detector { };
 
+  ninja_1_11 = callPackage ../by-name/ni/ninja/package.nix { ninjaRelease = "1.11"; };
+
   ninjas2 = callPackage ../applications/audio/ninjas2 { };
 
   nootka = qt5.callPackage ../applications/audio/nootka { };


### PR DESCRIPTION
Swift 5.8 doesn’t reliably build with Ninja 1.12, and apparently neither do old versions of ROCm, due to a build scheduling change breaking builds with undeclared dependencies. Upstream Swift have pinned 1.11 for now.

Reintroducing it isn’t a good long‐term solution, but seems like the easiest way to avoid shipping 24.11 with a broken Swift on Darwin. The patch for 32‐bit systems has not been restored, as Swift doesn’t support them anyway.

cc @azuwis @JohnRTitor. I think this is a better approach than `overrideAttrs`. I confirmed that `nix-update` can still update the package in this form.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
