### PR TITLE
postgresqlPackages: fix some builds on darwin

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/system_stats.nix
+++ b/pkgs/servers/sql/postgresql/ext/system_stats.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-/xXnui0S0ZjRw7P8kMAgttHVv8T41aOhM3pM8P0OTig=";
   };
 
+  buildFlags = [ "PG_CFLAGS=-Wno-error=vla" ];
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -165,6 +165,12 @@ let
         src = ./patches/locale-binary-path.patch;
         locale = "${if stdenv.hostPlatform.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
       })
+    ] ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "17") [
+      # TODO: Remove this with the next set of minor releases
+      (fetchpatch ({
+        url = "https://github.com/postgres/postgres/commit/0a883a067bd78f0ff0607afb18c4f783ac764504.patch";
+        hash = "sha256-F3zCaar6w6bwQDno7Tkg7ZbPJ+rhgi8/2NSvFakzQek=";
+      }))
     ] ++ lib.optionals (olderThan "17") [
       # TODO: Remove this with the next set of minor releases
       (fetchpatch (


### PR DESCRIPTION
We currently have the following failures on https://zh.fail/failed/all.html for `postgresqlXPackages`:

```
nixpkgs.postgresql12JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql12JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql12Packages.system_stats.aarch64-darwin
nixpkgs.postgresql12Packages.system_stats.x86_64-darwin
nixpkgs.postgresql13JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql13JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql13Packages.system_stats.aarch64-darwin
nixpkgs.postgresql13Packages.system_stats.x86_64-darwin
nixpkgs.postgresql14JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql14JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql14Packages.system_stats.aarch64-darwin
nixpkgs.postgresql14Packages.system_stats.x86_64-darwin
nixpkgs.postgresql15JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql15JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql15Packages.system_stats.aarch64-darwin
nixpkgs.postgresql15Packages.system_stats.x86_64-darwin
nixpkgs.postgresql16JitPackages.pg_auto_failover.aarch64-darwin
nixpkgs.postgresql16JitPackages.pg_auto_failover.x86_64-darwin
nixpkgs.postgresql16JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql16JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql16Packages.pg_auto_failover.aarch64-darwin
nixpkgs.postgresql16Packages.pg_auto_failover.x86_64-darwin
nixpkgs.postgresql16Packages.system_stats.aarch64-darwin
nixpkgs.postgresql16Packages.system_stats.x86_64-darwin
nixpkgs.postgresql17JitPackages.pg_cron.x86_64-darwin
nixpkgs.postgresql17JitPackages.pg_hll.x86_64-darwin
nixpkgs.postgresql17JitPackages.system_stats.aarch64-darwin
nixpkgs.postgresql17JitPackages.system_stats.x86_64-darwin
nixpkgs.postgresql17Packages.pg_cron.x86_64-darwin
nixpkgs.postgresql17Packages.pg_hll.x86_64-darwin
nixpkgs.postgresql17Packages.system_stats.aarch64-darwin
nixpkgs.postgresql17Packages.system_stats.x86_64-darwin
nixpkgs.postgresqlJitPackages.pg_auto_failover.aarch64-darwin
nixpkgs.postgresqlJitPackages.pg_auto_failover.x86_64-darwin
nixpkgs.postgresqlJitPackages.system_stats.aarch64-darwin
nixpkgs.postgresqlJitPackages.system_stats.x86_64-darwin
nixpkgs.postgresqlPackages.pg_auto_failover.aarch64-darwin
nixpkgs.postgresqlPackages.pg_auto_failover.x86_64-darwin
nixpkgs.postgresqlPackages.system_stats.aarch64-darwin
nixpkgs.postgresqlPackages.system_stats.x86_64-darwin
```

The `pg_auto_failover` failures should be fixed once #344039 [reaches master](https://nixpk.gs/pr-tracker.html?pr=344039).

The remaining failures are fixed in this PR.

ZHF: #352882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
