### PR TITLE
python312Packages.papis: 0.13 -> 0.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16258,6 +16258,13 @@
     github = "octodi";
     githubId = 127038896;
   };
+  octvs = {
+    name = "octvs";
+    email = "octvs@posteo.de";
+    matrix = "@octvs:matrix.org";
+    github = "octvs";
+    githubId = 42993892;
+  };
   oddlama = {
     email = "oddlama@oddlama.org";
     github = "oddlama";

--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  feedparser,
+  requests,
+
+  # tests
+  mock,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "arxiv";
+  version = "2.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lukasschwab";
+    repo = "arxiv.py";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Niu3N0QTVxucboQx1FQq1757Hjj1VVWeDZn7O7YtjWY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    feedparser
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    mock
+  ];
+
+  disabledTests = [
+    # Require network access
+    "test_from_feed_entry"
+    "test_download_from_query"
+    "test_download_tarfile_from_query"
+    "test_download_with_custom_slugify_from_query"
+    "test_get_short_id"
+    "test_invalid_format_id"
+    "test_invalid_id"
+    "test_legacy_ids"
+    "test_max_results"
+    "test_missing_title"
+    "test_no_duplicates"
+    "test_nonexistent_id_in_list"
+    "test_offset"
+    "test_query_page_count"
+    "test_result_shape"
+    "test_search_results_offset"
+  ];
+
+  pythonImportsCheck = [ "arxiv" ];
+
+  meta = {
+    description = "Python wrapper for the arXiv API";
+    homepage = "https://github.com/lukasschwab/arxiv.py";
+    changelog = "https://github.com/lukasschwab/arxiv.py/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.octvs ];
+  };
+}

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -1,62 +1,65 @@
 {
   lib,
-  stdenv,
-  arxiv2bib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  arxiv,
   beautifulsoup4,
   bibtexparser,
-  buildPythonPackage,
-  chardet,
   click,
   colorama,
-  configparser,
   dominate,
-  fetchFromGitHub,
   filetype,
   habanero,
   isbnlib,
   lxml,
+  platformdirs,
   prompt-toolkit,
   pygments,
   pyparsing,
-  pytestCheckHook,
   python-doi,
   python-slugify,
-  pythonOlder,
   pyyaml,
   requests,
   stevedore,
-  tqdm,
-  typing-extensions,
-  whoosh,
-}:
 
+  # tests
+  docutils,
+  git,
+  pytestCheckHook,
+  sphinx,
+  sphinx-click,
+}:
 buildPythonPackage rec {
   pname = "papis";
-  version = "0.13";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  version = "0.14";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "papis";
-    repo = pname;
+    repo = "papis";
     rev = "refs/tags/v${version}";
-    hash = "sha256-iRrf37hq+9D01JRaQIqg7yTPbLX6I0ZGnzG3r1DX464=";
+    hash = "sha256-UpZoMYk4URN8tSFGIynVzWMk+9S0izROAgbx6uI2cN8=";
   };
 
-  propagatedBuildInputs = [
-    arxiv2bib
+  build-system = [ hatchling ];
+
+  dependencies = [
+    arxiv
     beautifulsoup4
     bibtexparser
-    chardet
     click
     colorama
-    configparser
     dominate
     filetype
     habanero
     isbnlib
     lxml
+    platformdirs
     prompt-toolkit
     pygments
     pyparsing
@@ -65,52 +68,50 @@ buildPythonPackage rec {
     pyyaml
     requests
     stevedore
-    tqdm
-    typing-extensions
-    whoosh
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov=papis" ""
+    substituteInPlace pyproject.toml \
+      --replace-fail "--cov=papis" ""
   '';
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "papis" ];
+
+  nativeCheckInputs = [
+    docutils
+    git
+    pytestCheckHook
+    sphinx
+    sphinx-click
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [ "papis tests" ];
+  pytestFlagsArray = [
+    "papis"
+    "tests"
+  ];
 
   disabledTestPaths = [
+    # Require network access
     "tests/downloaders"
     "papis/downloaders/usenix.py"
   ];
 
   disabledTests = [
-    "get_document_url"
-    "match"
-    "test_doi_to_data"
-    "test_downloader_getter"
-    "test_general"
-    "test_get_config_dirs"
-    "test_get_configuration"
-    "test_get_data"
-    "test_valid_dblp_key"
-    "test_validate_arxivid"
-    "test_yaml"
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_default_opener" ];
+    # Require network access
+    "test_yaml_unicode_dump"
+  ];
 
-  pythonImportsCheck = [ "papis" ];
-
-  meta = with lib; {
+  meta = {
     description = "Powerful command-line document and bibliography manager";
     mainProgram = "papis";
     homepage = "https://papis.readthedocs.io/";
     changelog = "https://github.com/papis/papis/blob/v${version}/CHANGELOG.md";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       nico202
       teto
     ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -810,6 +810,8 @@ self: super: with self; {
 
   arviz = callPackage ../development/python-modules/arviz { };
 
+  arxiv = callPackage ../development/python-modules/arxiv { };
+
   arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
Papis had a recent minor release, the relevant parts of the [0.14 release
note](https://github.com/papis/papis/releases) are
  > - Minimum required Python version bumped to 3.8
  > ([#552](https://github.com/papis/papis/pull/552)). 
  > - Moved to `pyproject.toml` and removed `setup.py` completely. We use
  > [hatchling](https://github.com/pypa/hatch/tree/master/backend) as the build
  > backend. 
  > - Removed [arxiv2bib](https://github.com/nathangrigg/arxiv2bib) in
  > favor of [arxiv.py](https://github.com/lukasschwab/arxiv.py). 
  > - Removed [tqdm](https://github.com/tqdm/tqdm) dependency (using a progress
  > bar from `prompt_toolkit` instead). 
  > - Added [platformdirs](https://github.com/platformdirs/platformdirs)
  > dependency for platform-specific config locations.
  
I've added dependencies `arxiv.py` and `sphinx-click` which are mostly taken
from the [upstream flake](https://github.com/papis/papis/blob/980ce4c5a8755dd05ebb904186d7cf47057bca43/flake.nix).

Initially I tried having `fetchFromGithub` on `sphinx-click` so in essence
having

```diff
diff --git a/pkgs/development/python-modules/sphinx-click/default.nix b/pkgs/development/python-modules/sphinx-click/default.nix
index 587618b5fcb5..6f02207abcf8 100644
--- a/pkgs/development/python-modules/sphinx-click/default.nix
+++ b/pkgs/development/python-modules/sphinx-click/default.nix
@@ -1,16 +1,18 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGithub,
   pbr,
 }:
 buildPythonPackage rec {
   pname = "sphinx-click";
   version = "5.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-aBLC22LT+ucaSt2+WooKFsl+tJHzzWP+NLTtfgcjbzM=";
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = pname;
+    rev = version;
+    hash = "sha256-XDzJjxzHGnMWS/C60hQvfQCX7veMcXklpUjqDcJetM0=";
   };
 
   propagatedBuildInputs = [ pbr ];
```

However this fails with

```sh
Error parsing
Traceback (most recent call last):
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/core.py", line 105, in pbr
    attrs = util.cfg_to_args(path, dist.script_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/util.py", line 272, in cfg_to_args
    pbr.hooks.setup_hook(config)
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/hooks/__init__.py", line 25, in setup_hook
    metadata_config.run()
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/hooks/base.py", line 27, in run
    self.hook()
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/hooks/metadata.py", line 25, in hook
    self.config['version'] = packaging.get_version(
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/5kg9855711f90m0vczaxdjgd5spzgjy9-python3.12-pbr-6.1.0/lib/python3.12/site-packages/pbr/packaging.py", line 866, in get_version
    raise Exception("Versioning for this project requires either an sdist"
Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name sphinx-click was given, but was not able to be found.
error in setup command: Error parsing /build/source/setup.cfg: Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name sphinx-click was given, but was not able to be found.
```

As far as I can find over
[the internet](http://omeranson.github.io/blog/2017/02/22/Installing-with-pip-without-a-version)
`pbr` tries to figure out the version, probably in nix environment it fails to
do so.

Asking this around on matrix room, I was advised to stick by `fetchPypi`. 

Note: First time contributor, comments \& feedback highly welcome!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
