### PR TITLE
backblaze-b2: remove tomhoule as maintainer

### DIFF
--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -98,7 +98,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/Backblaze/B2_Command_Line_Tool";
     changelog = "https://github.com/Backblaze/B2_Command_Line_Tool/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ hrdinka tomhoule ];
+    maintainers = with maintainers; [ hrdinka ];
     mainProgram = "backblaze-b2";
   };
 }

--- a/pkgs/development/python-modules/phx-class-registry/default.nix
+++ b/pkgs/development/python-modules/phx-class-registry/default.nix
@@ -28,7 +28,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       hrdinka
-      tomhoule
     ];
   };
 }


### PR DESCRIPTION
I don't have the bandwidth or python expertise to maintain this derivation and/or its dependencies actively.

