### PR TITLE
nixosTests.postgresql: run tests with JIT as well

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -19,6 +19,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             extraPlugins = ps: [ ps.anonymizer ];
             settings.shared_preload_libraries = [ "anon" ];
           };

--- a/nixos/tests/postgresql/pgjwt.nix
+++ b/nixos/tests/postgresql/pgjwt.nix
@@ -23,6 +23,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             extraPlugins =
               ps: with ps; [
                 pgjwt

--- a/nixos/tests/postgresql/pgvecto-rs.nix
+++ b/nixos/tests/postgresql/pgvecto-rs.nix
@@ -24,9 +24,9 @@ let
   '';
 
   makeTestFor =
-    postgresqlPackage:
+    package:
     makeTest {
-      name = "pgvecto-rs-${postgresqlPackage.name}";
+      name = "pgvecto-rs-${package.name}";
       meta = with lib.maintainers; {
         maintainers = [ diogotcorreia ];
       };
@@ -35,8 +35,9 @@ let
         { ... }:
         {
           services.postgresql = {
+            inherit package;
             enable = true;
-            package = postgresqlPackage;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             extraPlugins =
               ps: with ps; [
                 pgvecto-rs

--- a/nixos/tests/postgresql/postgresql-tls-client-cert.nix
+++ b/nixos/tests/postgresql/postgresql-tls-client-cert.nix
@@ -50,6 +50,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             enableTCPIP = true;
             ensureUsers = [
               {

--- a/nixos/tests/postgresql/postgresql-wal-receiver.nix
+++ b/nixos/tests/postgresql/postgresql-wal-receiver.nix
@@ -31,6 +31,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             settings = {
               max_replication_slots = 10;
               max_wal_senders = 10;

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -40,8 +40,9 @@ let
         { ... }:
         {
           services.postgresql = {
-            inherit (package) ;
+            inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
           };
 
           services.postgresqlBackup = {
@@ -158,6 +159,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             ensureUsers = [
               {
                 name = "all-clauses";

--- a/nixos/tests/postgresql/timescaledb.nix
+++ b/nixos/tests/postgresql/timescaledb.nix
@@ -53,6 +53,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             extraPlugins =
               ps: with ps; [
                 timescaledb

--- a/nixos/tests/postgresql/tsja.nix
+++ b/nixos/tests/postgresql/tsja.nix
@@ -20,6 +20,7 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
             extraPlugins =
               ps: with ps; [
                 tsja

--- a/nixos/tests/postgresql/wal2json.nix
+++ b/nixos/tests/postgresql/wal2json.nix
@@ -16,6 +16,7 @@ let
         services.postgresql = {
           inherit package;
           enable = true;
+          enableJIT = lib.hasInfix "-jit-" package.name;
           extraPlugins = with package.pkgs; [ wal2json ];
           settings = {
             wal_level = "logical";


### PR DESCRIPTION
This was intended for quite some time already, but ever since enableJIT was changed to be the source of truth of JIT-iness for the PostgreSQL module, this hasn't worked for the tests anymore.

@ma27 @mweinelt 

Note: The timescaledb test for JIT currently fails because the dependency `timescaledb_toolkit` doesn't build with JIT enabled. But it's unfree anyway, so it won't breaky anything in CI...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
