### PR TITLE
Revert "rav1e: remove build-time dependency on libgit2"

### DIFF
--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -5,6 +5,8 @@
   rustPlatform,
   fetchCrate,
   cargo-c,
+  darwin,
+  libiconv,
   nasm,
   nix-update-script,
   testers,
@@ -25,6 +27,11 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     cargo-c
     nasm
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Security
   ];
 
   postPatch =

--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -4,12 +4,15 @@
   stdenv,
   rustPlatform,
   fetchCrate,
+  pkg-config,
   cargo-c,
   darwin,
+  libgit2,
   libiconv,
   nasm,
   nix-update-script,
   testers,
+  zlib,
   rav1e,
 }:
 
@@ -24,29 +27,28 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-VyQ6n2kIJ7OjK6Xlf0T0GNsBvgESRETzKZDZzAn8ZuY=";
 
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [
     cargo-c
+    libgit2
     nasm
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
-    darwin.apple_sdk.frameworks.Security
-  ];
+  buildInputs =
+    [ zlib ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libiconv
+      darwin.apple_sdk.frameworks.Security
+    ];
 
-  postPatch =
-    ''
-      # remove feature that requires libgit2 and is only used to print a version string
-      substituteInPlace Cargo.toml --replace-fail '"git_version",' ""
-    ''
-    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-      # Darwin uses `llvm-strip`, which results in link errors when using `-x` to strip the asm library
-      # and linking it with cctools ld64.
-      substituteInPlace build.rs --replace-fail '.arg("-x")' '.arg("-S")'
-
-      # Thin LTO doesn’t appear to work with Rust 1.79. rav1e fail to build when building fern.
-      substituteInPlace Cargo.toml --replace-fail 'lto = "thin"' 'lto = "fat"'
-    '';
+  # Darwin uses `llvm-strip`, which results in link errors when using `-x` to strip the asm library
+  # and linking it with cctools ld64.
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+    substituteInPlace build.rs --replace-fail '.arg("-x")' '.arg("-S")'
+    # Thin LTO doesn’t appear to work with Rust 1.79. rav1e fail to build when building fern.
+    substituteInPlace Cargo.toml --replace-fail 'lto = "thin"' 'lto = "fat"'
+  '';
 
   checkType = "debug";
 


### PR DESCRIPTION
Reverts https://github.com/NixOS/nixpkgs/pull/355325.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
