### PR TITLE
mpb: init at 1.11.1

### DIFF
--- a/pkgs/by-name/mp/mpb/package.nix
+++ b/pkgs/by-name/mp/mpb/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+  gfortran,
+  pkg-config,
+  blas,
+  lapack,
+  fftw,
+  hdf5,
+  libctl,
+  guile,
+  perl,
+}:
+
+assert !blas.isILP64;
+assert !lapack.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "mpb";
+  version = "1.11.1";
+
+  src = fetchFromGitHub {
+    owner = "NanoComp";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+2cMjZSGdfngtGoAeZRPRPBDvflTEIOWO8Se0W6jv9k=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gfortran
+    pkg-config
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    fftw
+    hdf5
+    libctl
+    guile
+    perl
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-libctl=yes"
+    "--with-libctl=${libctl}"
+    "--enable-maintainer-mode"
+    "--disable-dependency-tracking"
+  ] ++ lib.optional (!stdenv.hostPlatform.isStatic) "--enable-shared";
+
+  doCheck = true;
+
+  meta = {
+    description = "MIT Photonic-Bands: computation of photonic band structures in periodic media";
+    homepage = "https://mpb.readthedocs.io/en/latest/";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      sheepforce
+    ];
+  };
+}

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -19,6 +19,7 @@
   libctl,
   libGDSII,
   guile,
+  mpb,
   python,
   numpy,
   scipy,
@@ -72,6 +73,7 @@ buildPythonPackage rec {
     libGDSII
     guile
     gsl
+    mpb
   ];
 
   propagatedBuildInputs =
@@ -124,6 +126,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mpiCheckPhaseHook
   ];
+  pythonImportCheck = [
+    "meep.mpb"
+  ];
   checkPhase = ''
     runHook preCheck
 
@@ -154,12 +159,12 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Free finite-difference time-domain (FDTD) software for electromagnetic simulations";
     homepage = "https://meep.readthedocs.io/en/latest/";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       sheepforce
       markuskowa
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added support for MPB ([source](https://github.com/NanoComp/mpb), [docs](https://github.com/NanoComp/mpb)).
MPB is standalone C++ library, with bindings to Scheme and Python. It's packaged in a bit of convoluted way, Scheme binding live in the same repository as MPB itself while but Python binding are part of PyMeep package. Please see first paragraph from the [docs](https://mpb.readthedocs.io/en/latest/Python_User_Interface/). 
The only goal for this PR is to add support for MBP within PyMeep, not to have support for for MPB in full generality. This means:
* Scheme binding is out of scope
* MPI in MPB is out of scope, because PyMeep only supports serial MBP [source](https://meep.readthedocs.io/en/latest/Build_From_Source/#mpb)
Additionally:
* `--with-inv-symmetry` is not enabled, because we want as general version of MPB as possible.
* It's not clear to me if `--with-hermitian-eps` should be specified, or is it on by default. Package in [AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mpb-git) does not use it, however the from [conda-forge](https://github.com/conda-forge/mpb-feedstock/blob/main/recipe/build.sh) does.

On testing, I don't know how to test it from MPB itself, however I added a simple `import meep.mpb` to checks in `python3Packages.meep`

I tested if things work by creating a temporary `shell.nix` with `mpb`, `python3Packages.meep` and `python` available. Not sure what's the proper way of testing, so would appreciate any help on this.

@sheepforce for visibility

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
