### PR TITLE
trafficserver: 9.2.5 -> 9.2.6

### DIFF
--- a/pkgs/by-name/tr/trafficserver/package.nix
+++ b/pkgs/by-name/tr/trafficserver/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchzip
+, autoreconfHook
 , makeWrapper
 , nixosTests
 , pkg-config
@@ -10,7 +11,6 @@
 , pcre
 , perlPackages
 , python3
-, catch2
 # recommended dependencies
 , withHwloc ? true
 , hwloc
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   #
   # [1]: https://github.com/apache/trafficserver/pull/5617
   # [2]: https://github.com/apache/trafficserver/blob/3fd2c60/configure.ac#L742-L788
-  nativeBuildInputs = [ makeWrapper pkg-config file python3 ]
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config file python3 ]
     ++ (with perlPackages; [ perl ExtUtilsMakeMaker ])
     ++ lib.optionals stdenv.hostPlatform.isLinux [ linuxHeaders ];
 
@@ -93,10 +93,8 @@ stdenv.mkDerivation rec {
       src/traffic_via/test_traffic_via \
       src/traffic_logstats/tests \
       tools/check-unused-dependencies
-
-    substituteInPlace configure --replace '/usr/bin/file' '${file}/bin/file'
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace configure \
+    substituteInPlace configure.ac \
       --replace '/usr/include/linux' '${linuxHeaders}/include/linux'
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # 'xcrun leaks' probably requires non-free XCode

--- a/pkgs/by-name/tr/trafficserver/package.nix
+++ b/pkgs/by-name/tr/trafficserver/package.nix
@@ -47,11 +47,11 @@
 
 stdenv.mkDerivation rec {
   pname = "trafficserver";
-  version = "9.2.5";
+  version = "9.2.7";
 
   src = fetchzip {
     url = "mirror://apache/trafficserver/trafficserver-${version}.tar.bz2";
-    hash = "sha256-RwhTI31LyupkAbXHsNrjcJqUjVoVpX3/2Ofxl2NdasU=";
+    hash = "sha256-i3UTqOO3gQezL2HmQllJa+hwy03tJViyOOflW2iXBAM=";
   };
 
   # NOTE: The upstream README indicates that flex is needed for some features,

--- a/pkgs/by-name/tr/trafficserver/package.nix
+++ b/pkgs/by-name/tr/trafficserver/package.nix
@@ -95,11 +95,11 @@ stdenv.mkDerivation rec {
       tools/check-unused-dependencies
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace configure.ac \
-      --replace '/usr/include/linux' '${linuxHeaders}/include/linux'
+      --replace-fail '/usr/include/linux' '${linuxHeaders}/include/linux'
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # 'xcrun leaks' probably requires non-free XCode
     substituteInPlace iocore/net/test_certlookup.cc \
-      --replace 'xcrun leaks' 'true'
+      --replace-fail 'xcrun leaks' 'true'
   '';
 
   configureFlags = [
@@ -121,7 +121,6 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    substituteInPlace rc/trafficserver.service --replace "syslog.target" ""
     install -Dm644 rc/trafficserver.service $out/lib/systemd/system/trafficserver.service
 
     wrapProgram $out/bin/tspush \


### PR DESCRIPTION
Fixes:
 - CVE-2024-38479 - Cache key plugin is vulnerable to cache poisoning attack
 - CVE-2024-50305 - Valid Host field value can cause crashes
 - CVE-2024-50306 - Server process can fail to drop privilege

See https://www.openwall.com/lists/oss-security/2024/11/13/1

https://github.com/apache/trafficserver/compare/9.2.5-rc0...9.2.6
https://github.com/apache/trafficserver/compare/9.2.6...9.2.7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
