### PR TITLE
buildRustPackage: remove unused `patchRegistryDeps`

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -116,8 +116,6 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
 
   cargoCheckFeatures = checkFeatures;
 
-  patchRegistryDeps = ./patch-registry-deps;
-
   nativeBuildInputs = nativeBuildInputs ++ lib.optionals auditable [
     (buildPackages.cargo-auditable-cargo-wrapper.override {
       inherit cargo cargo-auditable;

--- a/pkgs/build-support/rust/build-rust-package/patch-registry-deps/pkg-config
+++ b/pkgs/build-support/rust/build-rust-package/patch-registry-deps/pkg-config
@@ -1,8 +1,0 @@
-for dir in pkg-config-*; do
-    [ -d "$dir" ] || continue
-
-    echo "Patching pkg-config registry dep"
-
-    substituteInPlace "$dir/src/lib.rs" \
-        --replace '"/usr"' '"'"$NIX_STORE"'/"'
-done


### PR DESCRIPTION
Long, long ago, there was a [feature](https://github.com/NixOS/nixpkgs/commit/b993c2113c8191ca9b454abfc79d02196b6a2bd0).
That feature, later, went through [erasure](https://github.com/NixOS/nixpkgs/pull/30088/commits/5f8cf0048ea089fa73d17512fc4f9f0f0644e225#diff-2a1ed919922467ae70edb73568bf534202c477cc098db942692503aacacf8f52).
Some artifacts [kept their place](https://github.com/NixOS/nixpkgs/blob/71091397ccd469d8dbfdc602bbbf23bc9cf773e7/pkgs/build-support/rust/build-rust-package/default.nix#L119) to this day.
And [this change](https://github.com/NixOS/nixpkgs/pull/355252) brings and end to their reign.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
