### PR TITLE
runInLinuxVM: fix for structured attrs

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -130,14 +130,14 @@ rec {
     mkdir -p /fs${storeDir}
     mount -t 9p store /fs${storeDir} -o trans=virtio,version=9p2000.L,cache=loose,msize=131072
 
+    echo "mounting host's build directory..."
+    mkdir -p /fs/build
+    mount -t 9p sa /fs/build -o trans=virtio,version=9p2000.L,cache=loose,msize=131072
+
     mkdir -p /fs/tmp /fs/run /fs/var
     mount -t tmpfs -o "mode=1777" none /fs/tmp
     mount -t tmpfs -o "mode=755" none /fs/run
     ln -sfn /run /fs/var/run
-
-    echo "mounting host's temporary directory..."
-    mkdir -p /fs/tmp/xchg
-    mount -t 9p xchg /fs/tmp/xchg -o trans=virtio,version=9p2000.L,msize=131072
 
     mkdir -p /fs/proc
     mount -t proc none /fs/proc
@@ -169,7 +169,12 @@ rec {
 
   stage2Init = writeScript "vm-run-stage2" ''
     #! ${bash}/bin/sh
-    source /tmp/xchg/saved-env
+    set -euo pipefail
+    source /build/xchg/saved-env
+    if [ -f "''${NIX_ATTRS_SH_FILE-}" ]; then
+      source "$NIX_ATTRS_SH_FILE"
+    fi
+    source $stdenv/setup
 
     # Set the system time from the hardware clock.  Works around an
     # apparent KVM > 1.5.2 bug.
@@ -179,7 +184,6 @@ rec {
     export NIX_BUILD_TOP=/tmp
     export TMPDIR=/tmp
     export PATH=/empty
-    out="$1"
     cd "$NIX_BUILD_TOP"
 
     if ! test -e /bin/sh; then
@@ -203,8 +207,10 @@ rec {
     if test -n "$origBuilder" -a ! -e /.debug; then
       exec < /dev/null
       ${coreutils}/bin/touch /.debug
-      $origBuilder $origArgs
-      echo $? > /tmp/xchg/in-vm-exit
+      declare -a argsArray=()
+      concatTo argsArray origArgs
+      "$origBuilder" "''${argsArray[@]}"
+      echo $? > /build/xchg/in-vm-exit
 
       ${busybox}/bin/mount -o remount,ro dummy /
 
@@ -223,11 +229,12 @@ rec {
       -nographic -no-reboot \
       -device virtio-rng-pci \
       -virtfs local,path=${storeDir},security_model=none,mount_tag=store \
+      -virtfs local,path=/build,security_model=none,mount_tag=sa \
       -virtfs local,path=$TMPDIR/xchg,security_model=none,mount_tag=xchg \
       ''${diskImage:+-drive file=$diskImage,if=virtio,cache=unsafe,werror=report} \
       -kernel ${kernel}/${img} \
       -initrd ${initrd}/initrd \
-      -append "console=${qemu-common.qemuSerialDevice} panic=1 command=${stage2Init} out=$out mountDisk=$mountDisk loglevel=4" \
+      -append "console=${qemu-common.qemuSerialDevice} panic=1 command=${stage2Init} mountDisk=$mountDisk loglevel=4" \
       $QEMU_OPTS
   '';
 
@@ -259,8 +266,6 @@ rec {
     cd $TMPDIR
     ${qemuCommand}
     EOF
-
-    mkdir -p -m 0700 $out
 
     chmod +x ./run-vm
     source ./run-vm


### PR DESCRIPTION
Closes #334705
Addresses #205690

The main issue was that the output variable (i.e. `$out` and friends) didn't exist. I figured the easiest way to add those is to source `stdenv` here. Given that we build another derivation in this builder, it's pretty likely that `stdenv` gets pulled already, so I don't expect a real overhead here.

Also, this mounts `/build` into the VM: this is required to make sure `.attrs.json` & `.attrs.sh` are available. Dropped the mount of `xchg` into `/tmp` now since it's also part of `/build`.

cc @ShamrockLee 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
