### PR TITLE
nerd-fonts: init; replace single package nerdfonts

### DIFF
--- a/pkgs/data/fonts/nerd-fonts/agave.nix
+++ b/pkgs/data/fonts/nerd-fonts/agave.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  makeNerdFont,
+}:
+
+makeNerdFont {
+  pname = "agave";
+  version = "0.0.1";
+  dirName = "bla";
+
+  unpatchedName = "";
+  meta = {
+    description = "";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4599,7 +4599,9 @@ with pkgs;
 
   navilu-font = callPackage ../data/fonts/navilu { stdenv = stdenvNoCC; };
 
-  nerdfonts = callPackage ../data/fonts/nerdfonts { };
+  nerd-fonts = lib.recurseIntoAttrs (import ./nerd-fonts.nix {
+    inherit lib stdenvNoCC newScope;
+  });
 
   netcdf-mpi = netcdf.override {
     hdf5 = hdf5-mpi.override { usev110Api = true; };

--- a/pkgs/top-level/nerd-fonts.nix
+++ b/pkgs/top-level/nerd-fonts.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenvNoCC,
+  newScope,
+}:
+
+lib.makeScope newScope (
+  self:
+  let
+    makeNerdFont =
+      args:
+      let
+        passthruAttributes = [
+          "dirName"
+          "originalName"
+          "declaresRFN"
+          "originalDescription"
+          "originalLicense"
+          "releaseVersion"
+        ];
+        args' = builtins.removeAttrs args passthruAttributes;
+      in
+      stdenvNoCC.mkDerivation (
+        lib.recursiveUpdate {
+          dontConfigure = true;
+          dontBuild = true;
+          installPhase = ''
+            runHook preInstall
+
+            dst_opentype=$out/share/fonts/opentype/NerdFonts/${args.dirName}
+            dst_truetype=$out/share/fonts/truetype/NerdFonts/${args.dirName}
+            find -name \*.otf -exec mkdir -p $dst_opentype \; -exec cp -p {} $dst_opentype \;
+            find -name \*.ttf -exec mkdir -p $dst_truetype \; -exec cp -p {} $dst_truetype \;
+
+            runHook postInstall
+          '';
+          dontFixup = true;
+
+          passthru = {
+            updateScript = [
+              ../data/fonts/nerd-fonts/update-specific-font.sh
+              # Helps specifying exactly which font are we updating - based on
+              # upstream's fonts.json file.
+              args.dirName
+            ];
+            # TODO: Inherit passthruAttributes of args here
+          };
+
+          meta = {
+            # description should be specified manually per font, as upstream's
+            # description (available here in args.originalDescription), doesn't
+            # fit our meta.description guidelines.
+            #
+            # License as well should be specified using the licenses in
+            # lib.licenses.
+            homepage = "https://nerdfonts.com/";
+            changelog = "https://github.com/ryanoasis/nerd-fonts/blob/v${args.releaseVersion}/changelog.md";
+            platforms = lib.platforms.all;
+            maintainers = with lib.maintainers; [
+              doronbehar
+              rc-zb
+            ];
+          };
+        } args'
+      );
+    callPackage = self.newScope {
+      inherit makeNerdFont;
+    };
+  in
+  lib.pipe ../data/fonts/nerd-fonts [
+    builtins.readDir
+    # Take only Nix files
+    (lib.filterAttrs (n: v: ((v == "regular") && (lib.hasSuffix ".nix" n))))
+    # Take the file names
+    builtins.attrNames
+    # Remove .nix suffix to get attribute names
+    (map (fName: lib.removeSuffix ".nix" fName))
+    (
+      attributes:
+      lib.genAttrs attributes (a: callPackage (../data/fonts/nerd-fonts + ("/" + a + ".nix")) { })
+    )
+  ]
+)


### PR DESCRIPTION
An alternative to https://github.com/NixOS/nixpkgs/pull/354543 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
