### PR TITLE
aegisub: update OpenAL build for new Darwin SDK

### DIFF
--- a/pkgs/by-name/ae/aegisub/package.nix
+++ b/pkgs/by-name/ae/aegisub/package.nix
@@ -46,16 +46,6 @@
   useBundledLuaJIT ? false,
 }:
 
-let
-  inherit (darwin.apple_sdk.frameworks)
-    AppKit
-    Carbon
-    Cocoa
-    CoreFoundation
-    CoreText
-    IOKit
-    OpenAL;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "aegisub";
   version = "3.3.3";
@@ -106,15 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals portaudioSupport [ portaudio ]
   ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
-  ++ lib.optionals spellcheckSupport [ hunspell ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    AppKit
-    Carbon
-    Cocoa
-    CoreFoundation
-    CoreText
-    IOKit
-  ];
+  ++ lib.optionals spellcheckSupport [ hunspell ];
 
   hardeningDisable = [
     "bindnow"
@@ -161,9 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     # The Aegisub sources are itself BSD/ISC, but they are linked against GPL'd
     # softwares - so the resulting program will be GPL
-    license = with lib.licenses; [
-      bsd3
-    ];
+    license = with lib.licenses; [ bsd3 ];
     mainProgram = "aegisub";
     maintainers = with lib.maintainers; [ AndersonTorres wegank ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ae/aegisub/package.nix
+++ b/pkgs/by-name/ae/aegisub/package.nix
@@ -4,7 +4,6 @@
   boost,
   cmake,
   config,
-  darwin,
   expat,
   fetchFromGitHub,
   fetchpatch,
@@ -91,9 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ]
   ++ lib.optionals alsaSupport [ alsa-lib ]
-  ++ lib.optionals openalSupport [
-    (if stdenv.hostPlatform.isDarwin then OpenAL else openal)
-  ]
+  ++ lib.optionals (openalSupport && !stdenv.hostPlatform.isDarwin) [ openal ]
   ++ lib.optionals portaudioSupport [ portaudio ]
   ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
   ++ lib.optionals spellcheckSupport [ hunspell ];
@@ -129,6 +126,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeBuildDir = "build-directory";
+
+  cmakeFlags = lib.optionals (stdenv.hostPlatform.isDarwin && !openalSupport) [
+    # OpenAL is in the SDK and linked unless we disable it
+    "-DWITH_OPENAL=OFF"
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
`aegisub` has the option to be built with or without OpenAL. On Darwin, this was done by explicitly importing the OpenAL framework from the SDK (and `openal` on other platforms).

The new Darwin setup imports the whole SDK, including OpenAL. So we need to explicitly *exclude* it when building without openal support.

Based on [this review comment](https://github.com/NixOS/nixpkgs/pull/355564#discussion_r1839770225) by @tjni

Darwin migration Tracker: #354146

## IMPORTANT

Merge #355564 first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
