### PR TITLE
mjpegtools: fix clang-19 by removing dead code

### DIFF
--- a/pkgs/by-name/mj/mjpegtools/package.nix
+++ b/pkgs/by-name/mj/mjpegtools/package.nix
@@ -16,9 +16,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sYBTbX2ZYLBeACOhl7ANyxAJKaSaq3HRnVX0obIQ9Jo=";
   };
 
-  # Clang 16 defaults to C++17. `std::auto_ptr` has been removed from C++17, and the
-  # `register` type class specifier is no longer allowed.
-  patches = [ ./c++-17-fixes.patch ];
+  patches = [
+    # Clang 16 defaults to C++17. `std::auto_ptr` has been removed from C++17,
+    # and the `register` type class specifier is no longer allowed.
+    ./c++-17-fixes.patch
+
+    # Clang-19 errors out for dead code (in header) which accesses undefined
+    # class members
+    ./remove-subtract-and-union-debug.diff
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/by-name/mj/mjpegtools/remove-subtract-and-union-debug.diff
+++ b/pkgs/by-name/mj/mjpegtools/remove-subtract-and-union-debug.diff
@@ -1,0 +1,347 @@
+diff --git a/y4mdenoise/Region2D.hh b/y4mdenoise/Region2D.hh
+index b44e93f..ebc2821 100644
+--- a/y4mdenoise/Region2D.hh
++++ b/y4mdenoise/Region2D.hh
+@@ -97,35 +97,11 @@ public:
+ 		// Add the given horizontal extent to the region.  Note that
+ 		// a_tnXEnd is technically one past the end of the extent.
+ 
+-	template <class REGION, class REGION_TEMP>
+-	void UnionDebug (Status_t &a_reStatus, INDEX a_tnY,
+-			INDEX a_tnXStart, INDEX a_tnXEnd, REGION_TEMP &a_rTemp);
+-		// Add the given horizontal extent to the region.  Note that
+-		// a_tnXEnd is technically one past the end of the extent.
+-		// Exhaustively (i.e. slowly) verifies the results, using a
+-		// much simpler algorithm.
+-		// Requires the use of a temporary region, usually of the
+-		// final subclass' type, in order to work.  (Since that can't
+-		// be known at this level, a template parameter is included for
+-		// it.)
+-
+ 	template <class REGION>
+ 	void Union (Status_t &a_reStatus, const REGION &a_rOther);
+ 		// Make the current region represent the union between itself
+ 		// and the other given region.
+ 
+-	template <class REGION, class REGION_O, class REGION_TEMP>
+-	void UnionDebug (Status_t &a_reStatus,
+-			REGION_O &a_rOther, REGION_TEMP &a_rTemp);
+-		// Make the current region represent the union between itself
+-		// and the other given region.
+-		// Exhaustively (i.e. slowly) verifies the results, using a
+-		// much simpler algorithm.
+-		// Requires the use of a temporary region, usually of the
+-		// final subclass' type, in order to work.  (Since that can't
+-		// be known at this level, a template parameter is included for
+-		// it.)
+-
+ 	//void Merge (Status_t &a_reStatus, INDEX a_tnY, INDEX a_tnXStart,
+ 	//		INDEX a_tnXEnd);
+ 		// Merge this extent into the current region.
+@@ -166,37 +142,12 @@ public:
+ 		// Subtract the given horizontal extent from the region.  Note
+ 		// that a_tnXEnd is technically one past the end of the extent.
+ 
+-	template <class REGION_TEMP>
+-	void SubtractDebug (Status_t &a_reStatus, INDEX a_tnY,
+-			INDEX a_tnXStart, INDEX a_tnXEnd, REGION_TEMP &a_rTemp);
+-		// Subtract the given horizontal extent from the region.  Note
+-		// that a_tnXEnd is technically one past the end of the extent.
+-		// Exhaustively (i.e. slowly) verifies the results, using a
+-		// much simpler algorithm.
+-		// Requires the use of a temporary region, usually of the
+-		// final subclass' type, in order to work.  (Since that can't
+-		// be known at this level, a template parameter is included for
+-		// it.)
+-
+ 	template <class REGION>
+ 	void Subtract (Status_t &a_reStatus, const REGION &a_rOther);
+ 		// Subtract the other region from the current region, i.e.
+ 		// remove from the current region any extents that exist in the
+ 		// other region.
+ 	
+-	template <class REGION, class REGION_O, class REGION_TEMP>
+-	void SubtractDebug (Status_t &a_reStatus, REGION_O &a_rOther,
+-			REGION_TEMP &a_rTemp);
+-		// Subtract the other region from the current region, i.e.
+-		// remove from the current region any extents that exist in the
+-		// other region.
+-		// Exhaustively (i.e. slowly) verifies the results, using a
+-		// much simpler algorithm.
+-		// Requires the use of a temporary region, usually of the
+-		// final subclass' type, in order to work.  (Since that can't
+-		// be known at this level, a template parameter is included for
+-		// it.)
+-
+ 	//typedef ... ConstIterator;
+ 	//ConstIterator Begin (void) const { return m_setExtents.Begin(); }
+ 	//ConstIterator End (void) const { return m_setExtents.End(); }
+@@ -404,85 +355,6 @@ Region2D<INDEX,SIZE>::~Region2D()
+ 
+ 
+ 
+-// Add the given horizontal extent to the region.
+-template <class INDEX, class SIZE>
+-template <class REGION, class REGION_TEMP>
+-void
+-Region2D<INDEX,SIZE>::UnionDebug (Status_t &a_reStatus, INDEX a_tnY,
+-	INDEX a_tnXStart, INDEX a_tnXEnd, REGION_TEMP &a_rTemp)
+-{
+-	typename REGION::ConstIterator itHere;
+-	typename REGION_TEMP::ConstIterator itHereO;
+-	INDEX tnX;
+-		// Used to loop through points.
+-
+-	// Make sure they didn't start us off with an error.
+-	assert (a_reStatus == g_kNoError);
+-
+-	// Calculate the union.
+-	a_rTemp.Assign (a_reStatus, *this);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	a_rTemp.Union (a_reStatus, a_tnY, a_tnXStart, a_tnXEnd);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	
+-	// Loop through every point in the result, make sure it's in
+-	// one of the two input regions.
+-	for (itHereO = a_rTemp.Begin(); itHereO != a_rTemp.End(); ++itHereO)
+-	{
+-		const Extent &rHere = *itHereO;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!((rHere.m_tnY == a_tnY
+-				&& (tnX >= a_tnXStart && tnX < a_tnXEnd))
+-			|| this->DoesContainPoint (rHere.m_tnY, tnX)))
+-				goto error;
+-		}
+-	}
+-
+-	// Loop through every point in the original region, make sure
+-	// it's in the result.
+-	for (itHere = this->Begin(); itHere != this->End(); ++itHere)
+-	{
+-		const Extent &rHere = *itHere;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!a_rTemp.DoesContainPoint (rHere.m_tnY, tnX))
+-				goto error;
+-		}
+-	}
+-
+-	// Loop through every point in the added extent, make sure it's in
+-	// the result.
+-	for (tnX = a_tnXStart; tnX < a_tnXEnd; ++tnX)
+-	{
+-		if (!a_rTemp.DoesContainPoint (a_tnY, tnX))
+-			goto error;
+-	}
+-
+-	// The operation succeeded.  Commit it.
+-	Assign (a_reStatus, a_rTemp);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-
+-	// All done.
+-	return;
+-
+-error:
+-	// Handle deviations.
+-	fprintf (stderr, "Region2D::Union() failed\n");
+-	fprintf (stderr, "Input region:\n");
+-	PrintRegion (*this);
+-	fprintf (stderr, "Input extent: [%d,%d-%d]\n",
+-		int (a_tnY), int (a_tnXStart), int (a_tnXEnd));
+-	fprintf (stderr, "Result:\n");
+-	PrintRegion (a_rTemp);
+-	assert (false);
+-}
+-
+-
+-
+ // Make the current region represent the union between itself
+ // and the other given region.
+ template <class INDEX, class SIZE>
+@@ -513,182 +385,6 @@ Region2D<INDEX,SIZE>::Union (Status_t &a_reStatus,
+ 
+ 
+ 
+-// Make the current region represent the union between itself
+-// and the other given region.
+-template <class INDEX, class SIZE>
+-template <class REGION, class REGION_O, class REGION_TEMP>
+-void
+-Region2D<INDEX,SIZE>::UnionDebug (Status_t &a_reStatus,
+-	REGION_O &a_rOther, REGION_TEMP &a_rTemp)
+-{
+-	typename REGION::ConstIterator itHere;
+-	typename REGION_O::ConstIterator itHereO;
+-	typename REGION_TEMP::ConstIterator itHereT;
+-	INDEX tnX;
+-		// Used to loop through points.
+-
+-	// Make sure they didn't start us off with an error.
+-	assert (a_reStatus == g_kNoError);
+-
+-	// Calculate the union.
+-	a_rTemp.Assign (a_reStatus, *this);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	a_rTemp.Union (a_reStatus, a_rOther);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	
+-	// Loop through every point in the result, make sure it's in
+-	// one of the two input regions.
+-	for (itHereT = a_rTemp.Begin(); itHereT != a_rTemp.End(); ++itHereT)
+-	{
+-		const Extent &rHere = *itHereT;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!a_rOther.DoesContainPoint (rHere.m_tnY, tnX)
+-			&& !this->DoesContainPoint (rHere.m_tnY, tnX))
+-				goto error;
+-		}
+-	}
+-
+-	// Loop through every point in the first input region, make sure
+-	// it's in the result.
+-	for (itHere = this->Begin(); itHere != this->End(); ++itHere)
+-	{
+-		const Extent &rHere = *itHere;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!a_rTemp.DoesContainPoint (rHere.m_tnY, tnX))
+-				goto error;
+-		}
+-	}
+-
+-	// Loop through every point in the second input region, make sure
+-	// it's in the result.
+-	for (itHereO = a_rOther.Begin();
+-		 itHereO != a_rOther.End();
+-		 ++itHereO)
+-	{
+-		const Extent &rHere = *itHereO;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!a_rTemp.DoesContainPoint (rHere.m_tnY, tnX))
+-				goto error;
+-		}
+-	}
+-
+-	// The operation succeeded.  Commit it.
+-	Assign (a_reStatus, a_rTemp);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-
+-	// All done.
+-	return;
+-
+-error:
+-	// Handle deviations.
+-	fprintf (stderr, "Region2D::Union() failed\n");
+-	fprintf (stderr, "First input region:\n");
+-	PrintRegion (*this);
+-	fprintf (stderr, "Second input region:\n");
+-	PrintRegion (a_rOther);
+-	fprintf (stderr, "Result:\n");
+-	PrintRegion (a_rTemp);
+-	assert (false);
+-}
+-
+-
+-
+-// Subtract the other region from the current region, i.e.
+-// remove from the current region any areas that exist in the
+-// other region.
+-template <class INDEX, class SIZE>
+-template <class REGION, class REGION_O, class REGION_TEMP>
+-void
+-Region2D<INDEX,SIZE>::SubtractDebug (Status_t &a_reStatus,
+-	REGION_O &a_rOther, REGION_TEMP &a_rTemp)
+-{
+-	typename REGION::ConstIterator itHere;
+-	typename REGION_O::ConstIterator itHereO;
+-	typename REGION_TEMP::ConstIterator itHereT;
+-	INDEX tnX;
+-		// Used to loop through points.
+-
+-	// Make sure they didn't start us off with an error.
+-	assert (a_reStatus == g_kNoError);
+-
+-	// Calculate the difference.
+-	a_rTemp.Assign (a_reStatus, *this);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	a_rTemp.Subtract (a_reStatus, a_rOther);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-	
+-	// Loop through every point in the result, make sure it's in
+-	// the first input region but not the second.
+-	for (itHereT = a_rTemp.Begin(); itHereT != a_rTemp.End(); ++itHereT)
+-	{
+-		const Extent &rHere = *itHereT;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!(this->DoesContainPoint (rHere.m_tnY, tnX)
+-			&& !a_rOther.DoesContainPoint (rHere.m_tnY, tnX)))
+-				goto error;
+-		}
+-	}
+-
+-	// Loop through every point in the first input region, and if it's
+-	// not in the second input region, make sure it's in the result.
+-	for (itHere = this->Begin(); itHere != this->End(); ++itHere)
+-	{
+-		const Extent &rHere = *itHere;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (!a_rOther.DoesContainPoint (rHere.m_tnY, tnX))
+-			{
+-				if (!a_rTemp.DoesContainPoint (rHere.m_tnY, tnX))
+-					goto error;
+-			}
+-		}
+-	}
+-
+-	// Loop through every point in the second input region, make sure
+-	// it's not in the result.
+-	for (itHereO = a_rOther.Begin();
+-		 itHereO != a_rOther.End();
+-		 ++itHereO)
+-	{
+-		const Extent &rHere = *itHere;
+-		for (tnX = rHere.m_tnXStart; tnX < rHere.m_tnXEnd; ++tnX)
+-		{
+-			if (a_rTemp.DoesContainPoint (rHere.m_tnY, tnX))
+-				goto error;
+-		}
+-	}
+-
+-	// The operation succeeded.  Commit it.
+-	Assign (a_reStatus, a_rTemp);
+-	if (a_reStatus != g_kNoError)
+-		return;
+-
+-	// All done.
+-	return;
+-
+-error:
+-	// Handle deviations.
+-	fprintf (stderr, "Region2D::Subtract() failed\n");
+-	fprintf (stderr, "First input region:\n");
+-	PrintRegion (*this);
+-	fprintf (stderr, "Second input region:\n");
+-	PrintRegion (a_rOther);
+-	fprintf (stderr, "Result:\n");
+-	PrintRegion (a_rTemp);
+-	assert (false);
+-}
+-
+-
+-
+ // Flood-fill the current region.
+ template <class INDEX, class SIZE>
+ template <class CONTROL>


### PR DESCRIPTION
clang-19 errors out due to some unused debugging functions which access undefined class members. Deleting the code fixes the build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@emilazy 