### PR TITLE
xonsh.xontribs.xontrib-*: init at various

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -348,6 +348,8 @@
 
 - `borgmatic` has been updated from 1.8.14 to 1.9.5, please check the [upstream changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases) for more details, especially for a few possibly breaking changes noted in the [1.9.0 changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases/tag/1.9.0).
 
+- `programs.xonsh.package` now gets overrided internally with `extraPackages` to support `programs.xonsh.extraPackages`. See `programs.xonsh.extraPackages` for more details.
+
 - `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
 - `virtualisation.azure.agent` option provided by `azure-agent.nix` is replaced by `services.waagent`, and will be removed in a future release.

--- a/nixos/modules/programs/xonsh.nix
+++ b/nixos/modules/programs/xonsh.nix
@@ -5,7 +5,7 @@
 let
 
   cfg = config.programs.xonsh;
-
+  package = cfg.package.override { inherit (cfg) extraPackages; };
 in
 
 {
@@ -32,6 +32,21 @@ in
         type = lib.types.lines;
       };
 
+      extraPackages = lib.mkOption {
+        default = (ps: [ ]);
+        type = with lib.types; coercedTo (listOf lib.types.package) (v: (_: v)) (functionTo (listOf lib.types.package));
+        description = ''
+          Add the specified extra packages to the xonsh package.
+          Preferred over using `programs.xonsh.package` as it composes with `programs.xonsh.xontribs`.
+
+          Take care in using this option along with manually defining the package
+          option above, as the two can result in conflicting sets of build dependencies.
+          This option assumes that the package option has an overridable argument
+          called `extraPackages`, so if you override the package option but also
+          intend to use this option, be sure that your resulting package still honors
+          the necessary option.
+        '';
+      };
     };
 
   };
@@ -64,11 +79,11 @@ in
       ${cfg.config}
     '';
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ package ];
 
     environment.shells = [
       "/run/current-system/sw/bin/xonsh"
-      "${lib.getExe cfg.package}"
+      "${lib.getExe package}"
     ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/package.nix
+++ b/pkgs/by-name/xo/xonsh/package.nix
@@ -7,14 +7,17 @@
 }:
 
 let
-  pythonEnv = python3.withPackages
-    (ps: [ ps.xonsh ] ++ extraPackages ps);
+  pythonEnv = python3.withPackages (ps: [ ps.xonsh ] ++ extraPackages ps);
   xonsh = python3.pkgs.xonsh;
 in
-runCommand
-  "xonsh-${xonsh.version}"
+runCommand "xonsh-${xonsh.version}"
   {
-    inherit (xonsh) pname version meta passthru;
+    inherit (xonsh)
+      pname
+      version
+      meta
+      passthru
+      ;
   }
   ''
     mkdir -p $out/bin

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -23,6 +23,7 @@
 
   nix-update-script,
   python,
+  callPackage,
 }:
 
 buildPythonPackage rec {
@@ -122,6 +123,7 @@ buildPythonPackage rec {
     shellPath = "/bin/xonsh";
     wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
     updateScript = nix-update-script { };
+    xontribs = import ./xontribs { inherit callPackage; };
   };
 
   meta = {

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -1,130 +1,135 @@
 {
   lib,
-  coreutils,
+  buildPythonPackage,
   fetchFromGitHub,
-  gitMinimal,
-  glibcLocales,
-  nix-update-script,
-  pythonPackages,
+
+  setuptools,
+  ply,
+  prompt-toolkit,
+  pygments,
+
   addBinToPathHook,
   writableTmpDirAsHomeHook,
+  gitMinimal,
+  glibcLocales,
+  pip,
+  pyte,
+  pytest-mock,
+  pytest-subprocess,
+  pytestCheckHook,
+  requests,
+
+  coreutils,
+
+  nix-update-script,
+  python,
 }:
 
-let
+buildPythonPackage rec {
+  pname = "xonsh";
+  version = "0.19.1";
+  pyproject = true;
 
-  argset = {
-    pname = "xonsh";
-    version = "0.19.1";
-    pyproject = true;
-
-    # PyPI package ships incomplete tests
-    src = fetchFromGitHub {
-      owner = "xonsh";
-      repo = "xonsh";
-      tag = argset.version;
-      hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
-    };
-
-    nativeBuildInputs = with pythonPackages; [
-      setuptools
-      wheel
-    ];
-
-    propagatedBuildInputs = (
-      with pythonPackages;
-      [
-        ply
-        prompt-toolkit
-        pygments
-      ]
-    );
-
-    nativeCheckInputs =
-      [
-        addBinToPathHook
-        gitMinimal
-        glibcLocales
-        writableTmpDirAsHomeHook
-      ]
-      ++ (with pythonPackages; [
-        pip
-        pyte
-        pytest-mock
-        pytest-subprocess
-        pytestCheckHook
-        requests
-      ]);
-
-    disabledTests = [
-      # fails on sandbox
-      "test_colorize_file"
-      "test_loading_correctly"
-      "test_no_command_path_completion"
-      "test_bsd_man_page_completions"
-      "test_xonsh_activator"
-
-      # fails on non-interactive shells
-      "test_capture_always"
-      "test_casting"
-      "test_command_pipeline_capture"
-      "test_dirty_working_directory"
-      "test_man_completion"
-      "test_vc_get_branch"
-      "test_bash_and_is_alias_is_only_functional_alias"
-
-      # flaky tests
-      "test_script"
-      "test_alias_stability"
-      "test_alias_stability_exception"
-      "test_complete_import"
-      "test_subproc_output_format"
-
-      # https://github.com/xonsh/xonsh/issues/5569
-      "test_spec_decorator_alias_output_format"
-
-      # Broken test
-      "test_repath_backslash"
-    ];
-
-    disabledTestPaths = [
-      # fails on sandbox
-      "tests/completers/test_command_completers.py"
-      "tests/shell/test_ptk_highlight.py"
-      # fails on non-interactive shells
-      "tests/prompt/test_gitstatus.py"
-      "tests/completers/test_bash_completer.py"
-    ];
-
-    # https://github.com/NixOS/nixpkgs/issues/248978
-    dontWrapPythonPrograms = true;
-
-    env.LC_ALL = "en_US.UTF-8";
-
-    postPatch = ''
-      sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
-      sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
-
-      for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
-        sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
-      done
-      patchShebangs .
-    '';
-
-    passthru = {
-      shellPath = "/bin/xonsh";
-      python = pythonPackages.python; # To the wrapper
-      wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
-      updateScript = nix-update-script { };
-    };
-
-    meta = {
-      homepage = "https://xon.sh/";
-      description = "Python-ish, BASHwards-compatible shell";
-      changelog = "https://github.com/xonsh/xonsh/raw/main/CHANGELOG.rst";
-      license = with lib.licenses; [ bsd3 ];
-      mainProgram = "xonsh";
-      maintainers = with lib.maintainers; [ samlukeyes123 ];
-    };
+  # PyPI package ships incomplete tests
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xonsh";
+    tag = version;
+    hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
   };
-in
-pythonPackages.buildPythonPackage argset
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    ply
+    prompt-toolkit
+    pygments
+  ];
+
+  nativeCheckInputs = [
+    addBinToPathHook
+    writableTmpDirAsHomeHook
+    gitMinimal
+    glibcLocales
+    pip
+    pyte
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTests = [
+    # fails on sandbox
+    "test_bsd_man_page_completions"
+    "test_colorize_file"
+    "test_loading_correctly"
+    "test_no_command_path_completion"
+    "test_xonsh_activator"
+
+    # fails on non-interactive shells
+    "test_bash_and_is_alias_is_only_functional_alias"
+    "test_capture_always"
+    "test_casting"
+    "test_command_pipeline_capture"
+    "test_dirty_working_directory"
+    "test_man_completion"
+    "test_vc_get_branch"
+
+    # flaky tests
+    "test_alias_stability"
+    "test_alias_stability_exception"
+    "test_complete_import"
+    "test_script"
+    "test_subproc_output_format"
+
+    # broken tests
+    "test_repath_backslash"
+
+    # https://github.com/xonsh/xonsh/issues/5569
+    "test_spec_decorator_alias_output_format"
+  ];
+
+  disabledTestPaths = [
+    # fails on sandbox
+    "tests/completers/test_command_completers.py"
+    "tests/shell/test_ptk_highlight.py"
+
+    # fails on non-interactive shells
+    "tests/prompt/test_gitstatus.py"
+    "tests/completers/test_bash_completer.py"
+  ];
+
+  # https://github.com/NixOS/nixpkgs/issues/248978
+  dontWrapPythonPrograms = true;
+
+  env.LC_ALL = "en_US.UTF-8";
+
+  postPatch = ''
+    sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
+    sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
+
+    for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
+      sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
+    done
+    patchShebangs .
+  '';
+
+  passthru = {
+    inherit python;
+    shellPath = "/bin/xonsh";
+    wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://xon.sh/";
+    description = "Python-ish, BASHwards-compatible shell";
+    changelog = "https://github.com/xonsh/xonsh/raw/main/CHANGELOG.rst";
+    license = with lib.licenses; [ bsd3 ];
+    mainProgram = "xonsh";
+    maintainers = with lib.maintainers; [ samlukeyes123 ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -9,4 +9,5 @@
   xontrib-distributed = callPackage ./xontrib-distributed { };
   xontrib-fish-completer = callPackage ./xontrib-fish-completer { };
   xontrib-jedi = callPackage ./xontrib-jedi { };
+  xontrib-jupyter = callPackage ./xontrib-jupyter { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -4,4 +4,5 @@
 {
   xonsh-direnv = callPackage ./xonsh-direnv { };
   xontrib-abbrevs = callPackage ./xontrib-abbrevs { };
+  xontrib-bashisms = callPackage ./xontrib-bashisms { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -5,4 +5,5 @@
   xonsh-direnv = callPackage ./xonsh-direnv { };
   xontrib-abbrevs = callPackage ./xontrib-abbrevs { };
   xontrib-bashisms = callPackage ./xontrib-bashisms { };
+  xontrib-debug-tools = callPackage ./xontrib-debug-tools { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -11,4 +11,5 @@
   xontrib-jedi = callPackage ./xontrib-jedi { };
   xontrib-jupyter = callPackage ./xontrib-jupyter { };
   xontrib-vox = callPackage ./xontrib-vox { };
+  xontrib-whole-word-jumping = callPackage ./xontrib-whole-word-jumping { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -10,4 +10,5 @@
   xontrib-fish-completer = callPackage ./xontrib-fish-completer { };
   xontrib-jedi = callPackage ./xontrib-jedi { };
   xontrib-jupyter = callPackage ./xontrib-jupyter { };
+  xontrib-vox = callPackage ./xontrib-vox { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -8,4 +8,5 @@
   xontrib-debug-tools = callPackage ./xontrib-debug-tools { };
   xontrib-distributed = callPackage ./xontrib-distributed { };
   xontrib-fish-completer = callPackage ./xontrib-fish-completer { };
+  xontrib-jedi = callPackage ./xontrib-jedi { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -1,0 +1,5 @@
+{
+  callPackage,
+}:
+{
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -3,4 +3,5 @@
 }:
 {
   xonsh-direnv = callPackage ./xonsh-direnv { };
+  xontrib-abbrevs = callPackage ./xontrib-abbrevs { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -7,4 +7,5 @@
   xontrib-bashisms = callPackage ./xontrib-bashisms { };
   xontrib-debug-tools = callPackage ./xontrib-debug-tools { };
   xontrib-distributed = callPackage ./xontrib-distributed { };
+  xontrib-fish-completer = callPackage ./xontrib-fish-completer { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -2,4 +2,5 @@
   callPackage,
 }:
 {
+  xonsh-direnv = callPackage ./xonsh-direnv { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -6,4 +6,5 @@
   xontrib-abbrevs = callPackage ./xontrib-abbrevs { };
   xontrib-bashisms = callPackage ./xontrib-bashisms { };
   xontrib-debug-tools = callPackage ./xontrib-debug-tools { };
+  xontrib-distributed = callPackage ./xontrib-distributed { };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  direnv,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xonsh-direnv";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "74th";
+    repo = "xonsh-direnv";
+    tag = version;
+    hash = "sha256-huBJ7WknVCk+WgZaXHlL+Y1sqsn6TYqMP29/fsUPSyU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    direnv
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Direnv support for Xonsh";
+    homepage = "https://github.com/74th/xonsh-direnv/";
+    changelog = "https://github.com/74th/xonsh-direnv/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  setuptools-scm,
+  poetry-core,
+  prompt-toolkit,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-abbrevs";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-abbrevs";
+    tag = "v${version}";
+    hash = "sha256-JxH5b2ey99tvHXSUreU5r6fS8nko4RrS/1c8psNbJNc=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.17", ' ""
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    poetry-core
+  ];
+
+  dependencies = [
+    prompt-toolkit
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command abbreviations for Xonsh";
+    homepage = "https://github.com/xonsh/xontrib-abbrevs";
+    changelog = "https://github.com/xonsh/xontrib-apprevs/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-bashisms";
+  version = "0.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-bashisms";
+    tag = version;
+    hash = "sha256-R1DCGMrRCJLnz/QMk6QB8ai4nx88vvyPdaCKg3od5/I=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.12.5"' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bash-like interactive mode extensions for the xonsh shell";
+    homepage = "https://github.com/xonsh/xontrib-bashisms";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-debug-tools";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-debug-tools";
+    tag = version;
+    hash = "sha256-Z8AXKk94NxmF5rO2OMZzNX0GIP/Vj+mOtYUaifRX1cw=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.12.5"' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Debug tools for xonsh shell";
+    homepage = "https://github.com/xonsh/xontrib-debug-tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  poetry-core,
+  distributed,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-distributed";
+  version = "0.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-distributed";
+    tag = "v${version}";
+    hash = "sha256-Hb7S3PqHi0w6zb9ki8ADMtgdYVv8O5WQZMgJzKF74qE=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'xonsh = ">=0.12"' ""
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    distributed
+  ];
+
+  # As of v0.0.4 has no tests that get run by pytest
+  doCheck = false;
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Dask Distributed integration for Xonsh";
+    homepage = "https://github.com/xonsh/xontrib-distributed";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  pytest-subprocess,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-fish-completer";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-fish-completer";
+    tag = version;
+    hash = "sha256-PhhdZ3iLPDEIG9uDeR5ctJ9zz2+YORHBhbsiLrJckyA=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.12.5"' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    pytest-subprocess
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Populate rich completions using fish and remove the default bash based completer";
+    homepage = "https://github.com/xonsh/xontrib-fish-completer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  poetry-core,
+  jedi,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-jedi";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-jedi";
+    tag = "v${version}";
+    hash = "sha256-T4Yxr91emM2mjclQOjQsnnPO/JijAGNcqmZjxrz72Bs=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'xonsh = ">=0.17"' ""
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    jedi
+  ];
+
+  preCheck = ''
+    substituteInPlace tests/test_jedi.py \
+      --replace-fail "/usr/bin" "${jedi}/bin"
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Xonsh Python mode completions using jedi";
+    homepage = "https://github.com/xonsh/xontrib-jedi";
+    changelog = "https://github.com/xonsh/xontrib-jedi.releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  poetry-core,
+  jupyter-client,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-jupyter";
+  version = "0.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-jupyter";
+    tag = "v${version}";
+    hash = "sha256-gf+jyA2il7MD+Moez/zBYpf4EaPiNcgr5ZrJFK4uD2k=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'xonsh = ">=0.12"' ""
+
+    substituteInPlace xonsh_jupyter/shell.py \
+      --replace-fail 'xonsh.base_shell' 'xonsh.shells.base_shell'
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    jupyter-client
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Xonsh jupyter kernel allows to run Xonsh shell code in Jupyter, JupyterLab, Euporia, etc";
+    homepage = "https://github.com/xonsh/xontrib-jupyter";
+    changelog = "https://github.com/xonsh/xontrib-jupyter/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  virtualenv,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  pytest-subprocess,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-vox";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-vox";
+    tag = version;
+    hash = "sha256-OB1O5GZYkg7Ucaqak3MncnQWXhMD4BM4wXsYCDD0mhk=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.12.5"' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    virtualenv
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    pytest-subprocess
+    xonsh
+  ];
+
+  disabledTests = [
+    # Monkeypatch in test fails, preventing test from running
+    "test_interpreter"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python virtual environment manager for the xonsh shell";
+    homepage = "https://github.com/xonsh/xontrib-vox";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  xonsh,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-whole-word-jumping";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-whole-word-jumping";
+    tag = version;
+    hash = "sha256-zLAOGW9prjYDQBDITFNMggn4X1JTyAnVdjkBOH9gXPs=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"xonsh>=0.12.5", ' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    xonsh
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Additional keyboard navigation for interactive xonsh shells";
+    homepage = "https://github.com/xonsh/xontrib-whole-word-jumping";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greg ];
+  };
+}


### PR DESCRIPTION
Closes #241386 

Supersedes the above PR, I've gone ahead and updated and cleaned up all of the packages (including a small fix for `xontrib-jupyter`, after an upstream Xonsh change.) It has also been rebased on master accordingly.

I am very driven to get this done to let nix-community/home-manager#5494 proceed, as I have wanted to switch to Xonsh for a while now.

CC @greg-hellings as author of the previous PR

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
