### PR TITLE
proton-ge-bin: Automate switching to new GE-Proton version after update

### DIFF
--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -25,7 +25,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Also leave some breadcrumbs in the file.
     echo "${finalAttrs.pname} should not be installed into environments. Please use programs.steam.extraCompatPackages instead." > $out
 
-    ln -s $src $steamcompattool
+    mkdir $steamcompattool
+    ln -s $src/* $steamcompattool
+    rm $steamcompattool/{compatibilitytool.vdf,proton,version}
+    cp $src/{compatibilitytool.vdf,proton,version} $steamcompattool
+
+    sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/compatibilitytool.vdf
+    sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/proton
+    sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/version
 
     runHook postBuild
   '';

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -32,7 +32,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/compatibilitytool.vdf
     sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/proton
-    sed -i -r 's|GE-Proton[0-9]*-[0-9]*|GE-Proton|' $steamcompattool/version
 
     runHook postBuild
   '';


### PR DESCRIPTION
The purpose of this package is to automate the downloading/updating of GE-Proton. Since steam only sees the most recent version, every update resets the places where this GE-Proton was selected and we have to reselect the new version manually in the steam UI.

Inspired by https://aur.archlinux.org/packages/proton-ge-custom-bin, this PR changes the version as steam sees it to just be "GE-Proton", so after setting it once in the steam UI, it always points to the most recent version and doesn't have to be changed manually after updates anymore.