### PR TITLE
kittycad-kcl-lsp: init at 0.1.61

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10445,6 +10445,12 @@
     githubId = 1058504;
     name = "José Luis Lafuente";
   };
+  jljox = {
+    email = "jeanluc.jox@gmail.com";
+    github = "jljox";
+    githubId = 3665886;
+    name = "Jean-Luc Jox";
+  };
   jloyet = {
     email = "ml@fatbsd.com";
     github = "fatpat";

--- a/pkgs/by-name/ki/kittycad-kcl-lsp/package.nix
+++ b/pkgs/by-name/ki/kittycad-kcl-lsp/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kittycad-kcl-lsp";
+  version = "0.1.61";
+
+  src = fetchFromGitHub {
+    owner = "KittyCAD";
+    repo = "kcl-lsp";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-VtrR4v0BJWYdoYFDJpWnmVqDhZMlPGm+g9yjxYfcFxQ=";
+  };
+
+  cargoHash = "sha256-51eFOJnc/GqgXtfVx/omR+KuC7x/oKGGR+s0z6nKXBg=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = {
+    description = "KittyCAD KCL language server";
+    changelog = "https://github.com/KittyCAD/kcl-lsp/releases/tag/v${version}";
+    homepage = "https://github.com/KittyCAD/kcl-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jljox ];
+    mainProgram = "kittycad-kcl-lsp";
+  };
+}


### PR DESCRIPTION
kittycad-kcl-lsp: init at 0.1.61
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
