### PR TITLE
panda3ds: init at 0.8.0-unstable-2024-11-12

### DIFF
--- a/pkgs/by-name/pa/panda3ds/config-file-path.patch
+++ b/pkgs/by-name/pa/panda3ds/config-file-path.patch
@@ -1,0 +1,17 @@
+diff --git a/src/emulator.cpp b/src/emulator.cpp
+index 9b856425..4a0ff113 100644
+--- a/src/emulator.cpp
++++ b/src/emulator.cpp
+@@ -104,7 +104,11 @@ std::filesystem::path Emulator::getConfigPath() {
+ 	if constexpr (Helpers::isAndroid()) {
+ 		return getAndroidAppPath() / "config.toml";
+ 	} else {
+-		return std::filesystem::current_path() / "config.toml";
++		if (!config.usePortableBuild) {
++			return Emulator::getAppDataRoot() / "config.toml";
++		} else {
++			return std::filesystem::current_path() / "config.toml";
++		}
+ 	}
+ }
+ #endif

--- a/pkgs/by-name/pa/panda3ds/no-vendor.patch
+++ b/pkgs/by-name/pa/panda3ds/no-vendor.patch
@@ -1,0 +1,163 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 051831e0..9bd3cc6b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,5 @@
++find_package(PkgConfig REQUIRED)
++
+ # We need to be able to use enable_language(OBJC) on Mac, so we need CMake 3.16 vs the 3.11 we use otherwise. Blame Apple.
+ if (APPLE)
+     set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+@@ -121,8 +123,6 @@ add_library(AlberCore STATIC)
+ 
+ include_directories(${PROJECT_SOURCE_DIR}/include/)
+ include_directories(${PROJECT_SOURCE_DIR}/include/kernel)
+-include_directories(${FMT_INCLUDE_DIR})
+-include_directories(third_party/boost/)
+ include_directories(third_party/elfio/)
+ include_directories(third_party/hips/include/)
+ include_directories(third_party/imgui/)
+@@ -142,8 +142,9 @@ add_compile_definitions(WIN32_LEAN_AND_MEAN)  # Make windows.h not include liter
+ add_compile_definitions(SDL_MAIN_HANDLED)
+ 
+ if(ENABLE_DISCORD_RPC AND NOT ANDROID)
+-    add_subdirectory(third_party/discord-rpc)
+-    include_directories(third_party/discord-rpc/include)
++    find_path(DISCORD_RPC_INCLUDE_DIR NAMES discord_rpc.h REQUIRED)
++    find_library(DISCORD_RPC_LIBRARY NAMES discord-rpc REQUIRED)
++    include_directories(${DISCORD_RPC_INCLUDE_DIR})
+ endif()
+ 
+ 
+@@ -160,7 +161,9 @@ if (NOT ANDROID)
+     endif()
+ endif()
+ 
+-add_subdirectory(third_party/fmt)
++find_package(fmt REQUIRED)
++include_directories(${FMT_INCLUDE_DIR})
++
+ add_subdirectory(third_party/toml11)
+ include_directories(third_party/toml11)
+ include_directories(third_party/glm)
+@@ -169,13 +172,13 @@ include_directories(third_party/duckstation)
+ 
+ add_subdirectory(third_party/cmrc)
+ 
+-set(BOOST_ROOT "${CMAKE_SOURCE_DIR}/third_party/boost")
+-set(Boost_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/third_party/boost")
+-set(Boost_NO_SYSTEM_PATHS ON)
+ add_compile_definitions(BOOST_NO_CXX98_FUNCTION_BASE) # Forbid Boost from using std::unary_function (Fixes MacOS build)
+ 
+-add_library(boost INTERFACE)
+-target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIR})
++pkg_check_modules(BOOST REQUIRED boost)
++include_directories(${BOOST_INCLUDE_DIRS})
++link_directories(${BOOST_LIBRARY_DIRS})
++target_link_libraries(AlberCore PRIVATE ${BOOST_LIBRARIES})
++add_definitions(${BOOST_CFLAGS_OTHER})
+ 
+ if(ANDROID)
+     set(CRYPTOPP_OPT_DISABLE_ASM ON CACHE BOOL "" FORCE)
+@@ -188,9 +191,9 @@ add_subdirectory(third_party/cryptopp)
+ add_subdirectory(third_party/glad)
+ 
+ if(ENABLE_LUAJIT)
+-    add_subdirectory(third_party/LuaJIT luajit)
+-    include_directories(third_party/LuaJIT/src ${CMAKE_BINARY_DIR}/luajit)
+-    set_target_properties(luajit PROPERTIES EXCLUDE_FROM_ALL 1)
++    pkg_check_modules(LUAJIT REQUIRED luajit)
++    include_directories(${LUAJIT_INCLUDE_DIRS})
++    link_directories(${LUAJIT_LIBRARY_DIRS})
+ 
+     if(MSVC)
+       target_compile_definitions(libluajit PRIVATE _CRT_SECURE_NO_WARNINGS)
+@@ -199,7 +202,8 @@ if(ENABLE_LUAJIT)
+     endif()
+ 
+     target_compile_definitions(AlberCore PUBLIC "PANDA3DS_ENABLE_LUA=1")
+-    target_link_libraries(AlberCore PRIVATE libluajit)
++    target_link_libraries(AlberCore PRIVATE ${LUAJIT_LIBRARIES})
++    add_definitions(${LUAJIT_CFLAGS_OTHER})
+ endif()
+ 
+ # Check for x64
+@@ -238,7 +242,7 @@ endif()
+ 
+ if(HOST_X64 OR HOST_ARM64)
+     set(DYNARMIC_TESTS OFF)
+-    #set(DYNARMIC_NO_BUNDLED_FMT ON)
++    set(DYNARMIC_NO_BUNDLED_FMT ON)
+     set(DYNARMIC_FRONTENDS "A32" CACHE STRING "")
+     add_subdirectory(third_party/dynarmic)
+     add_compile_definitions(CPU_DYNARMIC)
+@@ -247,7 +251,10 @@ else()
+ endif()
+ 
+ add_subdirectory(third_party/teakra EXCLUDE_FROM_ALL)
+-add_subdirectory(third_party/fdk-aac)
++
++pkg_check_modules(FDK_AAC REQUIRED fdk-aac)
++include_directories(${FDK_AAC_INCLUDE_DIRS})
++link_directories(${FDK_AAC_LIBRARY_DIRS})
+ 
+ set(CAPSTONE_ARCHITECTURE_DEFAULT OFF)
+ set(CAPSTONE_ARM_SUPPORT ON)
+@@ -362,12 +369,13 @@ if(ENABLE_LUAJIT AND NOT ANDROID)
+     # Build luv and libuv for Lua TCP server usage if we're not on Android
+     include_directories(third_party/luv/src)
+     include_directories(third_party/luv/deps/lua-compat-5.3/c-api)
+-    include_directories(third_party/libuv/include)
+     set(THIRD_PARTY_SOURCE_FILES ${THIRD_PARTY_SOURCE_FILES} third_party/luv/src/luv.c)
+-    set(LIBUV_BUILD_SHARED OFF)
+ 
+-    add_subdirectory(third_party/libuv)
+-    target_link_libraries(AlberCore PRIVATE uv_a)
++    pkg_check_modules(LIBUV REQUIRED libuv)
++    include_directories(${LIBUV_INCLUDE_DIRS})
++    link_directories(${LIBUV_LIBRARY_DIRS})
++    target_link_libraries(AlberCore PRIVATE ${LIBUV_LIBRARIES})
++    add_definitions(${LIBUV_CFLAGS_OTHER})
+ endif()
+ 
+ if(ENABLE_QT_GUI)
+@@ -577,12 +585,13 @@ set(ALL_SOURCES ${SOURCE_FILES} ${FS_SOURCE_FILES} ${CRYPTO_SOURCE_FILES} ${KERN
+     ${AUDIO_SOURCE_FILES} ${HEADER_FILES} ${FRONTEND_HEADER_FILES})
+ target_sources(AlberCore PRIVATE ${ALL_SOURCES})
+ 
+-target_link_libraries(AlberCore PRIVATE dynarmic cryptopp glad resources_console_fonts teakra fdk-aac)
++target_link_libraries(AlberCore PRIVATE dynarmic cryptopp glad resources_console_fonts teakra ${FDK_AAC_LIBRARIES})
+ target_link_libraries(AlberCore PUBLIC glad capstone fmt::fmt)
+ 
+ if(ENABLE_DISCORD_RPC AND NOT ANDROID)
+     target_compile_definitions(AlberCore PUBLIC "PANDA3DS_ENABLE_DISCORD_RPC=1")
+-    target_link_libraries(AlberCore PRIVATE discord-rpc)
++    target_link_libraries(AlberCore PRIVATE ${DISCORD_RPC_LIBRARY})
++    add_definitions(${DISCORD_RPC_CFLAGS_OTHER})
+ endif()
+ 
+ if(GPU_DEBUG_INFO)
+@@ -703,10 +712,7 @@ endif()
+ if(ENABLE_TESTS)
+     enable_testing()
+ 
+-    find_package(Catch2 3)
+-    if(NOT Catch2_FOUND)
+-        add_subdirectory(third_party/Catch2)
+-    endif()
++    find_package(Catch2 3 REQUIRED)
+ 
+     add_library(nihstro-headers INTERFACE)
+     target_include_directories(nihstro-headers SYSTEM INTERFACE ./third_party/nihstro/include)
+diff --git a/src/core/audio/aac_decoder.cpp b/src/core/audio/aac_decoder.cpp
+index 281539d8..e9b8832a 100644
+--- a/src/core/audio/aac_decoder.cpp
++++ b/src/core/audio/aac_decoder.cpp
+@@ -1,6 +1,6 @@
+ #include "audio/aac_decoder.hpp"
+ 
+-#include <aacdecoder_lib.h>
++#include <fdk-aac/aacdecoder_lib.h>
+ 
+ #include <vector>
+ using namespace Audio;

--- a/pkgs/by-name/pa/panda3ds/package.nix
+++ b/pkgs/by-name/pa/panda3ds/package.nix
@@ -1,0 +1,199 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+
+  xorg,
+  kdePackages,
+  cmake,
+  pkg-config,
+  imagemagick,
+
+  # Build the Emulator with Qt GUI
+  # Disable to compile with the SDL2 frontend instead
+  withQt ? false,
+
+  # (vulkan is currently experimental with qtgui and will cause a segfault, so don't even bother trying to compile it)
+  # (metal is not supported on qt gui at all, it always uses context_agl)
+  # (opengl is *always* required for the qt gui, even to just build it)
+  withVulkan ? stdenv.hostPlatform.isLinux && !withQt,
+  withMetal ? stdenv.hostPlatform.isDarwin && !withQt,
+  withOpenGL ? stdenv.hostPlatform.isLinux || withQt,
+
+  # Enable Lua (LuaJIT) scripting support
+  withLuaJIT ? true,
+
+  # Enable Discord RPC support
+  withDiscordRPC ? true,
+
+  # Enable RenderDoc API support
+  withRenderdoc ? false,
+
+  # Enable tests
+  # enableTests ? true,
+
+  SDL2,
+  libGL,
+  vulkan-headers,
+  vulkan-loader,
+  glslang,
+  wayland,
+  # misc. rt dep:
+  pulseaudio,
+
+  # msc. de-vendored deps
+  boost,
+  discord-rpc,
+  fdk_aac,
+  luajit,
+  libuv,
+  fmt,
+
+  # test framework
+  # catch2,
+}:
+stdenv.mkDerivation {
+  pname = "panda3ds";
+  version = "0.8.0-unstable-2024-11-12";
+
+  src = fetchFromGitHub {
+    owner = "wheremyfoodat";
+    repo = "panda3ds";
+    rev = "b85dba277fb777b095623a24cd924d0725e1596b";
+    hash = "sha256-zKpz7c3frSzHbIKnTB88y9GJOqW31xQdgUDjoAdDTi8=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./no-vendor.patch # de-vendor some dependencies
+    ./config-file-path.patch # move config file to the app data root
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    imagemagick
+  ] ++ (if withQt then [ kdePackages.wrapQtAppsHook ] else [ makeWrapper ]);
+
+  buildInputs =
+    [
+      SDL2
+      fdk_aac
+      boost
+      fmt
+    ]
+    ++ lib.optionals withQt [
+      kdePackages.qtbase
+      # kdePackages.qtwayland # (broken)
+    ]
+    ++ lib.optionals withLuaJIT [
+      luajit
+      libuv
+    ]
+    ++ lib.optionals withDiscordRPC [
+      discord-rpc
+    ]
+    ++ lib.optionals withVulkan [
+      vulkan-headers
+      vulkan-loader
+      glslang
+    ]
+    ++ lib.optionals withOpenGL [
+      libGL
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      xorg.libX11
+      wayland # required by context_egl_wayland
+    ];
+  # ++ lib.optionals enableTests [
+  #   catch2
+  # ];
+
+  # delete unused vendored third_party deps
+  postUnpack = ''
+    rm -r /build/source/third_party/{SDL2,discord-rpc,fdk-aac,LuaJIT,boost,Catch2,fmt}
+  '';
+
+  # fix missing ir/var/empty/constant_propagation_pass.cpp
+  postPatch = ''
+    mkdir -p third_party/dynarmic/src/dynarmic/ir/var
+    ln -s ../opt third_party/dynarmic/src/dynarmic/ir/var/empty
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # main binary
+    install -Dm755 /build/source/build/Alber $out/bin/Alber
+
+    # desktop file
+    install -Dm444 $src/.github/Alber.desktop $out/share/applications/Alber.desktop
+
+    # icons
+    for size in 16 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      magick convert \
+        -resize "$size"x"$size" \
+        $src/docs/img/Alber.png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/Alber.png
+    done
+
+    runHook postInstall
+  '';
+
+  postInstall =
+    let
+      libs = lib.makeLibraryPath (
+        lib.optionals withOpenGL [ libGL ]
+        ++ lib.optionals withVulkan [ vulkan-loader ]
+        ++ lib.optionals withDiscordRPC [ discord-rpc ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [ pulseaudio ]
+      );
+    in
+    if withQt then
+      ''
+        qtWrapperArgs+=(
+          --prefix LD_LIBRARY_PATH : ${libs}
+          --set QT_QPA_PLATFORM "xcb" # force x11, wayland segfaults
+        )
+      ''
+    else
+      ''
+        wrapProgram "$out/bin/Alber" \
+          --prefix LD_LIBRARY_PATH : ${libs}
+      '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_USER_BUILD" true)
+    (lib.cmakeBool "DISABLE_PANIC_DEV" true)
+    (lib.cmakeBool "ENABLE_RENDERDOC_API" withRenderdoc)
+    (lib.cmakeBool "ENABLE_METAL" withMetal)
+    (lib.cmakeBool "ENABLE_VULKAN" withVulkan)
+    (lib.cmakeBool "ENABLE_OPENGL" withOpenGL)
+    (lib.cmakeBool "ENABLE_LUAJIT" withLuaJIT)
+    (lib.cmakeBool "ENABLE_DISCORD_RPC" withDiscordRPC)
+    (lib.cmakeBool "ENABLE_QT_GUI" withQt)
+    (lib.cmakeBool "DISABLE_SSE4" (!stdenv.hostPlatform.sse4_1Support))
+    (lib.cmakeBool "ENABLE_LTO" true)
+    (lib.cmakeBool "USE_SYSTEM_SDL2" true)
+    (lib.cmakeBool "ENABLE_TESTS" false) # tests are broken
+  ];
+
+  meta = {
+    description = "HLE 3DS emulator" + lib.optionalString withQt " (Qt GUI)";
+    longDescription = ''
+      Panda3DS is an HLE, red-panda-themed Nintendo 3DS emulator written in C++ which started out as a fun project out
+       of curiosity, but evolved into something that can sort of play games!
+    '';
+    homepage = "https://panda3ds.com/";
+    changelog = "https://github.com/wheremyfoodat/Panda3DS/releases";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ griffi-gh ];
+    mainProgram = "Alber";
+    platforms = with lib.platforms; linux ++ darwin;
+    broken =
+      stdenv.hostPlatform.isDarwin # darwin needs more work (and i dont have a mac to test on)
+      || (withQt && !withOpenGL); # qt gui requires opengl (won't even build without -DENABLE_OPENGL=ON)
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9394,6 +9394,10 @@ with pkgs;
     stdenv = stdenvNoLibc;
   };
 
+  panda3ds-qt = panda3ds.override {
+    withQt = true;
+  };
+
   # These are used when buiding compiler-rt / libgcc, prior to building libc.
   preLibcCrossHeaders = let
     inherit (stdenv.targetPlatform) libc;


### PR DESCRIPTION
closes #355285

Open-source HLE Ninendo 3DS emulator
<img src="https://github.com/user-attachments/assets/c80789fa-c39c-42c0-918c-0c65fe3c9a4e" height="300">
 
Using unstable because latest stable release (0.8.0) is severely outdated and not recommended to be used by upstream.\
See note here: https://github.com/wheremyfoodat/Panda3DS/releases/tag/v0.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
