### PR TITLE
Revert "stdenv: set NIX_DONT_SET_RPATH_FOR_TARGET on Darwin"

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -114,9 +114,14 @@ let
         export NIX_NO_SELF_RPATH=1
       '' + lib.optionalString (hostPlatform.isDarwin && hostPlatform.isMacOS) ''
         export MACOSX_DEPLOYMENT_TARGET=${hostPlatform.darwinMinVersion}
-      '' + lib.optionalString targetPlatform.isDarwin ''
-        export NIX_DONT_SET_RPATH_FOR_TARGET=1
-      '';
+      ''
+      # TODO this should be uncommented, but it causes stupid mass rebuilds. I
+      # think the best solution would just be to fixup linux RPATHs so we don't
+      # need to set `-rpath` anywhere.
+      # + lib.optionalString targetPlatform.isDarwin ''
+      #   export NIX_DONT_SET_RPATH_FOR_TARGET=1
+      # ''
+      ;
 
       inherit initialPath shell
         defaultNativeBuildInputs defaultBuildInputs;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -115,8 +115,11 @@ let
       '' + lib.optionalString (hostPlatform.isDarwin && hostPlatform.isMacOS) ''
         export MACOSX_DEPLOYMENT_TARGET=${hostPlatform.darwinMinVersion}
       ''
-      # TODO this should be uncommented, but it causes stupid mass rebuilds. I
-      # think the best solution would just be to fixup linux RPATHs so we don't
+      # TODO this should be uncommented, but it causes stupid mass rebuilds due to
+      # `pkgsCross.*.buildPackages` not being the same, resulting in cross-compiling
+      # for a target rebuilding all of `nativeBuildInputs` for that target.
+      #
+      # I think the best solution would just be to fixup linux RPATHs so we don't
       # need to set `-rpath` anywhere.
       # + lib.optionalString targetPlatform.isDarwin ''
       #   export NIX_DONT_SET_RPATH_FOR_TARGET=1


### PR DESCRIPTION
This reverts commit 10c87ee2c7661b0e699b270744439b2643aaa43b.

Fixes https://github.com/NixOS/nixpkgs/issues/355622.

@emilazy @sternenseemann 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
