### PR TITLE
uhdm, surelog 1.83 -> 1.84-unstable-2024-11-09

### DIFF
--- a/pkgs/by-name/su/surelog/package.nix
+++ b/pkgs/by-name/su/surelog/package.nix
@@ -17,13 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "surelog";
-  version = "1.83";
+  version = "1.84-unstable-2024-11-09";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "surelog";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-V4LmW4ca6KfugOu0XnGwutRqWR/9K6ESokHOB2yAVag=";
+    # Once we're back on a stable tag, use "v$(finalAttrs.version}" below.
+    rev = "da88163a02dbc16f1af3514f281b93941d371ad9";
+    hash = "sha256-TIwXIMcDImZjCIiXwvT2MhukArgrWCgOf2AOvkG/55g=";
     fetchSubmodules = false;  # we use all dependencies from nix
   };
 
@@ -70,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/chipsalliance/Surelog";
     license = lib.licenses.asl20;
     mainProgram = "surelog";
-    maintainers = with lib.maintainers; [ matthuszagh ];
+    maintainers = with lib.maintainers; [ matthuszagh hzeller ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/uh/uhdm/package.nix
+++ b/pkgs/by-name/uh/uhdm/package.nix
@@ -11,13 +11,14 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "UHDM";
   # When updating this package, also consider updating science/logic/surelog
-  version = "1.83";
+  version = "1.84-unstable-2024-10-06";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "UHDM";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-va8qAzsg589C6rLmG1uIMDr4X30qpBgRO1ZVKdEs5ok=";
+    # After we're back on a stable tag, use v${finalAttrs.version}
+    rev = "857f68de3ce5b6f919f3a0f489c93072751b1578";
+    hash = "sha256-qHcRncsvMiSJji+JLOlfQ87+pfKg+zvlqMTXKpImvTM=";
     fetchSubmodules = false;  # we use all dependencies from nix
   };
 
@@ -45,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Universal Hardware Data Model";
     homepage = "https://github.com/chipsalliance/UHDM";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ matthuszagh ];
+    maintainers = with lib.maintainers; [ matthuszagh hzeller ];
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
Update both, UHDM and Surelog (that are somewhat version-locked) to 1.84 and their respective latest unstable upstream git hashes.

Two separate commits for UHDM and Surelog.

Replaces #332963 #354369

Also, adding myself as maintainer as discussed in https://github.com/NixOS/nixpkgs/pull/311846#issuecomment-2119457410

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
