### PR TITLE
immich: re-add perl to $PATH

### DIFF
--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -19,9 +19,6 @@ python.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml --replace-fail 'fastapi-slim' 'fastapi'
-
-    # AttributeError: module 'cv2' has no attribute 'Mat'
-    substituteInPlace app/test_main.py --replace-fail ": cv2.Mat" ""
   '';
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -23,6 +23,7 @@
   imagemagick,
   libraw,
   libheif,
+  perl,
   vips,
 }:
 let
@@ -188,8 +189,6 @@ buildNpmPackage' {
 
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH
     rm -r node_modules/exiftool-vendored.*
-    substituteInPlace node_modules/exiftool-vendored/dist/DefaultExifToolOptions.js \
-      --replace-fail "checkPerl: !(0, IsWin32_1.isWin32)()," "checkPerl: false,"
   '';
 
   installPhase = ''
@@ -212,6 +211,7 @@ buildNpmPackage' {
         lib.makeBinPath [
           exiftool
           jellyfin-ffmpeg
+          perl # exiftool-vendored checks for Perl even if exiftool comes from $PATH
         ]
       }"
 


### PR DESCRIPTION
Otherwise logging in to Immich fails with

    [Nest] 2432071  - 11/11/2024, 9:12:55 PM   ERROR [Api:Error: BatchCluster has ended, cannot enqueue -ver
    -ignoreMinorErrors
    -execute
        at BatchCluster.enqueueTask (/nix/store/s68j9ryvlcfayh8wc6s8mbqwbhhsb742-immich-1.120.1/node_modules/batch-cluster/dist/BatchCluster.js:186:25)
        at f (/nix/store/s68j9ryvlcfayh8wc6s8mbqwbhhsb742-immich-1.120.1/node_modules/exiftool-vendored/dist/ExifTool.js:402:38)
        at async g (/nix/store/s68j9ryvlcfayh8wc6s8mbqwbhhsb742-immich-1.120.1/node_modules/exiftool-vendored/dist/AsyncRetry.js:8:20)~92ys7db8] Unknown error: Error: BatchCluster has ended, cannot enqueue -ver
    -ignoreMinorErrors
    -execute


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
