### PR TITLE
amazon-ec2-utils: wrap programs

### DIFF
--- a/pkgs/by-name/am/amazon-ec2-utils/package.nix
+++ b/pkgs/by-name/am/amazon-ec2-utils/package.nix
@@ -1,12 +1,18 @@
 {
-  stdenv,
   lib,
   bash,
+  coreutils,
   curl,
   fetchFromGitHub,
   gawk,
+  gnugrep,
+  gnused,
   installShellFiles,
+  makeWrapper,
+  nix-update-script,
   python3,
+  stdenv,
+  util-linux,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,15 +26,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-plTBh2LAXkYVSxN0IZJQuPr7QxD7+OAqHl/Zl8JPCmg=";
   };
 
-  outputs = [
-    "out"
-    "man"
-  ];
-
   strictDeps = true;
 
   nativeBuildInputs = [
     installShellFiles
+    makeWrapper
   ];
 
   buildInputs = [
@@ -36,51 +38,76 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  postInstall = ''
-    install -Dm755 -t $out/bin/ ebsnvme-id
-    install -Dm755 -t $out/bin/ ec2-metadata
-    install -Dm755 -t $out/bin/ ec2nvme-nsid
-    install -Dm755 -t $out/bin/ ec2udev-vbd
+  installPhase = ''
+    mkdir $out
 
-    install -Dm644 -t $out/lib/udev/rules.d/ 51-ec2-hvm-devices.rules
-    install -Dm644 -t $out/lib/udev/rules.d/ 51-ec2-xen-vbd-devices.rules
-    install -Dm644 -t $out/lib/udev/rules.d/ 53-ec2-read-ahead-kb.rules
-    install -Dm644 -t $out/lib/udev/rules.d/ 70-ec2-nvme-devices.rules
-    install -Dm644 -t $out/lib/udev/rules.d/ 60-cdrom_id.rules
+    for file in {ebsnvme-id,ec2-metadata,ec2nvme-nsid,ec2udev-vbd}; do
+      install -D -m 755 -t $out/bin "$file"
+    done
+
+    wrapProgram $out/bin/ec2-metadata \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          curl
+          util-linux
+        ]
+      }
+
+    wrapProgram $out/bin/ec2nvme-nsid \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+        ]
+      }
+
+    wrapProgram $out/bin/ec2udev-vbd \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+
+    for file in *.rules; do
+      install -D -m 644 -t $out/lib/udev/rules.d "$file"
+    done
+
+    substituteInPlace $out/lib/udev/rules.d/{51-ec2-hvm-devices,70-ec2-nvme-devices}.rules \
+      --replace-fail /usr/sbin $out/bin
+
+    substituteInPlace $out/lib/udev/rules.d/53-ec2-read-ahead-kb.rules \
+      --replace-fail /bin/awk ${gawk}/bin/awk
 
     installManPage doc/*.8
   '';
 
-  postFixup = ''
-    substituteInPlace $out/lib/udev/rules.d/{51-ec2-hvm-devices,70-ec2-nvme-devices}.rules \
-      --replace-fail '/usr/sbin' "$out/bin"
-
-    substituteInPlace $out/lib/udev/rules.d/53-ec2-read-ahead-kb.rules \
-      --replace-fail '/bin/awk' '${gawk}/bin/awk'
-
-    substituteInPlace "$out/bin/ec2-metadata" \
-      --replace-fail 'curl' '${curl}/bin/curl'
-  '';
+  outputs = [
+    "out"
+    "man"
+  ];
 
   doInstallCheck = true;
 
-  # We cannot run
-  #     ec2-metadata --help
-  # because it actually checks EC2 metadata even if --help is given
-  # so it won't work in the test sandbox.
+  # We can't run `ec2-metadata` since it calls IMDS even with `--help`.
   installCheckPhase = ''
     $out/bin/ebsnvme-id --help
   '';
 
-  meta = with lib; {
-    changelog = "https://github.com/amazonlinux/amazon-ec2-utils/releases/tag/v${version}";
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Contains a set of utilities and settings for Linux deployments in EC2";
     homepage = "https://github.com/amazonlinux/amazon-ec2-utils";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      anthonyroussel
+      arianvp
       ketzacoatl
       thefloweringash
-      anthonyroussel
     ];
   };
 }


### PR DESCRIPTION
Wrapping the shell script programs to add all dependency programs to their `PATH` environment variable.

Upstream made some changes to the dependencies they're using (e.g. added a dependency on `getopt` which is from `util-linux`).

Also including some style changes to match https://github.com/NixOS/nixpkgs/pull/355111.

As a side note, upstream seems to plan on potentially replacing `ebsnvme-id` with `ebsnvme`, but this change hasn't been released yet (on `main` but not part of a release yet).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
