### PR TITLE
gdal: 3.9.3 -> 3.10.0

### DIFF
--- a/pkgs/by-name/pd/pdal/package.nix
+++ b/pkgs/by-name/pd/pdal/package.nix
@@ -2,6 +2,8 @@
 , stdenv
 , callPackage
 , fetchFromGitHub
+, fetchpatch
+, fetchurl
 , testers
 
 , enableE57 ? lib.meta.availableOn stdenv.hostPlatform libe57format
@@ -36,6 +38,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-aRWVBCMGr/FX3g8tF7PP3sarN2DHx7AG3vvGAkQTuAM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "pdal-tests-gdal-3.10-compatibility.patch";
+      url = "https://github.com/PDAL/PDAL/commit/e6df3aa21f84ea49c79c338b87fe2e2797f4e44f.patch";
+      hash = "sha256-8AeWcMeZXth6y+Ox1rhK7cEySql//Jig46rHw7PyJh4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -108,6 +118,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Failure
     "pdal_app_plugin_test"
   ];
+
+  # Add binary test file that we can’t apply from the patch.
+  postPatch = ''
+    ln -s ${fetchurl {
+      url = "https://github.com/PDAL/PDAL/raw/e6df3aa21f84ea49c79c338b87fe2e2797f4e44f/test/data/gdal/1234_red_0_green_0_blue.tif";
+      hash = "sha256-x/jHMhZTKmQxlTkswDGszhBIfP/qgY0zJ8QIz+wR5S4=";
+    }} test/data/gdal/1234_red_0_green_0_blue.tif
+  '';
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   useMinimalFeatures ? false,
   useArmadillo ? (!useMinimalFeatures),
@@ -82,26 +81,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdal" + lib.optionalString useMinimalFeatures "-minimal";
-  version = "3.9.3";
+  version = "3.10.0";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8LY63s5vOVK0V37jQ60qFsaW/2D/13Xuy9/2OPLyTso=";
+    hash = "sha256-pb2xKTmJB7U1jIG80ENmZrR7vFw6YDoees43u/JhU3Y=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/OSGeo/gdal/commit/40c3212fe4ba93e5176df4cd8ae5e29e06bb6027.patch";
-      sha256 = "sha256-D55iT6E/YdpSyfN7KUDTh1gdmIDLHXW4VC5d6D9B7ls=";
-    })
-    (fetchpatch {
-      name = "arrow-18.patch";
-      url = "https://github.com/OSGeo/gdal/commit/9a8c5c031404bbc81445291bad128bc13766cafa.patch";
-      sha256 = "sha256-tF46DmF7ZReqY8ACTTPXohWLsRn8lVxhKF1s+r254KM=";
-    })
-  ];
 
   nativeBuildInputs =
     [
@@ -301,7 +288,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # flaky on macos
       "test_rda_download_queue"
-      "test_ogr_gpkg_arrow_stream_huge_array"
     ]
     ++ lib.optionals (lib.versionOlder proj.version "8") [
       "test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members"

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -9,6 +9,7 @@
   useArrow ? (!useMinimalFeatures),
   useHDF ? (!useMinimalFeatures),
   useJava ? (!useMinimalFeatures),
+  useLibAvif ? (!useMinimalFeatures),
   useLibHEIF ? (!useMinimalFeatures),
   useLibJXL ? (!useMinimalFeatures),
   useMysql ? (!useMinimalFeatures),
@@ -42,6 +43,7 @@
   json_c,
   lerc,
   libaom,
+  libavif,
   libde265,
   libdeflate,
   libgeotiff,
@@ -137,6 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     let
       tileDbDeps = lib.optionals useTiledb [ tiledb ];
+      libAvifDeps = lib.optionals useLibAvif [ libavif ];
       libHeifDeps = lib.optionals useLibHEIF [
         libheif
         dav1d
@@ -205,6 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
       python3.pkgs.numpy
     ]
     ++ tileDbDeps
+    ++ libAvifDeps
     ++ libHeifDeps
     ++ libJxlDeps
     ++ mysqlDeps

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "rasterio";
-  version = "1.4.0";
+  version = "1.4.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     owner = "rasterio";
     repo = "rasterio";
     rev = "refs/tags/${version}";
-    hash = "sha256-A8o8FYuhlzL6Wl6sfB7D2KRAKZl28E6K2AdUik9zmgs=";
+    hash = "sha256-YGSd0IG6TWnHmDiVEE3F2KNQ4dXJhkPqAJsIrWyuHos=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/rio-tiler/default.nix
+++ b/pkgs/development/python-modules/rio-tiler/default.nix
@@ -62,5 +62,8 @@ buildPythonPackage rec {
     homepage = "https://cogeotiff.github.io/rio-tiler/";
     license = licenses.bsd3;
     maintainers = lib.teams.geospatial.members;
+    # Tests broken with gdal 3.10
+    # https://github.com/cogeotiff/rio-tiler/issues/769
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/rio-tiler/default.nix
+++ b/pkgs/development/python-modules/rio-tiler/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "rio-tiler";
-  version = "7.0.1";
+  version = "7.2.2";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "cogeotiff";
     repo = "rio-tiler";
     rev = "refs/tags/${version}";
-    hash = "sha256-E8gKXPj1n9HZ+zvQPcG28+2Vuif4B6NBhtuS009x6rU=";
+    hash = "sha256-uVLizNkUL7wGF0vFjPXb2iW9ILVkJcbDssXtp3E8ubE=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Follow up to https://github.com/NixOS/nixpkgs/pull/354783

https://github.com/OSGeo/gdal/releases/tag/v3.10.0
I see some new optional dependencies reported:

    New optional dependencies
    [libavif](https://github.com/AOMediaCodec/libavif) for AVIF driver
    [libopendrive](https://github.com/DLR-TS/libOpenDRIVE) for XODR driver

Added libavif optional dependency, but don't see libopendrive packaged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
