### PR TITLE
opengist: 1.7.5 -> 1.8.3

### DIFF
--- a/pkgs/by-name/op/opengist/update.sh
+++ b/pkgs/by-name/op/opengist/update.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl coreutils jq git prefetch-npm-deps moreutils common-updater-scripts common-updater-scripts
+
+# shellcheck shell=bash
+
+set -eou pipefail
+
+NIXPKGS_DIR="$PWD"
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+# Get latest release
+OPENGIST_RELEASE=$(
+    curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+        https://api.github.com/repos/thomiceli/opengist/releases/latest
+)
+
+# Get release information
+latestVersion=$(echo "$OPENGIST_RELEASE" | jq -r ".tag_name")
+latestVersion="${latestVersion:1}" # remove first char 'v'
+
+oldVersion=$(nix eval --raw -f "$NIXPKGS_DIR" opengist.version)
+
+if [[ "$oldVersion" == "$latestVersion" ]]; then
+    echo "opengist is up-to-date: ${oldVersion}"
+    exit 0
+fi
+
+echo "Updating opengist $oldVersion -> $latestVersion"
+
+update-source-version opengist "${latestVersion}"
+
+pushd "$SCRIPT_DIR" >/dev/null || exit 1
+
+## npm hash
+rm -f package{,-lock}.json
+curl -sLO "https://raw.githubusercontent.com/thomiceli/opengist/refs/tags/v$latestVersion/package-lock.json"
+
+npmDepsHash="$(prefetch-npm-deps package-lock.json)"
+sed -E 's#\bnpmDepsHash = ".*?"#npmDepsHash = "'"$npmDepsHash"'"#' --in-place package.nix
+
+popd >/dev/null
+
+# nix-prefetch broken due to ninja finalAttrs.src.rev
+# nix-update with goModules broken for this package
+
+setKV () {
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${SCRIPT_DIR}/package.nix"
+}
+
+setKV vendorHash "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # The same as lib.fakeHash
+
+set +e
+VENDOR_HASH=$(nix-build --no-out-link -A opengist "$NIXPKGS_DIR" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+set -e
+
+if [ -n "${VENDOR_HASH:-}" ]; then
+    setKV vendorHash "${VENDOR_HASH}"
+else
+    echo "Update failed. VENDOR_HASH is empty."
+    exit 1
+fi


### PR DESCRIPTION
- added an update script
- upstreamed a few cross platform build error fixes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
