### PR TITLE
froide: init at 0-unstable-2024-11-22

### DIFF
--- a/pkgs/by-name/fr/froide/django_42_storages.patch
+++ b/pkgs/by-name/fr/froide/django_42_storages.patch
@@ -1,0 +1,19 @@
+diff --git a/froide/settings.py b/froide/settings.py
+index 428349cb..1e1bd7a8 100644
+--- a/froide/settings.py
++++ b/froide/settings.py
+@@ -867,9 +867,11 @@ class Production(Base):
+ 
+     ALLOWED_HOSTS = values.TupleValue(("example.com",))
+     CELERY_TASK_ALWAYS_EAGER = values.BooleanValue(False)
+-    STATICFILES_STORAGE = (
+-        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+-    )
++    STORAGES = {
++        'staticfiles': {
++            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
++        },
++    }
+ 
+ 
+ class SSLSite(object):

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -1,0 +1,174 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  makeWrapper,
+  gdal,
+  geos,
+  pnpm,
+  nodejs,
+  postgresql,
+  postgresqlTestHook,
+  playwright-driver,
+}:
+let
+
+  python = python3Packages.python.override {
+    packageOverrides = self: super: { django = super.django.override { withGdal = true; }; };
+  };
+
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "froide";
+  version = "0-unstable-2024-11-22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "okfde";
+    repo = "froide";
+    rev = "a90f5c4d40b46a161111eefdc84e5214e85715b0";
+    hash = "sha256-Q+iNI3yqxqAtDONHY+SaZeMyjY6hqTxwy7YmiiY94+0=";
+  };
+
+  patches = [ ./django_42_storages.patch ];
+
+  pythonRelaxDeps = [
+    "pikepdf"
+    "channels"
+  ];
+
+  build-system = [ python.pkgs.setuptools ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm.configHook
+  ];
+
+  dependencies = with python.pkgs; [
+    bleach
+    celery
+    celery-singleton
+    channels
+    coreapi
+    dj-database-url
+    django
+    django-celery-beat
+    django-celery-email
+    django-configurations
+    django-contrib-comments
+    django-crossdomainmedia
+    django-elasticsearch-dsl
+    django-filingcabinet
+    django-filter
+    # Project discontinued upstream
+    # https://github.com/okfde/froide/issues/893
+    django-fsm
+    django-json-widget
+    django-leaflet
+    django-mfa3
+    django-oauth-toolkit
+    django-parler
+    django-storages
+    django-taggit
+    django-treebeard
+    djangorestframework
+    djangorestframework-csv
+    djangorestframework-jsonp
+    drf-spectacular
+    drf-spectacular-sidecar
+    easy-thumbnails
+    elasticsearch
+    elasticsearch-dsl
+    geoip2
+    icalendar
+    markdown
+    phonenumbers
+    pillow
+    pikepdf
+    psycopg
+    pygtail
+    pyisemail
+    pypdf
+    python-magic
+    python-mimeparse
+    python-slugify
+    requests
+    wand
+    weasyprint
+    websockets
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-DMoaXNm5S64XBERHFnFM6IKBkzXRGDEYWSTruccK9Hc=";
+  };
+
+  postBuild = ''
+    pnpm run build
+  '';
+
+  postInstall = ''
+    cp -r build manage.py $out/${python.sitePackages}/froide/
+    makeWrapper $out/${python.sitePackages}/froide/manage.py $out/bin/froide \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --set GDAL_LIBRARY_PATH "${gdal}/lib/libgdal.so" \
+      --set GEOS_LIBRARY_PATH "${geos}/lib/libgeos_c.so"
+  '';
+
+  nativeCheckInputs = with python.pkgs; [
+    (postgresql.withPackages (p: [ p.postgis ]))
+    postgresqlTestHook
+    pytest-django
+    pytest-playwright
+    pytestCheckHook
+  ];
+
+  checkInputs = with python.pkgs; [
+    beautifulsoup4
+    pytest-factoryboy
+    time-machine
+  ];
+
+  disabledTests = [
+    # Requires network connection: elastic_transport.ConnectionError
+    "test_search_similar"
+    "test_search"
+    "test_list_requests"
+    "test_list_jurisdiction_requests"
+    "test_tagged_requests"
+    "test_publicbody_requests"
+    "test_feed"
+    "test_request_list_filter_pagination"
+    "test_request_list_path_filter"
+    "test_web_page"
+    "test_autocomplete"
+    "test_list_no_identical"
+    "test_set_status"
+    "test_make_not_logged_in_request"
+    "test_make_logged_in_request"
+    # TypeError: Pygtail.with_offsets() got an unexpected keyword argument
+    "test_email_signal"
+    "test_pygtail_log_append"
+    "test_bouncing_email"
+    "test_multiple_partial"
+    "test_logfile_rotation"
+  ];
+
+  preCheck = ''
+    export PGUSER="froide"
+    export postgresqlEnableTCP=1
+    export postgresqlTestUserOptions="LOGIN SUPERUSER"
+    export GDAL_LIBRARY_PATH="${gdal}/lib/libgdal.so"
+    export GEOS_LIBRARY_PATH="${geos}/lib/libgeos_c.so"
+    export PLAYWRIGHT_BROWSERS_PATH="${playwright-driver.browsers}"
+  '';
+
+  meta = {
+    description = "Freedom of Information Portal";
+    homepage = "https://github.com/okfde/froide";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.onny ];
+    mainProgram = "froide";
+  };
+}

--- a/pkgs/development/python-modules/django-fsm/default.nix
+++ b/pkgs/development/python-modules/django-fsm/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  django,
+  python3,
+  django-guardian,
+}:
+
+buildPythonPackage rec {
+  pname = "django-fsm";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "viewflow";
+    repo = "django-fsm";
+    rev = "refs/tags/${version}";
+    hash = "sha256-woN0F4hTaPk8HTGNT6zQlZDJ9SCVRut9maKSlDmalUE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ django ];
+
+  checkInputs = [ django-guardian ];
+
+  checkPhase = ''
+    ${python3.interpreter} tests/manage.py test
+  '';
+
+  pythonImportsCheck = [ "django_fsm" ];
+
+  meta = {
+    description = "Django friendly finite state machine support";
+    homepage = "https://github.com/viewflow/django-fsm";
+    license = lib.licenses.mit;
+    knownVulnerabilities = [ "Package is marked as discontinued upstream." ];
+    maintainers = [ lib.maintainers.onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3440,6 +3440,8 @@ self: super: with self; {
 
   django-formset-js-improved = callPackage ../development/python-modules/django-formset-js-improved { };
 
+  django-fsm = callPackage ../development/python-modules/django-fsm { };
+
   django-graphiql-debug-toolbar = callPackage ../development/python-modules/django-graphiql-debug-toolbar { };
 
   django-gravatar2 = callPackage ../development/python-modules/django-gravatar2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4888,6 +4888,8 @@ self: super: with self; {
 
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
+  froide = toPythonModule (pkgs.froide.override { python3Packages = self; });
+
   frozendict = callPackage ../development/python-modules/frozendict { };
 
   frozenlist = callPackage ../development/python-modules/frozenlist { };


### PR DESCRIPTION
Adding web app [froide](https://github.com/okfde/froide), a portal for creating and following freedom of information act requests. Used by [FragDenStaat](https://fragdenstaat.de) project.

Adding it only as Python module as such it can also be used by other projects - in my use case https://github.com/NixOS/nixpkgs/pull/349750

Related:
  - https://github.com/NixOS/nixpkgs/pull/355390
  - https://github.com/okfde/froide/issues/893
  - https://github.com/okfde/froide/issues/902
  - https://github.com/okfde/froide/issues/901

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
