### PR TITLE
qownnotes: 24.9.8 -> 24.11.1

### DIFF
--- a/pkgs/applications/office/qownnotes/default.nix
+++ b/pkgs/applications/office/qownnotes/default.nix
@@ -20,14 +20,14 @@
 let
   pname = "qownnotes";
   appname = "QOwnNotes";
-  version = "24.9.8";
+  version = "24.11.1";
 in
 stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
     url = "https://github.com/pbek/QOwnNotes/releases/download/v${version}/qownnotes-${version}.tar.xz";
-    hash = "sha256-G5PLz1GzjfPM5tj3rtwJt4hR3v+oSq2bVr/llTSFbNk=";
+    hash = "sha256-OQ6p5VCdQZ2P1UFiCPtK+HogIgaoBQKdKO1tEDCA/5I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
# Changes

## 24.11.1
- The margins are now adapted correctly, when zooming in the note text edit, when
  the setting that the editor width should only be applied in distraction free mode
  is disabled (for [#3153](https://github.com/pbek/QOwnNotes/issues/3153))
- The [QOwnNotesAPI Nextcloud App](https://apps.nextcloud.com/apps/qownnotesapi)
  was updated to version 24.11.0 to **fix issues with the versioning API in Nextcloud 30**
  (for [#50](https://github.com/pbek/qownnotesapi/issues/50))
- Added more Spanish, Brazilian Portuguese, Romanian, Dutch, German translation
  (thank you, alejandromoc, ciel.p, ioancroitor, stephanp, rakekniven)

## 24.11.0
- There now is a new script settings for secret variables with the type `string-secret`
  - Those strings will be stored encrypted (but don't depend on that encryption)
  - In the settings dump, such variables will be masked with `********`
  - For more information, please take a look at the
    [scripting documentation](https://www.qownnotes.org/scripting/methods-and-objects.html#registering-script-settings-variables)
- Added more Spanish, Arabic, Russian (thank you, alejandromoc, noureddin, catmenmilota)

## 24.10.5
- The capturing of indented Markdown tables was improved (for [#3137](https://github.com/pbek/QOwnNotes/issues/3137))
- The actions in the *Find action* dialog is now using the correct font size, if you
  are overriding the global interface font size (for [#3145](https://github.com/pbek/QOwnNotes/issues/3145))
- Added more Russian, Spanish, Dutch, Korean, Swedish translation (thank you,
  catmenmilota, alejandromoc, stephanp, venusgirl, dzenan)

## 24.10.4
- Markdown tables can now be indented with up to three spaces to match the behavior
  of the preview (for [#3137](https://github.com/pbek/QOwnNotes/issues/3137))

## 24.10.3
- More warnings are now ignored in log dialog for Qt 6.8.0 (for [#3134](https://github.com/pbek/QOwnNotes/issues/3134))
- The contrast of the link color in the light color schema was increased to make
  it more readable (for [#3139](https://github.com/pbek/QOwnNotes/issues/3139))
- Added more Spanish translation (thank you, alejandromoc)

## 24.10.2
- A small graphical glitch on macOS in the *Markdown highlighting settings* was fixed
  (for [#3130](https://github.com/pbek/QOwnNotes/issues/3130))
- Added more Spanish translation (thank you, alejandromoc)

## 24.10.1
- In the *Stored image files* and the *Stored attachments* dialogs it's now possible
  to only show files of the current note (for [#2354](https://github.com/pbek/QOwnNotes/issues/2354))
- Added more Dutch, Korean, German, Spanish, French translation (thank you,
  stephanp, venusgirl, rakekniven, alejandromoc, jd-develop)

## 24.10.0
- [qc](https://github.com/qownnotes/qc) v0.6.1 was released
  - Add support for storing commands in [Atuin](https://atuin.sh/) on execution
    when using the `--atuin` flag (for [#15](https://github.com/qownnotes/qc/issues/15))
  - The `--color` flag now shows the command description in a calmer green, instead of red
    (for [#16](https://github.com/qownnotes/qc/issues/16))
  - Update dependencies
- Added more Chinese Simplified, Dutch, German, Swedish, Korean translation
  (thank you, huishengli, stephanp, rakekniven, dzenan, venusgirl)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
