### PR TITLE
speedtest: init at 1.3.0

### DIFF
--- a/pkgs/by-name/sp/speedtest/package.nix
+++ b/pkgs/by-name/sp/speedtest/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  appstream-glib,
+  blueprint-compiler,
+  desktop-file-utils,
+  fetchFromGitHub,
+  glib,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  python3Packages,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "speedtest";
+  version = "1.3.0";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Ketok4321";
+    repo = "speedtest";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-BFPOumMuFKttw8+Jp4c2d9r9C2eIzEX52SNdASdNldw=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--tags', check: false).stdout().strip()" "'v${version}'"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    appstream-glib
+    blueprint-compiler
+    desktop-file-utils # For `desktop-file-validate`
+    glib # For `glib-compile-schemas`
+    gobject-introspection
+    gtk4 # For `gtk-update-icon-cache`
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  dependencies = [
+    python3Packages.aiohttp
+    python3Packages.pygobject3
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  dontWrapGAppsHook = true;
+
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  meta = {
+    description = "Graphical librespeed client written using GTK4 + libadwaita";
+    homepage = "https://github.com/Ketok4321/speedtest";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "speedtest";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
[speedtest](https://github.com/Ketok4321/speedtest) is a graphical librespeed client written using GTK4 + libadwaita
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
