### PR TITLE
rpm-sequoia: fixup darwin build

### DIFF
--- a/pkgs/by-name/rp/rpm-sequoia/package.nix
+++ b/pkgs/by-name/rp/rpm-sequoia/package.nix
@@ -55,13 +55,17 @@ rustPlatform.buildRustPackage rec {
     ''
     +
       # Dependents will rely on the versioned symlinks
-      ''
+      lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
         install -d $out/lib
         find target/release/ \
           -maxdepth 1 \
           -type l -name 'librpm_sequoia.*' \
           -exec cp --no-dereference {} $out/lib/ \;
-      '';
+      ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install -d $out/lib
+      ln -s librpm_sequoia.dylib $out/lib/librpm_sequoia.${version}.dylib
+    '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
When building derivations that depends on rpm on darwin, we get the following error:
```
dyld[69225]: Library not loaded: /nix/store/cz9sppfrs9ag34lq2pq6wmhspwcnvbxq-rpm-sequoia-1.7.0/lib/librpm_sequoia.1.7.0.dylib
  Referenced from: <0EA94AC5-F54A-3791-9374-4092232F33A1> /nix/store/mak6qp2pvgz19dn0fb0pr2lksgca43qp-rpm-4.20.0/lib/librpmio.10.2.0.dylib
  Reason: tried: '/nix/store/cz9sppfrs9ag34lq2pq6wmhspwcnvbxq-rpm-sequoia-1.7.0/lib/librpm_sequoia.1.7.0.dylib' (no such file), '/System/Vol>
cpio: premature end of archive
```

This commit adds the correct symlinks on darwin.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
