### PR TITLE
R: patchelf libraries missing libR.so

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -101,7 +101,10 @@ stdenv.mkDerivation (finalAttrs: {
   # The store path to "which" is baked into src/library/base/R/unix/system.unix.R,
   # but Nix cannot detect it as a run-time dependency because the installed file
   # is compiled and compressed, which hides the store path.
-  postFixup = "echo ${which} > $out/nix-support/undetected-runtime-dependencies";
+  postFixup = ''
+    echo ${which} > $out/nix-support/undetected-runtime-dependencies
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''find $out -name "*.so" -exec patchelf {} --add-rpath $out/lib/R/lib \;''}
+  '';
 
   doCheck = true;
   preCheck = "export HOME=$TMPDIR; export TZ=CET; bin/Rscript -e 'sessionInfo()'";


### PR DESCRIPTION
Following up on #354392 which auto-closed after I was too aggressive when cleaning up the .git folder.

@jbedo this one uses `find` now. I've also checked on darwin and `find result/. \( -name "*.so" -o -name "*.dylib" \) -exec otool -L {} \;` reports that `libR.dylib` links to the nix store and doesn't say anything is missing for the other libraries so we're good as far as I can tell.

## Original PR

Trying out the new [ark](https://github.com/posit-dev/ark) kernel/LSP in neovim but it won't run with the current version of R as-is because of the following:

unable to load shared object '\<store path>R-4.4.1/lib/R/library/utils/libs/utils.so': 
  libR.so: cannot open shared object file: No such file or directory

ldd says this and a few other libraries need to be patched.

```bash
> nix-shell --pure -p pkgs.R pkgs.which pkgs.coreutils
> ldd $(dirname $(which R))/../lib/R/library/utils/libs/utils.so
...
...
libR.so => not found
```

## Things done

I've modified the postFixup phase to patch libR.so for specific files.

I originally started with the fixupPhase but ran into

```
> 1: package 'utils' in options("defaultPackages") was not found
      > 2: package 'stats' in options("defaultPackages") was not found
      > Error: .onLoad failed in loadNamespace() for 'utils', details:
      >   call: system(paste(which, shQuote(names[i])), intern = TRUE, ignore.stderr = TRUE)
      >   error: error in running command
```

Which I believe is what [this line](https://github.com/NixOS/nixpkgs/blob/daedb92c7ff1059b7f53a45e8bce954874ba790e/pkgs/applications/science/math/R/default.nix#L104) is meant to fix. So it was simpler to append to a later phase.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
