### PR TITLE
helmsman: only build helmsman subPackage

### DIFF
--- a/pkgs/by-name/he/helmsman/package.nix
+++ b/pkgs/by-name/he/helmsman/package.nix
@@ -1,4 +1,9 @@
-{ lib, buildGoModule, fetchFromGitHub, ... }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  ...
+}:
 
 buildGoModule rec {
   pname = "helmsman";

--- a/pkgs/by-name/he/helmsman/package.nix
+++ b/pkgs/by-name/he/helmsman/package.nix
@@ -16,6 +16,8 @@ buildGoModule rec {
     sha256 = "sha256-u/Fj3A81hH7i1yTg+kcqCPrwEkj0cyhZvNzRYURDoZU=";
   };
 
+  subPackages = [ "cmd/helmsman" ];
+
   vendorHash = "sha256-3eIMMKMvRzOSMvufETR9H1PnPDeEc+su8UuvbQJZ7kI=";
 
   doCheck = false;

--- a/pkgs/by-name/he/helmsman/package.nix
+++ b/pkgs/by-name/he/helmsman/package.nix
@@ -27,6 +27,9 @@ buildGoModule rec {
     mainProgram = "helmsman";
     homepage = "https://github.com/Praqma/helmsman";
     license = licenses.mit;
-    maintainers = with maintainers; [ lynty ];
+    maintainers = with maintainers; [
+      lynty
+      sarcasticadmin
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added myself as a maintainer and explicitly set the subPackages to only build `helmsman`. helmsman would otherwise try to build the following subPackages:
https://github.com/Praqma/helmsman/tree/dadf5fa910fb25e48b617cb71f7f380d53970ea1/internal

Removed the following from this PR based on the points raised in: https://github.com/NixOS/nixpkgs/pull/355293#issuecomment-2469960084
<s>
`nix shell nixpkgs#helmsman` would other fail to run:

```
helmsman --dry-run -f services.yml

 _          _
| |        | |
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | |
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_| version: v3.17.0
A Helm-Charts-as-Code tool.

2024-11-11 14:38:41 INFO: cmd.Start: exec: "helm": executable file not found in $PATH
2024-11-11 14:38:41 CRITICAL: While checking helm version: exec: "helm": executable file not found in $PATH
```

`helmsman` requires `kubernetes-helm` to be in the PATH for execution: https://github.com/Praqma/helmsman?tab=readme-ov-file#install Added myself as a maintainer and explicitly set the subPackages to only build `helmsman`.
> NOTE: `helm-diff` is an option dependency, currently not include in the drv

The following changes result in `helmsman` running as expected:

```
./result/bin/helmsman --dry-run -f services.yml
 _          _
| |        | |
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | |
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_| version: v3.17.1
A Helm-Charts-as-Code tool.

2024-11-11 14:34:06 WARNING: helm diff not found, using kubectl diff
2024-11-11 14:34:06 INFO: validating environment variables in services.yml
2024-11-11 14:34:06 INFO: Parsed [[ services.yml ]] successfully and found [ 3 ] apps
2024-11-11 14:34:06 INFO: Validating desired state definition
2024-11-11 14:34:06 INFO: Setting up kubectl
2024-11-11 14:34:06 INFO: Setting up helm
2024-11-11 14:34:07 INFO: Setting up namespaces
2024-11-11 14:34:07 INFO: Namespace [ metrics-server ] created
2024-11-11 14:34:07 INFO: Namespace [ datadog ] created
2024-11-11 14:34:07 INFO: Namespace [ ingress-nginx ] created
2024-11-11 14:34:07 INFO: Getting chart information
...
```
</s>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
