### PR TITLE
pay-respects: init at 0.4.18; nixos/pay-respects: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -115,6 +115,8 @@
 
 - [Eintopf](https://eintopf.info), a community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf.enable).
 
+- [`pay-respects`](https://codeberg.org/iff/pay-respects), a terminal command correction program, alternative to `thefuck`, written in Rust. Available as [programs.pay-respects](options.html#opt-programs.pay-respects).
+
 - [Radicle](https://radicle.xyz), an open source, peer-to-peer code collaboration stack built on Git. Available as [services.radicle](#opt-services.radicle.enable).
 
 - [ddns-updater](https://github.com/qdm12/ddns-updater), a service with a WebUI to update DNS records periodically for many providers. Available as [services.ddns-updater](#opt-services.ddns-updater.enable).

--- a/nixos/modules/programs/pay-respects.nix
+++ b/nixos/modules/programs/pay-respects.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  inherit (types) str;
+  cfg = config.programs.pay-respects;
+
+  initScript =
+    shell:
+    if (shell != "fish") then
+      ''
+        eval $(${getExe pkgs.pay-respects} ${shell} --alias ${cfg.alias})
+      ''
+    else
+      ''
+        ${getExe pkgs.pay-respects} ${shell} --alias ${cfg.alias} | source
+      '';
+in
+{
+  options = {
+    programs.pay-respects = {
+      enable = mkEnableOption "pay-respects, an app which corrects your previous console command";
+
+      alias = mkOption {
+        default = "f";
+        type = str;
+        description = ''
+          `pay-respects` needs an alias to be configured.
+          The default value is `f`, but you can use anything else as well.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.pay-respects ];
+
+    programs = {
+      bash.interactiveShellInit = initScript "bash";
+      fish.interactiveShellInit = mkIf config.programs.fish.enable initScript "fish";
+      zsh.interactiveShellInit = mkIf config.programs.zsh.enable initScript "zsh";
+    };
+  };
+  meta.maintainers = with maintainers; [ sigmasquadron ];
+}

--- a/pkgs/by-name/pa/pay-respects/package.nix
+++ b/pkgs/by-name/pa/pay-respects/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitea,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "pay-respects";
+  version = "0.4.18";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "iff";
+    repo = "pay-respects";
+    rev = "v${version}";
+    hash = "sha256-8YQgNOqZAMhn93rk0fw1SV02XhI/Wt9D5Rzo64cCs7s=";
+  };
+
+  cargoHash = "sha256-xLAJLwzX923E7Pzfwdw38moLOlY0Q4xK8himbKHQ7O8=";
+
+  meta = {
+    description = "Terminal command correction, alternative to `thefuck`, written in Rust";
+    homepage = "https://codeberg.org/iff/pay-respects";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ sigmasquadron ];
+    mainProgram = "pay-respects";
+  };
+}


### PR DESCRIPTION
A maintained replacement for `thefuck`.

Resolves #355631

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
