### PR TITLE
python3Packages.tidalapi: 0.7.6 -> 0.8.1; python3Packages.isodate: 0.6.1 -> 0.7.2 

### DIFF
--- a/pkgs/development/python-modules/isodate/default.nix
+++ b/pkgs/development/python-modules/isodate/default.nix
@@ -2,32 +2,32 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  unittestCheckHook,
-  six,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
 }:
-
 buildPythonPackage rec {
   pname = "isodate";
-  version = "0.6.1";
-  format = "setuptools";
+  version = "0.7.2";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "SMWIHefosKDWSMsCTIBi3ITnuEDtgehkx2FP08Envek=";
+    hash = "sha256-TNGqD0PKdvSmxsApKoX0CzXsLkPjFbWfBubTIXGpU+Y=";
   };
 
-  propagatedBuildInputs = [ six ];
-
-  nativeCheckInputs = [ unittestCheckHook ];
-
-  unittestFlagsArray = [
-    "-s"
-    "src/isodate/tests"
+  buildInputs = [
+    setuptools
+    setuptools-scm
   ];
 
-  meta = with lib; {
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "isodate" ];
+
+  meta = {
     description = "ISO 8601 date/time parser";
     homepage = "http://cheeseshop.python.org/pypi/isodate";
-    license = licenses.bsd0;
+    license = lib.licenses.bsd0;
   };
 }

--- a/pkgs/development/python-modules/isodate/default.nix
+++ b/pkgs/development/python-modules/isodate/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     description = "ISO 8601 date/time parser";
     homepage = "http://cheeseshop.python.org/pypi/isodate";
     license = lib.licenses.bsd0;
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 }

--- a/pkgs/development/python-modules/tidalapi/default.nix
+++ b/pkgs/development/python-modules/tidalapi/default.nix
@@ -2,22 +2,22 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  python-dateutil,
   poetry-core,
   requests,
+  python-dateutil,
+  typing-extensions,
   isodate,
   ratelimit,
-  typing-extensions,
   mpegdash,
 }:
 buildPythonPackage rec {
   pname = "tidalapi";
-  version = "0.7.6";
+  version = "0.8.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-X6U34T1sM4P+JFpOfcI7CmULcGZ4SCXwP2fFHKi1cWE=";
+    hash = "sha256-60jkJgBTNRMWH9n8mx7gbJeI2+HhEbuOkbmqlgOrOms=";
   };
 
   nativeBuildInputs = [ poetry-core ];
@@ -25,13 +25,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     requests
     python-dateutil
-    mpegdash
+    typing-extensions
     isodate
     ratelimit
-    typing-extensions
+    mpegdash
   ];
-
-  doCheck = false; # tests require internet access
 
   pythonImportsCheck = [ "tidalapi" ];
 


### PR DESCRIPTION
- Updated `tidalapi` to last release
- Update outdated dependency `isodate` to `v0.7.2`
- Add myself as maintainer for `isodate` as nobody was
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
