### PR TITLE
ngsolve: init at 6.2.2501

### DIFF
--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
-  makeWrapper,
   cmake,
   python3Packages,
   mpi,
@@ -80,12 +79,12 @@ stdenv.mkDerivation (finalAttrs: {
                      ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}:$ENV{PYTHONPATH}'
 
     substituteInPlace ng/ng.tcl ng/onetcl.cpp \
-      --replace-fail "libnggui" "$out/lib/libnggui"
+      --replace-fail "libnggui" "$out/lib/libnggui" \
+      --replace-fail "{dir}/ngsolve.tcl" "{dir}/../libexec/ngsolve.tcl"
   '';
 
   nativeBuildInputs = [
     cmake
-    makeWrapper
     python3Packages.pybind11-stubgen
   ];
 
@@ -139,8 +138,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pytest
     python3Packages.pytest-check
     python3Packages.pytest-mpi
+    python3Packages.pythonImportsCheckHook
     mpiCheckPhaseHook
   ];
+
+  pythonImportsCheck = [ "netgen" ];
 
   passthru = {
     inherit avxSupport avx2Support avx512Support;

--- a/pkgs/by-name/ng/ngsolve/fix-find-mumps.patch
+++ b/pkgs/by-name/ng/ngsolve/fix-find-mumps.patch
@@ -1,0 +1,25 @@
+diff --git a/cmake/cmake_modules/FindMUMPS.cmake b/cmake/cmake_modules/FindMUMPS.cmake
+index b3f880b46..b70481cd0 100644
+--- a/cmake/cmake_modules/FindMUMPS.cmake
++++ b/cmake/cmake_modules/FindMUMPS.cmake
+@@ -8,14 +8,14 @@ if(EXISTS ${MUMPS_DIR}/include/zmumps_c.h)
+     find_library(LIB_MUMPS_D dmumps PATHS ${MUMPS_DIR}/lib)
+     find_library(LIB_MUMPS_Z zmumps PATHS ${MUMPS_DIR}/lib)
+     find_library(LIB_PORD pord PATHS ${MUMPS_DIR}/lib)
+-    find_library(LIB_PARMETIS parmetis HINTS ${PARMETIS_DIR}/lib REQUIRED)
+-    find_library(LIB_METIS metis HINTS ${PARMETIS_DIR}/lib REQUIRED)
++    # find_library(LIB_PARMETIS parmetis HINTS ${PARMETIS_DIR}/lib REQUIRED)
++    # find_library(LIB_METIS metis HINTS ${PARMETIS_DIR}/lib REQUIRED)
+     
+-    if (NOT USE_MKL)
+-        find_library(LIB_SCALAPACK scalapack HINTS ${SCALAPACK_DIR}/lib REQUIRED)
+-    endif()
++    # if (NOT USE_MKL)
++    #     find_library(LIB_SCALAPACK scalapack HINTS ${SCALAPACK_DIR}/lib REQUIRED)
++    # endif()
+     
+-    set(MUMPS_LIBRARIES ${LIB_MUMPS_D} ${LIB_MUMPS_Z} ${LIB_MUMPS_COMMON} ${LIB_PARMETIS} ${LIB_METIS} ${LIB_SCALAPACK})
++    set(MUMPS_LIBRARIES ${LIB_MUMPS_D} ${LIB_MUMPS_Z} ${LIB_MUMPS_COMMON})
+ 
+     if (LIB_PORD)
+        list(APPEND MUMPS_LIBRARIES ${LIB_PORD})

--- a/pkgs/by-name/ng/ngsolve/package.nix
+++ b/pkgs/by-name/ng/ngsolve/package.nix
@@ -1,0 +1,170 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  replaceVars,
+  makeWrapper,
+  gfortran,
+  mpi,
+  cmake,
+  python3Packages,
+  blas,
+  lapack,
+  mumps_par,
+  hypre,
+  suitesparse,
+  catch2,
+  mpiCheckPhaseHook,
+  avxSupport ? python3Packages.netgen-mesher.avxSupport,
+  avx2Support ? python3Packages.netgen-mesher.avx2Support,
+  avx512Support ? python3Packages.netgen-mesher.avx512Support,
+  advSimdSupport ? false,
+}:
+assert advSimdSupport -> stdenv.hostPlatform.isAarch64;
+let
+  ngscxxInclude = toString [
+    "-I${python3Packages.pybind11}/include"
+    "-I${python3Packages.netgen-mesher}/include"
+    "-I${python3Packages.netgen-mesher}/include/include"
+  ];
+  ngsldFlags = toString [
+    "-L${python3Packages.netgen-mesher}/lib"
+    "-L${mumps_par}/lib"
+    "-L${suitesparse}/lib"
+  ];
+  archFlags = toString (
+    lib.optional avxSupport "-mavx"
+    ++ lib.optional avx2Support "-mavx2"
+    ++ lib.optional avx512Support "-mavx512"
+    ++ lib.optional advSimdSupport "-march=armv8.3-a+simd"
+  );
+  wrapPythonPath = "$out/${python3Packages.python.sitePackages}:${
+    python3Packages.makePythonPath (
+      with python3Packages;
+      [
+        scipy
+        netgen-mesher
+      ]
+    )
+  }";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ngsolve";
+  version = "6.2.2501";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ngsolve";
+    repo = "ngsolve";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-COba5y18i8PRcm3nmQDEB+H+2cbdA32wqMtxzCPOdO8=";
+  };
+
+  patches = [
+    # Add neccessary python path for standalone gui app netgen.
+    (replaceVars ./tcl-script-add-python-path.patch {
+      WRAP_PYTHONPATH = wrapPythonPath;
+    })
+    # looks for a shared mumps library
+    ./fix-find-mumps.patch
+  ];
+
+  postPatch = ''
+    sed -i "2i #include <paralleldofs.hpp>" comp/hypre_precond.hpp
+
+    substituteInPlace cmake/generate_version_file.cmake \
+      --replace-fail "Git REQUIRED" "Git"
+    echo "v${finalAttrs.version}-0" > version.txt
+
+    echo -e "add_custom_target(project_catch)" > cmake/external_projects/catch.cmake
+
+    echo -e "\nfrom mpi4py import MPI" >> tests/pytest/conftest.py
+
+    substituteInPlace py_tutorials/mixed.py tests/pytest/test_periodic.py \
+      --replace-fail "fes.FreeDofs()" "fes.FreeDofs(),inverse='umfpack'"
+
+    substituteInPlace python/CMakeLists.txt \
+      --replace-fail ''\'''${CMAKE_INSTALL_PREFIX}/''${NGSOLVE_INSTALL_DIR_PYTHON}' \
+                     ''\'''${CMAKE_INSTALL_PREFIX}/''${NGSOLVE_INSTALL_DIR_PYTHON}:$ENV{PYTHONPATH}'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    python3Packages.pybind11-stubgen
+    makeWrapper
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ngscxx_includes" ngscxxInclude)
+    (lib.cmakeFeature "ngsld_flags" ngsldFlags)
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" archFlags)
+    (lib.cmakeFeature "NETGEN_DIR" "${python3Packages.netgen-mesher}")
+    (lib.cmakeFeature "CATCH_INCLUDE_DIR" "${catch2}/include/catch2")
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "USE_MPI" true)
+    (lib.cmakeBool "USE_HYPRE" true)
+    (lib.cmakeBool "USE_MUMPS" true)
+    (lib.cmakeBool "USE_SUPERBUILD" false)
+    (lib.cmakeBool "BUILD_STUB_FILES" true)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+    (lib.cmakeBool "ENABLE_UNIT_TESTS" finalAttrs.finalPackage.doInstallCheck)
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    hypre
+    mumps_par
+    suitesparse
+    mpi
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    scipy
+    netgen-mesher
+  ];
+
+  propagatedUserEnvPkgs = [ python3Packages.netgen-mesher ];
+
+  # Ngsolve.tcl is a tcl script to be sourced by netgen and share not be binary wrapped.
+  # It should not be placed in bin directory as python-env will wrap every executable in bin.
+  # We move it into $out/libexec and netgen will look for ngsolve.tcl in dir/../libexec for each dir in $PATH.
+  postFixup = ''
+    mkdir $out/libexec
+    mv $out/bin/ngsolve.tcl $out/libexec
+    wrapProgram  $out/bin/ngspy --set PYTHONPATH "${wrapPythonPath}:\$PYTHONPATH"
+  '';
+
+  doInstallCheck = true;
+
+  installCheckTarget = "test";
+
+  # Test on ngscxx/ngsld that they can compile/link without NIX_CFLAGS_COMPILE/NIX_LDFLAGS
+  preInstallCheck = ''
+    unset NIX_CFLAGS_COMPILE
+    unset NIX_LDFLAGS
+    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
+    export PATH=$out/bin:$PATH
+  '';
+
+  nativeInstallCheckInputs = [
+    catch2
+    python3Packages.pytest
+    python3Packages.pythonImportsCheckHook
+    mpiCheckPhaseHook
+  ];
+
+  pythonImportsCheck = [ "ngsolve" ];
+
+  meta = {
+    homepage = "https://ngsolve.org";
+    description = "Multi-purpose finite element library";
+    license = lib.licenses.lgpl21Only;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})

--- a/pkgs/by-name/ng/ngsolve/tcl-script-add-python-path.patch
+++ b/pkgs/by-name/ng/ngsolve/tcl-script-add-python-path.patch
@@ -1,0 +1,14 @@
+diff --git a/ngsolve.tcl b/ngsolve.tcl
+index 4b0e10795..4837911b5 100644
+--- a/ngsolve.tcl
++++ b/ngsolve.tcl
+@@ -1,4 +1,9 @@
+ puts "loading ngsolve library"
++if {[info exists env(PYTHONPATH)]} {
++    set env(PYTHONPATH) $env(PYTHONPATH):@WRAP_PYTHONPATH@
++} else {
++	set env(PYTHONPATH) @WRAP_PYTHONPATH@
++}
+ 
+ # netgen_library_dir is set from python in pip packages
+ if { [ info exists netgen_library_dir ] } {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9508,6 +9508,8 @@ self: super: with self; {
     inherit (pkgs) nftables;
   };
 
+  ngsolve = toPythonModule (pkgs.ngsolve.override { python3Packages = self; });
+
   nh3 = callPackage ../development/python-modules/nh3 { };
 
   nhc = callPackage ../development/python-modules/nhc { };


### PR DESCRIPTION
close [[request for ngsolve](https://github.com/NixOS/nixpkgs/issues/231250)](https://github.com/NixOS/nixpkgs/issues/231250)

ngsolve is a Finite element software that intergate with netgen.

It can be used as a
1. netgen plugin via sourcing into the ngsolve.tcl script under PATH.
2. python module intergates with netgen-mesher and other gui frontend like webgui-jupyter-widgets https://github.com/NixOS/nixpkgs/pull/389452
3. wrapped g++ compiler: ngscxx/ngsld
4. wrapped python interpreter: ngspy

Typical use case

1. via systemPackages
```nix
{
    environment.systemPackages = with pkgs; [ ngsolve ];
}
```
2. via pythonModules
```nix
{
...
  devShells = {
    default = pkgs.mkShell {
      packages = pkgs.jupyter.withPackages (
        ps: with ps; [
          ngsolve
          matplotlib
          ipykernel
          webgui-jupyter-widget
        ]
      );
    };
  };
}
```

Difference from the official build of ngsolve:
1. official build of ngsolve bundles unfree intel pardiso solver while nixpkgs#ngsolve use mumps built with mpi as the priority choice.
4. official build support windows/linux/macos while this build only support linux platfrom. Pr for macos support is welcomed.

Note: the solver preferrence of ngsolve:
superLu(upstream work in progress) >pardiso (unfree) > mumps(nixpkgs#mumps_par) > sparsecholesky (builtin) > umfpack (depend on nixpkgs#suitesparse)

Test examples:
env: either in python-env or install via `nix profile install github:qbisi/nixpkgs/ngsolve#ngsolve`
run this poission.py code with `netgen poisson.py` (gui required or for ssh x11 run with `nixGL netgen poission.py`)

```python
# solve the Poisson equation -Delta u = f
# with Dirichlet boundary condition u = 0
from ngsolve import *
import sys

# from netgen.geom2d import unit_square

ngsglobals.msg_level = 1

# generate a triangular mesh of mesh-size 0.2
mesh = Mesh(unit_square.GenerateMesh(maxh=0.2))

# H1-conforming finite element space
fes = H1(mesh, order=3, dirichlet=[1,2,3,4])

# define trial- and test-functions
u = fes.TrialFunction()
v = fes.TestFunction()

# the right hand side
f = LinearForm(fes)
f += 32 * (y*(1-y)+x*(1-x)) * v * dx

# the bilinear-form 
a = BilinearForm(fes, symmetric=True)
a += grad(u)*grad(v)*dx

a.Assemble()
f.Assemble()

# the solution field 
gfu = GridFunction(fes)
gfu.vec.data = a.mat.Inverse(fes.FreeDofs(), inverse="sparsecholesky") * f.vec
# print (u.vec)


# plot the solution (netgen-gui only)
# print(help(Draw))
Draw (gfu)
# Draw (-grad(gfu), mesh, "Flux")

exact = 16*x*(1-x)*y*(1-y)
print ("L2-error:", sqrt (Integrate ( (gfu-exact)*(gfu-exact), mesh)))
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
