### PR TITLE
arma3-unix-launcher: replace curlpp.src with srcOnly curlpp to resolve build failure / remove unused dependencies

### DIFF
--- a/pkgs/by-name/ar/arma3-unix-launcher/package.nix
+++ b/pkgs/by-name/ar/arma3-unix-launcher/package.nix
@@ -4,7 +4,6 @@
   cmake,
   curl,
   curlpp,
-  doctest,
   srcOnly,
   fetchFromGitHub,
   fetchurl,
@@ -13,7 +12,6 @@
   qt5,
   spdlog,
   substituteAll,
-  trompeloeil,
   buildDayZLauncher ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
         rev = "45664c4e9f05ff287731a9ff8b724d0c89fb6e77";
         hash = "sha256-qLD9zD6hbItDn6ZHHWBXrAWhySvqcs40xA5+C/5Fkhw=";
       };
-      doctest_src = doctest;
       curlpp_src = srcOnly curlpp;
       fmt_src = fmt;
       nlohmann_json_src = nlohmann_json;
@@ -52,7 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/julianxhokaxhiu/SteamworksSDKCI/releases/download/1.53/SteamworksSDK-v1.53.0_x64.zip";
         hash = "sha256-6PQGaPsaxBg/MHVWw2ynYW6LaNSrE9Rd9Q9ZLKFGPFA=";
       };
-      trompeloeil_src = trompeloeil;
+      # Only required for testing?
+      doctest_src = null;
+      trompeloeil_src = null;
     })
     # game won't launch with steam integration anyways, disable it
     ./disable_steam_integration.patch
@@ -61,14 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     qt5.wrapQtAppsHook
     cmake
-  ];
-
-  buildInputs = [
     spdlog
-    curlpp.src
     curl
-    qt5.qtbase
-    qt5.qtsvg
+    curlpp
   ];
 
   cmakeFlags = [ "-Wno-dev" ] ++ lib.optionals buildDayZLauncher [ "-DBUILD_DAYZ_LAUNCHER=ON" ];

--- a/pkgs/by-name/ar/arma3-unix-launcher/package.nix
+++ b/pkgs/by-name/ar/arma3-unix-launcher/package.nix
@@ -5,6 +5,7 @@
   curl,
   curlpp,
   doctest,
+  srcOnly,
   fetchFromGitHub,
   fetchurl,
   fmt,
@@ -36,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
         rev = "45664c4e9f05ff287731a9ff8b724d0c89fb6e77";
         hash = "sha256-qLD9zD6hbItDn6ZHHWBXrAWhySvqcs40xA5+C/5Fkhw=";
       };
-      curlpp_src = curlpp.src;
       doctest_src = doctest;
+      curlpp_src = srcOnly curlpp;
       fmt_src = fmt;
       nlohmann_json_src = nlohmann_json;
       pugixml_src = fetchFromGitHub {


### PR DESCRIPTION
- Fix a build failure caused by the use of `curlpp.src`, replaced with `srcOnly curlpp` to ensure patches are applied. Fixes #354237

- Removing unused dependencies

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
