### PR TITLE
python3Packages.pyrad: 2.4-2023-06-13 -> 2.4-2024-07-24

### DIFF
--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -2,48 +2,23 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
-  poetry-core,
-  netaddr,
-  six,
   unittestCheckHook,
-  fetchPypi,
+  poetry-core,
 }:
-let
-  netaddr_0_8_0 = netaddr.overridePythonAttrs (oldAttrs: rec {
-    version = "0.8.0";
-
-    src = fetchPypi {
-      pname = "netaddr";
-      inherit version;
-      hash = "sha256-1sxXx6B7HZ0ukXqos2rozmHDW6P80bg8oxxaDuK1okM=";
-    };
-  });
-in
 
 buildPythonPackage rec {
   pname = "pyrad";
-  version = "2.4-unstable-2023-06-13";
-  format = "pyproject";
+  version = "2.4-unstable-2024-07-24";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyradius";
     repo = pname;
-    rev = "dd34c5a29b46d83b0bea841e85fd72b79f315b87";
-    hash = "sha256-U4VVGkDDyN4J/tRDaDGSr2TSA4JmqIoQj5qn9qBAvQU=";
+    rev = "f42a57cb0e80de42949810057d36df7c4a6b5146";
+    hash = "sha256-5SPVeBL1oMZ/XXgKch2Hbk6BRU24HlVl4oXZ2agF1h8=";
   };
 
   nativeBuildInputs = [ poetry-core ];
-
-  propagatedBuildInputs = [
-    netaddr_0_8_0
-    six
-  ];
-
-  preCheck = ''
-    substituteInPlace tests/testServer.py \
-      --replace-warn "def testBind(self):" "def dontTestBind(self):" \
-      --replace-warn "def testBindv6(self):" "def dontTestBindv6(self):" \
-  '';
 
   nativeCheckInputs = [ unittestCheckHook ];
 


### PR DESCRIPTION
Update pyrad to latest commit (4 month old) as they cleaned up pyproject to remove support for old python version and remove problematic dependencies (netaddr 0.8)

For context, we don't follow official release as they are outdated and failed in the last ZHF sprint.

[Last pull request.](https://github.com/NixOS/nixpkgs/pull/310187)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
