### PR TITLE
python3Packages.lark-oapi: init at 1.3.6

### DIFF
--- a/pkgs/development/libraries/protobuf/3.20.nix
+++ b/pkgs/development/libraries/protobuf/3.20.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic-v3.nix ({
+  version = "3.20.3";
+  sha256 = "sha256-u/1Yb8+mnDzc3OwirpGESuhjkuKPgqDAvlgo3uuzbbk=";
+} // args)

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv
+, fetchFromGitHub
+, autoreconfHook, zlib, gtest, buildPackages
+, version, sha256
+, ...
+}:
+
+let
+mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
+  pname = "protobuf";
+  inherit version;
+
+  # make sure you test also -A pythonPackages.protobuf
+  src = fetchFromGitHub {
+    owner = "protocolbuffers";
+    repo = "protobuf";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  postPatch = ''
+    rm -rf gmock
+    cp -r ${gtest.src}/googlemock gmock
+    cp -r ${gtest.src}/googletest googletest
+    chmod -R a+w gmock
+    chmod -R a+w googletest
+    ln -s ../googletest gmock/gtest
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/google/protobuf/testing/googletest.cc \
+      --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
+  '';
+
+  nativeBuildInputs = [ autoreconfHook buildPackages.which buildPackages.stdenv.cc buildProtobuf ];
+
+  buildInputs = [ zlib ];
+  configureFlags = lib.optional (buildProtobuf != null) "--with-protoc=${buildProtobuf}/bin/protoc";
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  dontDisableStatic = true;
+
+  meta = {
+    description = "Google's data interchange format";
+    longDescription =
+      ''Protocol Buffers are a way of encoding structured data in an efficient
+        yet extensible format. Google uses Protocol Buffers for almost all of
+        its internal RPC protocols and file formats.
+      '';
+    homepage = "https://developers.google.com/protocol-buffers/";
+    license = lib.licenses.bsd3;
+    mainProgram = "protoc";
+    platforms = lib.platforms.unix;
+  };
+};
+in mkProtobufDerivation(if (stdenv.buildPlatform != stdenv.hostPlatform)
+                        then (mkProtobufDerivation null buildPackages.stdenv)
+                        else null) stdenv

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -52,6 +52,7 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
     license = lib.licenses.bsd3;
     mainProgram = "protoc";
     platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ yoctocell ];
   };
 };
 in mkProtobufDerivation(if (stdenv.buildPlatform != stdenv.hostPlatform)

--- a/pkgs/development/python-modules/lark-oapi/default.nix
+++ b/pkgs/development/python-modules/lark-oapi/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  requests,
+  requests-toolbelt,
+  setuptools,
+  pycryptodome,
+  websockets,
+  protobuf3,
+  httpx,
+}:
+
+buildPythonPackage rec {
+  pname = "lark-oapi";
+  version = "1.3.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-jhis9H7z94KCJy2EM79Hy44ouDnmSIXirJ7fOCZA2G8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    requests-toolbelt
+    pycryptodome
+    websockets
+    protobuf3
+    httpx
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "lark_oapi" ];
+
+  meta = {
+    homepage = "https://github.com/larksuite/oapi-sdk-python";
+    description = "Larksuite development interface SDK";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yoctocell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10161,6 +10161,9 @@ with pkgs;
       protobuf_21 = callPackage ../development/libraries/protobuf/21.nix {
         abseil-cpp = abseil-cpp_202103;
       };
+      protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix {
+        abseil-cpp = abseil-cpp_202103;
+      };
     })
     protobuf_29
     protobuf_28
@@ -10170,6 +10173,7 @@ with pkgs;
     protobuf_24
     protobuf_23
     protobuf_21
+    protobuf3_20
     ;
 
   flatbuffers = callPackage ../development/libraries/flatbuffers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12066,6 +12066,11 @@ self: super: with self; {
   # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
   protobuf = protobuf5;
 
+  # Protobuf 3.x
+  protobuf3 = callPackage ../development/python-modules/protobuf/3.nix {
+    protobuf = pkgs.protobuf3_20;
+  };
+
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 
   # Protobuf 4.x


### PR DESCRIPTION
This reverts #334067 because [lark-oapi](https://github.com/larksuite/oapi-sdk-python) depends on protobuf <=3.20.  Doing `import lark_oapi` works in the python repl.

cc @aaronjheng 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
<!-- edit for nixfmt -->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
