### PR TITLE
backblaze-b2: remove tomhoule as maintainer

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -78,6 +78,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/Backblaze/B2_Command_Line_Tool";
     changelog = "https://github.com/Backblaze/B2_Command_Line_Tool/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ hrdinka kevincox tomhoule ];
+    maintainers = with maintainers; [ hrdinka kevincox ];
   };
 }


### PR DESCRIPTION
I don't have the bandwidth and the expertise to maintain a python package.