### PR TITLE
python3Packages.python-mapnik: mark broken

### DIFF
--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -132,5 +132,6 @@ buildPythonPackage rec {
     maintainers = [ ];
     homepage = "https://mapnik.org";
     license = licenses.lgpl21Plus;
+    broken = true; # At 2024-11-13, test_raster_warping fails.
   };
 }


### PR DESCRIPTION
~~Fixes build. (Skipping "test_raster_warping")~~

Mark broken. (Avoids false positives)

Unmaintained package.