### PR TITLE
amazon-ec2-net-utils: init at 2.5.4

### DIFF
--- a/pkgs/by-name/am/amazon-ec2-net-utils/package.nix
+++ b/pkgs/by-name/am/amazon-ec2-net-utils/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  bash,
+  coreutils,
+  curl,
+  fetchFromGitHub,
+  gnugrep,
+  gnused,
+  installShellFiles,
+  iproute2,
+  makeWrapper,
+  nix-update-script,
+  systemd,
+  util-linux,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "amazon-ec2-net-utils";
+  version = "2.5.4";
+
+  src = fetchFromGitHub {
+    owner = "amazonlinux";
+    repo = "amazon-ec2-net-utils";
+    tag = "v${version}";
+    hash = "sha256-uHYEavdBggdXBYUSDFvajRVLxcRge/kiu60c1a4SPRw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  buildInputs = [
+    bash
+  ];
+
+  # See https://github.com/amazonlinux/amazon-ec2-net-utils/blob/v2.5.4/GNUmakefile#L26-L37.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+
+    for file in bin/*.sh; do
+      install -D -m 755 "$file" $out/bin/$(basename --suffix ".sh" "$file")
+      substituteInPlace $out/bin/$(basename --suffix ".sh" "$file") \
+        --replace-fail AMAZON_EC2_NET_UTILS_LIBDIR $out/share/amazon-ec2-net-utils
+    done
+
+    substituteInPlace $out/bin/setup-policy-routes \
+      --replace-fail /lib/systemd ${systemd}/lib/systemd
+
+    wrapProgram $out/bin/setup-policy-routes \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          # bin/setup-policy-roots.sh sources lib/lib.sh which needs these.
+          #
+          # lib/lib.sh isn't executable so we can't use it with wrapProgram.
+          curl
+          gnugrep
+          gnused
+          iproute2
+          systemd
+          util-linux
+        ]
+      }
+
+    for file in lib/*.sh; do
+      install -D -m 644 -t $out/share/amazon-ec2-net-utils "$file"
+    done
+
+    substituteInPlace $out/share/amazon-ec2-net-utils/lib.sh \
+      --replace-fail /usr/lib/systemd $out/lib/systemd
+
+    for file in udev/*.rules; do
+      install -D -m 644 -t $out/lib/udev/rules.d "$file"
+    done
+
+    substituteInPlace $out/lib/udev/rules.d/99-vpc-policy-routes.rules \
+      --replace-fail /usr/bin/systemctl ${lib.getExe' systemd "systemctl"}
+
+    for file in systemd/network/*.network; do
+      install -D -m 644 -t $out/lib/systemd/network "$file"
+    done
+
+    for file in systemd/system/*.{service,timer}; do
+      install -D -m 644 -t $out/lib/systemd/system "$file"
+    done
+
+    substituteInPlace $out/lib/systemd/system/policy-routes@.service \
+      --replace-fail /usr/bin/setup-policy-routes $out/bin/setup-policy-routes
+
+    substituteInPlace $out/lib/systemd/system/refresh-policy-routes@.service \
+      --replace-fail /usr/bin/setup-policy-routes $out/bin/setup-policy-routes
+
+    installManPage doc/*.8
+
+    runHook postInstall
+  '';
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Contains a set of utilities for managing elastic network interfaces on Amazon EC2";
+    homepage = "https://github.com/amazonlinux/amazon-ec2-net-utils";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sielicki ];
+  };
+}


### PR DESCRIPTION
Initialize [amazon-ec2-net-utils](https://github.com/amazonlinux/amazon-ec2-net-utils) at [2.5.4](https://github.com/amazonlinux/amazon-ec2-net-utils/releases/tag/v2.5.4).

This includes udev rules which create systemd units and timers for refreshing systemd-networkd policies for Elastic Network Interfaces (ENIs) which can be hot-attached/detached.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
