### PR TITLE
python312Packages.magic-wormhole-mailbox-server: 0.4.1 -> 0.5.1

### DIFF
--- a/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
+++ b/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.magic-wormhole-mailbox-server;
   # keep semicolon in dataDir for backward compatibility
   dataDir = "/var/lib/magic-wormhole-mailbox-server;";
-  python = pkgs.python311.withPackages (
+  python = pkgs.python3.withPackages (
     py: with py; [
       magic-wormhole-mailbox-server
       twisted

--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -3,38 +3,24 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
   setuptools,
-  six,
   attrs,
   twisted,
   autobahn,
   treq,
-  mock,
   nixosTests,
-  pythonOlder,
-  pythonAtLeast,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "magic-wormhole-mailbox-server";
-  version = "0.4.1";
+  version = "0.5.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-GvEFkpCcqvUZwA5wbqyELF53+NQ1YhX+nGHHsiWKiPs=";
+    hash = "sha256-oAegNnIpMgRldoHb9QIEXW1YF8V/mq4vIibm6hoAjKE=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Remove the 'U' open mode removed, https://github.com/magic-wormhole/magic-wormhole-mailbox-server/pull/34
-      name = "fix-for-python-3.11.patch";
-      url = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/commit/4b358859ba80de37c3dc0a5f67ec36909fd48234.patch";
-      hash = "sha256-RzZ5kD+xhmFYusVzAbGE+CODXtJVR1zN2rZ+VGApXiQ=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -42,7 +28,6 @@ buildPythonPackage rec {
     attrs
     autobahn
     setuptools # pkg_resources is referenced at runtime
-    six
     twisted
   ] ++ autobahn.optional-dependencies.twisted ++ twisted.optional-dependencies.tls;
 
@@ -51,7 +36,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     treq
-    mock
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -69,7 +53,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/${version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
-    # Python 3.12 support: https://github.com/magic-wormhole/magic-wormhole-mailbox-server/issues/41
-    broken = pythonOlder "3.7" || pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -28,7 +28,6 @@
   # tests
   nettools,
   unixtools,
-  mock,
   magic-wormhole-transit-relay,
   magic-wormhole-mailbox-server,
   pytestCheckHook,
@@ -81,36 +80,15 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs =
-    # For Python 3.12, remove magic-wormhole-mailbox-server and magic-wormhole-transit-relay from test dependencies,
-    # which are not yet supported with this version.
-    lib.optionals
-      (!magic-wormhole-mailbox-server.meta.broken && !magic-wormhole-transit-relay.meta.broken)
-      [
-        magic-wormhole-mailbox-server
-        magic-wormhole-transit-relay
-      ]
-    ++ [
-      mock
+    [
+      magic-wormhole-mailbox-server
+      magic-wormhole-transit-relay
       pytestCheckHook
     ]
     ++ optional-dependencies.dilation
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ unixtools.locale ];
 
   __darwinAllowLocalNetworking = true;
-
-  disabledTestPaths =
-    # For Python 3.12, remove the tests depending on magic-wormhole-mailbox-server and magic-wormhole-transit-relay,
-    # which are not yet supported with this version.
-    lib.optionals
-      (magic-wormhole-mailbox-server.meta.broken || magic-wormhole-transit-relay.meta.broken)
-      [
-        "src/wormhole/test/dilate/test_full.py"
-        "src/wormhole/test/test_args.py"
-        "src/wormhole/test/test_cli.py"
-        "src/wormhole/test/test_transit.py"
-        "src/wormhole/test/test_wormhole.py"
-        "src/wormhole/test/test_xfer_util.py"
-      ];
 
   postInstall = ''
     install -Dm644 docs/wormhole.1 $out/share/man/man1/wormhole.1


### PR DESCRIPTION
## Description of changes

https://github.com/magic-wormhole/magic-wormhole-mailbox-server/compare/refs/tags/0.4.1...refs/tags/0.5.1
https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/0.5.1/NEWS.md

Python 3.12 is now supported

## `nixpkgs-review` result

`tahoe-lafs` is already broken on master

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc