### PR TITLE
remarshal_0_17: init at 0.17.1; pkgs.formats.yaml_1_1: rename from pkgs.formats.yaml

### DIFF
--- a/pkgs/by-name/re/remarshal_0_17/package.nix
+++ b/pkgs/by-name/re/remarshal_0_17/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchPypi,
+}:
+
+let
+  python = python3Packages.python.override {
+    self = python3Packages.python;
+    packageOverrides = self: super: {
+      tomlkit = super.tomlkit.overridePythonAttrs (oldAttrs: rec {
+        version = "0.12.5";
+        src = fetchPypi {
+          pname = "tomlkit";
+          inherit version;
+          hash = "sha256-7vNPujmDTU1rc8m6fz5NHEF6Tlb4mn6W4JDdDSS4+zw=";
+        };
+      });
+    };
+  };
+  pythonPackages = python.pkgs;
+in
+pythonPackages.buildPythonApplication rec {
+  pname = "remarshal";
+  version = "0.17.1"; # last version with YAML 1.1 support, do not update
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dbohdan";
+    repo = "remarshal";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-2WxMh5P/8NvElymnMU3JzQU0P4DMXFF6j15OxLaS+VA=";
+  };
+
+  pythonRemoveDeps = [ "pytest" ];
+
+  build-system = [ pythonPackages.poetry-core ];
+
+  dependencies = with pythonPackages; [
+    cbor2
+    colorama
+    python-dateutil
+    pyyaml
+    rich-argparse
+    ruamel-yaml
+    tomlkit
+    u-msgpack-python
+  ];
+
+  nativeCheckInputs = [ pythonPackages.pytestCheckHook ];
+
+  passthru.updateScript = throw "This package is pinned to 0.17.1 for YAML 1.1 support";
+
+  meta = with lib; {
+    changelog = "https://github.com/remarshal-project/remarshal/releases/tag/v${version}";
+    description = "Convert between TOML, YAML and JSON";
+    license = licenses.mit;
+    homepage = "https://github.com/dbohdan/remarshal";
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -78,8 +78,8 @@ rec {
 
   yaml = {}: {
 
-    generate = name: value: pkgs.callPackage ({ runCommand, remarshal }: runCommand name {
-      nativeBuildInputs = [ remarshal ];
+    generate = name: value: pkgs.callPackage ({ runCommand, remarshal_0_17 }: runCommand name {
+      nativeBuildInputs = [ remarshal_0_17 ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
       preferLocalBuild = true;

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -76,8 +76,9 @@ rec {
 
   };
 
-  yaml = {}: {
+  yaml = yaml_1_1;
 
+  yaml_1_1 = {}: {
     generate = name: value: pkgs.callPackage ({ runCommand, remarshal_0_17 }: runCommand name {
       nativeBuildInputs = [ remarshal_0_17 ];
       value = builtins.toJSON value;

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -118,7 +118,7 @@ in runBuildTests {
     '';
   };
 
-  yamlAtoms = shouldPass {
+  yaml_1_1Atoms = shouldPass {
     format = formats.yaml {};
     input = {
       null = null;
@@ -129,6 +129,8 @@ in runBuildTests {
       attrs.foo = null;
       list = [ null null ];
       path = ./formats.nix;
+      no = "no";
+      time = "22:30:00";
     };
     expected = ''
       attrs:
@@ -138,9 +140,11 @@ in runBuildTests {
       list:
       - null
       - null
+      'no': 'no'
       'null': null
       path: ${./formats.nix}
       str: foo
+      time: '22:30:00'
       'true': true
     '';
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

YAML 1.1 and 1.2 interpret various keywords and number formats differently, which can lead to unexpected issues when the generated YAML does not match the YAML version parsed by the application.

- Restores `remarshal_0_17`, the last release series to emit YAML 1.1
- Renames `pkgs.formats.yaml` to `pkgs.formats.yaml_1_1`
- Create `pkgs.formats.yaml` as a backwards compatible alias for `pkgs.formats.yaml_1_1`
- Updates test to include explicit YAML 1.1 gotchas, like the Norway-Issue

Optional:
- We could create `pkgs.formats.yaml_1_2` right now, but I'm not sure what the best abstraction would be

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
