### PR TITLE
llvmPackages.llvm: Drop dependency on target through libbfd

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -12,6 +12,7 @@ in
 , lib
 , noSysDirs
 , perl
+, runCommand
 , zlib
 , CoreServices
 
@@ -238,11 +239,18 @@ stdenv.mkDerivation (finalAttrs: {
     inherit targetPrefix;
     hasGold = enableGold;
     isGNU = true;
-    # Having --enable-plugins is not enough, system has to support
-    # dlopen() or equivalent. See config/plugins.m4 and configure.ac
-    # (around PLUGINS) for cases that support or not support plugins.
-    # No platform specific filters yet here.
-    hasPluginAPI = enableGold;
+
+    # The plugin API is not a function of any targets. Expose it separately,
+    # currently only used by LLVM for enabling BFD to do LTO with LLVM bitcode.
+    # (Tar will exit with an error if there are no matches).
+    plugin-api-header = runCommand "libbfd-plugin-api-header" {} ''
+      mkdir -p $out
+      tar --directory=$out \
+      --extract \
+      --file=${finalAttrs.src} \
+      --strip-components=1 \
+        --wildcards '*'/include/plugin-api.h
+    '';
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/libbfd.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    inherit (binutils-unwrapped-all-targets) dev hasPluginAPI;
+    inherit (binutils-unwrapped-all-targets) src dev plugin-api-header;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/libopcodes.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    inherit (binutils-unwrapped-all-targets) dev hasPluginAPI;
+    inherit (binutils-unwrapped-all-targets) dev;
   };
 
   meta = with lib; {


### PR DESCRIPTION
Currently the target triple leaks into the clang build via llvm using
libbfd, whose build varies according to the target triple.

LLVM only uses libbfd to enable LTO via the linker plugin (called
LLVMgold.so, though multiple linkers can use the same plugin).

Drop the dependency on the libbfd build, and consume the only needed
source instead.  (This would be a good use of CA-derivations FWIW).

The result of this commit is that these match:

* nix eval --raw nixpkgs#clang.cc
* nix eval --raw nixpkgs#pkgsStatic.pkgsLLVM.stdenv.cc.cc
* nix eval --raw nixpkgs#pkgsCross.aarch64-multiplatform.pkgsLLVM.stdenv.cc.cc

This means fewer clang builds will be needed to support cross
configurations, and users wanting to target an exotic cross
configuration should be able to do so without a rebuild of clang.

Also drops libbfd.hasPluginAPI which no longer has any users.

Signed-off-by: Peter Waller <p@pwaller.net>



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
