### PR TITLE
mud: 1.0.1 -> 1.0.10

### DIFF
--- a/pkgs/by-name/mu/mud/package.nix
+++ b/pkgs/by-name/mu/mud/package.nix
@@ -1,25 +1,24 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   python3Packages,
-  versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "mud";
-  version = "1.0.1";
+  version = "1.0.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jasursadikov";
     repo = "mud";
     rev = "refs/tags/v${version}";
-    hash = "sha256-pW4B4+RN7hKtG2enJ33OHBeGsLj8w20ylvjcOL6owAk=";
+    hash = "sha256-UPlAA63iANuChpqWLUDHQrcRjYkHvLcwXW/lVrAfY20=";
   };
 
   build-system = with python3Packages; [
     hatchling
+    setuptools-scm
   ];
 
   dependencies = with python3Packages; [
@@ -28,14 +27,9 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "mud" ];
 
-  # Version checking fails on darwin with:
-  # PermissionError: [Errno 1] Operation not permitted: '/var/empty/.mudsettings'
-  # despite adding `export HOME=$(mktemp -d)` in the `preVersionCheck` phase.
-  # The tool
-  nativeCheckInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    versionCheckHook
-  ];
-  versionCheckProgramArg = [ "--version" ];
+  # Removed versionCheckHook due to conflict with the new release,
+  # a mud config file is required to run the version check command.
+  # Mud can only be initialized in a directory containing git repos.
 
   meta = {
     description = "multi-directory git runner which allows you to run git commands in a multiple repositories";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add new build dependency.
Removed the versionCheckHook since the new build requires a mud config file to be initialized.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
