### PR TITLE
jellyfin-ffmpeg: use regular ffmpeg

### DIFF
--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -1,6 +1,7 @@
-{ ffmpeg
-, fetchFromGitHub
-, lib
+{
+  ffmpeg,
+  fetchFromGitHub,
+  lib,
 }:
 
 let
@@ -83,28 +84,29 @@ in
   buildPostproc = true;
   buildSwresample = true;
   buildSwscale = true;
-}).overrideAttrs (old: {
-  pname = "jellyfin-ffmpeg";
+}).overrideAttrs
+  (old: {
+    pname = "jellyfin-ffmpeg";
 
-  configureFlags = old.configureFlags ++ [
-    "--extra-version=Jellyfin"
-    "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
-  ];
+    configureFlags = old.configureFlags ++ [
+      "--extra-version=Jellyfin"
+      "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
+    ];
 
-  postPatch = ''
-    for file in $(cat debian/patches/series); do
-      patch -p1 < debian/patches/$file
-    done
+    postPatch = ''
+      for file in $(cat debian/patches/series); do
+        patch -p1 < debian/patches/$file
+      done
 
-    ${old.postPatch or ""}
-  '';
+      ${old.postPatch or ""}
+    '';
 
-  meta = {
-    inherit (old.meta) license mainProgram;
-    changelog = "https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v${version}";
-    description = "${old.meta.description} (Jellyfin fork)";
-    homepage = "https://github.com/jellyfin/jellyfin-ffmpeg";
-    maintainers = with lib.maintainers; [ justinas ];
-    pkgConfigModules = [ "libavutil" ];
-  };
-})
+    meta = {
+      inherit (old.meta) license mainProgram;
+      changelog = "https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v${version}";
+      description = "${old.meta.description} (Jellyfin fork)";
+      homepage = "https://github.com/jellyfin/jellyfin-ffmpeg";
+      maintainers = with lib.maintainers; [ justinas ];
+      pkgConfigModules = [ "libavutil" ];
+    };
+  })

--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -1,4 +1,4 @@
-{ ffmpeg_7-headless
+{ ffmpeg
 , fetchFromGitHub
 , fetchpatch
 , lib
@@ -8,7 +8,7 @@ let
   version = "7.0.2-5";
 in
 
-(ffmpeg_7-headless.override {
+(ffmpeg.override {
   inherit version; # Important! This sets the ABI.
   source = fetchFromGitHub {
     owner = "jellyfin";
@@ -17,9 +17,19 @@ in
     hash = "sha256-cqyXQNx65eLEumOoSCucNpAqShMhiPqzsKc/GjKKQOA=";
   };
 
+  ffmpegVariant = "barebones";
+
   # https://github.com/NixOS/nixpkgs/pull/354936#issuecomment-2466628369
   # https://github.com/jellyfin/jellyfin-ffmpeg/blob/jellyfin/debian/rules
   # --enable-gmp # not supported by our ffmpeg drv
+  withDoc = false;
+  buildFfplay = false;
+  withXcb = false;
+  withSdl2 = false;
+  withXlib = false;
+  withGPL = true;
+  withVersion3 = true;
+  withShared = true;
   withGnutls = true;
   withChromaprint = true;
   withOpencl = true;
@@ -44,6 +54,7 @@ in
   withX265 = true;
   withZvbi = true;
   withZimg = true;
+  withFdkAac = true;
 
   withShaderc = true;
   withPlacebo = true;
@@ -51,13 +62,25 @@ in
   withVaapi = true;
   withAmf = true;
   withVpl = true;
-  withMfx = false;
   withNvcodec = true;
   withCuda = true;
   withCudaLLVM = true;
   withCuvid = true;
   withNvdec = true;
   withNvenc = true;
+
+  # Unlike upstream, these aren't enabled in the barebones variant by default
+  # but we do need them to do anything useful.
+  buildFfmpeg = true;
+  # TODO are all of these actually required?
+  buildAvcodec = true;
+  buildAvdevice = true;
+  buildAvfilter = true;
+  buildAvformat = true;
+  buildAvutil = true;
+  buildPostproc = true;
+  buildSwresample = true;
+  buildSwscale = true;
 }).overrideAttrs (old: {
   pname = "jellyfin-ffmpeg";
 

--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -19,8 +19,11 @@ in
 
   ffmpegVariant = "barebones";
 
-  # https://github.com/NixOS/nixpkgs/pull/354936#issuecomment-2466628369
+  # These flags are intended to be the exact same as upstream's which can be
+  # found here:
   # https://github.com/jellyfin/jellyfin-ffmpeg/blob/jellyfin/debian/rules
+  # Please update these when upstream changes them.
+
   # --enable-gmp # not supported by our ffmpeg drv
   withDoc = false;
   buildFfplay = false;

--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -1,6 +1,5 @@
 { ffmpeg
 , fetchFromGitHub
-, fetchpatch
 , lib
 }:
 

--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -1,4 +1,4 @@
-{ ffmpeg_7-full
+{ ffmpeg_7-headless
 , fetchFromGitHub
 , fetchpatch
 , lib
@@ -8,7 +8,7 @@ let
   version = "7.0.2-5";
 in
 
-(ffmpeg_7-full.override {
+(ffmpeg_7-headless.override {
   inherit version; # Important! This sets the ABI.
   source = fetchFromGitHub {
     owner = "jellyfin";
@@ -16,6 +16,48 @@ in
     rev = "v${version}";
     hash = "sha256-cqyXQNx65eLEumOoSCucNpAqShMhiPqzsKc/GjKKQOA=";
   };
+
+  # https://github.com/NixOS/nixpkgs/pull/354936#issuecomment-2466628369
+  # https://github.com/jellyfin/jellyfin-ffmpeg/blob/jellyfin/debian/rules
+  # --enable-gmp # not supported by our ffmpeg drv
+  withGnutls = true;
+  withChromaprint = true;
+  withOpencl = true;
+  withDrm = true;
+  withXml2 = true;
+  withAss = true;
+  withFreetype = true;
+  withFribidi = true;
+  withFontconfig = true;
+  withHarfbuzz = true;
+  withBluray = true;
+  withMp3lame = true;
+  withOpus = true;
+  withTheora = true;
+  withVorbis = true;
+  withOpenmpt = true;
+  withDav1d = true;
+  withSvtav1 = true;
+  withWebp = true;
+  withVpx = true;
+  withX264 = true;
+  withX265 = true;
+  withZvbi = true;
+  withZimg = true;
+
+  withShaderc = true;
+  withPlacebo = true;
+  withVulkan = true;
+  withVaapi = true;
+  withAmf = true;
+  withVpl = true;
+  withMfx = false;
+  withNvcodec = true;
+  withCuda = true;
+  withCudaLLVM = true;
+  withCuvid = true;
+  withNvdec = true;
+  withNvenc = true;
 }).overrideAttrs (old: {
   pname = "jellyfin-ffmpeg";
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -29,6 +29,10 @@
   # instead.
 , withFullDeps ? ffmpegVariant == "full"
 
+  # Enable nothing but the bare minimum. This should only be used for highly
+  # custom builds of ffmpeg.
+, withBareBonesDeps ? ffmpegVariant == "barebones" || withHeadlessDeps
+
 , fetchgit
 , fetchpatch2
 
@@ -150,8 +154,8 @@
 /*
  *  Licensing options (yes some are listed twice, filters and such are not listed)
  */
-, withGPL ? true
-, withVersion3 ? true # When withGPL is set this implies GPLv3 otherwise it is LGPLv3
+, withGPL ? withHeadlessDeps
+, withVersion3 ? withHeadlessDeps # When withGPL is set this implies GPLv3 otherwise it is LGPLv3
 , withGPLv3 ? withGPL && withVersion3
 , withUnfree ? false
 
@@ -164,14 +168,14 @@
 , withSwscaleAlpha ? buildSwscale # Alpha channel support in swscale. You probably want this when buildSwscale.
 , withHardcodedTables ? withHeadlessDeps # Hardcode decode tables instead of runtime generation
 , withSafeBitstreamReader ? withHeadlessDeps # Buffer boundary checking in bitreaders
-, withMultithread ? true # Multithreading via pthreads/win32 threads
+, withMultithread ? withBareBonesDeps # Multithreading via pthreads/win32 threads
 , withNetwork ? withHeadlessDeps # Network support
   # Currently breaks tests if disabled while libavutil is enabled
   # https://github.com/NixOS/nixpkgs/issues/355077
 , withPixelutils ? buildAvutil # Pixel utils in libavutil
 , withStatic ? stdenv.hostPlatform.isStatic
 , withShared ? !stdenv.hostPlatform.isStatic
-, withPic ? true
+, withPic ? withBareBonesDeps
 , withThumb ? false # On some ARM platforms
 
 /*
@@ -374,7 +378,7 @@ let
 in
 
 
-assert lib.elem ffmpegVariant [ "headless" "small" "full" ];
+assert lib.elem ffmpegVariant [ "barebones" "headless" "small" "full" ];
 
 /*
  *  Licensing dependencies

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -166,7 +166,9 @@
 , withSafeBitstreamReader ? withHeadlessDeps # Buffer boundary checking in bitreaders
 , withMultithread ? true # Multithreading via pthreads/win32 threads
 , withNetwork ? withHeadlessDeps # Network support
-, withPixelutils ? withHeadlessDeps # Pixel utils in libavutil
+  # Currently breaks tests if disabled while libavutil is enabled
+  # https://github.com/NixOS/nixpkgs/issues/355077
+, withPixelutils ? buildAvutil # Pixel utils in libavutil
 , withStatic ? stdenv.hostPlatform.isStatic
 , withShared ? !stdenv.hostPlatform.isStatic
 , withPic ? true


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/271863

jellyfin-ffmpeg is a rebuild anyways, so we can simply cherry-pick the features that we actually need rather than smashing ffmpeg-full into it.

These should be all the "special" features jellyfin expects of it.

nvcodec and amf support are already enabled by default in regular ffmpeg.

@nyanmisaka are there any other features that we should ensure are enabled here?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
