### PR TITLE
fmt_8: drop

### DIFF
--- a/pkgs/by-name/sp/spdlog/package.nix
+++ b/pkgs/by-name/sp/spdlog/package.nix
@@ -41,6 +41,11 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/doc/spdlog
     cp -rv ../example $out/share/doc/spdlog
+
+    substituteInPlace $dev/include/spdlog/tweakme.h \
+      --replace-fail \
+        '// #define SPDLOG_FMT_EXTERNAL' \
+        '#define SPDLOG_FMT_EXTERNAL'
   '';
 
   doCheck = true;

--- a/pkgs/development/libraries/edencommon/default.nix
+++ b/pkgs/development/libraries/edencommon/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , boost
 , cmake
-, fmt_8
+, fmt_9
 , folly
 , glog
 , gtest
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glog
     folly
-    fmt_8
+    fmt_9
     boost
     gtest
   ];

--- a/pkgs/development/libraries/fbthrift/default.nix
+++ b/pkgs/development/libraries/fbthrift/default.nix
@@ -8,7 +8,7 @@
 , libsodium
 , fizz
 , flex
-, fmt_8
+, fmt_9
 , folly
 , glog
 , gflags
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     boost
     double-conversion
     fizz
-    fmt_8
+    fmt_9
     folly
     glog
     gflags

--- a/pkgs/development/libraries/fizz/default.nix
+++ b/pkgs/development/libraries/fizz/default.nix
@@ -6,7 +6,7 @@
 , double-conversion
 , glog
 , lib
-, fmt_8
+, fmt_9
 , zstd
 , gflags
 , libiberty
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   NIX_LDFLAGS = "-lz";
 
   buildInputs = [
-    fmt_8
+    fmt_9
     boost
     double-conversion
     folly

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -69,11 +69,6 @@ let
     };
 in
 {
-  fmt_8 = generic {
-    version = "8.1.1";
-    sha256 = "sha256-leb2800CwdZMJRWF5b1Y9ocK0jXpOX/nwo95icDf308=";
-  };
-
   fmt_9 = generic {
     version = "9.1.0";
     sha256 = "sha256-rP6ymyRc7LnKxUXwPpzhHOQvpJkpnRFOt2ctvUNlYI0=";

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -4,7 +4,7 @@
 , boost
 , cmake
 , double-conversion
-, fmt_8
+, fmt_9
 , gflags
 , glog
 , libevent
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     xz
     zlib
     libunwind
-    fmt_8
+    fmt_9
     zstd
   ] ++ lib.optional stdenv.hostPlatform.isLinux jemalloc;
 
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     # folly-config.cmake, will `find_package` these, thus there should be
     # a way to ensure abi compatibility.
     inherit boost;
-    fmt = fmt_8;
+    fmt = fmt_9;
 
     tests = {
       inherit watchman;

--- a/pkgs/development/libraries/kompute/default.nix
+++ b/pkgs/development/libraries/kompute/default.nix
@@ -6,41 +6,37 @@
 , vulkan-headers
 , vulkan-loader
 , fmt
+, spdlog
 , glslang
 , ninja
 }:
 
 stdenv.mkDerivation rec {
   pname = "kompute";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "KomputeProject";
     repo = "kompute";
     rev = "v${version}";
-    sha256 = "sha256-OkVGYh8QrD7JNqWFBLrDTYlk6IYHdvt4i7UtC4sQTzo=";
+    hash = "sha256-cf9Ef85R+VKao286+WHLgBWUqgwvuRocgeCzVJOGbdc=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/KomputeProject/kompute/commit/9a791b161dd58ca927fe090f65fa2b0e5e85e7ca.diff";
-      sha256 = "OtFTN8sgPlyiMmVzUnqzCkVMKj6DWxbCXtYwkRdEprY=";
-    })
-    (fetchpatch {
-      name = "enum-class-fix-for-fmt-8-x.patch";
-      url = "https://github.com/KomputeProject/kompute/commit/f731f2e55c7aaaa804111106c3e469f9a642d4eb.patch";
-      sha256 = "sha256-scTCYqkgKQnH27xzuY4FVbiwRuwBvChmLPPU7ZUrrL0=";
-    })
-  ];
-
   cmakeFlags = [
+    "-DKOMPUTE_OPT_USE_SPDLOG=ON"
+    # Doesn’t work without the vendored `spdlog`, and is redundant.
+    "-DKOMPUTE_OPT_LOG_LEVEL_DISABLED=ON"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_SPDLOG=OFF"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_GOOGLE_TEST=OFF"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_PYBIND11=OFF"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF"
+    "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON"
     "-DKOMPUTE_OPT_INSTALL=1"
-    "-DRELEASE=1"
-    "-DKOMPUTE_ENABLE_SPDLOG=1"
   ];
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ fmt ];
+  buildInputs = [ fmt spdlog ];
   propagatedBuildInputs = [ glslang vulkan-headers vulkan-loader ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/wangle/default.nix
+++ b/pkgs/development/libraries/wangle/default.nix
@@ -6,7 +6,7 @@
 , libevent
 , double-conversion
 , glog
-, fmt_8
+, fmt_9
 , gflags
 , openssl
 , fizz
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    fmt_8
+    fmt_9
     libsodium
     zlib
     boost

--- a/pkgs/development/tools/watchman/default.nix
+++ b/pkgs/development/tools/watchman/default.nix
@@ -11,7 +11,7 @@
 , fetchFromGitHub
 , fetchpatch
 , fizz
-, fmt_8
+, fmt_9
 , folly
 , glog
 , gtest
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     glog
     boost
     libevent
-    fmt_8
+    fmt_9
     libsodium
     zlib
     folly

--- a/pkgs/tools/misc/torrenttools/default.nix
+++ b/pkgs/tools/misc/torrenttools/default.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
   ];
   sourceRoot = "torrenttools";
 
+  patches = [
+    ./fmt-9.patch
+  ];
+
   postUnpack = ''
     cp -pr cliprogress torrenttools/external/cliprogress
     cp -pr dottorrent torrenttools/external/dottorrent

--- a/pkgs/tools/misc/torrenttools/fmt-9.patch
+++ b/pkgs/tools/misc/torrenttools/fmt-9.patch
@@ -1,0 +1,29 @@
+diff --git a/include/file_matcher.hpp b/include/file_matcher.hpp
+index c10c7be405..b67baec0ef 100644
+--- a/include/file_matcher.hpp
++++ b/include/file_matcher.hpp
+@@ -47,7 +47,7 @@
+         }
+ 
+         std::string error;
+-        std::string pattern = ".*.{}$"_format(extension);
++        std::string pattern = fmt::format(".*.{}$", extension);
+         file_include_list_.Add(pattern, &error);
+         file_include_list_empty_ = false;
+         Ensures(error.empty());
+@@ -62,7 +62,7 @@
+         }
+ 
+         std::string error;
+-        std::string pattern = ".*\\.{}$"_format(extension);
++        std::string pattern = fmt::format(".*\\.{}$", extension);
+         file_exclude_list_.Add(pattern, &error);
+         file_exclude_list_empty_ = false;
+         Ensures(error.empty());
+@@ -243,4 +243,4 @@
+ };
+ 
+ 
+-} // namespace torrenttools
+\ No newline at end of file
++} // namespace torrenttools

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -379,6 +379,7 @@ mapAliases {
   flutter316 = throw "flutter316 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-10-05
   flutter322 = throw "flutter322 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-10-05
   flutter323 = throw "flutter323 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-10-05
+  fmt_8 = throw "fmt_8 has been removed as it is obsolete and was no longer used in the tree"; # Added 2024-11-12
   foldingathome = throw "'foldingathome' has been renamed to/replaced by 'fahclient'"; # Converted to throw 2024-10-17
   forgejo-actions-runner = forgejo-runner; # Added 2024-04-04
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3961,7 +3961,7 @@ with pkgs;
     stdenv = llvmPackages_13.libcxxStdenv;
     libcxx = llvmPackages_13.libcxx;
     boost = boost178.override { inherit stdenv; };
-    fmt = fmt_8.override { inherit stdenv; };
+    fmt = fmt_9.override { inherit stdenv; };
     nanodbc_llvm = nanodbc.override { inherit stdenv; };
     avro-cpp_llvm = avro-cpp.override { inherit stdenv boost; };
     spdlog_llvm = spdlog.override { inherit stdenv fmt; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11195,7 +11195,7 @@ with pkgs;
     harfbuzz = harfbuzzFull;
   };
 
-  termbench-pro = callPackage ../development/libraries/termbench-pro { fmt = fmt_8; };
+  termbench-pro = callPackage ../development/libraries/termbench-pro { fmt = fmt_11; };
 
   texpresso = callPackage ../tools/typesetting/tex/texpresso {
     texpresso-tectonic = callPackage ../tools/typesetting/tex/texpresso/tectonic.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9295,7 +9295,7 @@ with pkgs;
   fltk = fltk13;
   fltk-minimal = fltk13-minimal;
 
-  inherit (callPackages ../development/libraries/fmt { }) fmt_8 fmt_9 fmt_10 fmt_11;
+  inherit (callPackages ../development/libraries/fmt { }) fmt_9 fmt_10 fmt_11;
 
   fmt = fmt_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18552,7 +18552,7 @@ with pkgs;
   kmonad = haskellPackages.kmonad.bin;
 
   kompute = callPackage ../development/libraries/kompute {
-    fmt = fmt_8;
+    fmt = fmt_10;
   };
 
   # In general we only want keep the last three minor versions around that

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16147,7 +16147,7 @@ with pkgs;
   };
 
   torrenttools = callPackage ../tools/misc/torrenttools {
-    fmt = fmt_8;
+    fmt = fmt_9;
   };
 
   tony = libsForQt5.callPackage ../applications/audio/tony { };


### PR DESCRIPTION
Doesn’t build out of the box with LLVM 19 and nothing in the tree needs it after this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (rebased on `master`)
  - [x] x86_64-linux (`torrenttools`)
  - [x] aarch64-linux (everything else except the Facebook stuff)
  - [x] x86_64-darwin (the Facebook stuff)
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
