### PR TITLE
circt: fix build for x86_64-darwin on rosetta

### DIFF
--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -67,12 +67,14 @@ stdenv.mkDerivation rec {
         # Disable some tests on x86_64-darwin
         ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-darwin") [
           # These test seem to pass on hydra (rosetta) but not on x86_64-darwin machines
-          "CIRCT :: Target/ExportSMTLIB/attributes.mlir"
-          "CIRCT :: Target/ExportSMTLIB/basic.mlir"
-          "CIRCT :: circt-bmc/comb-errors.mlir"
-          "CIRCT :: circt-bmc/seq-errors.mlir"
-          # This test was having issues with rosetta
-          "CIRCT :: Dialect/SMT/basic.mlir"
+          "CIRCT :: Target/ExportSMTLIB/.*\.mlir"
+          "CIRCT :: circt-bmc/.*\.mlir"
+          # These tests were having issues on rosetta
+          "CIRCT :: Dialect/.*/Reduction/.*\.mlir"
+          "CIRCT :: Dialect/SMT/.*\.mlir"
+          "CIRCT :: circt-as-dis/.*\.mlir"
+          "CIRCT :: circt-reduce/.*\.mlir"
+          "CIRCT :: circt-test/basic.mlir"
         ];
     in
     if lit-filters != [ ] then lib.strings.concatStringsSep "|" lit-filters else null;


### PR DESCRIPTION
This PR fixes building circt on x86_64-darwin platforms built on rosetta.
Some tests are having issues running on rosetta.

Sorry for making PRs for the same issue many times.
This issue has been very hard to debug since the build completed on a x86_64-darwin machine but not when cross-compiled with rosetta on aarch64-darwin.

ZHF: #352882

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
