### PR TITLE
rmapi: 0.25 -> 0.0.27.1 and switching to a maintained fork

### DIFF
--- a/pkgs/by-name/rm/rmapi/package.nix
+++ b/pkgs/by-name/rm/rmapi/package.nix
@@ -2,23 +2,23 @@
 
 buildGoModule rec {
   pname = "rmapi";
-  version = "0.0.25";
+  version = "0.0.27.1";
 
   src = fetchFromGitHub {
-    owner = "juruen";
+    owner = "ddvk";
     repo = "rmapi";
     rev = "v${version}";
-    sha256 = "sha256-7pwCd9tey7w5B8UgsMLHegPqmmY1prLM+Sk9o42X9lY=";
+    sha256 = "sha256-nwGTBCzA9+J3S3Gd3YgwCWAj/gMcoS19awluDZWZCbU=";
   };
 
-  vendorHash = "sha256-Id2RaiSxthyR6egDQz2zulbSZ4STRTaA3yQIr6Mx9kg=";
+  vendorHash = "sha256-5m3/XFyBEWM8UB3WylkBj+QWI5XsnlVD4K3BhKVVCB4=";
 
   doCheck = false;
 
   meta = with lib; {
     description = "Go app that allows access to the ReMarkable Cloud API programmatically";
-    homepage = "https://github.com/juruen/rmapi";
-    changelog = "https://github.com/juruen/rmapi/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/ddvk/rmapi";
+    changelog = "https://github.com/ddvk/rmapi/blob/v${version}/CHANGELOG.md";
     license = licenses.agpl3Only;
     maintainers = [ maintainers.nickhu ];
     mainProgram = "rmapi";


### PR DESCRIPTION
Current version is outdated and falls behind server API:
```console
$ rmapi
ERROR: 2024/11/10 23:41:20 main.go:77: failed to build documents tree, last error: request failed with status 410
```

https://github.com/juruen/rmapi repo is archived
https://github.com/ddvk/rmapi looks like a viable fork

This fork and version bump is suggested in
https://www.reddit.com/r/RemarkableTablet/comments/1flzmqq/rmapi_error/
https://github.com/ddvk/rmapi/issues/5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
