### PR TITLE
docs: make sample code valid Nix expressions

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -160,7 +160,9 @@ rec {
     A fixed-point function returning an attribute set has the form
 
     ```nix
-    final: { # attributes }
+    final: {
+      # attributes
+    }
     ```
 
     where `final` refers to the lazily evaluated attribute set returned by the fixed-point function.
@@ -168,7 +170,9 @@ rec {
     An overlay to such a fixed-point function has the form
 
     ```nix
-    final: prev: { # attributes }
+    final: prev: {
+      # attributes
+    }
     ```
 
     where `prev` refers to the result of the original function to `final`, and `final` is the result of the composition of the overlay and the original function.
@@ -177,8 +181,12 @@ rec {
 
     ```nix
     let
-      f = final: { # attributes };
-      overlay = final: prev: { # attributes };
+      f = final: {
+        # attributes
+      };
+      overlay = final: prev: {
+        # attributes
+      };
     in extends overlay f;
     ```
 
@@ -186,8 +194,12 @@ rec {
 
     ```nix
     let
-      f = final: { # attributes };
-      overlay = final: prev: { # attributes };
+      f = final: {
+        # attributes
+      };
+      overlay = final: prev: {
+        # attributes
+      };
       g = extends overlay f;
     in fix g
     ```


### PR DESCRIPTION
inline comments are compact but syntax highlighting will correctly show them as broken


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc