### PR TITLE
python312Packages.nitrokey: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/development/python-modules/nitrokey/default.nix
+++ b/pkgs/development/python-modules/nitrokey/default.nix
@@ -13,17 +13,16 @@
   semver,
   crcmod,
   hidapi,
-  ecdsa,
 }:
 
 buildPythonPackage rec {
   pname = "nitrokey";
-  version = "0.2.2";
+  version = "0.2.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-tG6+diyrauJEzpPG33+S5o1ik3n44/443szR7vXH4gE=";
+    hash = "sha256-8Ig2LI7waU/IbUwApyFI2TwtarT5bYolgeq14SgmbEo=";
   };
 
   disabled = pythonOlder "3.9";
@@ -38,7 +37,6 @@ buildPythonPackage rec {
     crcmod
     cryptography
     hidapi
-    ecdsa
     protobuf5
     pyserial
   ];


### PR DESCRIPTION
## Things done

https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.2.3
https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.2...v0.2.3

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
    <li>nitrokey-fido2-firmware</li>
    <li>pynitrokey (python312Packages.pynitrokey)</li>
    <li>pynitrokey.dist (python312Packages.pynitrokey.dist)</li>
    <li>python311Packages.nitrokey</li>
    <li>python311Packages.nitrokey.dist</li>
    <li>python311Packages.pynitrokey</li>
    <li>python311Packages.pynitrokey.dist</li>
    <li>python312Packages.nitrokey</li>
    <li>python312Packages.nitrokey.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
