### PR TITLE
nixosTests.frr: fix node.router.config warning

### DIFF
--- a/nixos/tests/frr.nix
+++ b/nixos/tests/frr.nix
@@ -5,10 +5,12 @@
 #
 # All interfaces are in OSPF Area 0.
 
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix (
+  { pkgs, ... }:
   let
 
-    ifAddr = node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;
+    ifAddr =
+      node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;
 
     ospfConf1 = ''
       router ospf
@@ -25,87 +27,94 @@ import ./make-test-python.nix ({ pkgs, ... }:
     '';
 
   in
-    {
-      name = "frr";
+  {
+    name = "frr";
 
-      meta = with pkgs.lib.maintainers; {
-        maintainers = [ ];
-      };
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ ];
+    };
 
-      nodes = {
+    nodes = {
 
-        client =
-          { nodes, ... }:
-          {
-            virtualisation.vlans = [ 1 ];
-            services.frr = {
-              config = ''
-                ip route 192.168.0.0/16 ${ifAddr nodes.router1 "eth1"}
-              '';
-            };
-          };
-
-        router1 =
-          { ... }:
-          {
-            virtualisation.vlans = [ 1 2 ];
-            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
-            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
-            services.frr = {
-              ospfd.enable = true;
-              config = ospfConf1;
-            };
-
-            specialisation.ospf.configuration = {
-              services.frr.config = ospfConf2;
-            };
-          };
-
-        router2 =
-          { ... }:
-          {
-            virtualisation.vlans = [ 3 2 ];
-            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
-            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
-            services.frr = {
-              ospfd.enable = true;
-              config = ospfConf2;
-            };
-          };
-
-        server =
-          { nodes, ... }:
-          {
-            virtualisation.vlans = [ 3 ];
-            services.frr = {
-              config = ''
-                ip route 192.168.0.0/16 ${ifAddr nodes.router2 "eth1"}
-              '';
-            };
-          };
-      };
-
-      testScript =
+      client =
         { nodes, ... }:
-        ''
-          start_all()
+        {
+          virtualisation.vlans = [ 1 ];
+          services.frr = {
+            config = ''
+              ip route 192.168.0.0/16 ${ifAddr nodes.router1 "eth1"}
+            '';
+          };
+        };
 
-          # Wait for the networking to start on all machines
-          for machine in client, router1, router2, server:
-              machine.wait_for_unit("network.target")
+      router1 =
+        { ... }:
+        {
+          virtualisation.vlans = [
+            1
+            2
+          ];
+          boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+          networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
+          services.frr = {
+            ospfd.enable = true;
+            config = ospfConf1;
+          };
 
-          with subtest("Wait for FRR"):
-              for gw in client, router1, router2, server:
-                  gw.wait_for_unit("frr")
+          specialisation.ospf.configuration = {
+            services.frr.config = ospfConf2;
+          };
+        };
 
-          router1.succeed("${nodes.router1.config.system.build.toplevel}/specialisation/ospf/bin/switch-to-configuration test >&2")
+      router2 =
+        { ... }:
+        {
+          virtualisation.vlans = [
+            3
+            2
+          ];
+          boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+          networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
+          services.frr = {
+            ospfd.enable = true;
+            config = ospfConf2;
+          };
+        };
 
-          with subtest("Wait for OSPF to form adjacencies"):
-              for gw in router1, router2:
-                  gw.wait_until_succeeds("vtysh -c 'show ip ospf neighbor' | grep Full")
-                  gw.wait_until_succeeds("vtysh -c 'show ip route' | grep '^O>'")
+      server =
+        { nodes, ... }:
+        {
+          virtualisation.vlans = [ 3 ];
+          services.frr = {
+            config = ''
+              ip route 192.168.0.0/16 ${ifAddr nodes.router2 "eth1"}
+            '';
+          };
+        };
+    };
 
-          with subtest("Test ICMP"):
-              client.wait_until_succeeds("ping -4 -c 3 server >&2")
-        '';
-    })
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
+
+        # Wait for the networking to start on all machines
+        for machine in client, router1, router2, server:
+            machine.wait_for_unit("network.target")
+
+        with subtest("Wait for FRR"):
+            for gw in client, router1, router2, server:
+                gw.wait_for_unit("frr")
+
+        router1.succeed("${nodes.router1.config.system.build.toplevel}/specialisation/ospf/bin/switch-to-configuration test >&2")
+
+        with subtest("Wait for OSPF to form adjacencies"):
+            for gw in router1, router2:
+                gw.wait_until_succeeds("vtysh -c 'show ip ospf neighbor' | grep Full")
+                gw.wait_until_succeeds("vtysh -c 'show ip route' | grep '^O>'")
+
+        with subtest("Test ICMP"):
+            client.wait_until_succeeds("ping -4 -c 3 server >&2")
+      '';
+  }
+)

--- a/nixos/tests/frr.nix
+++ b/nixos/tests/frr.nix
@@ -9,8 +9,7 @@ import ./make-test-python.nix (
   { pkgs, ... }:
   let
 
-    ifAddr =
-      node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;
+    ifAddr = node: iface: (pkgs.lib.head node.networking.interfaces.${iface}.ipv4.addresses).address;
 
     ospfConf1 = ''
       router ospf
@@ -106,7 +105,7 @@ import ./make-test-python.nix (
             for gw in client, router1, router2, server:
                 gw.wait_for_unit("frr")
 
-        router1.succeed("${nodes.router1.config.system.build.toplevel}/specialisation/ospf/bin/switch-to-configuration test >&2")
+        router1.succeed("${nodes.router1.system.build.toplevel}/specialisation/ospf/bin/switch-to-configuration test >&2")
 
         with subtest("Wait for OSPF to form adjacencies"):
             for gw in router1, router2:


### PR DESCRIPTION
- **nixosTests.frr: format using nixfmt**
- **nixosTests.frr: fix warning, use `nodes.router` instead of `nodes.router.config`**

ZHF: #352882 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
