### PR TITLE
sd-image: fix raspberry pi 0 boot

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
@@ -17,6 +17,10 @@
   sdImage = {
     populateFirmwareCommands = let
       configTxt = pkgs.writeText "config.txt" ''
+        # u-boot refuses to start (gets stuck at rainbow polygon) without this,
+        # at least on Raspberry Pi 0.
+        enable_uart=1
+
         # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
         # when attempting to show low-voltage or overtemperature warnings.
         avoid_warnings=1
@@ -28,7 +32,7 @@
         kernel=u-boot-rpi1.bin
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf *.dtb $NIX_BUILD_TOP/firmware/)
         cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin firmware/u-boot-rpi0.bin
         cp ${pkgs.ubootRaspberryPi}/u-boot.bin firmware/u-boot-rpi1.bin
         cp ${configTxt} firmware/config.txt


### PR DESCRIPTION
Raspberry Pi 0 was stuck at rainbow image on hdmi
output and was not booting.

Both dtbs are needed _and_ the enable_uart=1. Any
of them missing leaves RPI0 stuck at the rainbow
image.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've built this with this configuration.nix:
```
{ config, pkgs, lib, modulesPath, ... }:
{
        imports = [
                (modulesPath + "/profiles/minimal.nix")
                (modulesPath + "/profiles/headless.nix")
                (modulesPath + "/installer/sd-card/sd-image-raspberrypi.nix")
        ];
        disabledModules = [
                "${modulesPath}/profiles/base.nix"
        ];
        nixpkgs.crossSystem = lib.systems.elaborate lib.systems.examples.raspberryPi;
        boot.kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
        boot.initrd.availableKernelModules = pkgs.lib.mkForce [ "mmc_block" ];
        system.stateVersion = "24.05";
}
```

Built and flashed like so:
```
$ nix-build --log-format bar ./path/to/checkout/of/nixpkgs/nixos -I nixos-config=./configuration.nix -A config.system.build.sdImage
$ zstd -vdT0 < result/sd-image/nixos-sd-image-24.11pre-git-armv6l-linux.img.zst | sudo dd of=/dev/sda status=progress oflag=sync bs=1
```

The system boots on RPI0w.

Without the change it never gets past the rainbow screen on hdmi output.



---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
