### PR TITLE
nixos/postgresql: extension based hardening relaxation

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -40,9 +40,9 @@ let
       # works.
       base = if cfg.enableJIT then cfg.package.withJIT else cfg.package.withoutJIT;
     in
-    if cfg.extraPlugins == []
+    if cfg.extensions == []
       then base
-      else base.withPackages cfg.extraPlugins;
+      else base.withPackages cfg.extensions;
 
   toStr = value:
     if true == value then "yes"
@@ -59,7 +59,6 @@ let
   '';
 
   groupAccessAvailable = versionAtLeast postgresql.version "11.0";
-
 in
 
 {
@@ -68,6 +67,7 @@ in
 
     (mkRenamedOptionModule [ "services" "postgresql" "logLinePrefix" ] [ "services" "postgresql" "settings" "log_line_prefix" ])
     (mkRenamedOptionModule [ "services" "postgresql" "port" ] [ "services" "postgresql" "settings" "port" ])
+    (mkRenamedOptionModule [ "services" "postgresql" "extraPlugins" ] [ "services" "postgresql" "extensions" ])
   ];
 
   ###### interface
@@ -371,12 +371,12 @@ in
         '';
       };
 
-      extraPlugins = mkOption {
+      extensions = mkOption {
         type = with types; coercedTo (listOf path) (path: _ignorePg: path) (functionTo (listOf path));
         default = _: [];
         example = literalExpression "ps: with ps; [ postgis pg_repack ]";
         description = ''
-          List of PostgreSQL plugins.
+          List of PostgreSQL extensions to install.
         '';
       };
 

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -227,7 +227,7 @@ in
           ensureClauses.login = true;
         }
       ];
-      extraPlugins = ps: with ps; [ pgvecto-rs ];
+      extensions = ps: with ps; [ pgvecto-rs ];
       settings = {
         shared_preload_libraries = [ "vectors.so" ];
         search_path = "\"$user\", public, vectors";

--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -383,7 +383,7 @@ in
           ensureDBOwnership = false;
         }
       ];
-      extraPlugins = ps: with ps; [ postgis ];
+      extensions = ps: with ps; [ postgis ];
     };
 
     # Nginx config taken from support/nginx/mobilizon-release.conf

--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -20,7 +20,7 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extraPlugins = ps: [ ps.anonymizer ];
+            extensions = ps: [ ps.anonymizer ];
             settings.shared_preload_libraries = [ "anon" ];
           };
         };

--- a/nixos/tests/postgresql/pgjwt.nix
+++ b/nixos/tests/postgresql/pgjwt.nix
@@ -24,7 +24,7 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extraPlugins =
+            extensions =
               ps: with ps; [
                 pgjwt
                 pgtap

--- a/nixos/tests/postgresql/pgvecto-rs.nix
+++ b/nixos/tests/postgresql/pgvecto-rs.nix
@@ -38,7 +38,7 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extraPlugins =
+            extensions =
               ps: with ps; [
                 pgvecto-rs
               ];

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -14,32 +14,41 @@ let
       postgresql-clauses = makeEnsureTestFor package;
     };
 
-  test-sql = pkgs.writeText "postgresql-test" ''
-    CREATE EXTENSION pgcrypto; -- just to check if lib loading works
-    CREATE TABLE sth (
-      id int
+  test-sql =
+    enablePLv8Test:
+    pkgs.writeText "postgresql-test" (
+      ''
+        CREATE EXTENSION pgcrypto; -- just to check if lib loading works
+        CREATE TABLE sth (
+          id int
+        );
+        INSERT INTO sth (id) VALUES (1);
+        INSERT INTO sth (id) VALUES (1);
+        INSERT INTO sth (id) VALUES (1);
+        INSERT INTO sth (id) VALUES (1);
+        INSERT INTO sth (id) VALUES (1);
+        CREATE TABLE xmltest ( doc xml );
+        INSERT INTO xmltest (doc) VALUES ('<test>ok</test>'); -- check if libxml2 enabled
+      ''
+      + lib.optionalString enablePLv8Test ''
+        -- check if hardening gets relaxed
+        CREATE EXTENSION plv8;
+        -- try to trigger the V8 JIT, which requires MemoryDenyWriteExecute
+        DO $$
+          let xs = [];
+          for (let i = 0, n = 400000; i < n; i++) {
+              xs.push(Math.round(Math.random() * n))
+          }
+          console.log(xs.reduce((acc, x) => acc + x, 0));
+        $$ LANGUAGE plv8;
+      ''
     );
-    INSERT INTO sth (id) VALUES (1);
-    INSERT INTO sth (id) VALUES (1);
-    INSERT INTO sth (id) VALUES (1);
-    INSERT INTO sth (id) VALUES (1);
-    INSERT INTO sth (id) VALUES (1);
-    CREATE TABLE xmltest ( doc xml );
-    INSERT INTO xmltest (doc) VALUES ('<test>ok</test>'); -- check if libxml2 enabled
-    -- check if hardening gets relaxed
-    CREATE EXTENSION plv8;
-    -- try to trigger the V8 JIT, which requires MemoryDenyWriteExecute
-    DO $$
-      let xs = [];
-      for (let i = 0, n = 400000; i < n; i++) {
-          xs.push(Math.round(Math.random() * n))
-      }
-      console.log(xs.reduce((acc, x) => acc + x, 0));
-    $$ LANGUAGE plv8;
-  '';
 
   makeTestForWithBackupAll =
     package: backupAll:
+    let
+      enablePLv8Check = !package.pkgs.plv8.meta.broken;
+    in
     makeTest {
       name = "postgresql${lib.optionalString backupAll "-backup-all"}-${package.name}";
       meta = with lib.maintainers; {
@@ -47,13 +56,17 @@ let
       };
 
       nodes.machine =
-        { ... }:
+        { config, ... }:
         {
           services.postgresql = {
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extensions = ps: with ps; [ plv8 ];
+            # plv8 doesn't support postgresql with JIT, so we only run the test
+            # for the non-jit variant.
+            # TODO(@Ma27) split this off into its own VM test and move a few other
+            # extension tests to use postgresqlTestExtension.
+            extensions = lib.mkIf enablePLv8Check (ps: with ps; [ plv8 ]);
           };
 
           services.postgresqlBackup = {
@@ -80,7 +93,7 @@ let
 
           with subtest("Postgresql is available just after unit start"):
               machine.succeed(
-                  "cat ${test-sql} | sudo -u postgres psql"
+                  "cat ${test-sql enablePLv8Check} | sudo -u postgres psql"
               )
 
           with subtest("Postgresql survives restart (bug #1735)"):

--- a/nixos/tests/postgresql/timescaledb.nix
+++ b/nixos/tests/postgresql/timescaledb.nix
@@ -54,7 +54,7 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extraPlugins =
+            extensions =
               ps: with ps; [
                 timescaledb
                 timescaledb_toolkit

--- a/nixos/tests/postgresql/tsja.nix
+++ b/nixos/tests/postgresql/tsja.nix
@@ -21,7 +21,7 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            extraPlugins =
+            extensions =
               ps: with ps; [
                 tsja
               ];

--- a/nixos/tests/postgresql/wal2json.nix
+++ b/nixos/tests/postgresql/wal2json.nix
@@ -17,7 +17,7 @@ let
           inherit package;
           enable = true;
           enableJIT = lib.hasInfix "-jit-" package.name;
-          extraPlugins = with package.pkgs; [ wal2json ];
+          extensions = with package.pkgs; [ wal2json ];
           settings = {
             wal_level = "logical";
             max_replication_slots = "10";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -323,25 +323,33 @@ let
     };
   });
 
-  postgresqlWithPackages = { postgresql, buildEnv }: f: buildEnv {
+  postgresqlWithPackages = { postgresql, buildEnv }: f: let
+    installedExtensions = f postgresql.pkgs;
+  in buildEnv {
     name = "${postgresql.pname}-and-plugins-${postgresql.version}";
-    paths = f postgresql.pkgs ++ [
+    paths = installedExtensions ++ [
         postgresql
         postgresql.man   # in case user installs this into environment
     ];
 
     pathsToLink = ["/"];
 
-    passthru.version = postgresql.version;
-    passthru.psqlSchema = postgresql.psqlSchema;
-    passthru.withJIT = postgresqlWithPackages {
-      inherit buildEnv;
-      postgresql = postgresql.withJIT;
-    } f;
-    passthru.withoutJIT = postgresqlWithPackages {
-      inherit buildEnv;
-      postgresql = postgresql.withoutJIT;
-    } f;
+    passthru = {
+      inherit installedExtensions;
+      inherit (postgresql)
+        psqlSchema
+        version
+      ;
+
+      withJIT = postgresqlWithPackages {
+        inherit buildEnv;
+        postgresql = postgresql.withJIT;
+      } f;
+      withoutJIT = postgresqlWithPackages {
+        inherit buildEnv;
+        postgresql = postgresql.withoutJIT;
+      } f;
+    };
   };
 
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

So this is the initial idea I had about how to relax the hardening when certain plugins are used.

I fully expect the certain scenario to be incomplete wrt. MemoryDenyWriteExecute, if it does indeed us V8.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
