### PR TITLE
asciinema: 2.4.0 -> 3.0.0-rc.3

### DIFF
--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -1,29 +1,22 @@
 {
   lib,
-  python3Packages,
-  fetchFromGitHub,
+  rustPlatform,
+  fetchCrate,
 }:
 
-python3Packages.buildPythonApplication rec {
+rustPlatform.buildRustPackage rec {
   pname = "asciinema";
-  version = "2.4.0";
+  version = "3.0.0-rc.3";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "asciinema";
-    repo = "asciinema";
-    rev = "v${version}";
-    hash = "sha256-UegLwpJ+uc9cW3ozLQJsQBjIGD7+vzzwzQFRV5gmDmI=";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-BUVD+kdQBzIM0gbj8jNKjWoJIHJFPrwi36m1eefPZJM=";
   };
 
-  build-system = [ python3Packages.setuptools ];
+  cargoHash = "sha256-CYDy0CedwG/ThTV+XOfOg8ncxF3tdTEGakmu4MXfiE4=";
 
-  postPatch = ''
-    substituteInPlace tests/pty_test.py \
-      --replace-fail "python3" "${python3Packages.python.interpreter}"
-  '';
-
-  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+  doCheck = false; # TEMP until we fix checks
 
   meta = {
     description = "Terminal session recorder and the best companion of asciinema.org";


### PR DESCRIPTION
This works and builds. Not ready to be merged yet, since we currently have to disable tests for it to build, and I'd prefer to wait for the stable release rather than using a release candidate. However, we've done the work here of swapping to Rust instead of Python, due to the package being rewritten.

If anyone is able to help debug why it's failing tests, I'd appreciate it! This is the error output I'm getting: 
```sh
running 17 tests
test asciicast::tests::accelerate ... ok
test asciicast::tests::limit_idle_time ... ok
test asciicast::tests::open_v1_minimal ... ok
test asciicast::tests::open_v2_minimal ... ok
test asciicast::tests::open_v1_full ... ok
test asciicast::tests::open_v2_full ... ok
test asciicast::tests::write_header ... ok
test encoder::raw::tests::encoder_impl ... ok
test asciicast::tests::writer ... ok
test encoder::txt::tests::encoder_impl ... ok
test tty::tests::parse_color ... ok
test util::tests::utf8_decoder ... ok
test pty::tests::exec_basic ... FAILED
test pty::tests::exec_no_output ... ok
test pty::tests::exec_winsize_override ... ok
test pty::tests::exec_quick ... ok
test pty::tests::exec_extra_env ... ok

failures:

---- pty::tests::exec_basic stdout ----
thread 'pty::tests::exec_basic' panicked at src/pty.rs:463:9:
assertion `left == right` failed
  left: []
 right: ["foo", "bar"]
stack backtrace:
   0:     0x5555555fe7f6 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h9754a6437f1de22a
   1:     0x5555556552fb - core::fmt::write::hb706a393bb60a06f
   2:     0x555555606949 - std::io::Write::write_fmt::h45bf4fee0184c1a6
   3:     0x555555634d76 - std::panicking::default_hook::{{closure}}::h227952daede9dd84
   4:     0x555555634a36 - std::panicking::default_hook::h31626ee1feb8ee2a
   5:     0x5555555a2e6a - test::test_main::{{closure}}::hb863b6e1cc3ca57a
   6:     0x555555635516 - std::panicking::rust_panic_with_hook::h76d2aa694a00748e
   7:     0x5555555feff7 - std::panicking::begin_panic_handler::{{closure}}::h8855a344ffa1638b
   8:     0x5555555fea09 - std::sys::backtrace::__rust_end_short_backtrace::h3110d0cbfbf26886
   9:     0x555555634eb4 - rust_begin_unwind
  10:     0x5555555730e3 - core::panicking::panic_fmt::h3af706d0346c1c60
  11:     0x5555555733be - core::panicking::assert_failed_inner::h7817d57f580e4b84
  12:     0x55555556d9d3 - core::panicking::assert_failed::h37124c8def20a075
  13:     0x55555558dcb8 - asciinema::pty::tests::exec_basic::h1bd0e43fd651dc17
  14:     0x5555555943a9 - core::ops::function::FnOnce::call_once::h2533eae5be349a34
  15:     0x5555555a8a2b - test::__rust_begin_short_backtrace::h32dbc76e3657b1e4
  16:     0x5555555e13f2 - test::types::RunnableTest::run::hbd37082e743ae77e
  17:     0x5555555a8bd1 - test::run_test_in_process::ha03e943838708deb
  18:     0x5555555b110f - std::sys::backtrace::__rust_begin_short_backtrace::ha10de4c6e83c53f7
  19:     0x5555555b1895 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h338bbb43d876641d
  20:     0x555555607b6b - std::sys::pal::unix::thread::Thread::new::thread_start::h87241c7e32b9860b
  21:     0x7ffff7d49d02 - start_thread
  22:     0x7ffff7dc93ac - __GI___clone3
  23:                0x0 - <unknown>


failures:
    pty::tests::exec_basic

test result: FAILED. 16 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
