### PR TITLE
librist: fix build for musl

### DIFF
--- a/pkgs/by-name/li/librist/musl.patch
+++ b/pkgs/by-name/li/librist/musl.patch
@@ -1,0 +1,16 @@
+diff --git a/test/rist/unit/srp_examples.c b/test/rist/unit/srp_examples.c
+index 1c5193d..6f835b5 100644
+--- a/test/rist/unit/srp_examples.c
++++ b/test/rist/unit/srp_examples.c
+@@ -16,6 +16,11 @@
+ #define DEBUG_USE_EXAMPLE_CONSTANTS 1
+ 
+ #if HAVE_MBEDTLS
++// musl's sched.h includes a prototype for calloc, so we need to make
++// sure it's already been included before we redefine it to something
++// that won't expand to a valid prototype.
++#include <sched.h>
++
+ #define malloc(size) _test_malloc(size, __FILE__, __LINE__)
+ #define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
+ #define free(obj) _test_free(obj, __FILE__, __LINE__)

--- a/pkgs/by-name/li/librist/package.nix
+++ b/pkgs/by-name/li/librist/package.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/NixOS/nixpkgs/pull/257020
     ./darwin.patch
+    # https://code.videolan.org/rist/librist/-/merge_requests/257
+    ./musl.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
I'll submit this upstream, but I have to wait for my account for the VideoLAN GitLab to be approved, and I don't know how long that will take.  We have until the start of the next cycle, though, because it's too late to get this into staging-next.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
