### PR TITLE
[release-24.05] python311Packages.imap-tools: backport regression fix

### DIFF
--- a/pkgs/development/python-modules/imap-tools/0001-Fixed-bug-in-3.12.6-after-CVE-2023-27043.patch
+++ b/pkgs/development/python-modules/imap-tools/0001-Fixed-bug-in-3.12.6-after-CVE-2023-27043.patch
@@ -1,0 +1,68 @@
+From e7ee5f5d93315c48b1193a5d7471cbc0d8d97c41 Mon Sep 17 00:00:00 2001
+From: "v.kaukin" <v.kaukin@u6.ru>
+Date: Fri, 4 Oct 2024 10:32:50 +0500
+Subject: [PATCH] Fixed bug in 3.12.6+ after [CVE-2023-27043]
+
+(cherry picked from commit 017208a87d497aae6fe90f6d250a1c786615e241)
+---
+ imap_tools/utils.py |  7 ++++++-
+ tests/test_utils.py | 11 ++++++++++-
+ 2 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/imap_tools/utils.py b/imap_tools/utils.py
+index 18bacee..9c87bbf 100644
+--- a/imap_tools/utils.py
++++ b/imap_tools/utils.py
+@@ -78,6 +78,11 @@ class EmailAddress:
+         return all(getattr(self, i) == getattr(other, i) for i in self.__slots__)
+ 
+ 
++def remove_non_printable(value: str) -> str:
++    """Remove non-printable character from value"""
++    return ''.join(i for i in value if i.isprintable())
++
++
+ def parse_email_addresses(raw_header: Union[str, Header]) -> Tuple[EmailAddress, ...]:
+     """
+     Parse email addresses from header
+@@ -87,7 +92,7 @@ def parse_email_addresses(raw_header: Union[str, Header]) -> Tuple[EmailAddress,
+     result = []
+     if type(raw_header) is Header:
+         raw_header = decode_value(*decode_header(raw_header)[0])
+-    for raw_name, email in getaddresses([raw_header.replace('\r\n', '').replace('\n', '')]):
++    for raw_name, email in getaddresses([remove_non_printable(raw_header)]):
+         name = decode_value(*decode_header(raw_name)[0]).strip()
+         email = email.strip()
+         if not (name or email):
+diff --git a/tests/test_utils.py b/tests/test_utils.py
+index abc4b38..f586641 100644
+--- a/tests/test_utils.py
++++ b/tests/test_utils.py
+@@ -1,14 +1,23 @@
+ import unittest
+ import datetime
++import unicodedata
+ 
+ from imap_tools.errors import ImapToolsError, UnexpectedCommandStatusError, MailboxCopyError
+ from imap_tools.consts import MailMessageFlags
+ from imap_tools.utils import clean_flags, chunks, quote, pairs_to_dict, decode_value, check_command_status, \
+-    parse_email_date, parse_email_addresses, EmailAddress, clean_uids, replace_html_ct_charset
++    parse_email_date, parse_email_addresses, EmailAddress, clean_uids, replace_html_ct_charset, remove_non_printable
+ 
+ 
+ class UtilsTest(unittest.TestCase):
+ 
++    def test_remove_non_printable(self):
++        all_non_printable_chars = []
++        for i in range(0x110000):  # Диапазон всех кодовых точек Unicode
++            char = chr(i)
++            if unicodedata.category(char).startswith('C'):
++                all_non_printable_chars.append(char)
++        self.assertEqual(remove_non_printable('123{}'.format(''.join(all_non_printable_chars))), '123')
++
+     def test_clean_uids(self):
+         # *clean_uids also implicitly tested in test_query.py
+         self.assertEqual(clean_uids('11'), '11')
+-- 
+2.47.0
+

--- a/pkgs/development/python-modules/imap-tools/default.nix
+++ b/pkgs/development/python-modules/imap-tools/default.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
     hash = "sha256-kY6Y8Uu1HwSkcmlKL5+zPh4n+4mofX2aoPVXAZvInlI=";
   };
 
+  patches = [
+    # https://github.com/ikvk/imap_tools/commit/017208a87d497aae6fe90f6d250a1c786615e241
+    ./0001-Fixed-bug-in-3.12.6-after-CVE-2023-27043.patch
+  ];
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/354725

Closes https://github.com/NixOS/nixpkgs/pull/354728

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
