### PR TITLE
reason: refactor

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,54 +1,35 @@
-{ lib, callPackage, stdenv, makeWrapper, fetchurl, ocaml, findlib, dune_3
-, ncurses
-, fix, menhir, menhirLib, menhirSdk, merlin-extend, ppxlib, utop, cppo, ppx_derivers
+{ lib, callPackage, buildDunePackage, fetchurl
+, fix, menhir, menhirLib, menhirSdk, merlin-extend, ppxlib, cppo, ppx_derivers
 , dune-build-info
 }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-reason";
+buildDunePackage rec {
+  pname = "reason";
   version = "3.13.0";
+
+  minimalOCamlVersion = "4.11";
 
   src = fetchurl {
     url = "https://github.com/reasonml/reason/releases/download/${version}/reason-${version}.tbz";
     hash = "sha256-3yVEYGvIJKZwguIBGCbnoc3nrwzLW6RX6Tf+AYw85+Q=";
   };
 
-  strictDeps = true;
   nativeBuildInputs = [
-    makeWrapper
-    menhir
-    ocaml
     menhir
     cppo
-    dune_3
-    findlib
   ];
 
   buildInputs = [
     dune-build-info
     fix
     menhirSdk
-    ppxlib
-    utop
-  ] ++ lib.optional (lib.versionOlder ocaml.version "4.07") ncurses;
-
-  propagatedBuildInputs = [
-    menhirLib
     merlin-extend
-    ppx_derivers
   ];
 
-  buildFlags = [ "build" ]; # do not "make tests" before reason lib is installed
-
-  installPhase = ''
-    runHook preInstall
-    dune install --prefix=$out --libdir=$OCAMLFIND_DESTDIR
-    wrapProgram $out/bin/rtop \
-      --prefix PATH : "${utop}/bin" \
-      --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH" \
-      --prefix OCAMLPATH : "$OCAMLPATH:$OCAMLFIND_DESTDIR"
-    runHook postInstall
-  '';
+  propagatedBuildInputs = [
+    ppxlib
+    menhirLib
+  ];
 
   passthru.tests = {
     hello = callPackage ./tests/hello { };
@@ -57,9 +38,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://reasonml.github.io/";
     downloadPage = "https://github.com/reasonml/reason";
-    description = "Facebook's friendly syntax to OCaml";
+    description = "User-friendly programming language built on OCaml";
     license = licenses.mit;
-    inherit (ocaml.meta) platforms;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/compilers/reason/rtop.nix
+++ b/pkgs/development/compilers/reason/rtop.nix
@@ -1,0 +1,25 @@
+{ buildDunePackage, reason, cppo, utop, makeWrapper }:
+
+buildDunePackage {
+  pname = "rtop";
+  inherit (reason) version src;
+
+  nativeBuildInputs = [
+    makeWrapper
+    cppo
+  ];
+
+  propagatedBuildInputs = [ reason utop ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rtop \
+      --prefix PATH : "${utop}/bin" \
+      --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH" \
+      --prefix OCAMLPATH : "$OCAMLPATH:$OCAMLFIND_DESTDIR"
+  '';
+
+  meta = reason.meta // {
+    description = "Toplevel (or REPL) for Reason, based on utop";
+    mainProgram = "rtop";
+  };
+}

--- a/pkgs/development/compilers/reason/tests/hello/default.nix
+++ b/pkgs/development/compilers/reason/tests/hello/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, ppxlib, reason }:
+{ lib, buildDunePackage, reason }:
 
 buildDunePackage rec {
   pname = "helloreason";
@@ -19,7 +19,6 @@ buildDunePackage rec {
   ];
 
   buildInputs = [
-    ppxlib
     reason
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7743,7 +7743,7 @@ with pkgs;
   nqp = callPackage  ../development/interpreters/rakudo/nqp.nix { };
   zef = callPackage ../development/interpreters/rakudo/zef.nix { };
 
-  inherit (ocamlPackages) reason;
+  inherit (ocamlPackages) reason rtop;
 
   buildRubyGem = callPackage ../development/ruby-modules/gem {
     inherit (darwin) libobjc;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1691,6 +1691,8 @@ let
 
     rresult = callPackage ../development/ocaml-modules/rresult { };
 
+    rtop = callPackage ../development/compilers/reason/rtop.nix { };
+
     rusage = callPackage ../development/ocaml-modules/rusage { };
 
     ### S ###


### PR DESCRIPTION
Move rtop to a separate package.

Fix build with older OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
