### PR TITLE
traefik: 3.1.4 -> 3.2.0

### DIFF
--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -2,16 +2,16 @@
 
 buildGo123Module rec {
   pname = "traefik";
-  version = "3.1.4";
+  version = "3.2.0";
 
   # Archive with static assets for webui
   src = fetchzip {
     url = "https://github.com/traefik/traefik/releases/download/v${version}/traefik-v${version}.src.tar.gz";
-    hash = "sha256-e77PCMeN6Ck6hQ3Rx7MU4EL+f/1kpA2E+gVcISoUnf4=";
+    hash = "sha256-z3jRn+Kl8OWH/9uZF113JVI/U0AM9do8zSvaR7lGBUw=";
     stripRoot = false;
   };
 
-  vendorHash = "sha256-iYwA/y9AuHomyEckOyl4845lkQkeBAFDsGiZWESylqs=";
+  vendorHash = "sha256-L4x2+zADqZLJskpgGTRhDarNqD68aZR10aqMmE92Ue8=";
 
   subPackages = [ "cmd/traefik" ];
 


### PR DESCRIPTION
https://github.com/traefik/traefik/releases/tag/v3.2.0
