### PR TITLE
python312Packages.{localstack-ext,localstack}: fix build and refactor

### DIFF
--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -2,13 +2,17 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
+  setuptools-scm,
   dill,
   dnslib,
   dnspython,
   plux,
   pyaes,
+  pyotp,
   python-jose,
   requests,
+  python-dateutil,
   tabulate,
 
   # Sensitive downstream dependencies
@@ -18,7 +22,7 @@
 buildPythonPackage rec {
   pname = "localstack-ext";
   version = "3.7.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "localstack_ext";
@@ -26,32 +30,31 @@ buildPythonPackage rec {
     hash = "sha256-gd+HyZnezgtKrSKJOYtxUZHTPMrrpKWQHGvaIs9FyVs=";
   };
 
-  postPatch = ''
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRemoveDeps = [
     # Avoid circular dependency
-    sed -i '/localstack>=/d' setup.cfg
+    "localstack"
+    "build"
+  ];
 
-    # Pip is unable to resolve attr logic, so it will emit version as 0.0.0
-    substituteInPlace setup.cfg \
-      --replace "version = attr: localstack_ext.__version__" "version = ${version}"
-    cat setup.cfg
-
-    substituteInPlace setup.cfg \
-      --replace "dill==0.3.2" "dill~=0.3.0" \
-      --replace "requests>=2.20.0,<2.26" "requests~=2.20"
-  '';
-
-  propagatedBuildInputs = [
+  dependencies = [
     dill
     dnslib
     dnspython
     plux
     pyaes
+    pyotp
     python-jose
     requests
     tabulate
-  ];
+    python-dateutil
+  ] ++ python-jose.optional-dependencies.cryptography;
 
-  pythonImportsCheck = [ "localstack_ext" ];
+  pythonImportsCheck = [ "localstack" ];
 
   # No tests in repo
   doCheck = false;
@@ -60,10 +63,10 @@ buildPythonPackage rec {
     inherit localstack;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Extensions for LocalStack";
     homepage = "https://github.com/localstack/localstack";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/localstack/default.nix
+++ b/pkgs/development/python-modules/localstack/default.nix
@@ -19,6 +19,7 @@
   rich,
   semver,
   setuptools,
+  setuptools-scm,
   tailer,
 }:
 
@@ -34,7 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-8xdP/qpmfqmXDt1gNhzkAGlBR6dJYznKr9+/Un6N7mA=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     apispec


### PR DESCRIPTION
ZHF: #352882
https://hydra.nixos.org/build/276615127
https://hydra.nixos.org/build/276550822
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
