### PR TITLE
feat: refactor plexamp package, add support for darwin aarch64 and amd64

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7108,6 +7108,12 @@
       { fingerprint = "7E08 6842 0934 AA1D 6821  1F2A 671E 39E6 744C 807D"; }
     ];
   };
+  femiagbabiaka = {
+    email = "femi@femiagbabiaka.xyz";
+    github = "femiagbabiaka";
+    githubId = 5712318;
+    name = "Femi Agbabiaka";
+  };
   fernsehmuell = {
     email = "fernsehmuel@googlemail.com";
     matrix = "@fernsehmuell:matrix.org";

--- a/pkgs/applications/audio/plexamp/darwin.nix
+++ b/pkgs/applications/audio/plexamp/darwin.nix
@@ -1,18 +1,26 @@
-{ lib, stdenv, fetchurl, pname, meta, version, undmg }:
-
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pname,
+  meta,
+  version,
+  undmg,
+}:
 stdenv.mkDerivation {
   inherit pname version;
 
-  src = if stdenv.hostPlatform.isAarch64 then (
-    fetchurl {
-      url = "https://web.archive.org/web/20241108231325/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-arm64.dmg";
-      hash = "sha256-sXVJaL6E0VK0dNm6BBUqApD1HYwlWg+rQTkltMEK0zI=";
-    }) 
-  else (
-    fetchurl {
-      url = "https://web.archive.org/web/20241108231802/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-x64.dmg";
-      hash = "sha256-3O8xcy2hklOHKiFWzuanlq4MeCyS7DKHJysdqLoSl9Q=";
-    });
+  src =
+    if stdenv.hostPlatform.isAarch64 then
+      (fetchurl {
+        url = "https://web.archive.org/web/20241108231325/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-arm64.dmg";
+        hash = "sha256-sXVJaL6E0VK0dNm6BBUqApD1HYwlWg+rQTkltMEK0zI=";
+      })
+    else
+      (fetchurl {
+        url = "https://web.archive.org/web/20241108231802/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-x64.dmg";
+        hash = "sha256-3O8xcy2hklOHKiFWzuanlq4MeCyS7DKHJysdqLoSl9Q=";
+      });
 
   nativeBuildInputs = [ undmg ];
 
@@ -28,6 +36,6 @@ stdenv.mkDerivation {
   '';
 
   meta = meta // {
-    maintainers = with lib.maintainers; [femiagbabiaka];
+    maintainers = with lib.maintainers; [ femiagbabiaka ];
   };
 }

--- a/pkgs/applications/audio/plexamp/darwin.nix
+++ b/pkgs/applications/audio/plexamp/darwin.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, pname, meta, version, undmg }:
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = if stdenv.hostPlatform.isAarch64 then (
+    fetchurl {
+      url = "https://web.archive.org/web/20241108231325/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-arm64.dmg";
+      hash = "sha256-sXVJaL6E0VK0dNm6BBUqApD1HYwlWg+rQTkltMEK0zI=";
+    }) 
+  else (
+    fetchurl {
+      url = "https://web.archive.org/web/20241108231802/https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}-x64.dmg";
+      hash = "sha256-3O8xcy2hklOHKiFWzuanlq4MeCyS7DKHJysdqLoSl9Q=";
+    });
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = meta // {
+    maintainers = with lib.maintainers; [femiagbabiaka];
+  };
+}

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -1,34 +1,9 @@
-{ lib, fetchurl, appimageTools, makeWrapper }:
+{ lib, stdenv, fetchurl, appimageTools, makeWrapper, callPackage, ... }@args:
 
 let
   pname = "plexamp";
   version = "4.11.2";
-
-  src = fetchurl {
-    url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
-    name = "${pname}-${version}.AppImage";
-    hash = "sha512-cNBupLFHhq7GDoj/QYGsS0UShTKmDpf/JxBZS92VwTCuuBjScTMGF0cETGEYYnvxqv4vf9MSKNY0/HW9CuguaA==";
-  };
-
-  appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-
-  extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop
-    install -m 444 -D ${appimageContents}/plexamp.svg \
-      $out/share/icons/hicolor/scalable/apps/plexamp.svg
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
-    source "${makeWrapper}/nix-support/setup-hook"
-    wrapProgram "$out/bin/plexamp" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-  '';
-
-  passthru.updateScript = ./update-plexamp.sh;
+  extraArgs = removeAttrs args ["callPackage"];
 
   meta = with lib; {
     description = "Beautiful Plex music player for audiophiles, curators, and hipsters";
@@ -36,6 +11,9 @@ appimageTools.wrapType2 {
     changelog = "https://forums.plex.tv/t/plexamp-release-notes/221280/76";
     license = licenses.unfree;
     maintainers = with maintainers; [ killercup redhawk synthetica ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin"];
   };
-}
+
+in if stdenv.hostPlatform.isDarwin
+then callPackage ./darwin.nix (removeAttrs extraArgs ["appimageTools" "makeWrapper"] // { inherit pname version meta; })
+else callPackage ./linux.nix (removeAttrs extraArgs ["lib" "stdenv"] // { inherit pname version meta; })

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -1,19 +1,53 @@
-{ lib, stdenv, fetchurl, appimageTools, makeWrapper, callPackage, ... }@args:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+  callPackage,
+  ...
+}@args:
 
 let
   pname = "plexamp";
   version = "4.11.2";
-  extraArgs = removeAttrs args ["callPackage"];
+  extraArgs = removeAttrs args [ "callPackage" ];
 
   meta = with lib; {
     description = "Beautiful Plex music player for audiophiles, curators, and hipsters";
     homepage = "https://plexamp.com/";
     changelog = "https://forums.plex.tv/t/plexamp-release-notes/221280/76";
     license = licenses.unfree;
-    maintainers = with maintainers; [ killercup redhawk synthetica ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin"];
+    maintainers = with maintainers; [
+      killercup
+      redhawk
+      synthetica
+    ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 
-in if stdenv.hostPlatform.isDarwin
-then callPackage ./darwin.nix (removeAttrs extraArgs ["appimageTools" "makeWrapper"] // { inherit pname version meta; })
-else callPackage ./linux.nix (removeAttrs extraArgs ["lib" "stdenv"] // { inherit pname version meta; })
+in
+if stdenv.hostPlatform.isDarwin then
+  callPackage ./darwin.nix (
+    removeAttrs extraArgs [
+      "appimageTools"
+      "makeWrapper"
+    ]
+    // {
+      inherit pname version meta;
+    }
+  )
+else
+  callPackage ./linux.nix (
+    removeAttrs extraArgs [
+      "lib"
+      "stdenv"
+    ]
+    // {
+      inherit pname version meta;
+    }
+  )

--- a/pkgs/applications/audio/plexamp/linux.nix
+++ b/pkgs/applications/audio/plexamp/linux.nix
@@ -1,0 +1,28 @@
+{ fetchurl, appimageTools, makeWrapper, pname, version, meta }:
+let
+  src = fetchurl {
+    url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
+    name = "${pname}-${version}.AppImage";
+    hash = "sha512-cNBupLFHhq7GDoj/QYGsS0UShTKmDpf/JxBZS92VwTCuuBjScTMGF0cETGEYYnvxqv4vf9MSKNY0/HW9CuguaA==";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src meta;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop
+    install -m 444 -D ${appimageContents}/plexamp.svg \
+      $out/share/icons/hicolor/scalable/apps/plexamp.svg
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram "$out/bin/plexamp" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+  '';
+
+  passthru.updateScript = ./update-plexamp.sh;
+}

--- a/pkgs/applications/audio/plexamp/linux.nix
+++ b/pkgs/applications/audio/plexamp/linux.nix
@@ -1,4 +1,11 @@
-{ fetchurl, appimageTools, makeWrapper, pname, version, meta }:
+{
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+  pname,
+  version,
+  meta,
+}:
 let
   src = fetchurl {
     url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
@@ -11,7 +18,12 @@ let
   };
 in
 appimageTools.wrapType2 {
-  inherit pname version src meta;
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added aarch64 and x86_64 plexamp packages for darwin. Not sure if this is release notes worthy so omitted for now.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (rosetta)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
