### PR TITLE
pmbootstrap: 2.3.1 > 3.0.0

### DIFF
--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , git
+, multipath-tools
 , openssl
 , ps
 , fetchFromGitLab
@@ -11,14 +12,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "2.3.1";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitLab {
-    owner = "postmarketos";
+    owner = "postmarketOS";
     repo = pname;
     rev = version;
-    hash = "sha256-0hC84Gyfr1FOpZGAc7pAhz/QBSTA5A/Lu/ZJdzlEcX4=";
+    hash = "sha256-hUrWMU4V7tf/qVR4geR5FsCQ+BZA+zCPTdCZGN1PMKk=";
+    domain = "gitlab.postmarketos.org";
   };
 
   pmb_test = "${src}/test";
@@ -89,6 +91,7 @@ python3Packages.buildPythonApplication rec {
     "test_newapkbuild"
     "test_package"
     "test_package_from_aports"
+    "test_pkgrepo_pmaports"
     "test_pkgrel_bump"
     "test_pmbootstrap_status"
     "test_print_checks_git_repo"
@@ -110,7 +113,7 @@ python3Packages.buildPythonApplication rec {
     "test_version"
   ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git openssl ]}" ];
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git openssl multipath-tools ]}" ];
 
   passthru.updateScript = gitUpdater { };
 


### PR DESCRIPTION
Updated pmbootstrap to 3.0.0: [changelog](https://gitlab.postmarketos.org/postmarketOS/pmbootstrap/-/tags/3.0.0)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
