### PR TITLE
cargo: add curl-sys build script override to hooks

### DIFF
--- a/pkgs/build-support/rust/cargo-config-overrides.toml
+++ b/pkgs/build-support/rust/cargo-config-overrides.toml
@@ -1,0 +1,2 @@
+[target.@target@.curl]
+rustc-link-lib = ["curl"]

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -17,10 +17,15 @@ cargoBuildHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    CONFIG_OVERRIDES_FILE=$(mktemp --tmpdir cargo-config-overrides.XXXXXXXXXX)
+    substitute "@configOverrides@" "$CONFIG_OVERRIDES_FILE" \
+        --subst-var-by "target" "@rustHostPlatformSpec@"
+
     local flagsArray=(
         "-j" "$NIX_BUILD_CORES"
         "--target" "@rustHostPlatformSpec@"
         "--offline"
+        "--config" "$CONFIG_OVERRIDES_FILE"
     )
 
     if [ "${cargoBuildType}" != "debug" ]; then

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -9,6 +9,10 @@ cargoCheckHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    CONFIG_OVERRIDES_FILE=$(mktemp --tmpdir cargo-config-overrides.XXXXXXXXXX)
+    substitute "@configOverrides@" "$CONFIG_OVERRIDES_FILE" \
+        --subst-var-by "target" "@rustHostPlatformSpec@"
+
     local flagsArray=("-j" "$NIX_BUILD_CORES")
 
     if [[ -z ${dontUseCargoParallelTests-} ]]; then
@@ -32,6 +36,7 @@ cargoCheckHook() {
     flagsArray+=(
         "--target" "@rustHostPlatformSpec@"
         "--offline"
+        "--config" "$CONFIG_OVERRIDES_FILE"
     )
 
     prependToVar checkFlags "--"

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -9,9 +9,14 @@ cargoNextestHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    CONFIG_OVERRIDES_FILE=$(mktemp --tmpdir cargo-config-overrides.XXXXXXXXXX)
+    substitute "@configOverrides@" "$CONFIG_OVERRIDES_FILE" \
+        --subst-var-by "target" "@rustHostPlatformSpec@"
+
     local flagsArray=(
         "--target" "@rustHostPlatformSpec@"
         "--offline"
+        "--config" "$CONFIG_OVERRIDES_FILE"
     )
 
     if [[ -z ${dontUseCargoParallelTests-} ]]; then

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -5,9 +5,7 @@
 , clang
 , lib
 , makeSetupHook
-, maturin
 , rust
-, rustc
 , stdenv
 
 # This confusingly-named parameter indicates the *subdirectory of
@@ -23,6 +21,7 @@
       propagatedBuildInputs = [ cargo ];
       substitutions = {
         inherit (rust.envVars) rustHostPlatformSpec setEnv;
+        configOverrides = ../cargo-config-overrides.toml;
       };
     } ./cargo-build-hook.sh) {};
 
@@ -32,6 +31,7 @@
       propagatedBuildInputs = [ cargo ];
       substitutions = {
         inherit (rust.envVars) rustHostPlatformSpec setEnv;
+        configOverrides = ../cargo-config-overrides.toml;
       };
     } ./cargo-check-hook.sh) {};
 
@@ -50,6 +50,7 @@
       propagatedBuildInputs = [ cargo cargo-nextest ];
       substitutions = {
         inherit (rust.envVars) rustHostPlatformSpec;
+        configOverrides = ../cargo-config-overrides.toml;
       };
     } ./cargo-nextest-hook.sh) {};
 

--- a/pkgs/by-name/ca/cargo-bitbake/package.nix
+++ b/pkgs/by-name/ca/cargo-bitbake/package.nix
@@ -1,4 +1,4 @@
-{ lib, pkg-config, rustPlatform, fetchFromGitHub, openssl }:
+{ lib, pkg-config, rustPlatform, fetchFromGitHub, curl, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-bitbake";
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ];
+  buildInputs = [ curl openssl ];
 
   cargoHash = "sha256-LYdQ0FLfCopY8kPTCmiW0Qyx6sHA4nlb+hK9hXezGLg=";
 

--- a/pkgs/by-name/ca/cargo-duplicates/package.nix
+++ b/pkgs/by-name/ca/cargo-duplicates/package.nix
@@ -6,8 +6,6 @@
 , libgit2
 , openssl
 , zlib
-, stdenv
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -32,8 +30,6 @@ rustPlatform.buildRustPackage rec {
     libgit2
     openssl
     zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/ca/cargo-duplicates/package.nix
+++ b/pkgs/by-name/ca/cargo-duplicates/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-xkPvbC/ot4U3gca57pEEze0jaQhUAZV1MEX0E6E1BmE=";
 
   nativeBuildInputs = [
-    curl
     pkg-config
   ];
 

--- a/pkgs/by-name/ca/cargo-geiger/package.nix
+++ b/pkgs/by-name/ca/cargo-geiger/package.nix
@@ -32,11 +32,9 @@ rustPlatform.buildRustPackage rec {
     ./allow-warnings.patch
   ];
 
-  buildInputs = [ openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation Security libiconv curl ]);
-  nativeBuildInputs = [ pkg-config ]
-    # curl-sys wants to run curl-config on darwin
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ curl.dev ];
+  buildInputs = [ curl openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation Security libiconv ]);
+  nativeBuildInputs = [ pkg-config ];
 
   # skip tests with networking or other failures
   checkFlags = [

--- a/pkgs/by-name/ca/cargo-geiger/package.nix
+++ b/pkgs/by-name/ca/cargo-geiger/package.nix
@@ -4,9 +4,6 @@
 , rustPlatform
 , pkg-config
 , openssl
-  # darwin dependencies
-, darwin
-, libiconv
 , curl
 }:
 
@@ -32,8 +29,7 @@ rustPlatform.buildRustPackage rec {
     ./allow-warnings.patch
   ];
 
-  buildInputs = [ curl openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation Security libiconv ]);
+  buildInputs = [ curl openssl ];
   nativeBuildInputs = [ pkg-config ];
 
   # skip tests with networking or other failures

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -6,8 +6,6 @@
 , libgit2
 , openssl
 , zlib
-, stdenv
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -32,10 +30,6 @@ rustPlatform.buildRustPackage rec {
     libgit2
     openssl
     zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    darwin.apple_sdk.frameworks.CoreFoundation
   ];
 
   # tests require internet access

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-lTtxCRK4J3dQ6fwjOwYvKa0ykr28guAwVN/J8pfLn9s=";
 
   nativeBuildInputs = [
-    curl
     pkg-config
   ];
 

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -4,9 +4,7 @@
 , pkg-config
 , libgit2
 , openssl
-, stdenv
 , curl
-, darwin
 , git
 }:
 
@@ -35,8 +33,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     libgit2
     openssl
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -36,12 +36,15 @@ rustPlatform.buildRustPackage rec {
     libgit2
     openssl
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    curl
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
   nativeCheckInputs = [
     git
+  ];
+
+  checkInputs = [
+    curl
   ];
 
   # disable vendored-libgit2 and vendored-openssl

--- a/pkgs/by-name/ca/cargo-unused-features/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-features/package.nix
@@ -5,8 +5,6 @@
 , pkg-config
 , libgit2
 , openssl
-, stdenv
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,9 +26,6 @@ rustPlatform.buildRustPackage rec {
     curl
     libgit2
     openssl
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.CoreFoundation
-    darwin.apple_sdk.frameworks.Security
   ];
 
   env = {

--- a/pkgs/by-name/ca/cargo-unused-features/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-features/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-K9I7Eg43BS2SKq5zZ3eZrMkmuHAx09OX240sH0eGs+k=";
 
   nativeBuildInputs = [
-    curl.dev
     pkg-config
   ];
 

--- a/pkgs/by-name/ca/cargo-update/package.nix
+++ b/pkgs/by-name/ca/cargo-update/package.nix
@@ -30,17 +30,15 @@ rustPlatform.buildRustPackage rec {
     installShellFiles
     pkg-config
     ronn
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    curl
   ];
 
   buildInputs = [
+    curl
     libgit2
     libssh2
     openssl
     zlib
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    curl
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/by-name/ca/cargo-update/package.nix
+++ b/pkgs/by-name/ca/cargo-update/package.nix
@@ -5,13 +5,11 @@
 , installShellFiles
 , pkg-config
 , ronn
-, stdenv
 , curl
 , libgit2
 , libssh2
 , openssl
 , zlib
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -38,8 +36,6 @@ rustPlatform.buildRustPackage rec {
     libssh2
     openssl
     zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
   ];
 
   postBuild = ''

--- a/pkgs/by-name/gi/git-series/package.nix
+++ b/pkgs/by-name/gi/git-series/package.nix
@@ -3,8 +3,6 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
-  stdenv,
-  curl,
   installShellFiles,
   libgit2,
   libssh2,
@@ -28,14 +26,14 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     pkg-config
     installShellFiles
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ curl ];
+  ];
 
   buildInputs = [
     libgit2
     libssh2
     openssl
     zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ curl ];
+  ];
 
   env = {
     LIBGIT2_SYS_USE_PKG_CONFIG = true;

--- a/pkgs/by-name/jo/journaldriver/package.nix
+++ b/pkgs/by-name/jo/journaldriver/package.nix
@@ -1,6 +1,6 @@
-{ lib, fetchgit, rustPlatform, pkg-config, openssl, systemd }:
+{ lib, fetchgit, rustPlatform, pkg-config, curl, openssl, systemd }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "journaldriver";
   version = "5656.0.0";
   cargoHash = "sha256-uNzgH9UM2DuC+dBn5N9tC1/AosUP6C+RkGLOh6c+u0s=";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     rev = "4e191353228197ce548d63cb9955e53661244f9c";
   };
 
-  buildInputs = [ openssl systemd ];
+  buildInputs = [ curl openssl systemd ];
   nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {

--- a/pkgs/by-name/ni/nix-init/package.nix
+++ b/pkgs/by-name/ni/nix-init/package.nix
@@ -10,8 +10,6 @@
 , openssl
 , zlib
 , zstd
-, stdenv
-, darwin
 , spdx-license-list-data
 , nix
 , nurl
@@ -51,10 +49,6 @@ rustPlatform.buildRustPackage rec {
     openssl
     zlib
     zstd
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    darwin.apple_sdk.frameworks.CoreFoundation
   ];
 
   buildNoDefaultFeatures = true;

--- a/pkgs/by-name/ni/nix-init/package.nix
+++ b/pkgs/by-name/ni/nix-init/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   nativeBuildInputs = [
-    curl
     installShellFiles
     pkg-config
   ];

--- a/pkgs/by-name/ry/rye/package.nix
+++ b/pkgs/by-name/ry/rye/package.nix
@@ -11,7 +11,6 @@
   curl,
   openssl,
   stdenv,
-  darwin,
 
   versionCheckHook,
 
@@ -47,16 +46,10 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs =
-    [ curl openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk;
-      [
-        frameworks.CoreServices
-        frameworks.SystemConfiguration
-        Libsystem
-      ]
-    );
+  buildInputs = [
+    curl
+    openssl
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd rye \

--- a/pkgs/by-name/ry/rye/package.nix
+++ b/pkgs/by-name/ry/rye/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
 
   # buildInputs
+  curl,
   openssl,
   stdenv,
   darwin,
@@ -47,7 +48,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs =
-    [ openssl ]
+    [ curl openssl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk;
       [

--- a/pkgs/by-name/tr/transmission-rss/package.nix
+++ b/pkgs/by-name/tr/transmission-rss/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl, darwin }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl }:
 
 rustPlatform.buildRustPackage rec {
   version = "0.3.1";
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "herlon214";
     repo = pname;
     rev = "5bbad7a81621a194b7a8b11a56051308a7ccbf06";
-    sha256 = "sha256-SkEgxinqPA9feOIF68oewVyRKv3SY6fWWZLGJeH+r4M=";
+    hash = "sha256-SkEgxinqPA9feOIF68oewVyRKv3SY6fWWZLGJeH+r4M=";
   };
 
   cargoPatches = [ ./update-cargo-lock-version.patch ];
@@ -16,11 +16,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-QNMdqoxxY8ao2O44hJxZNgLrPwzu9+ieweTPc7pfFY4=";
 
   nativeBuildInputs = [pkg-config];
-  buildInputs = [curl openssl]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
-      Security
-      SystemConfiguration
-    ]);
+  buildInputs = [curl openssl];
 
   OPENSSL_NO_VENDOR = 1;
 

--- a/pkgs/by-name/tr/transmission-rss/package.nix
+++ b/pkgs/by-name/tr/transmission-rss/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, darwin }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl, darwin }:
 
 rustPlatform.buildRustPackage rec {
   version = "0.3.1";
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-QNMdqoxxY8ao2O44hJxZNgLrPwzu9+ieweTPc7pfFY4=";
 
   nativeBuildInputs = [pkg-config];
-  buildInputs = [openssl]
+  buildInputs = [curl openssl]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
       Security
       SystemConfiguration

--- a/pkgs/by-name/wy/wyvern/package.nix
+++ b/pkgs/by-name/wy/wyvern/package.nix
@@ -3,6 +3,7 @@
 , rustPlatform
 , cmake
 , pkg-config
+, curl
 , openssl
 }:
 
@@ -20,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-cwk8yFt8JrYkYlNUW9n/bgMUA6jyOpG0TSh5C+eERLY=";
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ openssl ];
+  buildInputs = [ curl openssl ];
 
   meta = with lib; {
     description = "Simple CLI client for installing and maintaining linux GOG games";

--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -27,17 +27,10 @@ rustPlatform.buildRustPackage rec {
 
   env.OPENSSL_NO_VENDOR = 1;
 
-  # Workaround for https://github.com/zellij-org/zellij/issues/3720
-  postPatch = ''
-    substituteInPlace zellij-utils/Cargo.toml \
-      --replace-fail 'isahc = "1.7.2"' 'isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }'
-  '';
-
   nativeBuildInputs = [
     mandown
     installShellFiles
     pkg-config
-    (lib.getDev curl)
   ];
 
   buildInputs = [

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgsHostHost
+{ lib, stdenv
 , file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, rustPlatform, rustc
 , CoreFoundation, Security
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage.override {
 
   nativeBuildInputs = [
     pkg-config cmake installShellFiles makeWrapper
-    (lib.getDev pkgsHostHost.curl)
     zlib
   ];
   buildInputs = [ file curl python3 openssl zlib ]

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,7 +1,6 @@
 { lib, stdenv
 , file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, rustPlatform, rustc
-, CoreFoundation, Security
 , auditable ? !cargo-auditable.meta.broken
 , cargo-auditable
 , pkgsBuildBuild
@@ -31,8 +30,7 @@ rustPlatform.buildRustPackage.override {
     pkg-config cmake installShellFiles makeWrapper
     zlib
   ];
-  buildInputs = [ file curl python3 openssl zlib ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreFoundation Security ];
+  buildInputs = [ file curl python3 openssl zlib ];
 
   # cargo uses git-rs which is made for a version of libgit2 from recent master that
   # is not compatible with the current version in nixpkgs.

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -93,7 +93,6 @@ in
       cargo = if (!fastCross) then self.callPackage ./cargo.nix {
         # Use boot package set to break cycle
         rustPlatform = bootRustPlatform;
-        inherit CoreFoundation Security;
       } else self.callPackage ./cargo_cross.nix {};
       cargo-auditable = self.callPackage ./cargo-auditable.nix { };
       cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -35,6 +35,6 @@ rec {
 
   # Hooks
   inherit (callPackages ../../../build-support/rust/hooks {
-    inherit stdenv cargo rustc;
+    inherit stdenv cargo;
   }) cargoBuildHook cargoCheckHook cargoInstallHook cargoNextestHook cargoSetupHook maturinBuildHook bindgenHook;
 }

--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UfhIz87s0CLUDbIpWMPzGQ7qVmh14GuiFoquauSbTOw=";
 
-  nativeBuildInputs = [ pkg-config (lib.getDev curl) ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl curl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     CoreFoundation
     libiconv

--- a/pkgs/development/tools/rust/cargo-clone/default.nix
+++ b/pkgs/development/tools/rust/cargo-clone/default.nix
@@ -4,10 +4,6 @@
 , pkg-config
 , curl
 , openssl
-, stdenv
-, CoreServices
-, Security
-, SystemConfiguration
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,18 +14,14 @@ rustPlatform.buildRustPackage rec {
     owner = "janlikar";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kK0J1Vfx1T17CgZ3DV9kQbAUxk4lEfje5p6QvdBS5VQ=";
+    hash = "sha256-kK0J1Vfx1T17CgZ3DV9kQbAUxk4lEfje5p6QvdBS5VQ=";
   };
 
   cargoHash = "sha256-6UUaOwu6N/XFdGEnoAX5zM4xTsqwHwPrmZ1t5huF6nM=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    CoreServices
-    Security
-    SystemConfiguration
-  ];
+  buildInputs = [ curl openssl ];
 
   # requires internet access
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-clone/default.nix
+++ b/pkgs/development/tools/rust/cargo-clone/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
+, curl
 , openssl
 , stdenv
 , CoreServices
@@ -24,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     CoreServices
     Security
     SystemConfiguration

--- a/pkgs/development/tools/rust/cargo-codspeed/default.nix
+++ b/pkgs/development/tools/rust/cargo-codspeed/default.nix
@@ -6,8 +6,6 @@
 , libgit2
 , openssl
 , zlib
-, stdenv
-, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -32,8 +30,6 @@ rustPlatform.buildRustPackage rec {
     libgit2
     openssl
     zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
   ];
 
   cargoBuildFlags = [ "-p=cargo-codspeed" ];

--- a/pkgs/development/tools/rust/cargo-codspeed/default.nix
+++ b/pkgs/development/tools/rust/cargo-codspeed/default.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-5Ps31Hdis+N/MT/o0IDHSJgHBM3F/ve50ovfFSviMtA=";
 
   nativeBuildInputs = [
-    curl
     pkg-config
   ];
 

--- a/pkgs/development/tools/rust/cargo-crev/default.nix
+++ b/pkgs/development/tools/rust/cargo-crev/default.nix
@@ -1,13 +1,9 @@
-{ lib, stdenv
+{ lib
 , fetchFromGitHub
 , rustPlatform
 , perl
 , pkg-config
-, SystemConfiguration
-, Security
-, CoreFoundation
 , curl
-, libiconv
 , openssl
 , git
 }:
@@ -33,7 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ perl pkg-config ];
 
-  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ SystemConfiguration Security CoreFoundation libiconv ];
+  buildInputs = [ curl openssl ];
 
   nativeCheckInputs = [ git ];
 

--- a/pkgs/development/tools/rust/cargo-crev/default.nix
+++ b/pkgs/development/tools/rust/cargo-crev/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ perl pkg-config ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ SystemConfiguration Security CoreFoundation libiconv curl ];
+  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ SystemConfiguration Security CoreFoundation libiconv ];
 
   nativeCheckInputs = [ git ];
 

--- a/pkgs/development/tools/rust/cargo-outdated/default.nix
+++ b/pkgs/development/tools/rust/cargo-outdated/default.nix
@@ -3,12 +3,7 @@
 , fetchCrate
 , pkg-config
 , openssl
-, stdenv
 , curl
-, CoreFoundation
-, CoreServices
-, Security
-, SystemConfiguration
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,12 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    CoreFoundation
-    CoreServices
-    Security
-    SystemConfiguration
-  ];
+  buildInputs = [ curl openssl ];
 
   meta = with lib; {
     description = "Cargo subcommand for displaying when Rust dependencies are out of date";

--- a/pkgs/development/tools/rust/cargo-outdated/default.nix
+++ b/pkgs/development/tools/rust/cargo-outdated/default.nix
@@ -29,8 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    curl
+  buildInputs = [ curl openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     CoreFoundation
     CoreServices
     Security

--- a/pkgs/development/tools/rust/cargo-udeps/default.nix
+++ b/pkgs/development/tools/rust/cargo-udeps/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl, CoreServices, Security, libiconv, SystemConfiguration }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-udeps";
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ curl openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices Security libiconv SystemConfiguration ];
+  buildInputs = [ curl openssl ];
 
   # Requires network access
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-udeps/default.nix
+++ b/pkgs/development/tools/rust/cargo-udeps/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, CoreServices, Security, libiconv, SystemConfiguration }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, curl, openssl, CoreServices, Security, libiconv, SystemConfiguration }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-udeps";
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  # TODO figure out how to use provided curl instead of compiling curl from curl-sys
-  buildInputs = [ openssl ]
+  buildInputs = [ curl openssl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices Security libiconv SystemConfiguration ];
 
   # Requires network access

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -291,7 +291,7 @@ stdenvs
       inherit
         (pkgs.callPackage ../../../build-support/rust/hooks {
           inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
-          inherit (pkgs) cargo rustc;
+          inherit (pkgs) cargo;
         })
         bindgenHook
         ;

--- a/pkgs/tools/games/ajour/default.nix
+++ b/pkgs/tools/games/ajour/default.nix
@@ -11,6 +11,7 @@
 , freetype
 , kdialog
 , zenity
+, curl
 , openssl
 , libglvnd
 , libX11
@@ -62,6 +63,7 @@ in rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
+    curl
     expat
     freetype
     openssl

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -12,11 +12,7 @@
   zstd,
   rust-jemalloc-sys,
   rust-jemalloc-sys-unprefixed,
-  Security,
-  libiconv,
   coreutils,
-  CoreServices,
-  SystemConfiguration,
   tzdata,
   cmake,
   perl,
@@ -76,11 +72,7 @@ rustPlatform.buildRustPackage {
     ++ lib.optionals stdenv.hostPlatform.isLinux [ rust-jemalloc-sys-unprefixed ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       rust-jemalloc-sys
-      Security
-      libiconv
       coreutils
-      CoreServices
-      SystemConfiguration
     ];
 
   # Rust 1.80.0 introduced the unexepcted_cfgs lint, which requires crates to allowlist custom cfg options that they inspect.

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   rustPlatform,
   pkg-config,
+  curl,
   openssl,
   protobuf,
   rdkafka,
@@ -62,8 +63,10 @@ rustPlatform.buildRustPackage {
     ]
     # Provides the mig command used by the build scripts
     ++ lib.optional stdenv.hostPlatform.isDarwin darwin.bootstrap_cmds;
+
   buildInputs =
     [
+      curl
       oniguruma
       openssl
       protobuf

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7073,9 +7073,7 @@ with pkgs;
   cargo-edit = callPackage ../development/tools/rust/cargo-edit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  cargo-outdated = callPackage ../development/tools/rust/cargo-outdated {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Security SystemConfiguration;
-  };
+  cargo-outdated = callPackage ../development/tools/rust/cargo-outdated { };
   inherit (callPackages ../development/tools/rust/cargo-pgrx { })
     cargo-pgrx_0_10_2
     cargo-pgrx_0_11_2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7099,9 +7099,7 @@ with pkgs;
   cargo-cache = callPackage ../development/tools/rust/cargo-cache {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  cargo-crev = callPackage ../development/tools/rust/cargo-crev {
-    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration CoreFoundation;
-  };
+  cargo-crev = callPackage ../development/tools/rust/cargo-crev { };
   cargo-fund = callPackage ../development/tools/rust/cargo-fund {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7130,9 +7130,7 @@ with pkgs;
   cargo-spellcheck = callPackage ../development/tools/rust/cargo-spellcheck {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
-  cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
-    inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
-  };
+  cargo-udeps = callPackage ../development/tools/rust/cargo-udeps { };
   cargo-vet = callPackage ../development/tools/rust/cargo-vet {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18534,9 +18534,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  vector = callPackage ../tools/misc/vector {
-    inherit (darwin.apple_sdk.frameworks) Security CoreServices SystemConfiguration;
-  };
+  vector = callPackage ../tools/misc/vector { };
 
   hjson = with python3Packages; toPythonApplication hjson;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7057,9 +7057,7 @@ with pkgs;
   cargo-c = callPackage ../development/tools/rust/cargo-c {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  cargo-clone = callPackage ../development/tools/rust/cargo-clone {
-    inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
-  };
+  cargo-clone = callPackage ../development/tools/rust/cargo-clone { };
   cargo-codspeed = callPackage ../development/tools/rust/cargo-codspeed {
     rustPlatform = makeRustPlatform {
       stdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;


### PR DESCRIPTION
This is an initial POC of an idea I had to ensure that Rust programs that depend on the `curl-sys` crate link against our curl instead  of building a vendored version. I learned about [the possibility to override a build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts) and wondered if we can make it so that `curl-sys` is always overridden to link against our libcurl.

This seems to work, at least for projects built using the cargo hooks. It has the following properties:

1. It will cause packages to break if libcurl was being vendored before. (I'll do my best to fix packages as I find them if this PR moves forward.)
2. It means we can clean up on Linux the inclusion of `curl.dev` in nativeBuildInputs, which used to be necessary so that the `curl-sys` build script can find our curl using pkg-config. It was confusing also to me which version of `curl.dev` was needed during cross-compilation.
3. We also no longer need to patch any projects that had enabled the `static-curl` feature (such as zellij in 0.41.0) since we completely replace the build script.

I believe this is the best way to handle `curl-sys`, since it does not contain any environment variables to guarantee that we do not use vendored libcurl, and the crate owner [suggests this method](https://github.com/alexcrichton/curl-rust/pull/192).

I was also floating around the idea of using this approach for other -sys crates: even if some of them have environment variable overrides or ways to specify dependencies using pkg-config, since those are quite bespoke and can be complex, but I'm not sure it's a good idea yet. One downside of this approach is that any crate with a build script that does more than selecting a library to link might still need to run. Some examples:

1. openssl-sys conditionally links against openssl only if the unstable_boringssl feature is disabled.
2. some crates can also generate bindings against whichever system library we provide through rust-bindgen, which feels like it would be nice to run.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
