### PR TITLE
maven.mavenPatchPomHook: init, add to buildMavenPackage

### DIFF
--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (builtins.removeAttrs args [ "mvnFetchExtraArgs" ] // {
 
   nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
     maven
+    maven.mavenPatchPomHook
   ];
 
   JAVA_HOME = mvnJdk;

--- a/pkgs/by-name/ma/maven/hooks/patch-pom-hook.sh
+++ b/pkgs/by-name/ma/maven/hooks/patch-pom-hook.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+
+# Set project.build.outputTimestamp in pom.xml to the first second of 1980 for reproducibility,
+# assuming that it is not already set.
+function mavenPatchPomPhase() {
+  runHook preMavenPatchPomPhase
+
+  local jarEpoch="1980-01-01T00:01:00Z"
+
+  if @xmlstarlet@ sel -N "ns=http://maven.apache.org/POM/4.0.0" -t -m "/project/properties/project.build.outputTimestamp" -v . -n pom.xml &>/dev/null; then
+    nixWarnLog "${FUNCNAME[0]}: property project.build.outputTimestamp in pom.xml already set, doing nothing"
+  else
+    nixInfoLog "${FUNCNAME[0]}: setting property project.build.outputTimestamp in pom.xml to $jarEpoch"
+    @xmlstarlet@ ed --inplace -N "ns=http://maven.apache.org/POM/4.0.0" \
+      -s "/ns:project/ns:properties" -t elem -n "project.build.outputTimestamp" -v "$jarEpoch" \
+      pom.xml
+  fi
+
+  runHook postMavenPatchPomPhase
+}
+
+if [ -z "${dontPatchMavenPom-}" ]; then
+  appendToVar preConfigurePhases mavenPatchPomPhase
+fi

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -5,6 +5,9 @@
   jdk_headless,
   makeWrapper,
   stdenvNoCC,
+  makeSetupHook,
+  substituteAll,
+  xmlstarlet,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -41,6 +44,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     buildMavenPackage = callPackage ./build-maven-package.nix {
       maven = finalAttrs.finalPackage;
     };
+    mavenPatchPomHook = makeSetupHook {
+      name = "maven-patch-pom-hook";
+      substitutions = {
+        xmlstarlet = lib.getExe xmlstarlet;
+      };
+    } ./hooks/patch-pom-hook.sh;
   };
 
   meta = {


### PR DESCRIPTION
Patch all `pom.xml`s to set `project.build.outputTimestamp` to the first second of 1980 for reproducibility.

Per Maven upstream guidance:
https://issues.apache.org/jira/browse/MNG-8258

Closes #25686

I placed the hook into a `hooks` subdirectory to simplify adding more hooks in the future.

Caveat: This adds `xmlstarlet` as a build-time dependency in every package that uses this builder, but `xmlstarlet` is the most reliable way to modify XML as far as I know.

~~I'm also not fond of the way that we append to `postPatch`; we should consider moving this builder to setup hooks, which is what the Rust builders and other builders do.~~ This is now a hook; I plan on eventually refactoring the rest of the Maven build story to use hooks.

### Testing this change

Pick a package that depends on Maven, like `gol`. Check out this branch, then:
```sh
nix-build -A gol
nix-build -A gol --check
```

The results should be byte-for-byte equal. Beware: Some packages have plugins that misbehave; this PR only fixes one part of the problem. It would be interesting to see which packages still aren't deterministic after this change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
