### PR TITLE
python312Packages.blivet: 3.10.1 -> 3.11.0

### DIFF
--- a/pkgs/by-name/li/libblockdev/package.nix
+++ b/pkgs/by-name/li/libblockdev/package.nix
@@ -28,6 +28,7 @@
 , e2fsprogs
 , libnvme
 , keyutils
+, nix-update-script
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libblockdev";
@@ -88,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/lvm-cache-stats --prefix PATH : \
       ${lib.makeBinPath [ thin-provisioning-tools ]}
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/storaged-project/libblockdev/raw/${finalAttrs.src.rev}/NEWS.rst";

--- a/pkgs/by-name/li/libblockdev/package.nix
+++ b/pkgs/by-name/li/libblockdev/package.nix
@@ -28,17 +28,19 @@
 , e2fsprogs
 , libnvme
 , keyutils
+, libatasmart
+, json-glib
 , nix-update-script
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libblockdev";
-  version = "3.1.1";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
-    rev = "${finalAttrs.version}-1";
-    hash = "sha256-WCMedMkaMMhZbB3iJu3c+CTT3AvOjzOSYP45J+NQEDQ=";
+    rev = finalAttrs.version;
+    hash = "sha256-85vfHHR6WqSPCW1QmD3HccIpOqNYrx1PDjTh297VA1A=";
   };
 
   outputs = [ "out" "dev" "devdoc" "python" ];
@@ -71,8 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     e2fsprogs
     glib
     gptfdisk
+    json-glib
     keyutils
     kmod
+    libatasmart
     libbytesize
     libndctl
     libnvme

--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -35,14 +35,14 @@ let
 in
 buildPythonPackage rec {
   pname = "blivet";
-  version = "3.10.1";
+  version = "3.11.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "blivet";
-    rev = "blivet-${version}";
-    hash = "sha256-Ooc63mf03ZO7zxm8s/Tm8jSQg5LWyKnHAqbyvn1UHB8=";
+    rev = "refs/tags/blivet-${version}";
+    hash = "sha256-X5U6XFmcsTfetpxwH0ONSnTasnwh2USukYtx+8HwVGc=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same as https://github.com/NixOS/nixpkgs/pull/354563 but includes the necessary version bump for dependency `libblockdev` as well.

Changelogs:
- blivet:
  - https://github.com/storaged-project/blivet/releases/tag/blivet-3.11.0
- libblockdev:
  - https://github.com/storaged-project/libblockdev/blob/master/NEWS.rst#libblockdev-320
  - https://github.com/storaged-project/libblockdev/blob/master/NEWS.rst#libblockdev-321

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
