### PR TITLE
hyprwall: init at 0.1.8

### DIFF
--- a/pkgs/by-name/hy/hyprwall/package.nix
+++ b/pkgs/by-name/hy/hyprwall/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+
+  pkg-config,
+  glib,
+  pango,
+  gtk3,
+  wrapGAppsHook4,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hyprwall";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "hyprutils";
+    repo = "hyprwall";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dzPd+5cws3hKhdd1CKKEO7EWMS0XW0y1vqxg1XKX+gY=";
+  };
+
+  cargoHash = "sha256-gT2ysWHckcUl1yx5tciy6kSvZZ0srrs4OwI1mr/58Pc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    glib
+    pango
+    wrapGAppsHook4
+  ];
+
+  # Required in build process, prevents gdk-sys build error.
+  buildInputs = [
+    gtk3
+  ];
+
+  postInstall = ''
+    install -Dm644 hyprwall.desktop -t $out/share/applications
+    install -Dm644 hyprwall.png -t $out/share/pixmaps
+    substituteInPlace "$out/share/applications/hyprwall.desktop" \
+      --replace-fail 'Exec=/usr/bin/hyprwall' "Exec=hyprwall"
+  '';
+
+  meta = {
+    description = "GUI for setting wallpapers with hyprpaper";
+    homepage = "https://github.com/hyprutils/hyprwall";
+    changelog = "https://github.com/hyprutils/hyprwall/releases/tag/v${version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ genga898 ];
+    mainProgram = "hyprwall";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #355314

Add [hyprwall](https://github.com/hyprutils/hyprwall) to nixpkgs, a gui for setting wallpapers with hyprpaper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
