### PR TITLE
python312Packages.magic-wormhole-transit-relay: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   setuptools,
   autobahn,
-  mock,
   twisted,
   python,
   pytestCheckHook,
@@ -12,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "magic-wormhole-transit-relay";
-  version = "0.3.1";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-LvLvvk008OYkhw+EIln9czuncVLtMQr0NJd0piiEkA4=";
+    hash = "sha256-kS2DXaIbESZsdxEdybXlgAJj/AuY8KF5liJn30GBnow=";
   };
 
   postPatch = ''
@@ -39,7 +38,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    mock
     twisted
   ];
 


### PR DESCRIPTION
## Description of changes

https://github.com/magic-wormhole/magic-wormhole-transit-relay/compare/refs/tags/0.3.1...refs/tags/0.4.0
https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/0.4.0/NEWS.md

## `nixpkgs-review` result

`tahoe-lafs` is already broken on master

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc