### PR TITLE
nixos/home-assistant: add support for amshan

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -708,6 +708,9 @@ in {
           "zha"
           "zwave"
           "zwave_js"
+
+          # Custom components, maintained manually.
+          "amshan"
         ];
       in {
         ExecStart = escapeSystemdExecArgs ([

--- a/pkgs/development/python-modules/amshan/default.nix
+++ b/pkgs/development/python-modules/amshan/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  construct,
+  paho-mqtt,
+  pyserial-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "amshan";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "toreamun";
+    repo = "amshan";
+    rev = version;
+    hash = "sha256-aw0wTqb2s84STVUN55h6L926pXwaMSppBCfXZVb87w0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    construct
+    paho-mqtt
+    pyserial-asyncio
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "han" ];
+
+  meta = {
+    description = "Decode smart power meter data stream of Cosem HDLC frames used by MBUS";
+    longDescription = ''
+      The package has special support of formats for Aidon, Kaifa and Kamstrup
+      meters used in Norway and Sweden (AMS HAN).
+    '';
+    homepage = "https://github.com/toreamun/amshan";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bjornfor ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/amshan/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/amshan/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  amshan,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "toreamun";
+  domain = "amshan";
+  version = "2024.12.0";
+
+  src = fetchFromGitHub {
+    owner = "toreamun";
+    repo = "amshan-homeassistant";
+    tag = version;
+    hash = "sha256-L7TGdUjDvIRP9dHIkng9GYwilmRzhGbUK6ivx8PVtQ4=";
+  };
+
+  dependencies = [
+    amshan
+  ];
+
+  meta = {
+    description = "Home Assistant integration for electricity meters (AMS/HAN/P1)";
+    longDescription = ''
+      The integration supports both streaming (serial port / TCP/IP) and MQTT
+      (Tibber Pulse, energyintelligence.se etc.).
+    '';
+    homepage = "https://github.com/toreamun/amshan-homeassistant";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bjornfor ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -588,6 +588,8 @@ self: super: with self; {
 
   amqtt = callPackage ../development/python-modules/amqtt { };
 
+  amshan = callPackage ../development/python-modules/amshan { };
+
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };
 
   ancp-bids = callPackage ../development/python-modules/ancp-bids { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Package [amshan-homeassistant](https://github.com/toreamun/amshan-homeassistant) and enable required serial port access in the NixOS module for home-assistant.

With these changes[1] I successfully got data from my electricity meter (via a small USB to MBUS slave adapter).

[1] I tested on NixOS 24.11, then rebased onto master.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
