### PR TITLE
llvmPackages: Fix update-git.py

### DIFF
--- a/pkgs/development/compilers/llvm/update-git.py
+++ b/pkgs/development/compilers/llvm/update-git.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from urllib.request import urlopen, Request
 
 
-DEFAULT_NIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'git/default.nix')
+DEFAULT_NIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default.nix')
 
 
 def get_latest_chromium_build():
@@ -43,7 +43,7 @@ def get_current_revision():
     """Get the current revision of llvmPackages_git."""
     with open(DEFAULT_NIX) as f:
         for line in f:
-            rev = re.search(r'^    rev = "(.*)";', line)
+            rev = re.search(r'^      rev = "(.*)";', line)
             if rev:
                 return rev.group(1)
     sys.exit(1)
@@ -75,12 +75,13 @@ hash = nix_prefetch_url(f'https://github.com/llvm/llvm-project/archive/{commit["
 print('Updating default.nix...')
 with fileinput.FileInput(DEFAULT_NIX, inplace=True) as f:
     for line in f:
-        if match := re.search(r'^    rev-version = "unstable-(.+)";', line):
+        if match := re.search(r'^      rev-version = "unstable-(.+)";', line):
                 old_date = match.group(1)
-        result = re.sub(r'^    version = ".+";', f'    version = "{release_version}";', line)
-        result = re.sub(r'^    rev = ".*";', f'    rev = "{commit["sha"]}";', result)
-        result = re.sub(r'^    rev-version = ".+";', f'    rev-version = "{version}";', result)
-        result = re.sub(r'^    sha256 = ".+";', f'    sha256 = "{hash}";', result)
+        result = line
+        result = re.sub(r'^      version = ".+";', f'    version = "{release_version}";', result)
+        result = re.sub(r'^      rev = ".*";', f'      rev = "{commit["sha"]}";', result)
+        result = re.sub(r'^      rev-version = ".+";', f'      rev-version = "{version}";', result)
+        result = re.sub(r'^      sha256 = ".+";', f'      sha256 = "{hash}";', result)
         print(result, end='')
 # Commit the result:
 commit_message = f"llvmPackages_git: {old_date} -> {date}"


### PR DESCRIPTION
This was broken since the change which got rid of llvm/git/default.nix.

Fairly obvious fixes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
