### PR TITLE
Mumps: use magic __structuredAttrs to handle space in makeFlags

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     gfortran
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames ++ lib.optional mpiSupport mpi;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   # Parmetis should be placed before scotch to avoid conflict of header file "parmetis.h"
   buildInputs =

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -125,7 +125,6 @@ stdenv.mkDerivation (finalAttrs: {
     ${lib.optionalString stdenv.hostPlatform.isDarwin "export DYLD_LIBRARY_PATH=$out/lib\n"}
     ${lib.optionalString mpiSupport "export MPIRUN='mpirun -n 2'\n"}
     cd examples
-    make all
     $MPIRUN ./ssimpletest <input_simpletest_real
     $MPIRUN ./dsimpletest <input_simpletest_real
     $MPIRUN ./csimpletest <input_simpletest_cmplx

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -21,43 +21,37 @@ assert withParmetis -> mpiSupport;
 assert withPtScotch -> mpiSupport;
 let
   profile = if mpiSupport then "debian.PAR" else "debian.SEQ";
-  metisFlags =
-    if withParmetis then
-      ''
-        IMETIS="-I${parmetis}/include -I${metis}/include" \
-        LMETIS="-L${parmetis}/lib -lparmetis -L${metis}/lib -lmetis"
-      ''
-    else
-      ''
-        IMETIS=-I${metis}/include \
-        LMETIS="-L${metis}/lib -lmetis"
-      '';
-  scotchFlags =
+  LMETIS = toString ([ "-lmetis" ] ++ lib.optional withParmetis "-lparmetis");
+  LSCOTCH = toString (
     if withPtScotch then
-      ''
-        ISCOTCH=-I${scotch.dev}/include \
-        LSCOTCH="-L${scotch}/lib -lptscotch -lptesmumps -lptscotcherr"
-      ''
+      [
+        "-lptscotch"
+        "-lptesmumps"
+        "-lptscotcherr"
+      ]
     else
-      ''
-        ISCOTCH=-I${scotch.dev}/include \
-        LSCOTCH="-L${scotch}/lib -lesmumps -lscotch -lscotcherr"
-      '';
-  macroFlags =
-    "-Dmetis -Dpord -Dscotch"
-    + lib.optionalString withParmetis " -Dparmetis"
-    + lib.optionalString withPtScotch " -Dptscotch";
-  # Optimized options
-  # Disable -fopenmp in lines below to benefit from OpenMP
-  optFlags = ''
-    OPTF="-O3 -fallow-argument-mismatch" \
-    OPTL="-O3" \
-    OPTC="-O3"
-  '';
+      [
+        "-lesmumps"
+        "-lscotch"
+        "-lscotcherr"
+      ]
+  );
+  ORDERINGSF = toString (
+    [
+      "-Dmetis"
+      "-Dpord"
+      "-Dscotch"
+    ]
+    ++ lib.optional withParmetis "-Dparmetis"
+    ++ lib.optional withPtScotch "-Dptscotch"
+  );
 in
 stdenv.mkDerivation (finalAttrs: {
   name = "mumps";
   version = "5.7.3";
+  # makeFlags contain space and one should use makeFlagsArray+
+  # Setting this magic var is an optional solution
+  __structuredAttrs = true;
 
   src = fetchzip {
     url = "https://mumps-solver.org/MUMPS_${finalAttrs.version}.tar.gz";
@@ -76,16 +70,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  preBuild = ''
-    makeFlagsArray+=(${metisFlags} ${scotchFlags} ORDERINGSF="${macroFlags}" ${optFlags})
-  '';
-
   makeFlags =
     lib.optionals stdenv.hostPlatform.isDarwin [
       "SONAME="
       "LIBEXT_SHARED=.dylib"
     ]
     ++ [
+      "ISCOTCH=-I${scotch.dev}/include"
+      "LMETIS=${LMETIS}"
+      "LSCOTCH=${LSCOTCH}"
+      "ORDERINGSF=${ORDERINGSF}"
+      "OPTF=-O3 -fallow-argument-mismatch"
+      "OPTC=-O3"
+      "OPTL=-O3"
       "SCALAP=-lscalapack"
       "allshared"
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
1. remove mpi from nativeBuildInputs (which should be buildInputs and is alreay propogated by scalapack)
2. remove "make all" in installCheckPhase that do nothing
3. use magic __structuredAttrs to handle space in makeFlags


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
