### PR TITLE
open62541pp: init at 0.15.0

### DIFF
--- a/pkgs/by-name/op/open62541pp/package.nix
+++ b/pkgs/by-name/op/open62541pp/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  open62541,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "open62541pp";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "open62541pp";
+    repo = "open62541pp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-6HQ8j23+xqJCOwCRK1GgNAoz/wXUBqdulfeQFFXSjEo=";
+  };
+
+  cmakeFlags = [
+    (lib.cmakeBool "UAPP_INTERNAL_OPEN62541" false)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    open62541
+  ];
+
+  meta = {
+    description = "C++ wrapper of the open62541 OPC UA library";
+    homepage = "https://open62541pp.github.io/open62541pp";
+    changelog = "https://github.com/open62541pp/open62541pp/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
C++ wrapper of the open62541 OPC UA library (https://github.com/open62541pp/open62541pp)

[![Packaging status](https://repology.org/badge/tiny-repos/open62541pp.svg)](https://repology.org/project/open62541pp/versions)

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
