### PR TITLE
nixos/k3s: refactor k3s multi node test

### DIFF
--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -16,10 +16,10 @@ import ../make-test-python.nix (
         socat
       ];
     };
-    pauseImage = pkgs.dockerTools.streamLayeredImage {
+    pauseImage = pkgs.dockerTools.buildImage {
       name = "test.local/pause";
       tag = "local";
-      contents = imageEnv;
+      copyToRoot = imageEnv;
       config.Entrypoint = [
         "/bin/tini"
         "--"
@@ -75,6 +75,7 @@ import ../make-test-python.nix (
             enable = true;
             role = "server";
             package = k3s;
+            images = [ pauseImage ];
             clusterInit = true;
             extraFlags = [
               "--disable coredns"
@@ -117,23 +118,17 @@ import ../make-test-python.nix (
             inherit tokenFile;
             enable = true;
             package = k3s;
+            images = [ pauseImage ];
             serverAddr = "https://192.168.1.1:6443";
             clusterInit = false;
-            extraFlags = builtins.toString [
-              "--disable"
-              "coredns"
-              "--disable"
-              "local-storage"
-              "--disable"
-              "metrics-server"
-              "--disable"
-              "servicelb"
-              "--disable"
-              "traefik"
-              "--node-ip"
-              "192.168.1.3"
-              "--pause-image"
-              "test.local/pause:local"
+            extraFlags = [
+              "--disable coredns"
+              "--disable local-storage"
+              "--disable metrics-server"
+              "--disable servicelb"
+              "--disable traefik"
+              "--node-ip 192.168.1.3"
+              "--pause-image test.local/pause:local"
             ];
           };
           networking.firewall.allowedTCPPorts = [
@@ -163,12 +158,11 @@ import ../make-test-python.nix (
             enable = true;
             role = "agent";
             package = k3s;
+            images = [ pauseImage ];
             serverAddr = "https://192.168.1.3:6443";
-            extraFlags = lib.concatStringsSep " " [
-              "--pause-image"
-              "test.local/pause:local"
-              "--node-ip"
-              "192.168.1.2"
+            extraFlags = [
+              "--pause-image test.local/pause:local"
+              "--node-ip 192.168.1.2"
             ];
           };
           networking.firewall.allowedTCPPorts = [ 6443 ];
@@ -185,52 +179,42 @@ import ../make-test-python.nix (
         };
     };
 
-    testScript = ''
-      machines = [server, server2, agent]
-      for m in machines:
-          m.start()
-          m.wait_for_unit("k3s")
+    testScript = # python
+      ''
+        start_all()
 
-      is_aarch64 = "${toString pkgs.stdenv.hostPlatform.isAarch64}" == "1"
+        machines = [server, server2, agent]
+        for m in machines:
+            m.wait_for_unit("k3s")
 
-      # wait for the agent to show up
-      server.wait_until_succeeds("k3s kubectl get node agent")
+        # wait for the agent to show up
+        server.wait_until_succeeds("k3s kubectl get node agent")
 
-      for m in machines:
-          m.succeed("k3s check-config")
-          m.succeed(
-              "${pauseImage} | k3s ctr image import -"
-          )
+        for m in machines:
+            m.succeed("k3s check-config")
 
-      server.succeed("k3s kubectl cluster-info")
-      # Also wait for our service account to show up; it takes a sec
-      server.wait_until_succeeds("k3s kubectl get serviceaccount default")
+        server.succeed("k3s kubectl cluster-info")
+        # Also wait for our service account to show up; it takes a sec
+        server.wait_until_succeeds("k3s kubectl get serviceaccount default")
 
-      # Now create a pod on each node via a daemonset and verify they can talk to each other.
-      server.succeed("k3s kubectl apply -f ${networkTestDaemonset}")
-      server.wait_until_succeeds(f'[ "$(k3s kubectl get ds test -o json | jq .status.numberReady)" -eq {len(machines)} ]')
+        # Now create a pod on each node via a daemonset and verify they can talk to each other.
+        server.succeed("k3s kubectl apply -f ${networkTestDaemonset}")
+        server.wait_until_succeeds(f'[ "$(k3s kubectl get ds test -o json | jq .status.numberReady)" -eq {len(machines)} ]')
 
-      # Get pod IPs
-      pods = server.succeed("k3s kubectl get po -o json | jq '.items[].metadata.name' -r").splitlines()
-      pod_ips = [server.succeed(f"k3s kubectl get po {name} -o json | jq '.status.podIP' -cr").strip() for name in pods]
+        # Get pod IPs
+        pods = server.succeed("k3s kubectl get po -o json | jq '.items[].metadata.name' -r").splitlines()
+        pod_ips = [server.succeed(f"k3s kubectl get po {name} -o json | jq '.status.podIP' -cr").strip() for name in pods]
 
-      # Verify each server can ping each pod ip
-      for pod_ip in pod_ips:
-          server.succeed(f"ping -c 1 {pod_ip}")
-          agent.succeed(f"ping -c 1 {pod_ip}")
-
-      # Verify the pods can talk to each other
-      resp = server.wait_until_succeeds(f"k3s kubectl exec {pods[0]} -- socat TCP:{pod_ips[1]}:8000 -")
-      assert resp.strip() == "server"
-      resp = server.wait_until_succeeds(f"k3s kubectl exec {pods[1]} -- socat TCP:{pod_ips[0]}:8000 -")
-      assert resp.strip() == "server"
-
-      # Cleanup
-      server.succeed("k3s kubectl delete -f ${networkTestDaemonset}")
-
-      for m in machines:
-          m.shutdown()
-    '';
+        # Verify each server can ping each pod ip
+        for pod_ip in pod_ips:
+            server.succeed(f"ping -c 1 {pod_ip}")
+            server2.succeed(f"ping -c 1 {pod_ip}")
+            agent.succeed(f"ping -c 1 {pod_ip}")
+            # Verify the pods can talk to each other
+            for pod in pods:
+                resp = server.succeed(f"k3s kubectl exec {pod} -- socat TCP:{pod_ip}:8000 -")
+                assert resp.strip() == "server"
+      '';
 
     meta.maintainers = lib.teams.k3s.members;
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This should originally fix the multi-nde test, however, t he fix was already merged in https://github.com/NixOS/nixpkgs/pull/355964 already. This is now only the refactoring which parallelizes preliminary tasks like the node start and import of the pause image to speed up execution of the test. It also includes all nodes in connection tests and uniforms the usage of extraFlags for all nodes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Fixes https://github.com/NixOS/nixpkgs/issues/354211

@NixOS/k3s 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
