### PR TITLE
pixdecor: init

### DIFF
--- a/pkgs/applications/window-managers/wayfire/pixdecor.nix
+++ b/pkgs/applications/window-managers/wayfire/pixdecor.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  meson,
+  ninja,
+  pkg-config,
+  wayfire,
+  libinput,
+  libxkbcommon,
+  libGL,
+  xcbutilwm,
+  nlohmann_json,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pixdecor";
+  version = "0-unstable-2024-08-17";
+
+  src = fetchFromGitHub {
+    owner = "soreau";
+    repo = "pixdecor";
+    rev = "18779dd970c703d3437173ee7f640aa210ec69ea";
+    hash = "sha256-3xdrGtEKFli/k1M5E4+0VJHs/eKhgw/50Y6YGWji6os=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  dontWrapGApps = true;
+
+  buildInputs = [
+    libGL
+    libinput
+    libxkbcommon
+    nlohmann_json
+    wayfire
+    xcbutilwm
+  ];
+
+  postPatch = ''
+    substituteInPlace metadata/meson.build \
+      --replace "wayfire.get_variable( pkgconfig: 'metadatadir' )" "join_paths(get_option('prefix'), 'share/wayfire/metadata')"
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/soreau/pixdecor";
+    description = "A highly configurable decorator plugin for wayfire,";
+    longDescription = "pixdecor features antialiased rounded corners with shadows and optional animated effects.";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _0x5a4 ];
+    inherit (wayfire.meta) platforms;
+  };
+})

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -6,6 +6,7 @@ lib.makeScope pkgs.newScope (self:
   in {
     firedecor = callPackage ./firedecor.nix { };
     focus-request = callPackage ./focus-request.nix { };
+    pixdecor = callPackage ./pixdecor.nix { };
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
     wayfire-shadows = callPackage ./wayfire-shadows.nix { };
     wcm = callPackage ./wcm.nix { };


### PR DESCRIPTION
Added the [pixdecor](https://github.com/soreau/pixdecor) wayfire plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
