### PR TITLE
airdrop-cli: init at 0-unstable-2024-04-13

### DIFF
--- a/pkgs/by-name/ai/airdrop-cli/package.nix
+++ b/pkgs/by-name/ai/airdrop-cli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  swift,
+  swiftPackages,
+  swiftpm,
+}:
+
+# Doesn't build without using the same stdenv (and Clang) to build swift
+swiftPackages.stdenv.mkDerivation {
+  pname = "airdrop-cli";
+  version = "0-unstable-2024-04-13";
+
+  src = fetchFromGitHub {
+    owner = "vldmrkl";
+    repo = "airdrop-cli";
+    rev = "dcdd570c3af3aae509ba7ad9fb26782b427f3a1a";
+    hash = "sha256-7gKKeedRayf27XrOhntu41AMXgxc7fqJRE8Jhbihh3o=";
+  };
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "Use Airdrop from the CLI on macOS written in Swift";
+    homepage = "https://github.com/vldmrkl/airdrop-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Enzime ];
+    mainProgram = "airdrop";
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
> A macOS CLI for AirDrop written in Swift

https://github.com/vldmrkl/airdrop-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
