### PR TITLE
flatpak: pass user fonts and icons

### DIFF
--- a/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
+++ b/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
@@ -1,8 +1,8 @@
 diff --git a/common/flatpak-run.c b/common/flatpak-run.c
-index 94ad013..5c9f55e 100644
+index 6df992d7..d6018e8f 100644
 --- a/common/flatpak-run.c
 +++ b/common/flatpak-run.c
-@@ -871,6 +871,49 @@ out:
+@@ -2256,11 +2256,55 @@ out:
    return res;
  }
  
@@ -52,7 +52,13 @@ index 94ad013..5c9f55e 100644
  static void
  add_font_path_args (FlatpakBwrap *bwrap)
  {
-@@ -898,6 +946,18 @@ add_font_path_args (FlatpakBwrap *bwrap)
+   g_autoptr(GString) xml_snippet = g_string_new ("");
+   gchar *path_build_tmp = NULL;
++  g_autoptr(GFile) user_font_nix = NULL;
+   g_autoptr(GFile) user_font1 = NULL;
+   g_autoptr(GFile) user_font2 = NULL;
+   g_autoptr(GFile) user_font_cache = NULL;
+@@ -2283,6 +2327,18 @@ add_font_path_args (FlatpakBwrap *bwrap)
                                "\t<remap-dir as-path=\"%s\">/run/host/fonts</remap-dir>\n",
                                SYSTEM_FONTS_DIR);
      }
@@ -71,7 +77,49 @@ index 94ad013..5c9f55e 100644
  
    if (g_file_test ("/usr/local/share/fonts", G_FILE_TEST_EXISTS))
      {
-@@ -998,6 +1058,13 @@ add_icon_path_args (FlatpakBwrap *bwrap)
+@@ -2317,6 +2373,10 @@ add_font_path_args (FlatpakBwrap *bwrap)
+                               NULL);
+     }
+ 
++  path_build_tmp = g_build_filename (g_get_home_dir (), ".nix-profile/share/fonts", NULL);
++  user_font_nix = g_file_new_for_path (path_build_tmp);
++  g_clear_pointer (&path_build_tmp, g_free);
++
+   path_build_tmp = g_build_filename (g_get_user_data_dir (), "fonts", NULL);
+   user_font1 = g_file_new_for_path (path_build_tmp);
+   g_clear_pointer (&path_build_tmp, g_free);
+@@ -2325,7 +2385,19 @@ add_font_path_args (FlatpakBwrap *bwrap)
+   user_font2 = g_file_new_for_path (path_build_tmp);
+   g_clear_pointer (&path_build_tmp, g_free);
+ 
+-  if (g_file_query_exists (user_font1, NULL))
++  if (g_file_query_exists (user_font_nix, NULL))
++    {
++      add_nix_store_symlink_targets (bwrap, g_file_get_path (user_font_nix));
++      flatpak_bwrap_add_args (bwrap,
++                              "--ro-bind",
++                              flatpak_file_get_path_cached (user_font_nix),
++                              "/run/host/user-fonts",
++                              NULL);
++      g_string_append_printf (xml_snippet,
++                              "\t<remap-dir as-path=\"%s\">/run/host/user-fonts</remap-dir>\n",
++                              flatpak_file_get_path_cached (user_font_nix));
++    }
++  else if (g_file_query_exists (user_font1, NULL))
+     {
+       flatpak_bwrap_add_args (bwrap,
+                               "--ro-bind", flatpak_file_get_path_cached (user_font1), "/run/host/user-fonts",
+@@ -2374,7 +2446,8 @@ add_font_path_args (FlatpakBwrap *bwrap)
+ static void
+ add_icon_path_args (FlatpakBwrap *bwrap)
+ {
+-  g_autofree gchar *user_icons_path = NULL;
++  gchar *path_build_tmp = NULL;
++  g_autoptr(GFile) user_icons_nix = NULL;
+   g_autoptr(GFile) user_icons = NULL;
+ 
+   if (g_file_test ("/usr/share/icons", G_FILE_TEST_IS_DIR))
+@@ -2383,10 +2456,30 @@ add_icon_path_args (FlatpakBwrap *bwrap)
                                "--ro-bind", "/usr/share/icons", "/run/host/share/icons",
                                NULL);
      }
@@ -83,5 +131,25 @@ index 94ad013..5c9f55e 100644
 +                              NULL);
 +    }
  
-   user_icons_path = g_build_filename (g_get_user_data_dir (), "icons", NULL);
-   user_icons = g_file_new_for_path (user_icons_path);
+-  user_icons_path = g_build_filename (g_get_user_data_dir (), "icons", NULL);
+-  user_icons = g_file_new_for_path (user_icons_path);
+-  if (g_file_query_exists (user_icons, NULL))
++  path_build_tmp = g_build_filename (g_get_home_dir (), ".nix-profile/share/icons", NULL);
++  user_icons_nix = g_file_new_for_path (path_build_tmp);
++  g_clear_pointer (&path_build_tmp, g_free);
++
++  path_build_tmp = g_build_filename (g_get_user_data_dir (), "icons", NULL);
++  user_icons = g_file_new_for_path (path_build_tmp);
++  g_clear_pointer (&path_build_tmp, g_free);
++
++  if (g_file_query_exists (user_icons_nix, NULL))
++    {
++      add_nix_store_symlink_targets(bwrap, flatpak_file_get_path_cached (user_icons_nix));
++      flatpak_bwrap_add_args(bwrap,
++                             "--ro-bind", flatpak_file_get_path_cached (user_icons_nix), "/run/host/user-share/icons",
++                             NULL);
++    }
++  else if (g_file_query_exists (user_icons, NULL))
+     {
+       flatpak_bwrap_add_args (bwrap,
+                               "--ro-bind", flatpak_file_get_path_cached (user_icons), "/run/host/user-share/icons",


### PR DESCRIPTION
Makes user fonts and icons available to Flatpak applications, similar to the existing implementation for system fonts and icons (in #262462).

This fixes inconsistent cursors in Flatpak applications.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
