### PR TITLE
lib: init lists.uniqueStrings

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -287,6 +287,7 @@ let
         init
         crossLists
         unique
+        uniqueStrings
         allUnique
         intersectLists
         subtractLists

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -11,7 +11,7 @@ let
     warn
     pipe
     ;
-  inherit (lib.attrsets) mapAttrs;
+  inherit (lib.attrsets) mapAttrs attrNames;
   inherit (lib) max;
 in
 rec {
@@ -1839,6 +1839,10 @@ rec {
   /**
     Remove duplicate elements from the `list`. O(n^2) complexity.
 
+    :::{.note}
+    If the list only contains strings and order is not important, the complexity can be reduced to O(n log n) by using [`lib.lists.uniqueStrings`](#function-library-lib.lists.uniqueStrings) instead.
+    :::
+
     # Inputs
 
     `list`
@@ -1863,6 +1867,43 @@ rec {
     :::
   */
   unique = foldl' (acc: e: if elem e acc then acc else acc ++ [ e ]) [ ];
+
+  /**
+    Removes duplicate strings from the `list`. O(n log n) complexity.
+
+    :::{.note}
+    Order is not preserved.
+
+    All elements of the list must be strings without context.
+
+    This function fails when the list contains a non-string element or a [string with context](https://nix.dev/manual/nix/latest/language/string-context.html).
+    In that case use [`lib.lists.unique`](#function-library-lib.lists.unique) instead.
+    :::
+
+    # Inputs
+
+    `list`
+
+    : List of strings
+
+    # Type
+
+    ```
+    uniqueStrings :: [ String ] -> [ String ]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.lists.uniqueStrings` usage example
+
+    ```nix
+    uniqueStrings [ "foo" "bar" "foo" ]
+    => [ "bar" "foo" ] # order is not preserved
+    ```
+
+    :::
+  */
+  uniqueStrings = list: attrNames (groupBy id list);
 
   /**
     Check if list contains only unique elements. O(n^2) complexity.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -113,6 +113,7 @@ let
     toIntBase10
     toShellVars
     types
+    uniqueStrings
     updateManyAttrsByPath
     versions
     xor
@@ -1932,6 +1933,69 @@ runTests {
       4
     ];
     expected = false;
+  };
+
+  testUniqueStrings_empty = {
+    expr = uniqueStrings [ ];
+    expected = [ ];
+  };
+  testUniqueStrings_singles = {
+    expr = uniqueStrings [
+      "all"
+      "unique"
+      "already"
+    ];
+    expected = [
+      "all"
+      "already"
+      "unique"
+    ];
+  };
+  testUniqueStrings_allDuplicates = {
+    expr = uniqueStrings [
+      "dup"
+      "dup"
+      "dup"
+    ];
+    expected = [ "dup" ];
+  };
+  testUniqueStrings_some_duplicates = {
+    expr = uniqueStrings [
+      "foo"
+      "foo"
+      "bar"
+      "bar"
+      "baz"
+    ];
+    expected = [
+      "bar"
+      "baz"
+      "foo"
+    ];
+  };
+  testUniqueStrings_unicode = {
+    expr = uniqueStrings [
+      "café"
+      "@"
+      "#"
+      "@"
+      "#"
+      "$"
+      "😎"
+      "😎"
+      "🙃"
+      ""
+      ""
+    ];
+    expected = [
+      ""
+      "#"
+      "$"
+      "@"
+      "café"
+      "😎"
+      "🙃"
+    ];
   };
 
   # ATTRSETS


### PR DESCRIPTION
Computing a `unique` from a list with potential duplicates is a common use case.

O(n^2) can be reduced to O(n log n ) if it is known ahead of time that the list contains only strings.


CC Thanks to @Mic92 who had this idea.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
