### PR TITLE
lib/types: init {types.attrsWith}

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -763,17 +763,24 @@ let
               };
             };
 
-          mergedType' =
-            if mergedType ? functor.wrappedDeprecationMessage then
-              addDeprecatedWrapped mergedType
-            else
-              mergedType;
-
           typeSet =
-            if (bothHave "type") && typesMergeable then
-              { type = mergedType'; }
-            else if opt.options ? type && opt.options.type ? functor.wrappedDeprecationMessage then
-              { type = addDeprecatedWrapped opt.options.type; }
+            if opt.options ? type then
+              if res ? type then
+                if typesMergeable then
+                  {
+                    type =
+                      if mergedType ? functor.wrappedDeprecationMessage then
+                        addDeprecatedWrapped mergedType
+                      else
+                        mergedType;
+                  }
+                else
+                  # Keep in sync with the same error below!
+                  throw "The option `${showOption loc}' in `${opt._file}' is already declared in ${showFiles res.declarations}."
+              else if opt.options.type ? functor.wrappedDeprecationMessage then
+                { type = addDeprecatedWrapped opt.options.type; }
+              else
+                {}
             else
               {};
 
@@ -782,9 +789,9 @@ let
       if bothHave "default" ||
          bothHave "example" ||
          bothHave "description" ||
-         bothHave "apply" ||
-         (bothHave "type" && (! typesMergeable))
+         bothHave "apply"
       then
+        # Keep in sync with the same error above!
         throw "The option `${showOption loc}' in `${opt._file}' is already declared in ${showFiles res.declarations}."
       else
         let

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -391,6 +391,10 @@ checkConfigError 'The option `mergedLazyNonLazy'\'' in `.*'\'' is already declar
 checkConfigOutput '^11$' config.lazyResult ./lazy-attrsWith.nix
 checkConfigError 'infinite recursion encountered' config.nonLazyResult ./lazy-attrsWith.nix
 
+# Test the attrsOf functor.wrapped warning
+# shellcheck disable=2016
+NIX_ABORT_ON_WARN=1 checkConfigError 'The deprecated `type.functor.wrapped` attribute of the option `mergedLazyLazy` is accessed, use `nestedTypes.elemType` instead.' options.mergedLazyLazy.type.functor.wrapped ./lazy-attrsWith.nix
+
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
 checkConfigError 'A definition for option .* is not of type .*' \
   config.value ./declare-int-unsigned-value.nix ./define-value-list.nix ./define-value-int-positive.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -386,6 +386,10 @@ checkConfigOutput '^true$' config.conditionalWorks ./declare-attrsOf.nix ./attrs
 checkConfigOutput '^false$' config.conditionalWorks ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 checkConfigOutput '^"empty"$' config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 
+# Check attrsWith type merging
+checkConfigError 'The option `mergedLazyNonLazy'\'' in `.*'\'' is already declared in `.*'\''\.' options.mergedLazyNonLazy ./lazy-attrsWith.nix
+checkConfigOutput '^11$' config.lazyResult ./lazy-attrsWith.nix
+checkConfigError 'infinite recursion encountered' config.nonLazyResult ./lazy-attrsWith.nix
 
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
 checkConfigError 'A definition for option .* is not of type .*' \
@@ -575,8 +579,6 @@ checkConfigOutput '^38|27$' options.submoduleLine38.declarationPositions.1.line 
 # nested options work
 checkConfigOutput '^34$' options.nested.nestedLine34.declarationPositions.0.line ./declaration-positions.nix
 
-# AttrsWith tests
-checkConfigOutput '^11$' config.result ./lazy-attrsWith.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -575,6 +575,9 @@ checkConfigOutput '^38|27$' options.submoduleLine38.declarationPositions.1.line 
 # nested options work
 checkConfigOutput '^34$' options.nested.nestedLine34.declarationPositions.0.line ./declaration-positions.nix
 
+# AttrsWith tests
+checkConfigOutput '^11$' config.result ./lazy-attrsWith.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/lazy-attrsWith.nix
+++ b/lib/tests/modules/lazy-attrsWith.nix
@@ -1,0 +1,45 @@
+# Check that AttrsWith { lazy = true; } is lazy
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    #  Module A
+    (
+      { ... }:
+      {
+        options.mergedLazy = mkOption {
+          # Same as lazyAttrsOf
+          type = types.attrsWith {
+            lazy = true;
+            elemType = types.int;
+          };
+        };
+      }
+    )
+    # Module B
+    (
+      { ... }:
+      {
+        options.mergedLazy = lib.mkOption {
+          # Same as lazyAttrsOf
+          type = types.attrsWith {
+            lazy = true;
+            elemType = types.int;
+          };
+        };
+      }
+    )
+    # Result
+    (
+      { config, ... }:
+      {
+        # Can only evaluate if lazy
+        config.mergedLazy.bar = config.mergedLazy.baz + 1;
+        config.mergedLazy.baz = 10;
+        options.result = mkOption { default = config.mergedLazy.bar; };
+      }
+    )
+  ];
+}

--- a/lib/tests/modules/lazy-attrsWith.nix
+++ b/lib/tests/modules/lazy-attrsWith.nix
@@ -2,6 +2,21 @@
 { lib, ... }:
 let
   inherit (lib) types mkOption;
+
+  lazyAttrsOf = mkOption {
+    # Same as lazyAttrsOf
+    type = types.attrsWith {
+      lazy = true;
+      elemType = types.int;
+    };
+  };
+
+  attrsOf = mkOption {
+    # Same as lazyAttrsOf
+    type = types.attrsWith {
+      elemType = types.int;
+    };
+  };
 in
 {
   imports = [
@@ -9,26 +24,18 @@ in
     (
       { ... }:
       {
-        options.mergedLazy = mkOption {
-          # Same as lazyAttrsOf
-          type = types.attrsWith {
-            lazy = true;
-            elemType = types.int;
-          };
-        };
+        options.mergedLazyLazy = lazyAttrsOf;
+        options.mergedLazyNonLazy = lazyAttrsOf;
+        options.mergedNonLazyNonLazy = attrsOf;
       }
     )
     # Module B
     (
       { ... }:
       {
-        options.mergedLazy = lib.mkOption {
-          # Same as lazyAttrsOf
-          type = types.attrsWith {
-            lazy = true;
-            elemType = types.int;
-          };
-        };
+        options.mergedLazyLazy = lazyAttrsOf;
+        options.mergedLazyNonLazy = attrsOf;
+        options.mergedNonLazyNonLazy = attrsOf;
       }
     )
     # Result
@@ -36,9 +43,14 @@ in
       { config, ... }:
       {
         # Can only evaluate if lazy
-        config.mergedLazy.bar = config.mergedLazy.baz + 1;
-        config.mergedLazy.baz = 10;
-        options.result = mkOption { default = config.mergedLazy.bar; };
+        config.mergedLazyLazy.bar = config.mergedLazyLazy.baz + 1;
+        config.mergedLazyLazy.baz = 10;
+        options.lazyResult = mkOption { default = config.mergedLazyLazy.bar; };
+
+        # Can not only evaluate if not lazy
+        config.mergedNonLazyNonLazy.bar = config.mergedNonLazyNonLazy.baz + 1;
+        config.mergedNonLazyNonLazy.baz = 10;
+        options.nonLazyResult = mkOption { default = config.mergedNonLazyNonLazy.bar; };
       }
     )
   ];

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -630,7 +630,8 @@ rec {
       getSubModules = elemType.getSubModules;
       substSubModules = m: attrsWith { elemType = elemType.substSubModules m; inherit lazy; };
       functor = defaultFunctor "attrsWith" // {
-        wrapped = elemType;
+        # TODO: This breaks stuff
+        # wrapped = elemType;
         payload = {
           # Important!: Add new function attributes here in case of future changes
           inherit elemType lazy;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -636,12 +636,8 @@ rec {
       substSubModules = m: attrsWith { elemType = elemType.substSubModules m; inherit lazy; };
       functor = defaultFunctor "attrsWith" // {
         wrappedDeprecationMessage = { loc }: lib.warn ''
-            Using 'functor.wrapped' on option types will be deprecated.
-
-            Use 'nestedTypes.elemType' instead.
-
-            option: '${showOption loc}'
-          '' elemType;
+          The deprecated `type.functor.wrapped` attribute of the option `${showOption loc}` is accessed, use `type.nestedTypes.elemType` instead.
+        '' elemType;
         payload = {
           # Important!: Add new function attributes here in case of future changes
           inherit elemType lazy;


### PR DESCRIPTION
`types.attrsWith` combines `attrsOf` and `lazyAttrsOf` with a configurable `lazy = true/false` parameter. 

Other parameters are possible and on hold see: https://github.com/NixOS/nixpkgs/pull/344216

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
