### PR TITLE
lanraragi: 0.9.21 -> 0.9.22

### DIFF
--- a/pkgs/by-name/la/lanraragi/install.patch
+++ b/pkgs/by-name/la/lanraragi/install.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/install.pl b/tools/install.pl
-index f09218f..a63de58 100644
+index 9e155f0..a63de58 100644
 --- a/tools/install.pl
 +++ b/tools/install.pl
 @@ -9,6 +9,7 @@ use Config;
@@ -10,7 +10,7 @@ index f09218f..a63de58 100644
  
  #Vendor dependencies
  my @vendor_css = (
-@@ -90,32 +91,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
+@@ -90,33 +91,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
      $cpanopt = " -l " . $ENV{HOMEBREW_FORMULA_PREFIX} . "/libexec";
  }
  
@@ -19,6 +19,7 @@ index f09218f..a63de58 100644
 -install_package( "Config::AutoConf", $cpanopt );
 -IPC::Cmd->import('can_run');
 -require Config::AutoConf;
+-
 -
 -say("\r\nWill now check if all LRR software dependencies are met. \r\n");
 -
@@ -43,7 +44,7 @@ index f09218f..a63de58 100644
  #Check for PerlMagick
  say("Checking for ImageMagick/PerlMagick...");
  my $imgk;
-@@ -135,37 +110,11 @@ if ($@) {
+@@ -136,37 +110,11 @@ if ($@) {
      say("OK!");
  }
  
@@ -81,7 +82,7 @@ index f09218f..a63de58 100644
      make_path getcwd . "/public/css/vendor";
      make_path getcwd . "/public/css/webfonts";
      make_path getcwd . "/public/js/vendor";
-@@ -212,19 +161,3 @@ sub cp_node_module {
+@@ -213,19 +161,3 @@ sub cp_node_module {
  
  }
  

--- a/pkgs/by-name/la/lanraragi/package.nix
+++ b/pkgs/by-name/la/lanraragi/package.nix
@@ -1,22 +1,24 @@
-{ lib
-, stdenv
-, buildNpmPackage
-, fetchFromGitHub
-, makeBinaryWrapper
-, perl
-, ghostscript
-, nixosTests
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  perl,
+  ghostscript,
+  nixosTests,
+  nix-update-script,
 }:
 
 buildNpmPackage rec {
   pname = "lanraragi";
-  version = "0.9.22";
+  version = "0.9.30";
 
   src = fetchFromGitHub {
     owner = "Difegue";
     repo = "LANraragi";
-    rev = "v.${version}";
-    hash = "sha256-4Yais1pkpwDUJ4e2yfgMERVm94S9+eFUotjVdMOwTNE=";
+    tag = "v.${version}";
+    hash = "sha256-qYmuGuGsEYFFitU55xBgKGjrJ3oL31mUr0OACSJQ/Jo=";
   };
 
   patches = [
@@ -27,41 +29,47 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-RAjZGuK0C6R22fVFq82GPQoD1HpRs3MYMluUAV5ZEc8=";
 
-  nativeBuildInputs = [ perl makeBinaryWrapper ];
-
-  buildInputs = with perl.pkgs; [
+  nativeBuildInputs = [
     perl
-    ImageMagick
-    locallib
-    Redis
-    Encode
-    ArchiveLibarchiveExtract
-    ArchiveLibarchivePeek
-    ListMoreUtils
-    NetDNSNative
-    SortNaturally
-    AuthenPassphrase
-    FileReadBackwards
-    URI
-    LogfileRotate
-    Mojolicious
-    MojoliciousPluginTemplateToolkit
-    MojoliciousPluginRenderFile
-    MojoliciousPluginStatus
-    IOSocketSocks
-    IOSocketSSL
-    CpanelJSONXS
-    Minion
-    MinionBackendRedis
-    ProcSimple
-    ParallelLoops
-    SysCpuAffinity
-    FileChangeNotify
-    ModulePluggable
-    TimeLocal
-    YAMLPP
-    StringSimilarity
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ LinuxInotify2 ];
+    makeBinaryWrapper
+  ];
+
+  buildInputs =
+    with perl.pkgs;
+    [
+      perl
+      ImageMagick
+      locallib
+      Redis
+      Encode
+      ArchiveLibarchiveExtract
+      ArchiveLibarchivePeek
+      ListMoreUtils
+      NetDNSNative
+      SortNaturally
+      AuthenPassphrase
+      FileReadBackwards
+      URI
+      LogfileRotate
+      Mojolicious
+      MojoliciousPluginTemplateToolkit
+      MojoliciousPluginRenderFile
+      MojoliciousPluginStatus
+      IOSocketSocks
+      IOSocketSSL
+      CpanelJSONXS
+      Minion
+      MinionBackendRedis
+      ProcSimple
+      ParallelLoops
+      SysCpuAffinity
+      FileChangeNotify
+      ModulePluggable
+      TimeLocal
+      YAMLPP
+      StringSimilarity
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ LinuxInotify2 ];
 
   buildPhase = ''
     runHook preBuild
@@ -115,8 +123,15 @@ buildNpmPackage rec {
 
   passthru.tests.module = nixosTests.lanraragi;
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v\\.(.*)"
+    ];
+  };
+
   meta = {
-    changelog = "https://github.com/Difegue/LANraragi/releases/tag/${src.rev}";
+    changelog = "https://github.com/Difegue/LANraragi/releases/tag/${src.tag}";
     description = "Web application for archival and reading of manga/doujinshi";
     homepage = "https://github.com/Difegue/LANraragi";
     license = lib.licenses.mit;

--- a/pkgs/by-name/la/lanraragi/package.nix
+++ b/pkgs/by-name/la/lanraragi/package.nix
@@ -10,13 +10,13 @@
 
 buildNpmPackage rec {
   pname = "lanraragi";
-  version = "0.9.21";
+  version = "0.9.22";
 
   src = fetchFromGitHub {
     owner = "Difegue";
     repo = "LANraragi";
     rev = "v.${version}";
-    hash = "sha256-2YdQeBW1MQiUs5nliloISaxG0yhFJ6ulkU/Urx8PN3Y=";
+    hash = "sha256-4Yais1pkpwDUJ4e2yfgMERVm94S9+eFUotjVdMOwTNE=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/Difegue/LANraragi/releases/tag/v.0.9.22
https://github.com/Difegue/LANraragi/releases/tag/v.0.9.30

This PR bumps the version of `lanraragi`

Haven't had time to debug https://github.com/NixOS/nixpkgs/issues/337669 yet, will try to once I have more free time

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
