### PR TITLE
stdenv: add Silvermont support, remove incorrect AES support

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -11,12 +11,13 @@ rec {
     x86-64-v3      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2"          "fma"        ];
     x86-64-v4      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2" "avx512" "fma"        ];
     # x86_64 Intel
-    nehalem        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
-    westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
-    sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
-    ivybridge      = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
-    haswell        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
-    broadwell      = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
+    nehalem        = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    silvermont     = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx"                              ];
+    ivybridge      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx"                              ];
+    haswell        = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2"          "fma"        ];
+    broadwell      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2"          "fma"        ];
     skylake        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
     skylake-avx512 = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2" "avx512" "fma"        ];
     cannonlake     = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2" "avx512" "fma"        ];


### PR DESCRIPTION
Add Silvermont support.

According to [gcc manual](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html), Nehalem, Westmere, Sandybridge, Ivybridge, Haswell and Broadwell have no AES support, so I remove it.

