### PR TITLE
python312Packages.pandera: init at 0.20.4

### DIFF
--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -1,0 +1,132 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  multimethod,
+  numpy,
+  packaging,
+  pandas,
+  pydantic,
+  typeguard,
+  typing-inspect,
+  wrapt,
+  # test
+  joblib,
+  pyarrow,
+  pytestCheckHook,
+  pytest-asyncio,
+  # optional dependencies
+  black,
+  dask,
+  fastapi,
+  geopandas,
+  hypothesis,
+  pandas-stubs,
+  polars,
+  pyyaml,
+  scipy,
+  shapely,
+}:
+
+buildPythonPackage rec {
+  pname = "pandera";
+  version = "0.20.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "unionai-oss";
+    repo = "pandera";
+    tag = "v${version}";
+    hash = "sha256-VetLfZlBWok7Mr1jxlHHjDH/D5xEsPFWQtX/hrvobgQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    multimethod
+    numpy
+    packaging
+    pandas
+    pydantic
+    typeguard
+    typing-inspect
+    wrapt
+  ];
+
+  optional-dependencies =
+    let
+      dask-dataframe = [ dask ] ++ dask.optional-dependencies.dataframe;
+      extras = {
+        strategies = [ hypothesis ];
+        hypotheses = [ scipy ];
+        io = [
+          pyyaml
+          black
+          #frictionless # not in nixpkgs
+        ];
+        # pyspark expression does not define optional-dependencies.connect:
+        #pyspark = [ pyspark ] ++ pyspark.optional-dependencies.connect;
+        # modin not in nixpkgs:
+        #modin = [
+        #  modin
+        #  ray
+        #] ++ dask-dataframe;
+        #modin-ray = [
+        #  modin
+        #  ray
+        #];
+        #modin-dask = [
+        #  modin
+        #] ++ dask-dataframe;
+        dask = dask-dataframe;
+        mypy = [ pandas-stubs ];
+        fastapi = [ fastapi ];
+        geopandas = [
+          geopandas
+          shapely
+        ];
+        polars = [ polars ];
+      };
+    in
+    extras // { all = lib.concatLists (lib.attrValues extras); };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    joblib
+    pyarrow
+  ] ++ optional-dependencies.all;
+
+  disabledTestPaths = [
+    "tests/fastapi/test_app.py" # tries to access network
+    "tests/core/test_docs_setting_column_widths.py" # tests doc generation, requires sphinx
+    "tests/modin" # requires modin, not in nixpkgs
+    "tests/mypy/test_static_type_checking.py" # some typing failures
+    "tests/pyspark" # requires spark
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # OOM error on ofborg:
+    "test_engine_geometry_coerce_crs"
+    # pandera.errors.SchemaError: Error while coercing 'geometry' to type geometry
+    "test_schema_dtype_crs_with_coerce"
+  ];
+
+  pythonImportsCheck = [
+    "pandera"
+    "pandera.api"
+    "pandera.config"
+    "pandera.dtypes"
+    "pandera.engines"
+  ];
+
+  meta = {
+    description = "Light-weight, flexible, and expressive statistical data testing library";
+    homepage = "https://pandera.readthedocs.io";
+    changelog = "https://github.com/unionai-oss/pandera/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9949,6 +9949,8 @@ self: super: with self; {
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
 
+  pandera = callPackage ../development/python-modules/pandera { };
+
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
 
   pandoc-latex-environment = callPackage ../development/python-modules/pandoc-latex-environment { };


### PR DESCRIPTION
Init `python312Packages.pandera`, a [Python library for Pydantic-style typing and validation of dataframes](https://pandera.readthedocs.io).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
