### PR TITLE
akkuPackages.chez-srfi: 0.0.0 -> 0.0.0-unstable-2024-10-31

### DIFF
--- a/pkgs/tools/package-management/akku/overrides.nix
+++ b/pkgs/tools/package-management/akku/overrides.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, akku, curl, git }:
+{ stdenv, lib, fetchFromGitHub, akku, curl, git }:
 let
   joinOverrides =
     overrides: pkg: old:
@@ -13,22 +13,29 @@ let
   runTests = pkg: old: { doCheck = true; };
   brokenOnAarch64 = _: lib.addMetaAttrs { broken = stdenv.hostPlatform.isAarch64; };
   brokenOnx86_64Darwin = lib.addMetaAttrs { broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64; };
+  brokenOnDarwin = lib.addMetaAttrs { broken = stdenv.hostPlatform.isDarwin; };
 in
 {
   chez-srfi = joinOverrides [
     (pkg: old: {
+      version = "0.0.0-unstable-2024-10-31";
       preCheck = ''
         SKIP='
         multi-dimensional-arrays.sps
         time.sps
         tables-test.ikarus.sps
         lazy.sps
+        pipeline-operators.sps
         '
       '';
+      src = fetchFromGitHub {
+        owner = "arcfide";
+        repo = "chez-srfi";
+        rev = "b424440b94037ace50fc8179f159b7e4c53e59e6";
+        hash = "sha256-Qg8XveLObiD6bZJ3FQNAgbZepnQHcB2GC+wzh58I5mA=";
+      };
+      unpackPhase = "";
     })
-
-    # nothing builds on ARM Macs because of this
-    brokenOnAarch64
   ];
 
   akku-r7rs = pkg: old: {
@@ -83,7 +90,7 @@ in
   # system-specific:
 
   # scheme-langserver doesn't work because of this
-  ufo-thread-pool = brokenOnx86_64Darwin;
+  ufo-thread-pool = brokenOnDarwin;
 
   # broken everywhere:
   chibi-math-linalg = broken;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #354530
As per @dbaynard's proposal, I added an override to update the source for `akkuPackages.chez-srfi` to this commit: https://github.com/arcfide/chez-srfi/commit/b424440b94037ace50fc8179f159b7e4c53e59e6. The srfi builds, though a test needed to be skipped. I will check if the change breaks anything later this week, but I am putting this up as a draft PR right now if anyone wants to try running it on Darwin. I can get access to x86 and ARM Macbooks this weekend, though

cc @dbaynard @nagy @corngood

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
