### PR TITLE
 python3Packages.djangocms-alias: init at 2.0.1 

### DIFF
--- a/pkgs/development/python-modules/djangocms-alias/default.nix
+++ b/pkgs/development/python-modules/djangocms-alias/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  django,
+  pythonOlder,
+  pytestCheckHook,
+  setuptools,
+  django-parler,
+  django-cms,
+  distutils,
+  pytest-django,
+  beautifulsoup4,
+  python,
+  django-app-helper,
+}:
+
+buildPythonPackage rec {
+  pname = "djangocms-alias";
+  version = "2.0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "django-cms";
+    repo = "djangocms-alias";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ZOushwfBMjzlnuY6vHtM6Ge/VotBHaosIhFItmVkqkc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    django-cms
+    django-parler
+  ];
+
+  checkInputs = [
+    beautifulsoup4
+    distutils
+    django-app-helper
+    pytestCheckHook
+    pytest-django
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} test_settings.py
+    runHook postCheck
+  '';
+
+  # Disable tests because dependency djangocms-versioning isn't packaged yet.
+  doCheck = false;
+
+  pythonImportCheck = [ "djangocms_alias" ];
+
+  meta = {
+    description = "Lean enterprise content management powered by Django";
+    homepage = "https://django-cms.org";
+    changelog = "https://github.com/django-cms/django-cms/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3323,6 +3323,8 @@ self: super: with self; {
 
   djangocms-text-ckeditor = callPackage ../development/python-modules/djangocms-text-ckeditor { };
 
+  djangocms-alias = callPackage ../development/python-modules/djangocms-alias { };
+
   django-admin-datta = callPackage ../development/python-modules/django-admin-datta { };
 
   django-admin-sortable2 = callPackage ../development/python-modules/django-admin-sortable2 { };


### PR DESCRIPTION
Adding Python module [djangocms-alias](https://github.com/django-cms/djangocms-alias), which „replicates and extends the alias function of django CMS version 3 for django CMS version 4“

Depends on

- https://github.com/NixOS/nixpkgs/pull/354163
- https://github.com/NixOS/nixpkgs/pull/352837

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
