### PR TITLE
nlohmann_json: patch tests to compile on clang-19

### DIFF
--- a/pkgs/by-name/nl/nlohmann_json/make-tests-build-clang-19.diff
+++ b/pkgs/by-name/nl/nlohmann_json/make-tests-build-clang-19.diff
@@ -1,0 +1,98 @@
+diff --git a/tests/src/unit-bson.cpp b/tests/src/unit-bson.cpp
+index 13216f2..fdfc350 100644
+--- a/tests/src/unit-bson.cpp
++++ b/tests/src/unit-bson.cpp
+@@ -621,7 +621,7 @@ TEST_CASE("BSON input/output_adapters")
+     {
+         SECTION("std::ostringstream")
+         {
+-            std::basic_ostringstream<std::uint8_t> ss;
++            std::basic_ostringstream<char> ss;
+             json::to_bson(json_representation, ss);
+             json j3 = json::from_bson(ss.str());
+             CHECK(json_representation == j3);
+diff --git a/tests/src/unit-cbor.cpp b/tests/src/unit-cbor.cpp
+index be94d2f..2b396b7 100644
+--- a/tests/src/unit-cbor.cpp
++++ b/tests/src/unit-cbor.cpp
+@@ -1881,7 +1881,7 @@ TEST_CASE("single CBOR roundtrip")
+         {
+             SECTION("std::ostringstream")
+             {
+-                std::basic_ostringstream<std::uint8_t> ss;
++                std::basic_ostringstream<char> ss;
+                 json::to_cbor(j1, ss);
+                 json j3 = json::from_cbor(ss.str());
+                 CHECK(j1 == j3);
+diff --git a/tests/src/unit-deserialization.cpp b/tests/src/unit-deserialization.cpp
+index 3bc161f..e4918b0 100644
+--- a/tests/src/unit-deserialization.cpp
++++ b/tests/src/unit-deserialization.cpp
+@@ -1131,13 +1131,11 @@ TEST_CASE("deserialization")
+     }
+ }
+ 
++
+ TEST_CASE_TEMPLATE("deserialization of different character types (ASCII)", T,
+-                   char, unsigned char, signed char,
++                   char,
+                    wchar_t,
+-                   char16_t, char32_t,
+-                   std::uint8_t, std::int8_t,
+-                   std::int16_t, std::uint16_t,
+-                   std::int32_t, std::uint32_t)
++                   char16_t, char32_t)
+ {
+     std::vector<T> const v = {'t', 'r', 'u', 'e'};
+     CHECK(json::parse(v) == json(true));
+@@ -1163,7 +1161,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-8)", T,
+ }
+ 
+ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T,
+-                   char16_t, std::uint16_t)
++                   char16_t)
+ {
+     // a star emoji
+     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};
+@@ -1176,7 +1174,7 @@ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-16)", T,
+ }
+ 
+ TEST_CASE_TEMPLATE("deserialization of different character types (UTF-32)", T,
+-                   char32_t, std::uint32_t)
++                   char32_t)
+ {
+     // a star emoji
+     std::vector<T> const v = {static_cast<T>('"'), static_cast<T>(0x2b50), static_cast<T>(0xfe0f), static_cast<T>('"')};
+diff --git a/tests/src/unit-msgpack.cpp b/tests/src/unit-msgpack.cpp
+index 61162af..cfbb1fa 100644
+--- a/tests/src/unit-msgpack.cpp
++++ b/tests/src/unit-msgpack.cpp
+@@ -1604,7 +1604,7 @@ TEST_CASE("single MessagePack roundtrip")
+         {
+             SECTION("std::ostringstream")
+             {
+-                std::basic_ostringstream<std::uint8_t> ss;
++                std::basic_ostringstream<char> ss;
+                 json::to_msgpack(j1, ss);
+                 json j3 = json::from_msgpack(ss.str());
+                 CHECK(j1 == j3);
+diff --git a/tests/src/unit-regression2.cpp b/tests/src/unit-regression2.cpp
+index fab9aae..98947c5 100644
+--- a/tests/src/unit-regression2.cpp
++++ b/tests/src/unit-regression2.cpp
+@@ -674,6 +674,7 @@ TEST_CASE("regression tests 2")
+         CHECK(j.dump() == "{}");
+     }
+ 
++#if 0
+ #ifdef JSON_HAS_CPP_20
+ #if __has_include(<span>)
+     SECTION("issue #2546 - parsing containers of std::byte")
+@@ -684,6 +685,7 @@ TEST_CASE("regression tests 2")
+         CHECK(j.dump() == "\"Hello, world!\"");
+     }
+ #endif
++#endif
+ #endif
+ 
+     SECTION("issue #2574 - Deserialization to std::array, std::pair, and std::tuple with non-default constructable types fails")

--- a/pkgs/by-name/nl/nlohmann_json/package.nix
+++ b/pkgs/by-name/nl/nlohmann_json/package.nix
@@ -21,6 +21,12 @@ in stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-7F0Jon+1oWL7uqet5i1IgHX0fUw/+z0QwEcA3zs5xHg=";
   };
 
+  patches = lib.optionals stdenv.cc.isClang [
+    # tests fail to compile on clang-19
+    # https://github.com/nlohmann/json/issues/4490
+    ./make-tests-build-clang-19.diff
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [


### PR DESCRIPTION
patch tests to compile on clang-19

https://github.com/nlohmann/json/issues/4490

https://releases.llvm.org/19.1.0/projects/libcxx/docs/ReleaseNotes.html

> The base template for std::char_traits has been removed in LLVM 19. If you are using std::char_traits with types other than char, wchar_t, char8_t, char16_t, char32_t or a custom character type for which you specialized std::char_traits, your code will stop working.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@emilazy 