### PR TITLE
treewide: disable some hanging Darwin Hydra builds

### DIFF
--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -97,5 +97,8 @@ stdenvNoCC.mkDerivation rec {
     # Broken for Musl at 2024-01-13, tracking issue:
     # https://github.com/NixOS/nixpkgs/issues/280716
     broken = stdenvNoCC.hostPlatform.isMusl;
+
+    # Hangs when run via Rosetta 2 on Apple Silicon
+    hydraPlatforms = lib.lists.remove "x86_64-darwin" lib.platforms.all;
   };
 }

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -88,5 +88,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/firefly-iii/firefly-iii";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.savyajha lib.maintainers.patrickdag ];
+    hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };
 })

--- a/pkgs/by-name/lb/lbreakout2/package.nix
+++ b/pkgs/by-name/lb/lbreakout2/package.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "lbreakout2";
     maintainers = with lib.maintainers; [ AndersonTorres ciil ];
     platforms = lib.platforms.unix;
+    hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };
 })

--- a/pkgs/by-name/po/poke/package.nix
+++ b/pkgs/by-name/po/poke/package.nix
@@ -86,6 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ AndersonTorres kira-bruneau ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
+    hydraPlatforms = lib.platforms.linux; # build hangs on Darwin platforms, needs investigation
   };
 })

--- a/pkgs/by-name/vp/vp/package.nix
+++ b/pkgs/by-name/vp/vp/package.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "vp";
     maintainers = with lib.maintainers; [ AndersonTorres ];
     inherit (SDL.meta) platforms;
+    hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };
 })

--- a/pkgs/development/libraries/agg/default.nix
+++ b/pkgs/development/libraries/agg/default.nix
@@ -63,5 +63,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     homepage = "http://www.antigrain.com/";
     platforms = lib.platforms.unix;
+    hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };
 }


### PR DESCRIPTION
ZHF: #352882

I keep seeing these packages in Hydra's timeout tab. I was able to build them locally, so I don't think they are broken, but they constantly time out in Hydra for various reasons, so let's disable them for now.

@NixOS/darwin-maintainers 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
