### PR TITLE
nbqa: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/by-name/nb/nbqa/package.nix
+++ b/pkgs/by-name/nb/nbqa/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 
   # optional-dependencies
@@ -8,27 +8,29 @@
 
   # tests
   versionCheckHook,
+
+  nix-update-script,
 }:
 
 let
-  nbqa = python3.pkgs.buildPythonApplication rec {
+  nbqa = python3Packages.buildPythonApplication rec {
     pname = "nbqa";
-    version = "1.9.0";
+    version = "1.9.1";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "nbQA-dev";
       repo = "nbQA";
       rev = "refs/tags/${version}";
-      hash = "sha256-9s+q2unh+jezU0Er7ZH0tvgntmPFts9OmsgAMeQXRrY=";
+      hash = "sha256-qVNJ8f8vUlTCi5DbvG70orcSnulH60UcI5iABtXYUog=";
     };
 
-    build-system = with python3.pkgs; [
+    build-system = with python3Packages; [
       setuptools
     ];
 
     optional-dependencies.toolchain =
-      (with python3.pkgs; [
+      (with python3Packages; [
         black
         blacken-docs
         flake8
@@ -42,7 +44,7 @@ let
         ruff
       ];
 
-    dependencies = with python3.pkgs; [
+    dependencies = with python3Packages; [
       autopep8
       ipython
       tokenize-rt
@@ -60,7 +62,7 @@ let
     '';
 
     nativeCheckInputs =
-      (with python3.pkgs; [
+      (with python3Packages; [
         autoflake
         distutils
         mdformat
@@ -71,6 +73,7 @@ let
       ])
       ++ lib.flatten (lib.attrValues optional-dependencies)
       ++ [ versionCheckHook ];
+    versionCheckProgramArg = [ "--version" ];
 
     disabledTests = [
       # Test data not found
@@ -98,10 +101,12 @@ let
         nbqa.overridePythonAttrs (
           { dependencies, ... }:
           {
-            dependencies = dependencies ++ selector python3.pkgs;
+            dependencies = dependencies ++ selector python3Packages;
             doCheck = false;
           }
         );
+
+      updateScript = nix-update-script { };
     };
 
     meta = {


### PR DESCRIPTION
## Things done

Changelog: https://nbqa.readthedocs.io/en/latest/history.html

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
