### PR TITLE
csharprepl: format, refactor meta, fix runtime environment, 0.6.6 -> 0.6.7

### DIFF
--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -1,4 +1,8 @@
-{ buildDotnetGlobalTool, dotnetCorePackages, lib }:
+{
+  buildDotnetGlobalTool,
+  dotnetCorePackages,
+  lib,
+}:
 
 buildDotnetGlobalTool {
   pname = "csharprepl";

--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -7,13 +7,13 @@
 buildDotnetGlobalTool {
   pname = "csharprepl";
   nugetName = "CSharpRepl";
-  version = "0.6.6";
+  version = "0.6.7";
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   # We're using an SDK here because it's a REPL, and it requires an SDK instaed of a runtime
   dotnet-runtime = dotnetCorePackages.sdk_8_0;
 
-  nugetHash = "sha256-VkZGnfD8p6oAJ7i9tlfwJfmKfZBHJU7Wdq+K4YjPoRs=";
+  nugetHash = "sha256-a0CiU3D6RZp1FF459NIUUry5TFRDgm4FRhqJZNAGYWs=";
 
   meta = {
     description = "C# REPL with syntax highlighting";

--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -10,7 +10,8 @@ buildDotnetGlobalTool {
   version = "0.6.6";
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  # We're using an SDK here because it's a REPL, and it requires an SDK instaed of a runtime
+  dotnet-runtime = dotnetCorePackages.sdk_8_0;
 
   nugetHash = "sha256-VkZGnfD8p6oAJ7i9tlfwJfmKfZBHJU7Wdq+K4YjPoRs=";
 

--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -14,13 +14,13 @@ buildDotnetGlobalTool {
 
   nugetHash = "sha256-VkZGnfD8p6oAJ7i9tlfwJfmKfZBHJU7Wdq+K4YjPoRs=";
 
-  meta = with lib; {
+  meta = {
     description = "C# REPL with syntax highlighting";
     homepage = "https://fuqua.io/CSharpRepl";
     changelog = "https://github.com/waf/CSharpRepl/blob/main/CHANGELOG.md";
-    license = licenses.mpl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ donteatoreo ];
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ donteatoreo ];
     mainProgram = "csharprepl";
   };
 }


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/338772

- Fix `No .NET SDKs were found.`
- Small refactor on formatting and `meta`
- Update to v0.6.7 *(Diff: https://github.com/waf/CSharpRepl/compare/v0.6.6...v0.6.7)*

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc