### PR TITLE
python312Packages.libpwquality: fix build

### DIFF
--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -33,24 +33,53 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YjvHzd4iEBvg+qHOVJ7/y9HqyeT+QDalNE/jdNM9BNs=";
   };
 
-  patches = [
-    # ensure python site-packages goes in $py output
-    ./python-binding-prefix.patch
-
-    (fetchpatch {
-      name = "musl.patch";
-      url = "https://github.com/libpwquality/libpwquality/commit/b0fcd96954be89e8c318e5328dd27c40b401de96.patch";
-      hash = "sha256-ykN1hcRKyX3QAqWTH54kUjOxN6+IwRpqQVsujTd9XWs=";
-    })
-  ];
+  patches =
+    lib.optionals (!enablePython) [
+      # this patch isn't useful but keeping it to avoid rebuilds on !enablePython
+      # before 24.11 fully lands
+      ./python-binding-prefix.patch
+    ]
+    ++ [
+      # remove next release
+      (fetchpatch {
+        name = "musl.patch";
+        url = "https://github.com/libpwquality/libpwquality/commit/b0fcd96954be89e8c318e5328dd27c40b401de96.patch";
+        hash = "sha256-ykN1hcRKyX3QAqWTH54kUjOxN6+IwRpqQVsujTd9XWs=";
+      })
+    ]
+    ++ lib.optionals enablePython [
+      # remove next release
+      (fetchpatch {
+        name = "pr-74-use-setuptools-instead-of-distutils.patch";
+        url = "https://github.com/libpwquality/libpwquality/commit/509b0a744adf533b524daaa65f25dda144a6ff40.patch";
+        hash = "sha256-AxiynPVxv/gONujyj8y6b1XlsNkKszzW5TT9oINR/oo=";
+      })
+      # remove next release
+      (fetchpatch {
+        name = "pr-80-respect-pythonsitedir.patch";
+        url = "https://github.com/libpwquality/libpwquality/commit/f92351b3998542e33d2b243fc446a4dd852dc972.patch";
+        hash = "sha256-1lmigZX/UiEFe9b0JXmlfw/371UYT4PF7Ev2Hv66v74=";
+      })
+      # ensure python site-packages goes in $py output
+      ./python-binding-root.patch
+    ];
 
   nativeBuildInputs = [
     autoreconfHook
     perl
-  ] ++ lib.optionals enablePython [ (python.withPackages (ps: with ps; [ distutils ])) ];
+  ] ++ lib.optionals enablePython [ (python.withPackages (ps: with ps; [ setuptools ])) ];
   buildInputs = [ cracklib ] ++ lib.optionals enablePAM [ pam ];
 
-  configureFlags = lib.optionals (!enablePython) [ "--disable-python-bindings" ];
+  configureFlags =
+    if enablePython then
+      [
+        "--enable-python-bindings=yes"
+        "--with-pythonsitedir=\"${python.sitePackages}\""
+      ]
+    else
+      # change to `--enable-python-bindings=no` in the future
+      # leave for now to avoid rebuilds on !enablePython before 24.11 fully lands
+      [ "--disable-python-bindings" ];
 
   meta = with lib; {
     homepage = "https://github.com/libpwquality/libpwquality";

--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -1,14 +1,15 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, fetchpatch
-, autoreconfHook
-, perl
-, cracklib
-, enablePAM ? stdenv.hostPlatform.isLinux
-, pam
-, enablePython ? false
-, python
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  autoreconfHook,
+  perl,
+  cracklib,
+  enablePAM ? stdenv.hostPlatform.isLinux,
+  pam,
+  enablePython ? false,
+  python,
 }:
 
 # python binding generates a shared library which are unavailable with musl build
@@ -18,7 +19,12 @@ stdenv.mkDerivation rec {
   pname = "libpwquality";
   version = "1.4.5";
 
-  outputs = [ "out" "dev" "lib" "man" ] ++ lib.optionals enablePython [ "py" ];
+  outputs = [
+    "out"
+    "dev"
+    "lib"
+    "man"
+  ] ++ lib.optionals enablePython [ "py" ];
 
   src = fetchFromGitHub {
     owner = "libpwquality";
@@ -38,7 +44,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ autoreconfHook perl ] ++ lib.optionals enablePython [ (python.withPackages (ps: with ps; [ distutils ])) ];
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+  ] ++ lib.optionals enablePython [ (python.withPackages (ps: with ps; [ distutils ])) ];
   buildInputs = [ cracklib ] ++ lib.optionals enablePAM [ pam ];
 
   configureFlags = lib.optionals (!enablePython) [ "--disable-python-bindings" ];
@@ -57,7 +66,11 @@ stdenv.mkDerivation rec {
       function and PAM module that can be used instead of pam_cracklib. The
       module supports all the options of pam_cracklib.
     '';
-    license = with licenses; [ bsd3 /* or */ gpl2Plus ];
+    license = with licenses; [
+      bsd3
+      # or
+      gpl2Plus
+    ];
     maintainers = with maintainers; [ jk ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libpwquality/python-binding-root.patch
+++ b/pkgs/development/libraries/libpwquality/python-binding-root.patch
@@ -1,0 +1,13 @@
+diff --git a/python/Makefile.am b/python/Makefile.am
+index 64d3892..365dc8e 100644
+--- a/python/Makefile.am
++++ b/python/Makefile.am
+@@ -14,7 +14,7 @@ all-local:
+ 	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV)
+ 
+ install-exec-local:
+-	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --root ${DESTDIR} --prefix=${prefix} --install-lib=$(pythonsitedir)
++	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --root ${py} --install-lib=$(pythonsitedir)
+ 
+ clean-local:
+ 	rm -rf py$(PYTHONREV)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #352882

Follow up from: #346286

- format to match the new standards in nixpkgs
- pull in patches to move from `distutils` which doesn't work in 3.12+ to `setuptools`
  - `setuptools` configuration works for `3.11`, might need to double check for the other python versions we support

I tried to drop the prefix patch all-together and just move the files from wherever they end up to `$py/lib/...` but I didn't manage to in the end

before:

```
S result-py
└── D lib
    └── D python3.11
        └── D site-packages
            ├── F pwquality-1.4.5-py3.11.egg-info
            └── F pwquality.cpython-311-x86_64-linux-gnu.so
```

after:

```
S result-py
└── D lib
    └── D python3.11
        └── D site-packages
            ├── D pwquality-1.4.5-py3.11.egg-info
            │   ├── F dependency_links.txt
            │   ├── F PKG-INFO
            │   ├── F SOURCES.txt
            │   └── F top_level.txt
            └── F pwquality.cpython-311-x86_64-linux-gnu.so
```

I expect this to be non breaking for egg-info but I'm not a python person

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
