### PR TITLE
use fmt_11 for mariadb and apply patch to fix fmt_11 build

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   enableShared ? !stdenv.hostPlatform.isStatic,
 
@@ -39,7 +40,7 @@ let
 
       nativeBuildInputs = [ cmake ];
 
-      cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}" ];
+      cmakeFlags = [ (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared) ];
 
       doCheck = true;
 
@@ -86,5 +87,12 @@ in
   fmt_11 = generic {
     version = "11.0.1";
     sha256 = "sha256-EPidbZxCvysrL64AzbpJDowiNxqy4ii+qwSWAFwf/Ps=";
+    patches = [
+      (fetchpatch {
+        name = "get-rid-of-std-copy-fix-clang.patch";
+        url = "https://github.com/fmtlib/fmt/commit/6e462b89aa22fd5f737ed162d0150e145ccb1914.patch";
+        hash = "sha256-tRU1y1VCxtQ5J2yvFmwUx+YNcQs8izzLImD37KBiCFk=";
+      })
+    ];
   };
 }

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -85,8 +85,8 @@ in
   };
 
   fmt_11 = generic {
-    version = "11.0.1";
-    sha256 = "sha256-EPidbZxCvysrL64AzbpJDowiNxqy4ii+qwSWAFwf/Ps=";
+    version = "11.0.2";
+    sha256 = "sha256-IKNt4xUoVi750zBti5iJJcCk3zivTt7nU12RIf8pM+0=";
     patches = [
       (fetchpatch {
         name = "get-rid-of-std-copy-fix-clang.patch";

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -14,7 +14,7 @@ let
     , bzip2, lz4, lzo, snappy, xz, zlib, zstd
     , cracklib, judy, libevent, libxml2
     , linux-pam, numactl
-    , fmt_8
+    , fmt_11
     , withStorageMroonga ? true, kytea, libsodium, msgpack, zeromq
     , withStorageRocks ? true
     , withEmbedded ? false
@@ -149,7 +149,7 @@ let
       ];
 
       buildInputs = common.buildInputs
-        ++ lib.optionals (lib.versionAtLeast common.version "10.7") [ fmt_8 ];
+        ++ lib.optionals (lib.versionAtLeast common.version "10.11") [ fmt_11 ];
 
       cmakeFlags = common.cmakeFlags ++ [
         "-DPLUGIN_AUTH_PAM=NO"
@@ -179,7 +179,7 @@ let
         ++ lib.optionals stdenv.hostPlatform.isLinux [ linux-pam ]
         ++ lib.optional (!stdenv.hostPlatform.isDarwin) mytopEnv
         ++ lib.optionals withStorageMroonga [ kytea libsodium msgpack zeromq ]
-        ++ lib.optionals (lib.versionAtLeast common.version "10.7") [ fmt_8 ];
+        ++ lib.optionals (lib.versionAtLeast common.version "10.11") [ fmt_11 ];
 
       propagatedBuildInputs = lib.optional withNuma numactl;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
apply fmt patch:
https://github.com/fmtlib/fmt/commit/6e462b89aa22fd5f737ed162d0150e145ccb1914

update fmt_11: 11.0.1 -> 11.0.2
https://github.com/fmtlib/fmt/releases/tag/11.0.2
https://github.com/fmtlib/fmt/compare/11.0.1...11.0.2
- see also #350061


mariadb builds with fmt_11:
https://github.com/MariaDB/server/blob/mariadb-10.11.10/cmake/libfmt.cmake

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@emilazy 