### PR TITLE
treewide: adopt/co-maintain some packages

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -313,5 +313,5 @@ in
     '';
 
   };
-
+  meta.maintainers = with lib.maintainers; [ sigmasquadron ];
 }

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.nano-editor.org/";
     description = "Small, user-friendly console text editor";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ joachifm nequissimus ];
+    maintainers = with maintainers; [ joachifm nequissimus sigmasquadron ];
     platforms = platforms.all;
     mainProgram = "nano";
   };

--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation rec {
     homepage = "https://keepassxc.org/";
     license = licenses.gpl2Plus;
     mainProgram = "keepassxc";
-    maintainers = with maintainers; [ blankparticle ];
+    maintainers = with maintainers; [ blankparticle sigmasquadron ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -205,7 +205,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = lib.licenses.bsd2;
     platforms = metaPlatforms;
-    maintainers = with lib.maintainers; [ adamcstephens raitobezarius mjoerg ];
+    maintainers = with lib.maintainers; [ adamcstephens raitobezarius mjoerg sigmasquadron ];
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 })

--- a/pkgs/by-name/as/asciiquarium/package.nix
+++ b/pkgs/by-name/as/asciiquarium/package.nix
@@ -26,6 +26,6 @@ in stdenv.mkDerivation {
     homepage = "https://robobunny.com/projects/asciiquarium/html/";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = [ maintainers.utdemir ];
+    maintainers = with maintainers; [ sigmasquadron utdemir ];
   };
 }

--- a/pkgs/by-name/ba/bat/package.nix
+++ b/pkgs/by-name/ba/bat/package.nix
@@ -75,6 +75,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/sharkdp/bat/raw/v${version}/CHANGELOG.md";
     license = with licenses; [ asl20 /* or */ mit ];
     mainProgram = "bat";
-    maintainers = with maintainers; [ dywedir zowoq SuperSandro2000 ];
+    maintainers = with maintainers; [ dywedir zowoq SuperSandro2000 sigmasquadron ];
   };
 }

--- a/pkgs/by-name/cn/cntr/package.nix
+++ b/pkgs/by-name/cn/cntr/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Mic92/cntr";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mic92 ];
+    maintainers = with maintainers; [ mic92 sigmasquadron ];
     mainProgram = "cntr";
   };
 }

--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.cryfs.org/";
     changelog   = "https://github.com/cryfs/cryfs/raw/${version}/ChangeLog.txt";
     license     = licenses.lgpl3Only;
-    maintainers = with maintainers; [ peterhoeg c0bw3b ];
+    maintainers = with maintainers; [ peterhoeg c0bw3b sigmasquadron ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     description =
       "C compiler, assembler and linker environment for the production of 8086 executables";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = with lib.maintainers; [ AndersonTorres sigmasquadron ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/du/duf/package.nix
+++ b/pkgs/by-name/du/duf/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
     homepage = "https://github.com/muesli/duf/";
     description = "Disk Usage/Free Utility";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda penguwin ];
+    maintainers = with maintainers; [ figsoda penguwin sigmasquadron ];
     mainProgram = "duf";
   };
 }

--- a/pkgs/by-name/er/er-patcher/package.nix
+++ b/pkgs/by-name/er/er-patcher/package.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
       that ensures the patched executable is never run with EAC enabled (unless explicity told to do so). Use at your own risk!
     '';
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.sigmasquadron ];
     mainProgram = "er-patcher";
   };
 }

--- a/pkgs/by-name/ez/eza/package.nix
+++ b/pkgs/by-name/ez/eza/package.nix
@@ -65,7 +65,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/eza-community/eza/releases/tag/v${version}";
     license = licenses.eupl12;
     mainProgram = "eza";
-    maintainers = with maintainers; [ cafkafk _9glenda ];
+    maintainers = with maintainers; [ cafkafk _9glenda sigmasquadron ];
     platforms = platforms.unix ++ platforms.windows;
   };
 }

--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
       ryneeverett
       alyaeanyx
       ryand56
+      sigmasquadron
     ];
     inherit (electron.meta) platforms;
     mainProgram = "freetube";

--- a/pkgs/by-name/la/lazygit/package.nix
+++ b/pkgs/by-name/la/lazygit/package.nix
@@ -37,6 +37,7 @@ buildGoModule rec {
       khaneliman
       paveloom
       starsep
+      sigmasquadron
     ];
     mainProgram = "lazygit";
   };

--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -278,7 +278,7 @@ stdenv.mkDerivation rec {
     mainProgram = "mullvad-browser";
     homepage = "https://mullvad.net/en/browser";
     platforms = attrNames sources;
-    maintainers = with maintainers; [ felschr panicgh ];
+    maintainers = with maintainers; [ felschr panicgh sigmasquadron ];
     # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
     # the compound is "libre" in a strict sense (some components place certain
     # restrictions on redistribution), it's free enough for our purposes.

--- a/pkgs/by-name/mu/music-player/package.nix
+++ b/pkgs/by-name/mu/music-player/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/tsirysndr/music-player";
     changelog = "https://github.com/tsirysndr/music-player/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.sigmasquadron ];
     mainProgram = "music-player";
   };
 }

--- a/pkgs/by-name/se/seabios/package.nix
+++ b/pkgs/by-name/se/seabios/package.nix
@@ -9,7 +9,7 @@
   ___build-type ? "csm",
 }:
 
-assert lib.elem (___build-type) [
+assert lib.elem ___build-type [
   "coreboot"
   # SeaBIOS with CSM (Compatible Support Module) support; learn more at
   # https://www.electronicshub.org/what-is-csm-bios/
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
       use of coreboot.
     '';
     license = with lib.licenses; [ lgpl3Plus ];
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ sigmasquadron ];
     platforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isUnix lib.systems.inspect.patterns.isx86;
     badPlatforms = [ lib.systems.inspect.patterns.isDarwin ];
   };

--- a/pkgs/by-name/st/steamguard-cli/package.nix
+++ b/pkgs/by-name/st/steamguard-cli/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dyc3/steamguard-cli";
     license = with licenses; [ gpl3Only ];
     mainProgram = "steamguard";
-    maintainers = with maintainers; [ surfaceflinger ];
+    maintainers = with maintainers; [ surfaceflinger sigmasquadron ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -315,7 +315,7 @@ let
       changelog = "https://github.com/fish-shell/fish-shell/releases/tag/${version}";
       license = licenses.gpl2Only;
       platforms = platforms.unix;
-      maintainers = with maintainers; [ adamcstephens cole-h winter ];
+      maintainers = with maintainers; [ adamcstephens cole-h winter sigmasquadron ];
       mainProgram = "fish";
     };
 

--- a/pkgs/tools/games/scarab/default.nix
+++ b/pkgs/tools/games/scarab/default.nix
@@ -76,7 +76,10 @@ buildDotnetModule rec {
     downloadPage = "https://github.com/fifty-six/Scarab/releases";
     changelog = "https://github.com/fifty-six/Scarab/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ huantian ];
+    maintainers = with lib.maintainers; [
+      huantian
+      sigmasquadron
+    ];
     mainProgram = "Scarab";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Hello maintainers! This PR adds me as a co-maintainer for a few packages I use, and would be happy to keep up-to-date and working. I'm also adopting two leaf packages and SeaBIOS, which is a critical dependency for Xen. I also plan to refactor some of these in the future to remove some of the legacy cruft that accumulated over the years.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
