### PR TITLE
bootc: add composefs support

### DIFF
--- a/pkgs/by-name/bo/bootc/package.nix
+++ b/pkgs/by-name/bo/bootc/package.nix
@@ -7,7 +7,7 @@
   pkg-config,
   openssl,
   glib,
-  ostree,
+  ostree-full,
   versionCheckHook,
 }:
 
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
     zstd
     openssl
     glib
-    ostree
+    ostree-full
   ];
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/os/ostree-full/package.nix
+++ b/pkgs/by-name/os/ostree-full/package.nix
@@ -1,0 +1,7 @@
+{
+  ostree,
+}:
+
+ostree.override {
+  withComposefs = true;
+}

--- a/pkgs/by-name/os/ostree/package.nix
+++ b/pkgs/by-name/os/ostree/package.nix
@@ -33,6 +33,10 @@
 , docbook-xsl-nons
 , docbook_xml_dtd_42
 , python3
+
+  # Optional ComposeFS support
+, withComposefs ? false
+, composefs
 }:
 
 let
@@ -87,6 +91,8 @@ in stdenv.mkDerivation rec {
     # for installed tests
     testPython
     gjs
+  ] ++ lib.optionals withComposefs [
+    (lib.getDev composefs)
   ];
 
   enableParallelBuilding = true;
@@ -97,6 +103,8 @@ in stdenv.mkDerivation rec {
     "--with-systemdsystemgeneratordir=${placeholder "out"}/lib/systemd/system-generators"
     "--enable-installed-tests"
     "--with-ed25519-libsodium"
+  ] ++ lib.optionals withComposefs [
+    "--with-composefs"
   ];
 
   makeFlags = [


### PR DESCRIPTION
This changes adds a package variant, `ostree-full`, which builds OSTree with `composefs` support, and makes it a dependency for `bootc` to enable it to work on `composefs` repositories.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
