### PR TITLE
nixos/phosh: enable services.graphical-desktop

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -157,7 +157,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.defaultUnit = "graphical.target";
     # Inspired by https://gitlab.gnome.org/World/Phosh/phosh/-/blob/main/data/phosh.service
     systemd.services.phosh = {
       wantedBy = [ "graphical.target" ];
@@ -213,7 +212,7 @@ in
 
     security.pam.services.phosh = {};
 
-    hardware.graphics.enable = lib.mkDefault true;
+    services.graphical-desktop.enable = true;
 
     services.gnome.core-shell.enable = true;
     services.gnome.core-os-services.enable = true;


### PR DESCRIPTION
The `services.graphical-desktop` module (code in `nixos/modules/services/misc/graphical-desktop.nix`) is enabled automatically if `services.xserver.enable` or `services.displayManager.enable` is true but this does not cover `phosh`, so enable it manually.
My main motivation for this change is that `fonts.enableDefaultPackages` was set to false, unlike with all (most?) other desktop managers, which causes many characters to not be displayed.
Since enabling `services.graphical-desktop.enable` also enables `hardware.graphics.enable`, I removed the latter option from the `phosh` module.
The `services.graphical-desktop` module also sets `systemd.defaultUnit` to `"graphical.target"` if `services.xserver.autorun` or `services.displayManager.enable` are enabled, with the former option being enabled by default, so I also removed this option from the `phosh` module. This also better aligns with the intent of the user when disabling `services.xserver.autorun`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
