### PR TITLE
cudaPackages.nsight_systems: fix autoPatchelf errors (and more)

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -288,6 +288,7 @@ filterAndCreateOverrides {
       cudaOlder,
       gst_all_1,
       lib,
+      libssh,
       nss,
       numactl,
       pulseaudio,
@@ -315,7 +316,9 @@ filterAndCreateOverrides {
       # https://github.com/ConnorBaker/cuda-redist-find-features/issues/11
       env.rmPatterns = toString [
         "nsight-systems/*/*/lib{arrow,jpeg}*"
-        "nsight-systems/*/*/lib{ssl,ssh,crypto}*"
+        "nsight-systems/*/*/libssl*"
+        "nsight-systems/*/*/libssh*"
+        "nsight-systems/*/*/libcrypto*"
         "nsight-systems/*/*/libboost*"
         "nsight-systems/*/*/libexec"
         "nsight-systems/*/*/libQt*"
@@ -328,7 +331,7 @@ filterAndCreateOverrides {
         prevAttrs.postPatch or ""
         + ''
           for path in $rmPatterns; do
-            rm -r "$path"
+            rm -r $path
           done
         ''
         + ''
@@ -353,6 +356,7 @@ filterAndCreateOverrides {
         xorg.libXdamage
         xorg.libXrandr
         xorg.libXtst
+        libssh
       ];
 
       brokenConditions = prevAttrs.brokenConditions // {

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -330,6 +330,9 @@ filterAndCreateOverrides {
           for path in $rmPatterns; do
             rm -r "$path"
           done
+        ''
+        + ''
+          patchShebangs nsight-systems
         '';
       nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ qt.wrapQtAppsHook ];
       buildInputs = prevAttrs.buildInputs ++ [
@@ -358,6 +361,17 @@ filterAndCreateOverrides {
         "Qt 5 missing (<2022.4.2.1)" = !(versionOlder version "2022.4.2.1" -> qt5 != null);
         "Qt 6 missing (>=2022.4.2.1)" = !(versionAtLeast version "2022.4.2.1" -> qt6 != null);
       };
+      postInstall =
+        let
+          inherit (prevAttrs) version;
+          versionString = with lib.versions; "${majorMinor version}.${patch version}";
+        in
+        ''
+          moveToOutput 'nsight-systems/*/host-linux-*' "''${!outputBin}"
+          moveToOutput 'nsight-systems/*/target-linux-*' "''${!outputBin}"
+          substituteInPlace $bin/bin/nsys $bin/bin/nsys-ui \
+            --replace-fail 'nsight-systems-#VERSION_RSPLIT#' nsight-systems/${versionString}
+        '';
     };
 
   nvidia_driver =

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -25,6 +25,8 @@
   # See ./modules/generic/manifests/feature/release.nix
   featureRelease,
   cudaMajorMinorVersion,
+  boost178,
+  e2fsprogs,
 }:
 let
   inherit (lib)
@@ -216,6 +218,8 @@ backendStdenv.mkDerivation (finalAttrs: {
     # nvcc forces us to use an older gcc
     # NB: We don't actually know if this is the right thing to do
     (lib.getLib stdenv.cc.cc)
+    boost178
+    e2fsprogs
   ];
 
   # Picked up by autoPatchelf
@@ -287,6 +291,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   autoPatchelfIgnoreMissingDeps = [
     "libcuda.so"
     "libcuda.so.*"
+    "libQtPropertyBrowser.so"
   ];
 
   # _multioutPropagateDev() currently expects a space-separated string rather than an array


### PR DESCRIPTION
## Things done

Add the following missing dependencies for cudaPackages.nsight_systems: boost178, e2fsprogs and libQtPropertyBrowser.so

Should address #354189 

There are still some issues, possibly with a wrapper somewhere.
Running `nix-build -A cudaPackages.nsight_systems` completes successfully. The `nsys` binary can then be run without problems from the `result` folder.

However, creating a simple shell with `cudaPackages.nsight_systems` and running `nsys` gives the following error:
```
Error: Nsight Systems #VERSION_RSPLIT# hasn't been installed with CUDA Toolkit #CUDA_MAJOR#.#CUDA_MINOR#
```

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
