### PR TITLE
formats.ini: expose INI atom from all ini formats

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -312,6 +312,8 @@ have a predefined type and string generator already declared under
     may be transformed into multiple key-value pairs depending on
     `listToValue`).
 
+    The attribute `lib.type.atom` contains the used INI atom.
+
 `pkgs.formats.iniWithGlobalSection` { *`listsAsDuplicateKeys`* ? false, *`listToValue`* ? null, \.\.\. }
 
 :   A function taking an attribute set with values
@@ -332,6 +334,8 @@ have a predefined type and string generator already declared under
     sections as with *pkgs.formats.ini* and *globalSection* being just a single
     attrset of key-value pairs for a single section, the global section which
     preceedes the section definitions.
+
+    The attribute `lib.type.atom` contains the used INI atom.
 
 `pkgs.formats.toml` { }
 

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -7,7 +7,7 @@ let
   stateDir = "/var/lib/public-inbox";
 
   gitIni = pkgs.formats.gitIni { listsAsDuplicateKeys = true; };
-  iniAtom = elemAt gitIni.type/*attrsOf*/.functor.wrapped/*attrsOf*/.functor.wrapped/*either*/.functor.wrapped 0;
+  iniAtom = gitIni.lib.types.atom;
 
   useSpamAssassin = cfg.settings.publicinboxmda.spamcheck == "spamc" ||
                     cfg.settings.publicinboxwatch.spamcheck == "spamc";

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -123,9 +123,9 @@ rec {
           }
         else
           singleIniAtom;
-      iniSection = { listsAsDuplicateKeys, listToValue, atomsCoercedToLists }@args:
-        attrsOf (iniAtom args) // {
-          description = "section of an INI file (attrs of " + (iniAtom args).description + ")";
+      iniSection = atom:
+        attrsOf atom // {
+          description = "section of an INI file (attrs of " + atom.description + ")";
         };
 
       maybeToList = listToValue: if listToValue != null then lib.mapAttrs (key: val: if lib.isList val then listToValue val else val) else lib.id;
@@ -144,12 +144,14 @@ rec {
         assert atomsCoercedToLists != null -> (listsAsDuplicateKeys || listToValue != null);
         let
           atomsCoercedToLists' = if atomsCoercedToLists == null then false else atomsCoercedToLists;
+          atom = iniAtom { inherit listsAsDuplicateKeys listToValue; atomsCoercedToLists = atomsCoercedToLists'; };
         in
         {
 
         type = lib.types.attrsOf (
-          iniSection { inherit listsAsDuplicateKeys listToValue; atomsCoercedToLists = atomsCoercedToLists'; }
+          iniSection atom
         );
+        lib.types.atom = atom;
 
         generate = name: value:
           lib.pipe value
@@ -174,24 +176,26 @@ rec {
         assert atomsCoercedToLists != null -> (listsAsDuplicateKeys || listToValue != null);
         let
           atomsCoercedToLists' = if atomsCoercedToLists == null then false else atomsCoercedToLists;
+          atom = iniAtom { inherit listsAsDuplicateKeys listToValue; atomsCoercedToLists = atomsCoercedToLists'; };
         in
         {
           type = lib.types.submodule {
             options = {
               sections = lib.mkOption rec {
                 type = lib.types.attrsOf (
-                  iniSection { inherit listsAsDuplicateKeys listToValue; atomsCoercedToLists = atomsCoercedToLists'; }
+                  iniSection atom
                 );
                 default = {};
                 description = type.description;
               };
               globalSection = lib.mkOption rec {
-                type = iniSection { inherit listsAsDuplicateKeys listToValue; atomsCoercedToLists = atomsCoercedToLists'; };
+                type = iniSection atom;
                 default = {};
                 description = "global " + type.description;
               };
             };
           };
+          lib.types.atom = atom;
           generate = name: { sections ? {}, globalSection ? {}, ... }:
             pkgs.writeText name (lib.generators.toINIWithGlobalSection (removeAttrs args ["listToValue" "atomsCoercedToLists"])
             {
@@ -200,17 +204,19 @@ rec {
             });
         };
 
-      gitIni = { listsAsDuplicateKeys ? false, ... }@args: {
-        type = let
+      gitIni = { listsAsDuplicateKeys ? false, ... }@args:
+        let
           atom = iniAtom {
-            listsAsDuplicateKeys = listsAsDuplicateKeys;
+            inherit listsAsDuplicateKeys;
             listToValue = null;
             atomsCoercedToLists = false;
           };
-        in attrsOf (attrsOf (either atom (attrsOf atom)));
-
-        generate = name: value: pkgs.writeText name (lib.generators.toGitINI value);
-      };
+        in
+        {
+          type = attrsOf (attrsOf (either atom (attrsOf atom)));
+          lib.types.atom = atom;
+          generate = name: value: pkgs.writeText name (lib.generators.toGitINI value);
+        };
 
     }) ini iniWithGlobalSection gitIni;
 


### PR DESCRIPTION
Exposes `INI atom` from all ini formats.

Used i.e. in `public-inbox`

The old implementation was using the option-type tree to get the internal atom which seems very cumbersome.

Additionally stability of the option tree is not guaranteed as an API anywhere.
There might be future efforts to provide methods for walking an option-tree but for now, just exposing the needed thing would be much better / cleaner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
