### PR TITLE
rpm-sequoia: init at 1.7.0

### DIFF
--- a/pkgs/by-name/rp/rpm-sequoia/objdump.patch
+++ b/pkgs/by-name/rp/rpm-sequoia/objdump.patch
@@ -1,0 +1,18 @@
+objdump may be prefixed on cross-compilation, read the path from $OBJDUMP instead
+
+diff --git a/tests/symbols.rs b/tests/symbols.rs
+index 9375619..5f161fc 100644
+--- a/tests/symbols.rs
++++ b/tests/symbols.rs
+@@ -27,7 +27,10 @@ fn symbols() -> anyhow::Result<()> {
+         }
+     };
+ 
+-    let cmd = Command::new("objdump")
++    let cmd = Command::new("bash")
++        .arg("-c")
++        .arg(r#"exec "$OBJDUMP" "$@""#)
++        .arg("--")
+         .arg("-T")
+         .arg(lib)
+         .unwrap();

--- a/pkgs/by-name/rp/rpm-sequoia/package.nix
+++ b/pkgs/by-name/rp/rpm-sequoia/package.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  nettle,
+  nix-update-script,
+  rustPlatform,
+  pkg-config,
+  runCommand,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rpm-sequoia";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = "rpm-sequoia";
+    rev = "v${version}";
+    hash = "sha256-AZCsboUv4muKOw5El2Hw5O1cvAgD3JhBppacrQCJT2k=";
+  };
+
+  cargoHash = "sha256-0yO1+OAkXje/ir8i8URVhIcW8gwXleYx+XL1U4bjtXk=";
+
+  patches = [
+    ./objdump.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  propagatedBuildInputs = [ nettle ];
+
+  # Tests will parse the symbols, on darwin we have two issues:
+  # - library name is hardcoded to librpm_sequoia.so
+  # - The output of the objdump differs and the parsing logic needs to be adapted
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  # Ensure the generated .pc file gets the correct prefix
+  env.PREFIX = placeholder "out";
+
+  # Install extra files, the same as this is done on fedora:
+  # https://src.fedoraproject.org/rpms/rust-rpm-sequoia/blob/f41/f/rust-rpm-sequoia.spec#_81
+  preInstall =
+    # Install the generated pc file for consumption by the dependents
+    ''
+      install -Dm644 target/release/rpm-sequoia.pc -t $dev/lib/pkgconfig
+    ''
+    +
+      # Dependents will rely on the versioned symlinks
+      ''
+        install -d $out/lib
+        find target/release/ \
+          -maxdepth 1 \
+          -type l -name 'librpm_sequoia.*' \
+          -exec cp --no-dereference {} $out/lib/ \;
+      '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An OpenPGP backend for rpm using Sequoia PGP";
+    homepage = "https://sequoia-pgp.org/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ baloo ];
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
