### PR TITLE
nixos/plymouth: Respect plymouth.enable=0 in scripted stage 1

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -333,26 +333,41 @@ in
 
     # We use `mkAfter` to ensure that LUKS password prompt would be shown earlier than the splash screen.
     boot.initrd.preLVMCommands = mkIf (!config.boot.initrd.systemd.enable) (mkAfter ''
-      mkdir -p /etc/plymouth
-      mkdir -p /run/plymouth
-      ln -s $extraUtils/etc/plymouth/logo.png /etc/plymouth/logo.png
-      ln -s ${configFile} /etc/plymouth/plymouthd.conf
-      ln -s $extraUtils/share/plymouth/plymouthd.defaults /run/plymouth/plymouthd.defaults
-      ln -s $extraUtils/share/plymouth/themes /run/plymouth/themes
-      ln -s $extraUtils/lib/plymouth /run/plymouth/plugins
-      ln -s $extraUtils/etc/fonts /etc/fonts
+      plymouth_enabled=1
+      for o in $(cat /proc/cmdline); do
+          case $o in
+              plymouth.enable=0)
+                  plymouth_enabled=0
+                  ;;
+          esac
+      done
 
-      plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session
-      plymouth show-splash
+      if [ "$plymouth_enabled" != 0 ]; then
+        mkdir -p /etc/plymouth
+        mkdir -p /run/plymouth
+        ln -s $extraUtils/etc/plymouth/logo.png /etc/plymouth/logo.png
+        ln -s ${configFile} /etc/plymouth/plymouthd.conf
+        ln -s $extraUtils/share/plymouth/plymouthd.defaults /run/plymouth/plymouthd.defaults
+        ln -s $extraUtils/share/plymouth/themes /run/plymouth/themes
+        ln -s $extraUtils/lib/plymouth /run/plymouth/plugins
+        ln -s $extraUtils/etc/fonts /etc/fonts
+
+        plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session
+        plymouth show-splash
+      fi
     '');
 
     boot.initrd.postMountCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      plymouth update-root-fs --new-root-dir="$targetRoot"
+      if [ "$plymouth_enabled" != 0 ]; then
+        plymouth update-root-fs --new-root-dir="$targetRoot"
+      fi
     '';
 
     # `mkBefore` to ensure that any custom prompts would be visible.
     boot.initrd.preFailCommands = mkIf (!config.boot.initrd.systemd.enable) (mkBefore ''
-      plymouth quit --wait
+      if [ "$plymouth_enabled" != 0 ]; then
+        plymouth quit --wait
+      fi
     '');
 
   };


### PR DESCRIPTION
Removing the splash param only causes plymouth to display console output by default; it still runs. Systemd stage 1 respects this flag due to unit conditions preventing plymouth from even running. So this brings parity to scripted stage 1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
