### PR TITLE
wmii: fix build by not building the python part that was disabled anyways

### DIFF
--- a/pkgs/by-name/wm/wmii/001-disable-python2-build.patch
+++ b/pkgs/by-name/wm/wmii/001-disable-python2-build.patch
@@ -1,0 +1,14 @@
+diff --git a/alternative_wmiircs/Makefile b/alternative_wmiircs/Makefile
+index 3b9c3709..3ce46169 100644
+--- a/alternative_wmiircs/Makefile
++++ b/alternative_wmiircs/Makefile
+@@ -3,8 +3,7 @@ include $(ROOT)/mk/hdr.mk
+ include $(ROOT)/mk/wmii.mk
+ 
+ BIN = $(GLOBALCONF)
+-DIRS =	python	\
+-	plan9port \
++DIRS =	plan9port \
+ 	ruby
+ 
+ DOCS   = README

--- a/pkgs/by-name/wm/wmii/package.nix
+++ b/pkgs/by-name/wm/wmii/package.nix
@@ -1,17 +1,19 @@
-{ lib, stdenv
-, fetchFromGitHub
-, dash
-, libX11
-, libXext
-, libXft
-, libXinerama
-, libXrandr
-, libXrender
-, libixp
-, pkg-config
-, txt2tags
-, unzip
-, which
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  dash,
+  libX11,
+  libXext,
+  libXft,
+  libXinerama,
+  libXrandr,
+  libXrender,
+  libixp,
+  pkg-config,
+  txt2tags,
+  unzip,
+  which,
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +50,10 @@ stdenv.mkDerivation rec {
     rm -rf $out/lib/python* $out/etc/wmii-hg/python
   '';
 
-  nativeBuildInputs = [ pkg-config unzip ];
+  nativeBuildInputs = [
+    pkg-config
+    unzip
+  ];
   buildInputs = [
     dash
     libX11

--- a/pkgs/by-name/wm/wmii/package.nix
+++ b/pkgs/by-name/wm/wmii/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wmii";
-  version = "unstable-2022-04-04";
+  version = "0-unstable-2023-09-30";
 
   src = fetchFromGitHub {
     owner = "0intro";
     repo = "wmii";
-    rev = "ff120c7fee6e1b3a30a4a800074394327fb1da9d";
-    hash = "sha256-KEmWnobpT/5TdgT2HGPCpG1duz9Q6Z6PFSEBs2Ce+7g=";
+    rev = "26848c93457606b350f57d6d313112a745a0cf3d";
+    hash = "sha256-5l2aYAoThbA0Aq8M2vPTzaocQO1AvrnWqgXhmBLADVk=";
   };
 
   # for dlopen-ing
@@ -45,10 +45,11 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  # Remove optional python2 functionality
-  postInstall = ''
-    rm -rf $out/lib/python* $out/etc/wmii-hg/python
-  '';
+  patches = [
+    # the python alternative wmiirc was not building due to errors with pyxp
+    # this patch disables building it altogether
+    ./001-disable-python2-build.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- **wmii: format using nixfmt**
- **wmii: fix build by disabling python building**

The built python part was stripped by the derivation anyways, Patched it so that it doesn't build at all to fix the build

ZHF: #352882 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
