### PR TITLE
python312Packages.graph-tool: 2.78 -> 2.80

### DIFF
--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -33,12 +33,12 @@ let
 in
 buildPythonPackage rec {
   pname = "graph-tool";
-  version = "2.79";
+  version = "2.80";
   format = "other";
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
-    hash = "sha256-UqJUlC517TBw3qcOaSrhAYd7vvEAnkPsYv4YBqjeAVQ=";
+    hash = "sha256-wacOB12+co+tJdw/WpqVl4gKbW/2hDW5HSHwtE742+Y=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -4,7 +4,6 @@
   fetchurl,
   stdenv,
 
-  autoreconfHook,
   boost185,
   cairomm,
   cgal,
@@ -34,26 +33,19 @@ let
 in
 buildPythonPackage rec {
   pname = "graph-tool";
-  version = "2.78";
+  version = "2.79";
   format = "other";
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
-    hash = "sha256-gG9TWKRJISOowRIXI1/ROTIwrVwhxFtMOextXqN6KiU=";
+    hash = "sha256-UqJUlC517TBw3qcOaSrhAYd7vvEAnkPsYv4YBqjeAVQ=";
   };
 
-  # Remove error messages about tput during build process without adding ncurses,
-  # and replace unavailable git commit hash and date.
   postPatch = ''
-    substituteInPlace configure.ac \
+    # remove error messages about tput during build process without adding ncurses
+    substituteInPlace configure \
       --replace-fail 'tput setaf $1' : \
-      --replace-fail 'tput sgr0' : \
-      --replace-fail \
-        "\"esyscmd(git show | head -n 1 | sed 's/commit //' |  grep -o -e '.\{8\}' | head -n 1 |tr -d '\n')\"" \
-        '["(nixpkgs-${version})"]' \
-      --replace-fail \
-        "\"esyscmd(git log -1 | head -n 3 | grep 'Date:' | sed s/'Date:   '// | tr -d '\n')\"" \
-        '["(unavailable)"]'
+      --replace-fail 'tput sgr0' :
   '';
 
   configureFlags = [
@@ -64,10 +56,7 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  build-system = [
-    autoreconfHook
-    pkg-config
-  ];
+  build-system = [ pkg-config ];
 
   # https://graph-tool.skewed.de/installation.html#manual-compilation
   dependencies = [


### PR DESCRIPTION
## Description of changes

https://git.skewed.de/count0/graph-tool/-/compare/refs/tags/release-2.78..refs/tags/release-2.80

close #361352

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>python311Packages.graph-tool</li>
    <li>python312Packages.graph-tool</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc