### PR TITLE
clang-tools: Improve wrapper script, add tests

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang-tools/wrapper
+++ b/pkgs/development/compilers/llvm/common/clang-tools/wrapper
@@ -18,10 +18,23 @@ buildcpath() {
   echo $path${after:+':'}$after
 }
 
-export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                               $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
-export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                                                                      $(<@clang@/nix-support/libcxx-cxxflags) \
-                                                                                      $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
+# When user passes `--query-driver`, avoid extending `CPATH` et al, since we
+# don't want to infect user-specified toolchain and headers with our stuff.
+extendcpath=true
 
-exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"
+for arg in "$@"; do
+  if [[ "${arg}" == \-\-query\-driver* ]]; then
+    extendcpath=false
+  fi
+done
+
+if [ "$extendcpath" = true ]; then
+  export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                 $(<@clang@/nix-support/libc-cflags))
+
+  export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                                                        $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                        $(<@clang@/nix-support/libc-cflags))
+fi
+
+@out@/bin/$(basename $0)-unwrapped "$@"


### PR DESCRIPTION
clang-tools invokes clangd through a wrapper script whose sole purpose is to extend `CPATH` and `CPLUS_INCLUDE_PATH` envs, so that clangd is later able to find built-in and stdlib headers.

This script does two things wrong:

1. We extend `CPATH` et al with entries from both `@clang@/nix-support/libc-cflags` and `@clang@/resource-root/include`, which is kind of a self-made problem, since clangd already has some header auto-detection logic which we (used to) circumvent (for more details, see the diff).

2. We extend `CPATH` et al unconditionally, breaking the `--query-driver` option. I'm not sure what's the perfect solution here, but skipping this logic when we detect `--query-driver` should be good enough. I mean, ideally we wouldn't be playing with `CPATH` etc. whatsoever, but well.

Closes https://github.com/NixOS/nixpkgs/issues/351962
Closes https://github.com/NixOS/nixpkgs/issues/348791
Closes https://github.com/NixOS/nixpkgs/issues/345704

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
