### PR TITLE
python3Packages.django-filingcabinet: init at 0-unstable-2024-11-15

### DIFF
--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  django,
+  pytestCheckHook,
+  setuptools,
+  celery,
+  django-taggit,
+  feedgen,
+  reportlab,
+  jsonschema,
+  wand,
+  django-filter,
+  django-treebeard,
+  djangorestframework,
+  pikepdf,
+  pypdf,
+  pycryptodome,
+  python-poppler,
+  zipstream-ng,
+  django-json-widget,
+  factory-boy,
+  pytest-django,
+  camelot,
+  pytesseract,
+  pytest-factoryboy,
+  poppler_utils,
+  pytest-playwright,
+  playwright-driver,
+  pnpm,
+  nodejs,
+}:
+
+buildPythonPackage rec {
+  pname = "django-filingcabinet";
+  version = "0-unstable-2024-11-15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "okfde";
+    repo = "django-filingcabinet";
+    # No release tagged yet on GitHub
+    # https://github.com/okfde/django-filingcabinet/issues/69
+    rev = "33c88e1ca9fccd0ea70f8b609580eeec486bda5c";
+    hash = "sha256-p7VJUiO7dhTR+S3/4QrmrQeJO6xGj7D7I8W3CBF+jo8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "zipstream" "zipstream-ng"
+  '';
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+
+  dependencies = [
+    celery
+    django
+    django-filter
+    django-json-widget
+    django-taggit
+    django-treebeard
+    djangorestframework
+    feedgen
+    jsonschema
+    pikepdf
+    pycryptodome
+    pypdf
+    python-poppler
+    reportlab
+    wand
+    zipstream-ng
+  ];
+
+  optional-dependencies = {
+    tabledetection = [ camelot ];
+    ocr = [ pytesseract ];
+    # Dependencies not yet packaged
+    #webp = [ webp ];
+    #annotate = [ fcdocs-annotate ];
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-32kOhB2+37DD4hKXKep08iDxhXpasKPfcv9fkwISxeU=";
+  };
+
+  postBuild = ''
+    pnpm run build
+  '';
+
+  postInstall = ''
+    cp -r build $out/
+  '';
+
+  nativeCheckInputs = [
+    poppler_utils
+    pytest-django
+    pytest-factoryboy
+    pytest-playwright
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError: Locator expected to be visible
+    "test_keyboard_scroll"
+    "test_number_input_scroll"
+    # playwright._impl._errors.TimeoutError: Locator.click: Timeout 30000ms exceeded
+    "test_sidebar_hide"
+    "test_show_search_bar"
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE="test_project.settings"
+    export PLAYWRIGHT_BROWSERS_PATH="${playwright-driver.browsers}"
+  '';
+
+  pythonImportCheck = [ "filingcabinet" ];
+
+  meta = {
+    description = "Django app that manages documents with pages, annotations and collections";
+    homepage = "https://github.com/okfde/django-filingcabinet";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3427,6 +3427,8 @@ self: super: with self; {
 
   django-filer = callPackage ../development/python-modules/django-filer { };
 
+  django-filingcabinet = callPackage ../development/python-modules/django-filingcabinet { };
+
   django-filter = callPackage ../development/python-modules/django-filter { };
 
   django-formtools = callPackage ../development/python-modules/django-formtools { };


### PR DESCRIPTION
Adding Python module [django-filingcabinet](https://github.com/okfde/django-filingcabinet), a „PDF document viewer Django app“
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
