### PR TITLE
demucs-cpp: init at 0.0.4-alpha

### DIFF
--- a/pkgs/by-name/de/demucs-cpp/package.nix
+++ b/pkgs/by-name/de/demucs-cpp/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  blas,
+}:
+stdenv.mkDerivation rec {
+  pname = "demucs-cpp";
+  version = "0.0.4-alpha";
+  src = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "sevagh";
+    repo = "demucs.cpp";
+    rev = "v${version}";
+    hash = "sha256-STbD2bJnMhcglkNKzExZbteFbmT1lDnfnhJPuV3TgAk=";
+  };
+
+  buildInputs = [ blas ];
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv *.cpp.main $out/bin
+  '';
+
+  meta = with lib; {
+    description = ''
+      C++17 port of Demucs v3 (hybrid) and v4 (hybrid transformer) models with ggml and Eigen3.
+      The weights are not included and need to be downloaded, as explained here:
+      https://github.com/sevagh/demucs.cpp/tree/main?tab=readme-ov-file#download-weights
+    '';
+    homepage = "https://github.com/sevagh/demucs.cpp";
+    license = licenses.mit;
+    mainProgram = "demucs_mt.cpp.main";
+    maintainers = with maintainers; [ lenny ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[This](https://github.com/sevagh/demucs.cpp) is a cpp implementation of the [facebook demucs](https://github.com/facebookresearch/demucs) model to do musical source separation, i.e. split a music file into vocals, drums, bass, etc. 

I omitted the weights for now (they can be easily downloaded [here](https://huggingface.co/datasets/Retrobear/demucs.cpp/tree/main) and are also MIT. I'm unsure what the policy for weights is in nixpkgs, do we want them in the cache or should users manually download them?  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
