### PR TITLE
mopidy: include the PipeWire GStreamer plugin

### DIFF
--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, pythonPackages, wrapGAppsNoGuiHook
-, gst_all_1, glib-networking, gobject-introspection
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pythonPackages,
+  wrapGAppsNoGuiHook,
+  gst_all_1,
+  glib-networking,
+  gobject-introspection,
 }:
 
 pythonPackages.buildPythonApplication rec {
@@ -24,17 +31,22 @@ pythonPackages.buildPythonApplication rec {
     gst-plugins-rs
   ];
 
-  propagatedBuildInputs = [
-    gobject-introspection
-  ] ++ (with pythonPackages; [
-      gst-python
-      pygobject3
-      pykka
-      requests
-      setuptools
-      tornado
-    ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) dbus-python
-  );
+  propagatedBuildInputs =
+    [
+      gobject-introspection
+    ]
+    ++ (
+      with pythonPackages;
+      [
+        gst-python
+        pygobject3
+        pykka
+        requests
+        setuptools
+        tornado
+      ]
+      ++ lib.optional (!stdenv.hostPlatform.isDarwin) dbus-python
+    );
 
   propagatedNativeBuildInputs = [
     gobject-introspection
@@ -49,6 +61,6 @@ pythonPackages.buildPythonApplication rec {
     mainProgram = "mopidy";
     license = licenses.asl20;
     maintainers = [ maintainers.fpletz ];
-    hydraPlatforms = [];
+    hydraPlatforms = [ ];
   };
 }

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -7,6 +7,7 @@
   gst_all_1,
   glib-networking,
   gobject-introspection,
+  pipewire,
 }:
 
 pythonPackages.buildPythonApplication rec {
@@ -54,6 +55,12 @@ pythonPackages.buildPythonApplication rec {
 
   # There are no tests
   doCheck = false;
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${pipewire}/lib/gstreamer-1.0"
+    )
+  '';
 
   meta = with lib; {
     homepage = "https://www.mopidy.com/";


### PR DESCRIPTION
The Mopidy application can use the PipeWire GStreamer elements `pipewiresink` and `pipewiresrc`, but they are not currently available.
This PR just includes them.

The `mopidy.nix` file was also formatted appropriately.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
