### PR TITLE
descent3: init at 1.5.0-beta-unstable-2024-10-29

### DIFF
--- a/pkgs/by-name/de/descent3-unwrapped/package.nix
+++ b/pkgs/by-name/de/descent3-unwrapped/package.nix
@@ -1,0 +1,152 @@
+{
+  SDL2,
+  cmake,
+  fetchFromGitHub,
+  glm,
+  lib,
+  runCommand,
+  stdenv,
+  unstableGitUpdater,
+  writeShellScript,
+  zlib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "descent3-unwrapped";
+  # I’m using an unstable version here because we need to use -additionaldir in
+  # the wrapped version of Descent 3. Once there’s a stable version of Descent
+  # 3 that supports the -additionaldir command-line option, we can stop using
+  # an unstable version of Descent 3.
+  version = "1.5.0-beta-unstable-2024-10-29";
+  src = fetchFromGitHub {
+    owner = "DescentDevelopers";
+    repo = "Descent3";
+    rev = "d51ce964c7a925333ea64f00cf8d9ae15ee63a6b";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    # Descent 3 is supposed to display its Git commit hash in the bottom right
+    # corner of the main menu. That feature only works if either the .git
+    # directory or a git-hash.txt file exists at build time. We don’t want .git
+    # to exist at build time (see #8567), so we create a git-hash.txt file and
+    # then delete the .git directory.
+    #
+    # Technically, we could simplify the code by reading the value of src.rev.
+    # src.rev contains a Git commit hash at the moment, but it won’t contain a
+    # Git commit hash in the future when we switch to a stable version of
+    # Descent 3.
+    #
+    # Upstream expects git-hash.txt to contain a short commit hash, but I’ve
+    # decided to use a full commit hash. Full commit hashes are more
+    # reproducible. The short hash “1234” might correspond to one commit today,
+    # but correspond to two commits tomorrow. Full commit hashes don’t have
+    # that problem.
+    #
+    # Also, upstream expects git-hash.txt to contain no newlines. If
+    # git-hash.txt contains a newline, then Descent 3 will fail to build.
+    postFetch = ''
+      cd "$out"
+      git rev-parse --verify HEAD | tr --delete '\n' > git-hash.txt
+      rm -r .git
+    '';
+    hash = "sha256-C6r06cntQ14jPFO9EUzLisZjsl22cIaJb8I7xFzXrNc=";
+  };
+
+  hardeningDisable = [ "format" ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    SDL2
+    glm
+    zlib
+  ];
+  cmakeFlags = [ "-DFORCE_PORTABLE_INSTALL=OFF" ];
+  # This is a workaround for a problem that will eventually get fixed upstream.
+  postInstall = ''
+    cd "$out"
+    mv lib/* share/
+    rmdir lib
+  '';
+
+  passthru = {
+    # The idea here is to make sure that we don’t forget to update meta.license
+    # when reviewing a pull request from @r-ryantm.
+    tests.licenseInfoIsUpToDate = runCommand "${pname}-license-info-is-up-to-date" { } ''
+      function on_success {
+        echo Test succeeded. > "$out"
+      }
+
+      function on_failure {
+        echo \
+          It looks like at least one of Descent 3’s licensing-related files \
+          changed. Before you continue to update this package, you should \
+          check to see if meta.license needs to be updated. Once you’ve done \
+          that, you can update the hashes in the \
+          passthru.tests.licenseInfoIsUpToDate script and then try running the \
+          package tests again. >&2
+        return 1
+      }
+
+      cd ${lib.strings.escapeShellArg src}
+      sha256sum --check << EOF && on_success || on_failure
+        8b1ba204bb69a0ade2bfcf65ef294a920f6bb361b317dba43c7ef29d96332b9b  LICENSE
+        55d65dbf5d785111cf7029941cb7f72dbef084509e6126bcc58b6bb20203f8c6  THIRD_PARTY.md
+      EOF
+    '';
+    updateScript = unstableGitUpdater {
+      shallowClone = false;
+      # unstableGitUpdater assumes that the version number should be 0 if there
+      # isn’t any tags in the repo’s default branch. For most packages, that is
+      # the correct decision, but for Descent 3 it’s not. Descent 3’s source
+      # code lived in private repos until 2024. In 2024, a new public repo was
+      # created [1], but the old commit history wasn’t imported into the new
+      # repo. Version 1.5.0-beta from 2005 [2] was the last release that was
+      # created from one of the private repos.*
+      #
+      # *Technically, there was one release that came after the 2005 one. There
+      # was a Linux version and a macOS version of Descent 3 that were released
+      # on Steam in 2020 [3][4][5]. Those versions don’t count because they
+      # haven’t been fully merged into the public repo yet [6].
+      #
+      # [1]: <https://github.com/DescentDevelopers/Descent3/commit/637df31ca1e47371fb8ca822f928734c13afd8cf>
+      # [2]: <http://descent3.com/downloads.php>
+      # [3]: <https://www.patreon.com/posts/project-descent-33611585>
+      # [4]: <https://steamdb.info/depot/273592>
+      # [5]: <https://steamdb.info/depot/273593>
+      # [6]: <https://github.com/DescentDevelopers/Descent3/issues/240>
+      tagConverter = writeShellScript "${pname}-tag-converter.sh" ''
+        read -r input_tag
+        if [ "$input_tag" = 0 ]
+        then
+          printf '%s' 1.5.0-beta
+        else
+          printf '%s' "$input_tag"
+        fi
+      '';
+    };
+  };
+
+  meta = {
+    description = "Game engine for a 6DOF first-person shooter";
+    homepage = "https://github.com/DescentDevelopers/Descent3";
+    license = with lib.licenses; [
+      # See LICENSE and header that’s at the top of many source files.
+      gpl3Plus
+      # See THIRD_PARTY.md.
+      isc
+      mit
+    ];
+    mainProgram = "Descent3";
+    maintainers = [ lib.maintainers.jayman2000 ];
+    platforms = lib.platforms.all;
+    badPlatforms = [
+      # Descent 3 stores modules in HOG2 archives. It extracts those modules
+      # and then tries to dlopen() them at runtime.
+      lib.systems.inspect.platformPatterns.isStatic
+      # When you build Descent 3 on Darwin, it produces a different directory
+      # structure (no bin/ directory) [1]. I’m sure that this derivation could be
+      # updated to account for that different directory structure, but I don’t
+      # have any Darwin systems to test things on at the moment.
+      #
+      # [1]: <https://logs.ofborg.org/?key=nixos/nixpkgs.355710&attempt_id=747dd630-5068-4ba9-9c50-6f150634ef1a>
+    ] ++ lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/de/descent3/package.nix
+++ b/pkgs/by-name/de/descent3/package.nix
@@ -1,0 +1,60 @@
+{
+  descent3-unwrapped,
+  lib,
+  makeBinaryWrapper,
+  runCommand,
+}:
+
+runCommand "descent3-${descent3-unwrapped.version}"
+  {
+    pname = "descent3";
+    inherit (descent3-unwrapped) version;
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    passthru.unwrapped = descent3-unwrapped;
+
+    meta = descent3-unwrapped.meta // {
+      # The code that produces the wrapper is in the Nixpkgs repo, and the
+      # Nixpkgs repo is MIT Licensed.
+      license = [ lib.licenses.mit ];
+      longDescription = ''
+        Playing Descent 3 using the Nix package manager is a little bit awkward
+        at the moment. This wrapper makes it slightly less awkward. Here’s how
+        you use this wrapper:
+
+        1. Install the `descent3` package, or start an ephemeral shell with the
+        `descent3` package.
+
+        2. Find the documentation folder for `descent3-unwrapped` by running this
+        command:
+
+            ```bash
+            nix-instantiate --eval --expr '(import <nixpkgs> { }).descent3-unwrapped + "/share/doc/Descent3"'
+            ```
+
+        3. Open `<descent3-unwrapped-doc-folder>/USAGE.md`.
+
+        4. Follow steps 1–6 of Descent 3’s usage instructions.
+
+        5. Change directory into the `D3-open-source` folder:
+
+          ```bash
+          cd <path-to-D3-open-source>
+          ```
+
+        6. Start Descent 3 by running this command:
+
+            ```bash
+            Descent3
+            ```
+      '';
+    };
+  }
+  ''
+    mkdir --parents "$out/bin"
+    descent3_unwrapped=${lib.strings.escapeShellArg descent3-unwrapped}
+    makeBinaryWrapper \
+      "$descent3_unwrapped/bin/Descent3" \
+      "$out/bin/Descent3" \
+      --append-flags -additionaldir \
+      --append-flags "$descent3_unwrapped/share"
+  ''


### PR DESCRIPTION
This pull request adds two packages: `descent3` and `descent3-unwrapped`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
