### PR TITLE
equicord: 1.10.4 -> 1.10.6; equibop: 2.0.9 -> 2.1.1

### DIFF
--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "equibop";
-  version = "2.0.9";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equibop";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-mK/zoW8Km6xlppxJnVbuas4yE1rpAOd9QnjETlxxnsE=";
+    hash = "sha256-LGgmWaC7iYj0Mx5wPKmLkYV2ozyhkiwrE4v4uFB0erg=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    hash = "sha256-TSdkHSZTbFf3Nq0QHDNTeUHmd6N+L1N1kSiKt0uNF6s=";
+    hash = "sha256-dIz/HyhzFU86QqQEQ9qWSthKB9HfoRJbmpc3raWNbcA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -9,7 +9,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "equicord";
-  version = "1.10.4"; # from package.json
+  version = "1.10.6"; # from package.json
 
   src = fetchFromGitHub {
     owner = "Equicord";


### PR DESCRIPTION
- **equibop: 2.0.9 -> 2.1.1**
- **equicord: 1.10.4 -> 1.10.6**

Updates Equicord and Equibop packages to their latest versions as per upstream
request. I think Equibop is supposed to be updated automatically, but r-ryantm
did not yet get to it.
