### PR TITLE
wings: format via nixfmt; bump to 2.3

### DIFF
--- a/pkgs/by-name/wi/wings/package.nix
+++ b/pkgs/by-name/wi/wings/package.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, fetchurl, fetchpatch, erlang, cl, libGL, libGLU, runtimeShell }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  erlang,
+  cl,
+  libGL,
+  libGLU,
+  runtimeShell,
+}:
 
 stdenv.mkDerivation rec {
   pname = "wings";
@@ -27,7 +37,12 @@ stdenv.mkDerivation rec {
     find . -type f -name "*.[eh]rl" -exec sed -i 's,wings/intl_tools/,../intl_tools/,' {} \;
   '';
 
-  buildInputs = [ erlang cl libGL libGLU ];
+  buildInputs = [
+    erlang
+    cl
+    libGL
+    libGLU
+  ];
 
   ERL_LIBS = "${cl}/lib/erlang/lib";
 

--- a/pkgs/by-name/wi/wings/package.nix
+++ b/pkgs/by-name/wi/wings/package.nix
@@ -2,29 +2,22 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   erlang,
   cl,
   libGL,
   libGLU,
+  libigl,
+  eigen,
   runtimeShell,
 }:
-
 stdenv.mkDerivation rec {
   pname = "wings";
-  version = "2.2.4";
+  version = "2.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/wings/wings-${version}.tar.bz2";
-    sha256 = "1xcmifs4vq2810pqqvsjsm8z3lz24ys4c05xkh82nyppip2s89a3";
+    sha256 = "sha256-dEf6iPbPCLmMqvWjvgEROVACZW8SCsXKi3TWlic+bws=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/dgud/wings/commit/94b3a3c6a0cfdcdbd98edce055d5c83ecb361f37.patch";
-      hash = "sha256-DHT1TiYoowloIWrdutBu70mL+557cTFr1dRcNgwbkpE=";
-    })
-  ];
 
   postPatch = ''
     find . -type f -name "Makefile" -exec sed -i 's,-Werror ,,' {} \;
@@ -35,6 +28,18 @@ stdenv.mkDerivation rec {
     find . -type f -name "*.[eh]rl" -exec sed -i 's,wings/src/,../src/,' {} \;
     find . -type f -name "*.[eh]rl" -exec sed -i 's,wings/e3d/,../e3d/,' {} \;
     find . -type f -name "*.[eh]rl" -exec sed -i 's,wings/intl_tools/,../intl_tools/,' {} \;
+    # Remove external dependency rules (such as libigl, eigen, cl)
+    find . -type f -name "Makefile" -exec sed -i 's,libigl: _deps/libigl,,g' {} \;
+    find . -type f -name "Makefile" -exec sed -i 's,eigen: _deps/eigen,,g' {} \;
+    find . -type f -name "Makefile" -exec sed -i 's,cl: _deps/cl,,g' {} \;
+    # The following lines were added during an update to 2.3 due to changes to the Makefile. Chances are
+    # there are better ways to do this, but I'm not aware if there are. PRs welcome.
+    # Remove any targets that depend on these dependencies (e.g., c_src)
+    find . -type f -name "Makefile" -exec sed -i 's,c_src: $(DEPS),c_src:,g' {} \;
+    find . -type f -name "Makefile" -exec sed -i 's,src: intl_tools e3d,src: intl_tools,g' {} \;
+    find . -type f -name "Makefile" -exec sed -i 's,plugins_src: intl_tools src,plugins_src: intl_tools,g' {} \;
+    # Make sure the Makefile is able to find Eigen. Without this line, it will fail.
+    find . -type f -name "Makefile" -exec sed -i 's,-I../_deps/eigen,-I${eigen}/include/eigen3,' {} \;
   '';
 
   buildInputs = [
@@ -42,12 +47,16 @@ stdenv.mkDerivation rec {
     cl
     libGL
     libGLU
+    libigl
+    eigen
   ];
 
   ERL_LIBS = "${cl}/lib/erlang/lib";
 
   # I did not test the *cl* part. I added the -pa just by imitation.
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/lib/wings-${version}/ebin
     cp ebin/* $out/lib/wings-${version}/ebin
     cp -R textures shaders plugins $out/lib/wings-${version}
@@ -56,15 +65,17 @@ stdenv.mkDerivation rec {
     ${erlang}/bin/erl \
       -pa $out/lib/wings-${version}/ebin -run wings_start start_halt "$@"
     EOF
+
     chmod +x $out/bin/wings
+    runHook postInstall
   '';
 
   meta = {
     homepage = "http://www.wings3d.com/";
     description = "Subdivision modeler inspired by Nendo and Mirai from Izware";
     license = lib.licenses.tcltk;
-    maintainers = [ ];
-    platforms = with lib.platforms; linux;
+    maintainers = with lib.maintainers; [ NotAShelf ];
+    platforms = lib.platforms.linux;
     mainProgram = "wings";
   };
 }


### PR DESCRIPTION
Update Wings from 2.2.4 to 2.3. Contains a few hacks, so reviews appreciated.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
