### PR TITLE
py-spy: 0.3.14-unstable-2024-02-27 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/py-spy/default.nix
+++ b/pkgs/development/tools/py-spy/default.nix
@@ -9,21 +9,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "py-spy";
-  version = "0.3.14-unstable-2024-02-27";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "benfred";
     repo = "py-spy";
-    rev = "8dd54929106916a3c961cc57c1172793ce126180";
-    hash = "sha256-rrngOqlXIJXbh3A7OBEcgoakZyyuvlHHXhWo3/1BRpY=";
+    rev = "v${version}";
+    hash = "sha256-T96F8xgB9HRwuvDLXi6+lfi8za/iNn1NAbG4AIpE0V0=";
   };
 
-  cargoHash = "sha256-gNnuuq2cz168Gaw+gL2nJ8EC32BMPu9DgnRzIh1hGKk=";
+  cargoHash = "sha256-SkHlXvhmw7swjZDdat0z0o5ATDJ1qSE/iwiwywsFOyw=";
 
-  # error: linker `arm-linux-gnueabihf-gcc` not found
-  postPatch = ''
-    rm .cargo/config
-  '';
+  buildFeatures = [ "unwind" ];
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
@@ -41,11 +38,8 @@ rustPlatform.buildRustPackage rec {
   env.NIX_CFLAGS_COMPILE = "-L${libunwind}/lib";
 
   checkFlags = [
-    # thread 'python_data_access::tests::test_copy_string' panicked at 'called `Result::unwrap()` on an `Err`
-    "--skip=python_data_access::tests::test_copy_string"
-  ] ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
-    # panicked at 'called `Result::unwrap()` on an `Err` value: failed to get os threadid
-    "--skip=test_thread_reuse"
+    # assertion `left == right` failed
+    "--skip=test_negative_linenumber_increment"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5053,10 +5053,7 @@ with pkgs;
 
   pypass = with python3Packages; toPythonApplication pypass;
 
-  py-spy = darwin.apple_sdk_11_0.callPackage ../development/tools/py-spy {
-    # https://github.com/benfred/py-spy/issues/633
-    python3 = python311;
-  };
+  py-spy = darwin.apple_sdk_11_0.callPackage ../development/tools/py-spy { };
 
   pydeps = with python3Packages; toPythonApplication pydeps;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/benfred/py-spy/releases/tag/v0.4.0
https://github.com/benfred/py-spy/compare/8dd54929106916a3c961cc57c1172793ce126180...593d6d8d26fddfe2287e36a673e4a8a9ba46ebcd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
