### PR TITLE
starc: init at 0.7.5

### DIFF
--- a/pkgs/by-name/st/starc/package.nix
+++ b/pkgs/by-name/st/starc/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "starc";
+  version = "0.7.5";
+
+  src = fetchurl {
+    url = "https://github.com/story-apps/starc/releases/download/v${finalAttrs.version}/starc-setup.AppImage";
+    hash = "sha256-KAY04nXVyXnjKJxzh3Pvi50Vs0EPbLk0VgfZuz7MQR0=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase =
+    let
+      appimageContents = appimageTools.extract { inherit (finalAttrs) pname version src; };
+      starc-unwrapped = appimageTools.wrapType2 { inherit (finalAttrs) pname version src; };
+    in
+    ''
+      runHook preInstall
+
+      # Fixup desktop item icons
+      install -D ${appimageContents}/starc.desktop -t $out/share/applications/
+
+      substituteInPlace $out/share/applications/starc.desktop \
+      --replace-fail "Icon=starc" "${''
+        Icon=dev.storyapps.starc
+        StartupWMClass=Story Architect''}"
+
+      cp -r ${appimageContents}/share/* $out/share/
+
+      makeWrapper ${starc-unwrapped}/bin/starc $out/bin/starc \
+        --unset QT_PLUGIN_PATH
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Intuitive screenwriting app that streamlines the writing process";
+    homepage = "https://starc.app/";
+    mainProgram = "starc";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Story Architect is the successor to Kit Scenarist, a screenwriting software.
homepage: https://starc.app/

Some notes on packaging: I would have liked to avoid using the stdenvNoCC here, but I wasn't successful in getting a wrapProgram to function correctly if placed in the fixupPhase of the appimageTools.wrapType2 itself. If someone else is able to get it to behave we could move most of the installPhase to the appimage's extraInstallCommands, and clean up the derivation significantly.

Also, I've elected for an unfree license, rather than  GPL-3 as listed in the github repo, as some features of the paid version are proprietary.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
