### PR TITLE
jetbrains: 2024.2.2 -> 2024.2.5

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,10 +11,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2024.2.2",
-      "sha256": "1658fb15d41dfb804ab0ea3ed4781d4ae0f41d25cc9df17c3f536a565423aa5b",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.2.tar.gz",
-      "build_number": "242.22855.75"
+      "version": "2024.2.3",
+      "sha256": "0afb6e32fe1ceb77ddd07ca7fa7d01a0a5e73a0df42ec58183f9c1a06b84446e",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.3.tar.gz",
+      "build_number": "242.23726.125"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -108,34 +108,34 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2024.2.3",
-      "sha256": "54991cb37fd6495ad52a1b2b6bc1d6d7ab4fff20a1bd393cab72ac57ca4e31a5",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.3.tar.gz",
-      "build_number": "242.23339.18"
+      "version": "2024.2.4",
+      "sha256": "20638d9ac06d840b3bbd5782de4230735380a3b42844ca8fc22af6b2f33f3c58",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.4.tar.gz",
+      "build_number": "242.23726.97"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2024.2.4",
-      "sha256": "e8ba0dd398c5ec426128640ffc7eb94728b8f13cd33874712da0c04efa02286c",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.4.tar.gz",
-      "build_number": "242.23726.110"
+      "version": "2024.2.5",
+      "sha256": "b3ce4f354d4fdbee8dff5d8120db098502f7393fbebe25891f8bd76e51736b69",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.5.tar.gz",
+      "build_number": "242.23726.162"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2024.2.4",
-      "sha256": "c7cd4f9c5affc7f2d24e50130d5565165cc88ac3a4f7fbefd9986a03727f753e",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.4.tar.gz",
-      "build_number": "242.23726.96"
+      "version": "2024.3",
+      "sha256": "23858c20f84a10f3be6ac05cdb03a47e6862fabbf4a748ecef7902f882a9e935",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.tar.gz",
+      "build_number": "243.21565.180"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.tar.gz",
-      "version": "2024.2 EAP",
-      "sha256": "89d1f4bda404bb81c315600f6b673f89e2798066f68b661a904c9e30db45b4e8",
-      "url": "https://download.jetbrains.com/writerside/writerside-242.21870.138.tar.gz",
-      "build_number": "242.21870.138"
+      "version": "2024.3 EAP",
+      "sha256": "651491afd8a42431045b8d6af13954c001aa45f59f905481b1b3b821f140b60b",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.21565.432.tar.gz",
+      "build_number": "243.21565.432"
     }
   },
   "aarch64-linux": {
@@ -150,10 +150,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2024.2.2",
-      "sha256": "35e089b8d8bf5f32c80022f394fe525b8aa37540d26c27e861db0df9e34716a4",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.2-aarch64.tar.gz",
-      "build_number": "242.22855.75"
+      "version": "2024.2.3",
+      "sha256": "be3e6f0d490517c8f6e7c7ac248ab8e8823bf19c8102e7695725f80df6c11d63",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.3-aarch64.tar.gz",
+      "build_number": "242.23726.125"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -247,34 +247,34 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2024.2.3",
-      "sha256": "2be5fa28bd5313b9a043818207b9f76f3f38513ec400dfd76b01b543ff8013cf",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.3-aarch64.tar.gz",
-      "build_number": "242.23339.18"
+      "version": "2024.2.4",
+      "sha256": "2d08c9b203db20f4d0f78ddd2a1c6a861a78659045a38e9868d060588f3c3cd3",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.4-aarch64.tar.gz",
+      "build_number": "242.23726.97"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2024.2.4",
-      "sha256": "d0ca0cd4e6023fd4494c5f50f07acc35809721ef04b82735a367526d0d4ffc5e",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.4-aarch64.tar.gz",
-      "build_number": "242.23726.110"
+      "version": "2024.2.5",
+      "sha256": "b208af1d63ccdf6411916c087a08830b947fd6d63d86c2b6ceee7394f5538383",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.5-aarch64.tar.gz",
+      "build_number": "242.23726.162"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2024.2.4",
-      "sha256": "80b64046d1eab7f1487110095fdcbb4b1bb2543f900e3a7ab7badcf2f7c17c96",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.4-aarch64.tar.gz",
-      "build_number": "242.23726.96"
+      "version": "2024.3",
+      "sha256": "85541c9e8209d7b99422ea2bd1c3b3c14b680f7c5a92cd37f9476c41bfb3c0eb",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3-aarch64.tar.gz",
+      "build_number": "243.21565.180"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.tar.gz",
-      "version": "2024.2 EAP",
-      "sha256": "28a7504a29ba573632e300fbe845d3b2fe3f2c689a853abf83e32ae161e476da",
-      "url": "https://download.jetbrains.com/writerside/writerside-242.21870.138-aarch64.tar.gz",
-      "build_number": "242.21870.138"
+      "version": "2024.3 EAP",
+      "sha256": "c745b284f057bd150b19f773fdfbb4f54922040faaa01293538f51ede9802e35",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.21565.432-aarch64.tar.gz",
+      "build_number": "243.21565.432"
     }
   },
   "x86_64-darwin": {
@@ -289,10 +289,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2024.2.2",
-      "sha256": "35e1a0348353bc8c741c2dea429d0554c7d2a201e9c69b3bfc11c67accab2c52",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.2.dmg",
-      "build_number": "242.22855.75"
+      "version": "2024.2.3",
+      "sha256": "0dfc4d50268e58bb6b3c42c270ea8cca638a8733a5e2e010447cc74d585895e8",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.3.dmg",
+      "build_number": "242.23726.125"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -386,34 +386,34 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2024.2.3",
-      "sha256": "abb6c51d39c3132f60f0f5d8fd5038f908247c0c029b34ef63821ef2fc79b7fa",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.3.dmg",
-      "build_number": "242.23339.18"
+      "version": "2024.2.4",
+      "sha256": "b3eec9db897a46c4becb5e1cd123d47879a2547632d11ec8c04e946182b74ccf",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.4.dmg",
+      "build_number": "242.23726.97"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2024.2.4",
-      "sha256": "1f14c203ef186339a5305008ce2112275a6b293ce422b355bba0e8554b9656e2",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.4.dmg",
-      "build_number": "242.23726.110"
+      "version": "2024.2.5",
+      "sha256": "906bc85ada746fd8e783c4fa524458f6cedde7c77499728da8ccae050201a400",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.5.dmg",
+      "build_number": "242.23726.162"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2024.2.4",
-      "sha256": "63ebaffb17bcbe8759fbe256a7764aea3feadf18ac817a27f80b8cfed1af62d1",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.4.dmg",
-      "build_number": "242.23726.96"
+      "version": "2024.3",
+      "sha256": "fccac67e93d69ad98a36b0b8c092913fbc8bfc06b1cb7ee3932bad4394f78c78",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.dmg",
+      "build_number": "243.21565.180"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.dmg",
-      "version": "2024.2 EAP",
-      "sha256": "bcf989440a220fff70600d38333bc99feef0453779e60caae0d05d1168cfffb0",
-      "url": "https://download.jetbrains.com/writerside/writerside-242.21870.138.dmg",
-      "build_number": "242.21870.138"
+      "version": "2024.3 EAP",
+      "sha256": "5a44fc83964514916c52b9cd49fa13e3f16757474a84dca85af7c6d97c2ede4b",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.21565.432.dmg",
+      "build_number": "243.21565.432"
     }
   },
   "aarch64-darwin": {
@@ -428,10 +428,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2024.2.2",
-      "sha256": "428d557d4b5eb7687c7c8142b61591ef4fe7825891d91616019292280696180e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.2-aarch64.dmg",
-      "build_number": "242.22855.75"
+      "version": "2024.2.3",
+      "sha256": "998d629381e6f596b8e0cf5289fe8ca7cfd3221fc73b6c8548d768889b14196f",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.2.3-aarch64.dmg",
+      "build_number": "242.23726.125"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -525,34 +525,34 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2024.2.3",
-      "sha256": "79ac4f9fb54f7049c2bb5ab3ec78280fe4991e3aaa4cc608cb06ce980c76a05a",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.3-aarch64.dmg",
-      "build_number": "242.23339.18"
+      "version": "2024.2.4",
+      "sha256": "4ccaff57fe8605962797313b3dcea2b4f373249bbaa9e56f242acacbd88d5635",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.4-aarch64.dmg",
+      "build_number": "242.23726.97"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2024.2.4",
-      "sha256": "3bdde43216bd21fcb93483dd9026ea15859e3e5a8d3d14c6e59526b734ebed69",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.4-aarch64.dmg",
-      "build_number": "242.23726.110"
+      "version": "2024.2.5",
+      "sha256": "f0ccd53e5cd8a0a143db956fbc6d118d3771bc42c62b846e9d396a620bea79d1",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.2.5-aarch64.dmg",
+      "build_number": "242.23726.162"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2024.2.4",
-      "sha256": "38c75389c1948e9a1343ad54e050483966a6eae1a4b862dc1d1bbe8e580de5f4",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.4-aarch64.dmg",
-      "build_number": "242.23726.96"
+      "version": "2024.3",
+      "sha256": "b3fed87c00746694419b0da71baf71ebb10a8c3803c5a1502c689ff9ce7831f4",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3-aarch64.dmg",
+      "build_number": "243.21565.180"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.dmg",
-      "version": "2024.2 EAP",
-      "sha256": "cb815cfe2fa9fd69675a31cb870ccf5037ac429a954cb950141074668f250014",
-      "url": "https://download.jetbrains.com/writerside/writerside-242.21870.138-aarch64.dmg",
-      "build_number": "242.21870.138"
+      "version": "2024.3 EAP",
+      "sha256": "04996f17dfb4a840c74270266efc4dad9b78fa498fb9016109d1b58b498791b5",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.21565.432-aarch64.dmg",
+      "build_number": "243.21565.432"
     }
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -19,15 +19,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip"
       },
       "name": "ideavim"
     },
@@ -69,15 +69,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip"
       },
       "name": "string-manipulation"
     },
@@ -100,15 +100,15 @@
       "builds": {
         "241.19072.1155": null,
         "242.21829.162": null,
-        "242.22855.75": null,
-        "242.23339.18": null,
         "242.23339.24": null,
         "242.23726.100": null,
         "242.23726.102": null,
         "242.23726.103": null,
         "242.23726.107": null,
-        "242.23726.110": null,
-        "242.23726.96": null
+        "242.23726.125": null,
+        "242.23726.162": null,
+        "242.23726.97": null,
+        "243.21565.180": null
       },
       "name": "kotlin"
     },
@@ -131,15 +131,15 @@
       "builds": {
         "241.19072.1155": null,
         "242.21829.162": null,
-        "242.22855.75": null,
-        "242.23339.18": "https://plugins.jetbrains.com/files/6981/609355/ini-242.23339.18.zip",
-        "242.23339.24": "https://plugins.jetbrains.com/files/6981/609355/ini-242.23339.18.zip",
+        "242.23339.24": null,
         "242.23726.100": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/6981/632272/ini-243.21565.180.zip"
       },
       "name": "ini"
     },
@@ -162,15 +162,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -191,8 +191,8 @@
         "phpstorm"
       ],
       "builds": {
-        "242.23726.103": "https://plugins.jetbrains.com/files/7320/619870/PHP_Annotations-11.1.0.zip",
-        "242.23726.107": "https://plugins.jetbrains.com/files/7320/619870/PHP_Annotations-11.1.0.zip"
+        "242.23726.103": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
+        "242.23726.107": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
       },
       "name": "php-annotations"
     },
@@ -210,13 +210,13 @@
       ],
       "builds": {
         "242.21829.162": "https://plugins.jetbrains.com/files/7322/595111/python-ce-242.21829.142.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/7322/605059/python-ce-242.22855.74.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/7322/608478/python-ce-242.23339.11.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/7322/630160/python-ce-243.21565.129.zip"
       },
       "name": "python-community-edition"
     },
@@ -238,16 +238,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip",
-        "242.21829.162": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23339.24": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.100": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.102": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.103": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.107": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip"
+        "242.21829.162": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23339.24": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.100": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.102": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.103": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.107": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.125": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip"
       },
       "name": "asciidoc"
     },
@@ -269,14 +269,14 @@
       "builds": {
         "241.19072.1155": null,
         "242.21829.162": null,
-        "242.22855.75": null,
-        "242.23339.18": null,
         "242.23339.24": null,
         "242.23726.100": null,
         "242.23726.102": null,
         "242.23726.103": null,
         "242.23726.107": null,
-        "242.23726.96": null
+        "242.23726.125": null,
+        "242.23726.97": null,
+        "243.21565.180": null
       },
       "name": "-deprecated-rust"
     },
@@ -298,14 +298,14 @@
       "builds": {
         "241.19072.1155": null,
         "242.21829.162": null,
-        "242.22855.75": null,
-        "242.23339.18": null,
         "242.23339.24": null,
         "242.23726.100": null,
         "242.23726.102": null,
         "242.23726.103": null,
         "242.23726.107": null,
-        "242.23726.96": null
+        "242.23726.125": null,
+        "242.23726.97": null,
+        "243.21565.180": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -319,10 +319,10 @@
         "ruby-mine"
       ],
       "builds": {
-        "242.23339.18": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip",
-        "242.23726.103": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip"
+        "242.23726.103": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -345,15 +345,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip"
       },
       "name": "nixidea"
     },
@@ -387,15 +387,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip"
       },
       "name": "csv-editor"
     },
@@ -416,17 +416,17 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/11349/622098/aws-toolkit-jetbrains-standalone-3.34-241.zip",
-        "242.21829.162": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23339.24": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.100": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.102": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.103": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.107": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip"
+        "241.19072.1155": "https://plugins.jetbrains.com/files/11349/632694/aws-toolkit-jetbrains-standalone-3.39-241.zip",
+        "242.21829.162": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23339.24": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.100": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.102": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.103": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.107": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.125": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/11349/632696/aws-toolkit-jetbrains-standalone-3.39-243.zip"
       },
       "name": "aws-toolkit"
     },
@@ -447,17 +447,17 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.19072.1155": null,
         "242.21829.162": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
       },
       "name": "vscode-keymap"
     },
@@ -480,15 +480,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -509,17 +509,17 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.19072.1155": null,
         "242.21829.162": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -542,15 +542,15 @@
       "builds": {
         "241.19072.1155": null,
         "242.21829.162": "https://plugins.jetbrains.com/files/14004/587347/protoeditor-242.21829.3.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/14004/587347/protoeditor-242.21829.3.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/14004/629971/protoeditor-243.21565.122.zip"
       },
       "name": "protocol-buffers"
     },
@@ -573,15 +573,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.21829.162": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "242.22855.75": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "242.23339.18": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.23339.24": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.23726.100": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.23726.102": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.23726.103": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "242.23726.107": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "242.23726.110": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "242.23726.96": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "242.23726.125": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "242.23726.162": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "242.23726.97": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.21565.180": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -602,19 +602,19 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.21829.162": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23339.24": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.100": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.102": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.103": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.107": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip"
+        "241.19072.1155": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.21829.162": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23339.24": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.100": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.102": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.103": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.107": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.125": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip"
       },
-      "name": "github-copilot"
+      "name": "github-copilot-intellij"
     },
     "18444": {
       "compatible": [
@@ -635,15 +635,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.21565.180": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -666,15 +666,15 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.21829.162": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
-        "242.22855.75": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
-        "242.23339.18": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.23339.24": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.23726.100": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.23726.102": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.23726.103": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "242.23726.107": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
-        "242.23726.96": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip"
+        "242.23726.125": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
+        "242.23726.97": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
+        "243.21565.180": null
       },
       "name": "mermaid"
     },
@@ -685,9 +685,9 @@
         "rust-rover"
       ],
       "builds": {
-        "242.22855.75": "https://plugins.jetbrains.com/files/22407/623488/intellij-rust-242.23726.110.zip",
-        "242.23726.103": "https://plugins.jetbrains.com/files/22407/623488/intellij-rust-242.23726.110.zip",
-        "242.23726.110": "https://plugins.jetbrains.com/files/22407/623488/intellij-rust-242.23726.110.zip"
+        "242.23726.103": "https://plugins.jetbrains.com/files/22407/629692/intellij-rust-242.23726.162.zip",
+        "242.23726.125": "https://plugins.jetbrains.com/files/22407/629692/intellij-rust-242.23726.162.zip",
+        "242.23726.162": "https://plugins.jetbrains.com/files/22407/629692/intellij-rust-242.23726.162.zip"
       },
       "name": "rust"
     }
@@ -695,36 +695,40 @@
   "files": {
     "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip": "sha256-QwguD4ENrL7GxmX+CGEyCPowbAPNpYgntVGAbHxOlyQ=",
     "https://plugins.jetbrains.com/files/10037/614791/intellij-csv-validator-4.0.0.zip": "sha256-DuztEfLOmwSWrWk+Q9rWYn/BzHrkx2giKTTpIbZdAOQ=",
-    "https://plugins.jetbrains.com/files/11349/622098/aws-toolkit-jetbrains-standalone-3.34-241.zip": "sha256-Q9Wi/ngotmka1fHorAQCTk3u7lXU7IMbBlCDZyzcFLA=",
-    "https://plugins.jetbrains.com/files/11349/622102/aws-toolkit-jetbrains-standalone-3.34-242.zip": "sha256-XgnQFwzWoxyO3Rk31oZgMxSHVzynoZIanuAlg4ZnaIE=",
-    "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip": "sha256-LeQ5vi9PCJYmWNmT/sutWjSlwZaAYYuEljVJBYG2VpY=",
+    "https://plugins.jetbrains.com/files/11349/632694/aws-toolkit-jetbrains-standalone-3.39-241.zip": "sha256-It4hm8A0RA8mWAPvAsz06V6zAmePVDxCDJwKFiFXXuo=",
+    "https://plugins.jetbrains.com/files/11349/632696/aws-toolkit-jetbrains-standalone-3.39-243.zip": "sha256-p+vbtqaIvaVOLQl5bCdwDe6UveObY9D3qdGmWEQ69TM=",
+    "https://plugins.jetbrains.com/files/11349/632698/aws-toolkit-jetbrains-standalone-3.39-242.zip": "sha256-DpgF0bayWT6hu3vlwsTXEGPNRQPgKWhyx16u0J/X8Jc=",
     "https://plugins.jetbrains.com/files/12062/586741/keymap-vscode-242.20224.385.zip": "sha256-LpooujwYaX339yZJVe7HPYIOw+YdJLeEtRgwPxLJ9eI=",
+    "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip": "sha256-/hEx0gIFvUXD799tRmMHAt9Z5ziFgaQs1RX0zQwTJIA=",
     "https://plugins.jetbrains.com/files/12559/579737/keymap-eclipse-242.20224.204.zip": "sha256-bAN0ifNiUqj51TYc7RLKwTMtv9OxjzqEQwXa6KtFlsU=",
-    "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip": "sha256-tNgt0vIkdCB/LcaSj58mT6cNlw4lytRo0cZSt7sIERU=",
+    "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
     "https://plugins.jetbrains.com/files/13017/591092/keymap-visualStudio-242.21829.44.zip": "sha256-aIwiMT30L3KCvbrkMUdgDdUdyBqGmT4w6c4pZEnMGNo=",
+    "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
     "https://plugins.jetbrains.com/files/1347/623989/scala-intellij-bin-2024.2.29.zip": "sha256-mgR+H69cpaXwF1z/HiWYFYzukcvEE2cPVZ6bP3TjHTk=",
     "https://plugins.jetbrains.com/files/14004/587347/protoeditor-242.21829.3.zip": "sha256-Y6xplTjA9bmhwLS9clcu/4znltSgDsga8Na5BmOWX5E=",
     "https://plugins.jetbrains.com/files/14004/608477/protoeditor-242.23339.11.zip": "sha256-gI3sY4jDXsY6pUhzqejJnvGJwLj6bNMs45UR8ekrZcs=",
+    "https://plugins.jetbrains.com/files/14004/629971/protoeditor-243.21565.122.zip": "sha256-cv6JTujoD5g90ngXTtnj5x31wjbIZlKZ6Zn0H+vHCTk=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip": "sha256-uMIrYoZE16X/K96HuDJx8QMh6wUbi4+qSw+HJAq7ukI=",
-    "https://plugins.jetbrains.com/files/17718/623947/github-copilot-intellij-1.5.27.7265.zip": "sha256-BxoQXtnDFm8a/8bN6Ow309K7UlDXJ23fTN4017x3VEo=",
+    "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip": "sha256-ljVGVi/i36EnLxzK7IVGiKVF8EyQTeNVCVKBtGlYNmg=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip": "sha256-DUiIQYIzYoXmgtBakSLtMB+xxJMaR70Jgg9erySa3wQ=",
     "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip": "sha256-OqeQCqFe8iW/8NPg+9i+UKh+twIPQ9uLZrItMukCi7k=",
-    "https://plugins.jetbrains.com/files/22407/623488/intellij-rust-242.23726.110.zip": "sha256-faN4knSIL9qR31zRBKt1TmxJFNBDtdGiViFJj+rLnRw=",
+    "https://plugins.jetbrains.com/files/22407/629692/intellij-rust-242.23726.162.zip": "sha256-QLh4Im0+rQqwk9nUVDv3HSRgMMqR7hwtN2CMaUNT2Go=",
     "https://plugins.jetbrains.com/files/631/622862/python-242.23726.103.zip": "sha256-rLGDVLj+HBe3EFzuwCNkHvVPaqT3z7qZnCil0kAO75I=",
-    "https://plugins.jetbrains.com/files/6981/609355/ini-242.23339.18.zip": "sha256-WucgAKBoKxnZvRfN2g8in8LjOOKAtECEN0sGcz28j4c=",
     "https://plugins.jetbrains.com/files/6981/623497/ini-242.23726.110.zip": "sha256-gSbiV74fQNU0xOkcK5BHozmy9Msslkhx9APH0JY74J8=",
+    "https://plugins.jetbrains.com/files/6981/632272/ini-243.21565.180.zip": "sha256-OV1hRCKODSnv6hcv5YaFkOwwpljhFVdOBoe12PH6cT4=",
+    "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip": "sha256-kVUEgfEKUupV/qlB4Dpzi5pFHjhVvX74XIPetKtjysM=",
     "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip": "sha256-Qp24juITBXEF5izdzayWq28Ioy4/kgT0qz6snZ0dND0=",
     "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip": "sha256-drNmhJMe+kuY2fcHjY+SQmkACvFk0rVI4vAhyZ/bgLc=",
-    "https://plugins.jetbrains.com/files/7320/619870/PHP_Annotations-11.1.0.zip": "sha256-jvK3J3NwUrOO7+izYM/SagnqJGAUHa9yGFCcZvkPfrA=",
+    "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip": "sha256-05aBYbqNIuwe/JTwntFdIqML8NHbTOwVusl1P9FzuYY=",
     "https://plugins.jetbrains.com/files/7322/595111/python-ce-242.21829.142.zip": "sha256-DwQNhbNO1zk75lcf35spNnzo0u103UAhXignhO+grek=",
-    "https://plugins.jetbrains.com/files/7322/605059/python-ce-242.22855.74.zip": "sha256-As1MgvssBg+45DLRtNbirT5HyXPcabzt3ulKYBIiWj8=",
     "https://plugins.jetbrains.com/files/7322/608478/python-ce-242.23339.11.zip": "sha256-tWsshZfm5czxBtF4ZfPHzi843Oztx2i0JEHcpnlLcSo=",
     "https://plugins.jetbrains.com/files/7322/622853/python-ce-242.23726.103.zip": "sha256-mHh0o6RN1Ey1dq+9yEDBCrE3CuF9Hx7fpmxUzPlWtlA=",
+    "https://plugins.jetbrains.com/files/7322/630160/python-ce-243.21565.129.zip": "sha256-d6YzBt753DNMdfPsZ7kFTIwgUbmXaVG5F7esY8BaGtA=",
     "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip": "sha256-oKczkLHAk2bJRNRgToVe0ySEJGF8+P4oWqQ33olwzWw=",
-    "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip": "sha256-AGP8YY6NG/hy7xIDoiJy3GZHRB9stVNYYoHtqOmYCx0=",
+    "https://plugins.jetbrains.com/files/7391/625836/asciidoctor-intellij-plugin-0.43.2.zip": "sha256-O5eLrj01zxW9b8GYkJMLZjmWLAq5nbWljGDrEal4AjA=",
     "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip": "sha256-pL+j0K6U0DZibnmcIE6kY9Kj/+5g8akuHeuppuZiEII=",
     "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip": "sha256-9GMqs/hSavcw1E4ZJTLDH1lx3HEeQ5NR8BT+Q9pN3io=",
     "https://plugins.jetbrains.com/files/9568/608453/go-plugin-242.23339.11.zip": "sha256-eEZw5q0+IHlf1Re3M6RwZOF7AXMn99a7n4nF54x5yew=",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Ran the updater for the jetbrains tools since some of them were outdated.

jetbrains.clion: 2024.2.2 -> 2024.2.3
jetbrains.ruby-mine: 2024.2.3 -> 2024.2.4
jetbrains.rust-rover: 2024.2.4 -> 2024.2.5
jetbrains.webstorm: 2024.2.4 -> 2024.3
jetbrains.writerside: 2024.2 EAP -> 2024.3 EAP

and a bunch of plugins.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
