### PR TITLE
cyrus-imapd: fix wrong mainProgram; remove unused inputs

### DIFF
--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -10,8 +10,6 @@
 
   # fetchers
   fetchFromGitHub,
-  fetchpatch,
-  fetchurl,
 
   # build inputs
   bison,

--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -192,7 +192,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.cyrusimap.org";
     description = "Email, contacts and calendar server";
     license = with lib.licenses; [ bsdOriginal ];
-    mainProgram = "cyrus";
+    mainProgram = "cyradm";
     maintainers = with lib.maintainers; [
       moraxyc
       pingiun

--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://www.cyrusimap.org";
     description = "Email, contacts and calendar server";
+    changelog = "https://www.cyrusimap.org/imap/download/release-notes/${lib.versions.majorMinor finalAttrs.version}/x/${finalAttrs.version}.html";
     license = with lib.licenses; [ bsdOriginal ];
     mainProgram = "cyradm";
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
 - fix wrong mainProgram
 - remove unused inputs

I'm not sure if it's a good idea to point it to `cyradm`. Debian added [an extra shell](https://salsa.debian.org/debian/cyrus-imapd/-/raw/master/debian/cyrus) script to call the various executable programs in `cyrus-imapd/{bin, libexec}`, which is what I original thought of in #305538. But someone said that this is a bit strange, so I removed that part but forgot to modify mainProgram :(

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
