### PR TITLE
chore: update references to `nix-review` to `nixpkgs-review`

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
     [
       "--prefix PATH : ${lib.makeBinPath binPath}"
       "--set-default NIX_SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt"
-      # we don't have any runtime deps but nix-review shells might inject unwanted dependencies
+      # we don't have any runtime deps but nixpkgs-review shells might inject unwanted dependencies
       "--unset PYTHONPATH"
     ];
 

--- a/pkgs/development/python-modules/aiofile/default.nix
+++ b/pkgs/development/python-modules/aiofile/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "aiofile" ];
 
   disabledTests = [
-    # Tests (SystemError) fails randomly during nix-review
+    # Tests (SystemError) fails randomly during nixpkgs-review
     "test_async_open_fp"
     "test_async_open_iter_chunked"
     "test_async_open_iter_chunked"

--- a/pkgs/tools/package-management/nix/README.md
+++ b/pkgs/tools/package-management/nix/README.md
@@ -11,7 +11,7 @@ Alternatively, you can request access to the Nix community builder for all platf
 To build all dependent packages, use:
 
 ```
-nix-review pr <your-pull-request>
+nixpkgs-review pr <your-pull-request>
 ```
 
 And to build all important NixOS tests, run:


### PR DESCRIPTION
This makes our docs consistent with https://github.com/Mic92/nix-review now pointing to https://github.com/Mic92/nixpkgs-review.