### PR TITLE
gcc{10,11,12,13,14}: reorder .cfi_startproc with label

### DIFF
--- a/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-09-1.diff
+++ b/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-09-1.diff
@@ -1,0 +1,16 @@
+this patch fixes build for clang-18+
+
+diff --git a/libgcc/config/aarch64/lse.S b/libgcc/config/aarch64/lse.S
+index d3235bc33..1a56eb61c 100644
+--- a/libgcc/config/aarch64/lse.S
++++ b/libgcc/config/aarch64/lse.S
+@@ -170,8 +170,8 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ 	.globl	\name
+ 	.hidden	\name
+ 	.type	\name, %function
+-	.cfi_startproc
+ \name:
++	.cfi_startproc
+ 	BTI_C
+ .endm
+ 

--- a/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-14-1.diff
+++ b/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-14-1.diff
@@ -1,0 +1,16 @@
+this patch fixes build for clang-18+
+
+diff --git a/libgcc/config/aarch64/lse.S b/libgcc/config/aarch64/lse.S
+index ecef47086..b478dd4d9 100644
+--- a/libgcc/config/aarch64/lse.S
++++ b/libgcc/config/aarch64/lse.S
+@@ -174,8 +174,8 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ 	.globl	\name
+ 	HIDDEN(\name)
+ 	SYMBOL_TYPE(\name, %function)
+-	.cfi_startproc
+ \name:
++	.cfi_startproc
+ .endm
+ 
+ .macro	ENDFN name

--- a/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-2.diff
+++ b/pkgs/development/compilers/gcc/patches/cfi_startproc-reorder-label-2.diff
@@ -1,0 +1,16 @@
+this patch fixes build for clang-18+
+
+diff --git a/libgcc/config/aarch64/lse.S b/libgcc/config/aarch64/lse.S
+index d3235bc33..1a56eb61c 100644
+--- a/libgcc/config/aarch64/lse.S
++++ b/libgcc/config/aarch64/lse.S
+@@ -197,8 +197,8 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ 	.text
+ 	.balign	16
+ 	.private_extern	_\name
+-	.cfi_startproc
+ _\name:
++	.cfi_startproc
+ 	BTI_C
+ .endm
+ 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -40,6 +40,15 @@ let
   is9  = majorVersion == "9";
   is8  = majorVersion == "8";
   is7  = majorVersion == "7";
+
+  # We only apply these patches when building a native toolchain for
+  # aarch64-darwin, as it breaks building a foreign one:
+  # https://github.com/iains/gcc-12-branch/issues/18
+  canApplyIainsDarwinPatches = stdenv.hostPlatform.isDarwin
+    && stdenv.hostPlatform.isAarch64
+    && buildPlatform == hostPlatform
+    && hostPlatform == targetPlatform;
+
   inherit (lib) optionals optional;
 in
 
@@ -71,6 +80,8 @@ in
 ++ optional langFortran (if atLeast12 then ./gcc-12-gfortran-driving.patch else ./gfortran-driving.patch)
 ++ [ ./ppc-musl.patch ]
 ++ optional (atLeast9 && langD) ./libphobos.patch
+++ optional (atLeast9 && !atLeast14) ./cfi_startproc-reorder-label-09-1.diff
+++ optional (atLeast14 && !canApplyIainsDarwinPatches) ./cfi_startproc-reorder-label-14-1.diff
 
 
 
@@ -135,10 +146,9 @@ in
   "12" = [ ./gnat-darwin-dylib-install-name.patch ];
 }.${majorVersion} or [])
 
-# We only apply this patch when building a native toolchain for aarch64-darwin, as it breaks building
-# a foreign one: https://github.com/iains/gcc-12-branch/issues/18
-++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && buildPlatform == hostPlatform && hostPlatform == targetPlatform) ({
-  "14" = [ (fetchpatch {
+++ optionals canApplyIainsDarwinPatches ({
+  "14" = [
+    (fetchpatch {
     # There are no upstream release tags in https://github.com/iains/gcc-14-branch.
     # 04696df09633baf97cdbbdd6e9929b9d472161d3 is the commit from https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-14.2.0
     name = "gcc-14-darwin-aarch64-support.patch";
@@ -149,24 +159,24 @@ in
     name = "gcc-13-darwin-aarch64-support.patch";
     url = "https://raw.githubusercontent.com/Homebrew/formula-patches/bda0faddfbfb392e7b9c9101056b2c5ab2500508/gcc/gcc-13.3.0.diff";
     sha256 = "sha256-RBTCBXIveGwuQGJLzMW/UexpUZdDgdXprp/G2NHkmQo=";
-  }) ];
+  }) ./cfi_startproc-reorder-label-2.diff ];
   "12" = [ (fetchurl {
     name = "gcc-12-darwin-aarch64-support.patch";
     url = "https://raw.githubusercontent.com/Homebrew/formula-patches/1ed9eaea059f1677d27382c62f21462b476b37fe/gcc/gcc-12.4.0.diff";
     sha256 = "sha256-wOjpT79lps4TKG5/E761odhLGCphBIkCbOPiQg/D1Fw=";
-  }) ];
+  }) ./cfi_startproc-reorder-label-2.diff ];
   "11" = [ (fetchpatch {
     # There are no upstream release tags in https://github.com/iains/gcc-11-branch.
     # 5cc4c42a0d4de08715c2eef8715ad5b2e92a23b6 is the commit from https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-11.5.0
     url = "https://github.com/iains/gcc-11-branch/compare/5cc4c42a0d4de08715c2eef8715ad5b2e92a23b6..gcc-11.5-darwin-r0.diff";
     hash = "sha256-7lH+GkgkrE6nOp9PMdIoqlQNWK31s6oW+lDt1LIkadE=";
-  }) ];
+  }) ./cfi_startproc-reorder-label-2.diff ];
   "10" = [ (fetchpatch {
     # There are no upstream release tags in https://github.com/iains/gcc-10-branch.
     # d04fe55 is the commit from https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-10.5.0
     url = "https://github.com/iains/gcc-10-branch/compare/d04fe5541c53cb16d1ca5c80da044b4c7633dbc6...gcc-10-5Dr0-pre-0.diff";
     hash = "sha256-kVUHZKtYqkWIcqxHG7yAOR2B60w4KWLoxzaiFD/FWYk=";
-  }) ];
+  }) ./cfi_startproc-reorder-label-2.diff ];
 }.${majorVersion} or [])
 
 # Work around newer AvailabilityInternal.h when building older versions of GCC.


### PR DESCRIPTION
fixes llvm-18+ builds which require that an asm label precedes the .cfi_startproc pseudo instruction.


testing: built gcc13, verified patch applies on gcc10,11,12,14

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@emilazy 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
