### PR TITLE
lua-language-server: move to by-name; clean derivation

### DIFF
--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -10,6 +10,9 @@
   # buildInputs
   apple-sdk_11,
   darwinMinVersionHook,
+  rsync,
+
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -20,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "luals";
     repo = "lua-language-server";
-    rev = finalAttrs.version;
+    rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-wyQ4oXGemoT5QVZughFKd386RjzlW4ArtQL0ofMnhpU=";
     fetchSubmodules = true;
   };
@@ -31,37 +34,49 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.ditto
     # aligned_alloc
     apple-sdk_11
     (darwinMinVersionHook "10.15")
+    rsync
   ];
 
   postPatch =
     ''
       # filewatch tests are failing on darwin
       # this feature is not used in lua-language-server
-      sed -i /filewatch/d 3rd/bee.lua/test/test.lua
+      substituteInPlace 3rd/bee.lua/test/test.lua \
+        --replace-fail 'require "test_filewatch"' ""
 
       # flaky tests on linux
       # https://github.com/LuaLS/lua-language-server/issues/2926
-      sed -i /load-relative-library/d test/tclient/init.lua
+      substituteInPlace test/tclient/init.lua \
+        --replace-fail "require 'tclient.tests.load-relative-library'" ""
 
       pushd 3rd/luamake
     ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin (
       # This package uses the program clang for C and C++ files. The language
       # is selected via the command line argument -std, but this do not work
       # in combination with the nixpkgs clang wrapper. Therefor we have to
       # find all c++ compiler statements and replace $cc (which expands to
       # clang) with clang++.
-      sed -i compile/ninja/macos.ninja \
-        -e '/c++/s,$cc,clang++,' \
-        -e '/test.lua/s,= .*,= true,' \
-        -e '/ldl/s,$cc,clang++,'
-      sed -i scripts/compiler/gcc.lua \
-        -e '/cxx_/s,$cc,clang++,'
-    '';
+      ''
+        sed -i compile/ninja/macos.ninja \
+          -e '/c++/s,$cc,clang++,' \
+          -e '/test.lua/s,= .*,= true,' \
+          -e '/ldl/s,$cc,clang++,'
+        sed -i scripts/compiler/gcc.lua \
+          -e '/cxx_/s,$cc,clang++,'
+      ''
+      # Avoid relying on ditto (impure)
+      + ''
+        substituteInPlace compile/ninja/macos.ninja \
+          --replace-fail "ditto" "rsync -a"
+
+        substituteInPlace scripts/writer.lua \
+          --replace-fail "ditto" "rsync -a"
+      ''
+    );
 
   ninjaFlags = [
     "-fcompile/ninja/${if stdenv.hostPlatform.isDarwin then "macos" else "linux"}.ninja"
@@ -95,19 +110,25 @@ stdenv.mkDerivation (finalAttrs: {
   # some tests require local networking
   __darwinAllowLocalNetworking = true;
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Language server that offers Lua language support";
     homepage = "https://github.com/luals/lua-language-server";
     changelog = "https://github.com/LuaLS/lua-language-server/blob/${finalAttrs.version}/changelog.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       figsoda
       gepbird
       sei40kr
     ];
     mainProgram = "lua-language-server";
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -2,11 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   ninja,
   makeWrapper,
-  CoreFoundation,
-  Foundation,
-  ditto,
+
+  # buildInputs
+  apple-sdk_11,
+  darwinMinVersionHook,
   nix-update-script,
 }:
 
@@ -28,9 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    CoreFoundation
-    Foundation
-    ditto
+    darwin.ditto
+    # aligned_alloc
+    apple-sdk_11
+    (darwinMinVersionHook "10.15")
   ];
 
   postPatch =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7929,11 +7929,6 @@ with pkgs;
 
   fortran-language-server = python3.pkgs.callPackage ../development/tools/language-servers/fortran-language-server { };
 
-  lua-language-server = darwin.apple_sdk_11_0.callPackage ../development/tools/language-servers/lua-language-server {
-    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Foundation;
-    inherit (darwin) ditto;
-  };
-
   inherit (callPackages ../development/tools/language-servers/nixd {
     llvmPackages = llvmPackages_16;
     nix = nixVersions.nix_2_19;


### PR DESCRIPTION
## Things done

- **lua-language-server: move to by-name**
- **lua-language-server: clean derivation**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
