### PR TITLE
qt{5,6}.qtbase: build without libinput by default

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -7,7 +7,7 @@
 , apple-sdk_13, darwinMinVersionHook, xcbuild
 
 , dbus, fontconfig, freetype, glib, harfbuzz, icu, libdrm, libX11, libXcomposite
-, libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng , libxcb
+, libXcursor, libXext, libXi, libXrender, libjpeg, libpng , libxcb
 , libxkbcommon, libxml2, libxslt, openssl, pcre2, sqlite, udev, xcbutil
 , xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm , zlib, at-spi2-core
 
@@ -15,6 +15,7 @@
 , cups ? null, postgresql ? null
 , withGtk3 ? false, dconf, gtk3
 , withQttranslation ? true, qttranslations ? null
+, withLibinput ? false, libinput
 
   # options
 , libGLSupported ? !stdenv.hostPlatform.isDarwin
@@ -80,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: ({
   buildInputs = [ python3 at-spi2-core ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin)
     (
-      [ libinput ]
+      lib.optional withLibinput libinput
       ++ lib.optional withGtk3 gtk3
     )
     ++ lib.optional stdenv.isDarwin darwinVersionInputs
@@ -352,14 +353,13 @@ stdenv.mkDerivation (finalAttrs: ({
       "-L" "${libXrender.out}/lib"
       "-I" "${libXrender.out}/include"
 
-      "-libinput"
-
       ''-${lib.optionalString (cups == null) "no-"}cups''
       "-dbus-linked"
       "-glib"
     ] ++ [
       "-system-libpng"
     ] ++ lib.optional withGtk3 "-gtk"
+      ++ lib.optional withLibinput "-libinput"
       ++ [
         "-inotify"
     ] ++ lib.optionals (cups != null) [

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -44,7 +44,6 @@
 , libXext
 , libXi
 , libXrender
-, libinput
 , libjpeg
 , libpng
 , libxcb
@@ -78,6 +77,8 @@
 , withGtk3 ? false
 , dconf
 , gtk3
+, withLibinput ? false
+, libinput
   # options
 , libGLSupported ? stdenv.hostPlatform.isLinux
 , libGL
@@ -163,10 +164,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform at-spi2-core) [
     at-spi2-core
-  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform libinput) [
-    libinput
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin darwinVersionInputs
   ++ lib.optional withGtk3 gtk3
+  ++ lib.optional withLibinput libinput
   ++ lib.optional (libmysqlclient != null && !stdenv.hostPlatform.isMinGW) libmysqlclient
   ++ lib.optional (postgresql != null && lib.meta.availableOn stdenv.hostPlatform postgresql) postgresql;
 


### PR DESCRIPTION
libinput in Qt itself is only really relevant to embedded-brained use cases (linuxfb/eglfb backends), and this will allow us to update libinput trivially on master.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
