### PR TITLE
[24.05] python312Packages.celery: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -102,6 +102,8 @@ buildPythonPackage rec {
       # seems to only fail on higher core counts
       # AssertionError: assert 3 == 0
       "test_setup_security_disabled_serializers"
+      # Test is flaky, especially on hydra
+      "test_ready"
       # fails with pytest-xdist
       "test_itercapture_limit"
       "test_stamping_headers_in_options"


### PR DESCRIPTION
Cherry-pick to get celery to build again.

(Previously: imap-tools fixes, obsoleted by #355108)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).