### PR TITLE
lomiri.*: OTA-6

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -79,7 +79,6 @@ in
           ])
           ++ (with pkgs.lomiri; [
             hfd-service
-            history-service
             libusermetrics
             lomiri
             lomiri-calculator-app
@@ -90,6 +89,7 @@ in
             lomiri-download-manager
             lomiri-filemanager-app
             lomiri-gallery-app
+            lomiri-history-service
             lomiri-polkit-agent
             lomiri-schemas # exposes some required dbus interfaces
             lomiri-session # wrappers to properly launch the session

--- a/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   cmake,
@@ -27,71 +26,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-clock-app";
-  version = "4.0.4";
+  version = "4.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-clock-app";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IWNLMYrebYQe5otNwZtRUs4YGPo/5OFic3Nh2pWxROs=";
+    hash = "sha256-bYnAdlpY2Ka08hrJOyqW8+VbCTOi0NNrW+8MHLF7+2E=";
   };
-
-  patches = [
-    # Fix GNUInstallDirs variables usage
-    # Remove when version > 4.0.4
-    (fetchpatch {
-      name = "0002-lomiri-clock-app-Fix-GNUInstallDirs-variable-concatenations-in-CMake.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/33c62d0382f69462de0567628d7a6ef162944e12.patch";
-      hash = "sha256-JEoRjc6RugtznNtgJsXz9wnAL/7fkoog40EVl7uu2pc=";
-    })
-
-    # Fix installation of splash icon
-    # Remove when version > 4.0.4
-    (fetchpatch {
-      name = "0003-lomiri-clock-app-Fix-splash-file-installation-in-non-clock-mode.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/97fd6fd91ee787dfe107bd36bc895f2ff234b5e3.patch";
-      hash = "sha256-g9eR6yYgKFDohuZMs1Ub0TwPM2AWbwWLDvZMrT4gMls=";
-    })
-
-    # Port from qmlscene to dedicated C++ entry, and apply abunch of fixes that this move enables
-    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/217 merged & in release
-    (fetchpatch {
-      name = "0004-lomiri-clock-app-Migrate-to-C++-app.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/c690d65baf2d28f99364dec2244f8d4ebdb09178.patch";
-      hash = "sha256-JCQFlHFAXbgiSGNtEsq/khblhAD/3BdE68Qctn7j5T0=";
-    })
-    (fetchpatch {
-      name = "0005-lomiri-clock-app-Call-i18n.bindtextdomain-and-fix-app-icon-load.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/0619730ca639228b1c0a3403082a6a13e2fe3ff3.patch";
-      hash = "sha256-NQQYvJ141fU2iQ+xzYoNkuuzvqQg1BGZNGq24u8i1is=";
-    })
-    (fetchpatch {
-      name = "0006-lomiri-clock-app-Pass-through-project-version.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/ae1467fe44813eef2fc6cc4b9d6ddc02edee7640.patch";
-      hash = "sha256-E6yk5H+YVH4oSg6AIAJ+Rynu0HFkNomX7sTjM/x37PU=";
-    })
-    (fetchpatch {
-      name = "0007-lomiri-clock-app-Fix-tests-after-module-changes.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/40cbd7847c4a850184e553ac5b8981672b7deed0.patch";
-      hash = "sha256-AA4KRYZNBQ0/Nk65kyzzDFhs/zWO7fb5f2Toy1diPBg=";
-    })
-
-    # Don't ignore PATH when looking for qmltestrunner, saves us a patch for hardcoded fallback
-    # Remove when version > 4.0.4
-    (fetchpatch {
-      name = "0008-lomiri-clock-app-tests-Drop-NO_DEFAULT_PATH.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/190ef47e2efaaf139920d0556e0522f95479ea95.patch";
-      hash = "sha256-jy4E+VfVyRu99eGqbhlYi/xjDgPajozHPSlqEcGVOA4=";
-    })
-
-    # Make tests honour BUILD_TESTING
-    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/219 merged & in release
-    (fetchpatch {
-      name = "0009-lomiri-clock-app-tests-Honour-BUILD_TESTING.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/b0ca583238f011e23a99286a1d2b61f2dcd85303.patch";
-      hash = "sha256-TyM5Y8BRAqinvZiZ5TEXd5caVesFluPi6iGmTS1wRlI=";
-    })
-  ];
 
   postPatch = ''
     # QT_IMPORTS_DIR returned by qmake -query is broken

--- a/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
+++ b/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
@@ -1,10 +1,11 @@
-{ stdenvNoCC
-, lib
-, fetchFromGitLab
-, gitUpdater
-, gtk3
-, hicolor-icon-theme
-, ubuntu-themes
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  gtk3,
+  hicolor-icon-theme,
+  ubuntu-themes,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -25,9 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hicolor-icon-theme # theme setup hook
   ];
 
-  propagatedBuildInputs = [
-    ubuntu-themes
-  ];
+  propagatedBuildInputs = [ ubuntu-themes ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
+++ b/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "suru-icon-theme";
-  version = "2024.02.1";
+  version = "2024.10.13";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/suru-icon-theme";
     rev = finalAttrs.version;
-    hash = "sha256-7T9FILhZrs5bbdBEV/FszCOwUd/C1Rl9tbDt77SIzRk=";
+    hash = "sha256-rbhfcjca0vMBa0tJWGpXMRGGygZH1hmdQv/nLJWPS7s=";
   };
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
+++ b/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
@@ -47,12 +47,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     description = "Suru Icon Theme for Lomiri Operating Environment";
     homepage = "https://gitlab.com/ubports/development/core/suru-icon-theme";
     changelog = "https://gitlab.com/ubports/development/core/suru-icon-theme/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.cc-by-sa-30;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.all;
+    license = lib.licenses.cc-by-sa-30;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -58,8 +58,8 @@ let
       biometryd = callPackage ./services/biometryd { };
       lomiri-content-hub = callPackage ./services/lomiri-content-hub { };
       hfd-service = callPackage ./services/hfd-service { };
-      history-service = callPackage ./services/history-service { };
       lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
+      lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
@@ -71,5 +71,6 @@ in
 lib.makeScope libsForQt5.newScope packages
 // lib.optionalAttrs config.allowAliases {
   content-hub = lib.warn "`content-hub` was renamed to `lomiri-content-hub`." pkgs.lomiri.lomiri-content-hub; # Added on 2024-09-11
+  history-service = lib.warn "`history-service` was renamed to `lomiri-history-service`." pkgs.lomiri.lomiri-history-service; # Added on 2024-11-11
   lomiri-system-settings-security-privacy = lib.warn "`lomiri-system-settings-security-privacy` upstream was merged into `lomiri-system-settings`. Please use `pkgs.lomiri.lomiri-system-settings-unwrapped` if you need to directly access the plugins that belonged to this project." pkgs.lomiri.lomiri-system-settings-unwrapped; # Added on 2024-08-08
 }

--- a/pkgs/desktops/lomiri/services/history-service/default.nix
+++ b/pkgs/desktops/lomiri/services/history-service/default.nix
@@ -1,30 +1,33 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, gitUpdater
-, testers
-, cmake
-, dbus
-, dbus-test-runner
-, dconf
-, gnome-keyring
-, libphonenumber
-, libqtdbustest
-, pkg-config
-, protobuf
-, qtbase
-, qtdeclarative
-, qtpim
-, sqlite
-, telepathy
-, telepathy-mission-control
-, validatePkgConfig
-, wrapQtAppsHook
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  testers,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  dconf,
+  gnome-keyring,
+  libphonenumber,
+  libqtdbustest,
+  pkg-config,
+  protobuf,
+  qtbase,
+  qtdeclarative,
+  qtpim,
+  sqlite,
+  telepathy,
+  telepathy-mission-control,
+  validatePkgConfig,
+  wrapQtAppsHook,
+  xvfb-run,
 }:
 
 let
-  replaceDbusService = pkg: name: "--replace-fail \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
+  replaceDbusService =
+    pkg: name:
+    "--replace-fail \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "history-service";
@@ -42,46 +45,48 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  postPatch = ''
-    # Upstream's way of generating their schema doesn't work for us, don't quite understand why.
-    # (gdb) bt
-    # #0  QSQLiteResult::prepare (this=0x4a4650, query=...) at qsql_sqlite.cpp:406
-    # #1  0x00007ffff344bcf4 in QSQLiteResult::reset (this=0x4a4650, query=...) at qsql_sqlite.cpp:378
-    # #2  0x00007ffff7f95f39 in QSqlQuery::exec (this=this@entry=0x7fffffffaad8, query=...) at kernel/qsqlquery.cpp:406
-    # #3  0x00000000004084cb in SQLiteDatabase::dumpSchema (this=<optimized out>) at /build/source/plugins/sqlite/sqlitedatabase.cpp:148
-    # #4  0x0000000000406d70 in main (argc=<optimized out>, argv=<optimized out>)
-    #     at /build/source/plugins/sqlite/schema/generate_schema.cpp:56
-    # (gdb) p lastError().driverText().toStdString()
-    # $17 = {_M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>},
-    #     _M_p = 0x4880d0 "Unable to execute statement"}, _M_string_length = 27, {
-    #     _M_local_buf = "\033\000\000\000\000\000\000\000+\344\371\367\377\177\000", _M_allocated_capacity = 27}}
-    # (gdb) p lastError().databaseText().toStdString()
-    # $18 = {_M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>},
-    #     _M_p = 0x48c480 "no such column: rowid"}, _M_string_length = 21, {
-    #     _M_local_buf = "\025\000\000\000\000\000\000\000A\344\371\367\377\177\000", _M_allocated_capacity = 21}}
-    #
-    # This makes the tests stall indefinitely and breaks history-service usage.
-    # This replacement script should hopefully achieve the same / a similar-enough result with just sqlite
-    cp ${./update_schema.sh.in} plugins/sqlite/schema/update_schema.sh.in
+  postPatch =
+    ''
+      # Upstream's way of generating their schema doesn't work for us, don't quite understand why.
+      # (gdb) bt
+      # #0  QSQLiteResult::prepare (this=0x4a4650, query=...) at qsql_sqlite.cpp:406
+      # #1  0x00007ffff344bcf4 in QSQLiteResult::reset (this=0x4a4650, query=...) at qsql_sqlite.cpp:378
+      # #2  0x00007ffff7f95f39 in QSqlQuery::exec (this=this@entry=0x7fffffffaad8, query=...) at kernel/qsqlquery.cpp:406
+      # #3  0x00000000004084cb in SQLiteDatabase::dumpSchema (this=<optimized out>) at /build/source/plugins/sqlite/sqlitedatabase.cpp:148
+      # #4  0x0000000000406d70 in main (argc=<optimized out>, argv=<optimized out>)
+      #     at /build/source/plugins/sqlite/schema/generate_schema.cpp:56
+      # (gdb) p lastError().driverText().toStdString()
+      # $17 = {_M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>},
+      #     _M_p = 0x4880d0 "Unable to execute statement"}, _M_string_length = 27, {
+      #     _M_local_buf = "\033\000\000\000\000\000\000\000+\344\371\367\377\177\000", _M_allocated_capacity = 27}}
+      # (gdb) p lastError().databaseText().toStdString()
+      # $18 = {_M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>},
+      #     _M_p = 0x48c480 "no such column: rowid"}, _M_string_length = 21, {
+      #     _M_local_buf = "\025\000\000\000\000\000\000\000A\344\371\367\377\177\000", _M_allocated_capacity = 21}}
+      #
+      # This makes the tests stall indefinitely and breaks history-service usage.
+      # This replacement script should hopefully achieve the same / a similar-enough result with just sqlite
+      cp ${./update_schema.sh.in} plugins/sqlite/schema/update_schema.sh.in
 
-    # Uses pkg_get_variable, cannot substitute prefix with that
-    substituteInPlace daemon/CMakeLists.txt \
-      --replace-fail 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_UNIT_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/user")'
+      # Uses pkg_get_variable, cannot substitute prefix with that
+      substituteInPlace daemon/CMakeLists.txt \
+        --replace-fail 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_UNIT_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/user")'
 
-    # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "\''${QMAKE_EXECUTABLE} -query QT_INSTALL_QML" "echo $out/${qtbase.qtQmlPrefix}"
-  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
-    # Tests launch these DBus services, fix paths related to them
-    substituteInPlace tests/common/dbus-services/CMakeLists.txt \
-      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.MissionControl5.service"} \
-      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.AccountManager.service"} \
-      ${replaceDbusService dconf "ca.desrt.dconf.service"}
+      # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "\''${QMAKE_EXECUTABLE} -query QT_INSTALL_QML" "echo $out/${qtbase.qtQmlPrefix}"
+    ''
+    + lib.optionalString finalAttrs.finalPackage.doCheck ''
+      # Tests launch these DBus services, fix paths related to them
+      substituteInPlace tests/common/dbus-services/CMakeLists.txt \
+        ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.MissionControl5.service"} \
+        ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.AccountManager.service"} \
+        ${replaceDbusService dconf "ca.desrt.dconf.service"}
 
-    substituteInPlace cmake/modules/GenerateTest.cmake \
-      --replace-fail '/usr/lib/dconf' '${lib.getLib dconf}/libexec' \
-      --replace-fail '/usr/lib/telepathy' '${lib.getLib telepathy-mission-control}/libexec'
-  '';
+      substituteInPlace cmake/modules/GenerateTest.cmake \
+        --replace-fail '/usr/lib/dconf' '${lib.getLib dconf}/libexec' \
+        --replace-fail '/usr/lib/telepathy' '${lib.getLib telepathy-mission-control}/libexec'
+    '';
 
   strictDeps = true;
 
@@ -114,11 +119,14 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # Many deprecation warnings with Qt 5.15
     (lib.cmakeBool "ENABLE_WERROR" false)
-    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
-      # DaemonTest is flaky
-      # https://gitlab.com/ubports/development/core/history-service/-/issues/13
-      "-E" "^DaemonTest"
-    ]))
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (
+      lib.concatStringsSep ";" [
+        # DaemonTest is flaky
+        # https://gitlab.com/ubports/development/core/history-service/-/issues/13
+        "-E"
+        "^DaemonTest"
+      ]
+    ))
   ];
 
   preBuild = ''
@@ -156,8 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = lib.teams.lomiri.members;
     platforms = lib.platforms.linux;
-    pkgConfigModules = [
-      "lomiri-history-service"
-    ];
+    pkgConfigModules = [ "lomiri-history-service" ];
   };
 })

--- a/pkgs/desktops/lomiri/services/history-service/default.nix
+++ b/pkgs/desktops/lomiri/services/history-service/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitLab
-, fetchpatch
 , gitUpdater
 , testers
 , cmake
@@ -29,48 +28,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "history-service";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/history-service";
     rev = finalAttrs.version;
-    hash = "sha256-m/ytJoHxW0q1vlVKK6Z9ovHzjoiS1AodCSGHTeKygfQ=";
+    hash = "sha256-pcTYuumywTarW+ZciwwvmmBQQH6aq4+FdVjV62VzSZU=";
   };
 
   outputs = [
     "out"
     "dev"
-  ];
-
-  patches = [
-    # Drop deprecated qt5_use_modules usage
-    # Remove when https://gitlab.com/ubports/development/core/history-service/-/merge_requests/36 merged & in release
-    (fetchpatch {
-      url = "https://gitlab.com/ubports/development/core/history-service/-/commit/b36ab377aca93555b29d1471d6eaa706b5c843ca.patch";
-      hash = "sha256-mOpXqqd4JI7lHtcWDm9LGCrtB8ERge04jMpHIagDM2k=";
-    })
-
-    # Add more / correct existing GNUInstallDirs usage
-    # Remove when https://gitlab.com/ubports/development/core/history-service/-/merge_requests/37 merged & in release
-    (fetchpatch {
-      url = "https://gitlab.com/ubports/development/core/history-service/-/commit/bb4dbdd16e80dcd286d8edfb86b08f0b61bc7fec.patch";
-      hash = "sha256-C/XaygI663yaU06klQD9g0NnbqYxHSmzdbrRxcfiJkk=";
-    })
-
-    # Correct version information
-    # Remove when https://gitlab.com/ubports/development/core/history-service/-/merge_requests/38 merged & in release
-    (fetchpatch {
-      url = "https://gitlab.com/ubports/development/core/history-service/-/commit/98458126f9f494b124134fb35c198af0545f6a98.patch";
-      hash = "sha256-4EfLsaueKTCovl8EilN30cmfNfg19wvyCsbKqOrXtuw=";
-    })
-
-    # Make tests optional
-    # Remove when https://gitlab.com/ubports/development/core/history-service/-/merge_requests/39 merged & in release
-    (fetchpatch {
-      url = "https://gitlab.com/ubports/development/core/history-service/-/commit/cb5c80cffc35611657244e15a7eb10edcd598ccd.patch";
-      hash = "sha256-MFHGu4OMScdThq9htUgFMpezP7Ym6YTIZUHWol20wqw=";
-    })
   ];
 
   postPatch = ''
@@ -193,7 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = teams.lomiri.members;
     platforms = platforms.linux;
     pkgConfigModules = [
-      "history-service"
+      "lomiri-history-service"
     ];
   };
 })

--- a/pkgs/desktops/lomiri/services/lomiri-history-service/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-history-service/default.nix
@@ -30,7 +30,7 @@ let
     "--replace-fail \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "history-service";
+  pname = "lomiri-history-service";
   version = "0.6";
 
   src = fetchFromGitLab {
@@ -159,8 +159,8 @@ stdenv.mkDerivation (finalAttrs: {
 
       Database location: ~/.local/share/history-service/history.sqlite
     '';
-    homepage = "https://gitlab.com/ubports/development/core/history-service";
-    changelog = "https://gitlab.com/ubports/development/core/history-service/-/blob/${finalAttrs.version}/ChangeLog";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-history-service";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-history-service/-/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.gpl3Only;
     maintainers = lib.teams.lomiri.members;
     platforms = lib.platforms.linux;

--- a/pkgs/desktops/lomiri/services/lomiri-history-service/update_schema.sh.in
+++ b/pkgs/desktops/lomiri/services/lomiri-history-service/update_schema.sh.in
@@ -25,7 +25,7 @@ done
 # To output the schema
 echo ".fullschema" >> $MERGED_COMMANDS
 
-# The schemas may use functions that history-service defines in C which don't affect the generated schema in a meaningful way.
+# The schemas may use functions that lomiri-history-service defines in C which don't affect the generated schema in a meaningful way.
 # sqlite will return an error after processing queries with such function calls, so remove them.
 sed -i -e '/normalizeId(/d' $MERGED_COMMANDS
 

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -66,6 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/18e0ba8e025b097eef1217d97d98ef4a4940fe84.patch";
       hash = "sha256-vOIy+B/OQeccsVn4pXsnr8LYyEapqbebW1I6dBg5u2c=";
     })
+
+    # Remove when version > 0.5.3
+    (fetchpatch {
+      name = "0003-lomiri-telephony-service-Handle-renamed-history-service.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/3a387670ed13041db069068292b1f41229e79583.patch";
+      hash = "sha256-b7gxzr6Mmtogclq3hR7a/zl+816H2wmJqv3oHjUJggw=";
+    })
   ];
 
   postPatch =

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -15,11 +15,11 @@
   gettext,
   glib,
   gnome-keyring,
-  history-service,
   libnotify,
   libphonenumber,
   libpulseaudio,
   libusermetrics,
+  lomiri-history-service,
   lomiri-url-dispatcher,
   makeWrapper,
   pkg-config,
@@ -111,11 +111,11 @@ stdenv.mkDerivation (finalAttrs: {
     dconf
     gettext
     glib
-    history-service
     libnotify
     libphonenumber
     libpulseaudio
     libusermetrics
+    lomiri-history-service
     lomiri-url-dispatcher
     protobuf
     (python3.withPackages (


### PR DESCRIPTION
https://ubports.com/en/blog/ubports-news-1/post/ubuntu-touch-ota-6-focal-release-3942

- https://gitlab.com/ubports/development/core/lomiri-history-service/-/blob/0.6/ChangeLog
- https://gitlab.com/ubports/development/core/suru-icon-theme/-/blob/2024.10.13/ChangeLog
- https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/blob/v4.1.0/ChangeLog

Closes #356832

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
