### PR TITLE
dwlmsg: init at 0-unstable-YYYY-MM-DD

### DIFF
--- a/pkgs/by-name/dw/dwlmsg/README.md
+++ b/pkgs/by-name/dw/dwlmsg/README.md
@@ -1,0 +1,16 @@
+This package depends on DWL being built with the IPC patch found at https://codeberg.org/dwl/dwl-patches/raw/commit/d235f0f88ed069eca234da5a544fb1c6e19f1d33/patches/ipc/ipc.patch
+
+this requires the following to be included in your configuration.nix (or flake)
+
+....
+environment.systemPackages = with pkgs; [
+  (dwl.overrideAttrs (
+    attrs: {
+    patches = [ (fetchpatch {
+        url = "https://codeberg.org/dwl/dwl-patches/raw/commit/d235f0f88ed069eca234da5a544fb1c6e19f1d33/patches/ipc/ipc.patch";
+        sha256 = "sha256-c5225c483aa6217700d2649dd7f67478e2f5f0b60610cc3d0cc0ebedd8356fdf";
+      })
+      ];
+      }))
+    ];
+....

--- a/pkgs/by-name/dw/dwlmsg/README.md
+++ b/pkgs/by-name/dw/dwlmsg/README.md
@@ -2,7 +2,7 @@ This package depends on DWL being built with the IPC patch found at https://code
 
 this requires the following to be included in your configuration.nix (or flake)
 
-....
+```
 environment.systemPackages = with pkgs; [
   (dwl.overrideAttrs (
     attrs: {
@@ -13,4 +13,4 @@ environment.systemPackages = with pkgs; [
       ];
       }))
     ];
-....
+```

--- a/pkgs/by-name/dw/dwlmsg/default.nix
+++ b/pkgs/by-name/dw/dwlmsg/default.nix
@@ -1,0 +1,13 @@
+let
+
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
+
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+
+in
+
+{
+
+  dwlmsg = pkgs.callPackage ./package.nix { };
+
+}

--- a/pkgs/by-name/dw/dwlmsg/default.nix
+++ b/pkgs/by-name/dw/dwlmsg/default.nix
@@ -2,7 +2,10 @@ let
 
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
 
-  pkgs = import nixpkgs { config = {}; overlays = []; };
+  pkgs = import nixpkgs {
+    config = { };
+    overlays = [ ];
+  };
 
 in
 

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = "This tool allows for scripting of window manager features in DWL, It relies on the IPC patch for DWL";
     homepage = "https://codeberg.org/notchoc/dwlmsg";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ Person1873 ];
+    #maintainers = with maintainers; [ Person1873 ];
     platforms = platforms.all;
   };
 

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = "This tool allows for scripting of window manager features in DWL, It relies on the IPC patch for DWL";
     homepage = "https://codeberg.org/notchoc/dwlmsg";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ notchoc ];
+    maintainers = with maintainers; [ Person1873 ];
     platforms = platforms.all;
   };
 

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitea,
+  pkg-config,
+  stdenv,
+  wayland,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dwlmsg";
+  version = "git";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "notchoc";
+    repo = "dwlmsg";
+    rev = "3fc9780f4e";
+    hash = "sha256-LTrWb9IxGvm9yUy47+Om9V5GbLygDcEAbVAExGWgFQw=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      wayland
+    ];
+
+  outputs = [
+    "out"
+  ];
+
+  makeFlags =
+    [
+      "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
+      "PREFIX=$(out)"
+    ];
+
+  strictDeps = true;
+
+  # required for whitespaces in makeFlags
+  __structuredAttrs = true;
+
+})

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -39,4 +39,13 @@ stdenv.mkDerivation (finalAttrs: {
   # required for whitespaces in makeFlags
   __structuredAttrs = true;
 
+  meta = with lib; {
+    description = "A CLI tool for IPC communications with DWL window manager";
+    longDescription = "This tool allows for scripting of window manager features in DWL, It relies on the IPC patch for DWL";
+    homepage = "https://codeberg.org/notchoc/dwlmsg";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ notchoc ];
+    platforms = platforms.all;
+  };
+
 })

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -21,20 +21,18 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      wayland
-    ];
+  buildInputs = [
+    wayland
+  ];
 
   outputs = [
     "out"
   ];
 
-  makeFlags =
-    [
-      "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
-      "PREFIX=$(out)"
-    ];
+  makeFlags = [
+    "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
+    "PREFIX=$(out)"
+  ];
 
   strictDeps = true;
 

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchFromGitea,
   pkg-config,
   stdenv,

--- a/pkgs/by-name/dw/dwlmsg/package.nix
+++ b/pkgs/by-name/dw/dwlmsg/package.nix
@@ -4,6 +4,7 @@
   pkg-config,
   stdenv,
   wayland,
+  wayland-scanner,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayland
+    wayland-scanner
   ];
 
   outputs = [


### PR DESCRIPTION
<!--
Create build files for dwlmsg.
NOTE: this package requires DWL to be built with the IPC patch included
See README.md

Project can be found [here](https://codeberg.org/notchoc/dwlmsg)
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

I have built and tested on my NixOS machine this the package.nix file included in my configuration.nix file.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
