### PR TITLE
lib.attrsets: add `flattenAttrs` function

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -823,6 +823,54 @@ rec {
         ) a (attrNames n)
     ) {} list_of_attrs;
 
+  /**
+    Flatten an attribute set to the bottom name and value pairs as
+    one singular final attribute set, stripping everything else
+    above.
+
+    In a few words, this does what `lib.lists.flatten` does, but for
+    attribute sets, rather than lists.
+
+
+    # Inputs
+
+    `attrs`
+
+    : The top-level attribute set to flatten.
+
+    # Type
+
+    ```
+    flattenAttrs :: AttrSet -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.flattenAttrs` usage example
+
+    ```nix
+    flattenAttrs { a.b.c.d = "e"; one.two.three.four.five = 6; foo.bar = null; }
+    => { d = "e"; five = 6; bar = null; }
+    ```
+
+    :::
+  */
+  flattenAttrs = attrs:
+    let
+      op = acc: n:
+        let
+          v = attrs.${n};
+          x =
+            if (lib.isAttrs v)
+            then flattenAttrs v
+            else { ${n} = v; };
+        in
+        acc // x;
+    in
+    lib.foldl'
+      op
+      {}
+      (lib.attrNames attrs);
 
   /**
     Recursively collect sets that verify a given predicate named `pred`

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -83,7 +83,7 @@ let
       toExtension;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive foldlAttrs foldAttrs flattenAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -51,6 +51,7 @@ let
     fix
     fold
     foldAttrs
+    flattenAttrs
     foldl
     foldl'
     foldlAttrs
@@ -892,6 +893,43 @@ runTests {
     { a = 3;        c = 8; }
     ];
     expected = { a = [ 2 3 ]; b = [7]; c = [8];};
+  };
+
+  testFlattenAttrs = {
+    expr = flattenAttrs {
+        a.b.c.d = "e";
+        one.two.three.four.five = 6;
+        foo.bar = null;
+        yes.no.maybe = true;
+      };
+    expected = {
+      d = "e";
+      five = 6;
+      bar = null;
+      maybe = true;
+    };
+  };
+
+  testFlattenAttrsEmptyAttrs = {
+    expr = flattenAttrs { };
+    expected = { };
+  };
+
+  testFlattenAttrsRecAttrs = {
+    expr = flattenAttrs rec {
+        a.b.c.d = "e";
+        one.two.three.four.five = 6;
+        foo.bar = null;
+        yes.no.maybe = true;
+        f = a;
+        seven = one.two.three.four;
+      };
+    expected = {
+      d = "e";
+      five = 6;
+      bar = null;
+      maybe = true;
+    };
   };
 
   testListCommonPrefixExample1 = {

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -850,6 +850,8 @@
 - `services.localtimed.enable = true` will now set `time.timeZone = null`.
   This is to avoid silently shadowing a user's explicitly defined timezone without recognition on the user's part.
 
+- Function `flattenAttrs` was added to `lib.attrsets` for extracting the bottom name-value pairs of an attribute set.
+
 - `qgis` and `qgis-ltr` are now built without `grass` by default. `grass` support can be enabled with `qgis.override { withGrass = true; }`.
 
 ## Detailed Migration Information {#sec-release-24.11-migration}


### PR DESCRIPTION
**_Suggestions for how to better implement the functionality or what else to
name the function are welcome. If there is already an existing solution for this
use case that I've missed, please do let me know. If anything at all is missing or out of place, do mention, since this is my first time contributing to `lib`. Please do make sure to read [Points of Consideration](#points-of-consideration) down below. Many thanks._**

> `lib.attrsets.flattenAttrs`: Flatten an attribute set to the bottom name and
> value pairs as one singular final attribute set, stripping everything else
> above.
>
> In a few words, this does what `lib.lists.flatten` does, but for attribute
> sets, rather than lists.

Attribute sets are useful for structuring code, with attribute names serving as
labels, rather than relying on comments.

One example would be when working defining `environment.shellAliases.`

```nix
environment.shellAliases =
  let
    aliases = {
      fd.f = "fd --hidden --no-ignore";

      lsd = {
        ls = {
          lc = "lsd --almost-all";

          lci = "lsd --almost-all --inode";

          lac = "lsd --all";
          lca = "lsd --all";

        };
        tree = {
          tc = "lsd --almost-all --ignore-glob .git --tree";

          tcd = "lsd --almost-all --ignore-glob .git --tree --depth";

          tci = "lsd --all --ignore-glob .git --inode --tree";
          tic = "lsd --all --ignore-glob .git --inode --tree";

          tcid = "lsd --all --ignore-glob .git --inode --tree --depth";
          ticd = "lsd --all --ignore-glob .git --inode --tree --depth";
        };
      };

      ripgrep = {
        r = "rg --glob='!.git'";
        rh = "rg --glob='!.git' --hidden";
        rhn = "rg --glob='!.git' --hidden --no-ignore";
        rhnn = "rg --hidden --no-ignore";
      };
    };
  in
    flattenAttrs aliases;
```

Here, the aliases are categorized by the binary that is being aliased. The `lsd`
set also has another subsection layer for `ls` and `tree`. Comments could be
used, but an in-code approach is better, especially when the attribute set is
large and not just a brief example like what is shown here. This allows for
inspection using Nix directly along with any other transformations that are
desired.

`environment.shellAliases` only takes one attribute set with direct string
name-value pairs. `flattenAttrs` will strip the "labels" and return only the
bottom level across the passed attribute set, being equivalent to:

```nix
environment.shellAliases = {
  # fd
  f = "fd --hidden --no-ignore";

  # lsd - ls
  lc = "lsd --almost-all";

  lci = "lsd --almost-all --inode";

  lac = "lsd --all";
  lca = "lsd --all";

  # lsd - tree
  tc = "lsd --almost-all --ignore-glob .git --tree";

  tcd = "lsd --almost-all --ignore-glob .git --tree --depth";

  tci = "lsd --all --ignore-glob .git --inode --tree";
  tic = "lsd --all --ignore-glob .git --inode --tree";

  tcid = "lsd --all --ignore-glob .git --inode --tree --depth";
  ticd = "lsd --all --ignore-glob .git --inode --tree --depth";

  # ripgrep
  r = "rg --glob='!.git'";
  rh = "rg --glob='!.git' --hidden";
  rhn = "rg --glob='!.git' --hidden --no-ignore";
  rhnn = "rg --hidden --no-ignore";
};
```

This brings the usefulness of `lib.lists.flatten` to attribute sets. This
doesn't conflict with nor modify any existing implementations, this is an
addition, so this change should be safe.

### Points of Consideration
If there are duplicate names in the flattened attribute set, values will be lost since the last added value is favoured when merging the `acc` attribute set with `x`. Whatever is in `x` will override what was in `acc`. I'm not sure what the recommendation for handling this would be. Should the function be modified to compensate for this? Should unique values be enforced? Should the later added values have the name modified to preserve all additions? Should these possible variations be split into other function variations? Is a simple warning in the function definition documentation/comment to make known this behaviour sufficient generally?

I'm not sure what the best practice would be for handing this. Suggestions for ensuring this is implemented correctly in line with common practices and behaviour that other library functions follow are greatly appreciated. Particularly, since I am still new to the Nix ecosystem.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [x] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  (or backporting
  [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  and
  [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
  - [x]  Added a line mentioning the function addition to `lib.attrsets`
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]:
  https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]:
  https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
