### PR TITLE
nixos/hypridle: only run the service on Hyprland

### DIFF
--- a/nixos/modules/services/wayland/hypridle.nix
+++ b/nixos/modules/services/wayland/hypridle.nix
@@ -10,17 +10,31 @@ let
 in
 {
   options.services.hypridle = {
-    enable = lib.mkEnableOption "hypridle, Hyprland's idle daemon";
+    enable = lib.mkEnableOption null // {
+      description = ''
+        Whether to enable Hypridle, Hyprland's idle daemon.
+
+        ::: {.note}
+        For this service to work properly on Hyprland, you
+        need to have `programs.hyprland.withUWSM` enabled.
+        :::
+      '';
+    };
     package = lib.mkPackageOption pkgs "hypridle" { };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    systemd = {
-      packages = [ cfg.package ];
-      user.services.hypridle.wantedBy = [ "graphical-session.target" ];
-      user.services.hypridle.path = [
+    systemd.packages = [ cfg.package ];
+
+    systemd.user.services.hypridle = {
+      # Service should be only be started on Hyprland
+      # this target is started by UWSM
+      wantedBy = [ "wayland-session@Hyprland.target" ];
+
+      # Essential package needed for the service to run properly
+      path = [
         config.programs.hyprland.package
         config.programs.hyprlock.package
         pkgs.procps


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/355959 have been merged we can finally get this going.

This PR makes the service only start with "wayland-session@Hyprland.target". This needs a UWSM configured setup.

Finally closes https://github.com/NixOS/nixpkgs/issues/347651

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - With my own configuration
