### PR TITLE
libvdpau: fix tracing feature

### DIFF
--- a/pkgs/by-name/li/libvdpau/installdir.patch
+++ b/pkgs/by-name/li/libvdpau/installdir.patch
@@ -1,9 +1,0 @@
---- a/trace/meson.build	2020-02-15 16:34:58.698832000 +0100
-+++ b/trace/meson.build	2020-02-15 16:39:05.359952802 +0100
-@@ -4,5 +4,5 @@
-     dependencies : libdl,
-     version : '1.0.0',
-     install : true,
--    install_dir : moduledir,
-+    install_dir : get_option('prefix') + '/lib/libvdpau',
- )

--- a/pkgs/by-name/li/libvdpau/package.nix
+++ b/pkgs/by-name/li/libvdpau/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://gitlab.freedesktop.org/vdpau/libvdpau/-/archive/${version}/${pname}-${version}.tar.bz2";
     sha256 = "sha256-pdUKQrjCiP68BxUatkOsjeBqGERpZcckH4m06BCCGRM=";
   };
-  patches = [ ./installdir.patch ];
+  patches = [ ./tracing.patch ];
 
   outputs = [ "out" "dev" ];
 
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
   mesonFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-Dmoduledir=${mesa.driverLink}/lib/vdpau" ];
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-lX11";
+
+  # The tracing library in this package must be conditionally loaded with dlopen().
+  # Therefore, we must restore the RPATH entry for the library itself that was removed by the patchelf hook.
+  postFixup = lib.optionalString stdenv.hostPlatform.isElf ''
+    patchelf $out/lib/libvdpau.so --add-rpath $out/lib
+  '';
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/VDPAU/";

--- a/pkgs/by-name/li/libvdpau/tracing.patch
+++ b/pkgs/by-name/li/libvdpau/tracing.patch
@@ -1,0 +1,24 @@
+diff --git a/src/vdpau_wrapper.c b/src/vdpau_wrapper.c
+index 79dcb94..6249af4 100644
+--- a/src/vdpau_wrapper.c
++++ b/src/vdpau_wrapper.c
+@@ -185,8 +185,7 @@ static VdpStatus _vdp_open_driver(
+     if (vdpau_trace && atoi(vdpau_trace)) {
+         SetDllHandle * set_dll_handle;
+
+-        _vdp_trace_dll = dlopen(VDPAU_MODULEDIR "/libvdpau_trace.so.1",
+-                                RTLD_NOW | RTLD_GLOBAL);
++        _vdp_trace_dll = dlopen("libvdpau_trace.so.1", RTLD_NOW | RTLD_GLOBAL);
+         if (!_vdp_trace_dll) {
+             fprintf(stderr, "Failed to open VDPAU trace library %s\n", dlerror());
+             _VDP_ERROR_BREAKPOINT();
+diff --git a/trace/meson.build b/trace/meson.build
+index 5381b8b..4af408f 100644
+--- a/trace/meson.build
++++ b/trace/meson.build
+@@ -4,5 +4,4 @@ trace = shared_library('vdpau_trace',
+     dependencies : libdl,
+     version : '1.0.0',
+     install : true,
+-    install_dir : moduledir,
+ )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes the optional tracing feature of `libvdpau` enabled with environment variable `VDPAU_TRACE=1` . The tracing library must be conditionally loaded with`dlopen()`, so we must account for how `patchelf` RPATH shrinking often scrubs RPATHs needed for conditionally loaded libraries.

Fixes #338490

Tested by running `vdpauinfo` using this fixed version of the library to verify the tracing feature with `VDPAU_TRACE=1` . See the above issue for more info on how to exercise the tracing feature. Successfully ran of `nixpkgs-review` scoped to packages `libvdpau` `vdpauinfo` `mpv` `vlc`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
