### PR TITLE
pcsc-safenet: 10.8.28 -> 10.8.1050

### DIFF
--- a/pkgs/by-name/pc/pcsc-safenet/package.nix
+++ b/pkgs/by-name/pc/pcsc-safenet/package.nix
@@ -4,24 +4,22 @@
 , autoPatchelfHook
 , dpkg
 , gtk3
-, openssl_1_1
+, openssl
 , pcsclite
 }:
 
 stdenv.mkDerivation rec {
   pname = "pcsc-safenet";
-  version = "10.8.28";
+  version = "10.8.1050";
 
-  debName = "Installation/Standard/Ubuntu-2004/safenetauthenticationclient_${version}_amd64.deb";
+  debName = "Installation/Standard/Ubuntu-2204/safenetauthenticationclient_${version}_amd64.deb";
 
   # extract debian package from larger zip file
-  src =
-    let
-      versionWithUnderscores = builtins.replaceStrings ["."] ["_"] version;
-    in fetchzip {
-      url = "https://www.digicert.com/StaticFiles/SAC_${versionWithUnderscores}_GA_Build.zip";
-      hash = "sha256-7XWj3T9/KnmgQ05urOJV6dqgkAS/A2G7efnqjQO2ing=";
-    };
+  src = fetchzip {
+    # URL version name is different that the version name of the .deb file inside
+    url = "https://www.digicert.com/StaticFiles/Linux_SAC_10_8_R1_GA.zip";
+    hash = "sha256-Wh2Ax4ZVFKqn0yDwZmwvtUqwQNYyBng08IPfemHzZC0=";
+  };
 
   dontBuild = true;
   dontConfigure = true;
@@ -32,12 +30,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    openssl_1_1
+    openssl
     pcsclite
   ];
 
   runtimeDependencies = [
-    openssl_1_1
+    openssl
   ];
 
   nativeBuildInputs = [
@@ -75,7 +73,7 @@ stdenv.mkDerivation rec {
       done
     ) || exit
 
-    ln -sf ${lib.getLib openssl_1_1}/lib/libcrypto.so $out/lib/libcrypto.so.1.1.0
+    ln -sf ${lib.getLib openssl}/lib/libcrypto.so $out/lib/libcrypto.so.3
   '';
 
   dontAutoPatchelf = true;


### PR DESCRIPTION
## Description of changes

Update Safenet Authentication Client to 10.8.1050 (or 10.8 R1).

Switch to a supported, up to date openssl version.

Submitting again, because I accidentally closed old PR [here](https://github.com/NixOS/nixpkgs/pull/341808), and couldn't figure out a way to reopen.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [X] Tested SACTools, and the pkcs11 module library.
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@wldhx 
@FliegendeWurst - Sorry, I accidentally closed the other PR where you had requested changes - should be fixed here

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
