### PR TITLE
python311Packages.pysnow: fix deps and tests, unbreak

### DIFF
--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -9,6 +9,7 @@
   poetry-core,
   python-magic,
   pytz,
+  six,
   pytestCheckHook,
   requests-oauthlib,
 }:
@@ -25,6 +26,8 @@ buildPythonPackage rec {
     hash = "sha256-nKOPCkS2b3ObmBnk/7FTv4o4vwUX+tOtZI5OQQ4HSTY=";
   };
 
+  pythonRelaxDeps = [ "requests-oauthlib" ];
+
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
@@ -32,6 +35,7 @@ buildPythonPackage rec {
     ijson
     python-magic
     pytz
+    six
     requests-oauthlib
   ];
 

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -58,6 +58,10 @@ buildPythonPackage rec {
       --replace 'ijson = "^2.5.1"' 'ijson = "*"' \
       --replace 'pytz = "^2019.3"' 'pytz = "*"' \
       --replace 'oauthlib = "^3.1.0"' 'oauthlib = "*"'
+
+    # https://github.com/rbw/pysnow/pull/201 doesn't apply via fetchpatch, so we recreate it
+    substituteInPlace tests/test_client.py tests/test_oauth_client.py tests/test_params_builder.py tests/test_resource.py \
+      --replace-fail "self.assertEquals" "self.assertEqual"
   '';
 
   pythonImportsCheck = [ "pysnow" ];


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/276546539 ~~but not~~ and https://hydra.nixos.org/build/276558831
zhf https://github.com/NixOS/nixpkgs/issues/352882

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
