### PR TITLE
spotify-player: clean up old Darwin SDK pattern; fix x86_64-darwin

### DIFF
--- a/pkgs/by-name/sp/spotify-player/package.nix
+++ b/pkgs/by-name/sp/spotify-player/package.nix
@@ -15,6 +15,7 @@
   dbus,
   fontconfig,
   libsixel,
+  apple-sdk_11,
 
   # build options
   withStreaming ? true,
@@ -73,6 +74,9 @@ rustPlatform.buildRustPackage rec {
       openssl
       dbus
       fontconfig
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_11 # can be removed once x86_64-darwin defaults to a newer SDK
     ]
     ++ lib.optionals withSixel [ libsixel ]
     ++ lib.optionals (withAudioBackend == "alsa") [ alsa-lib ]

--- a/pkgs/by-name/sp/spotify-player/package.nix
+++ b/pkgs/by-name/sp/spotify-player/package.nix
@@ -27,7 +27,6 @@
   withSixel ? true,
   withFuzzy ? true,
   stdenv,
-  darwin,
   makeBinaryWrapper,
 
   # passthru
@@ -91,18 +90,7 @@ rustPlatform.buildRustPackage rec {
       gst_all_1.gst-devtools
       gst_all_1.gst-plugins-base
       gst_all_1.gst-plugins-good
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && withMediaControl) [
-      darwin.apple_sdk.frameworks.MediaPlayer
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk.frameworks;
-      [
-        AppKit
-        AudioUnit
-        Cocoa
-      ]
-    );
+    ];
 
   buildNoDefaultFeatures = true;
 

--- a/pkgs/by-name/sp/spotify-player/package.nix
+++ b/pkgs/by-name/sp/spotify-player/package.nix
@@ -1,39 +1,50 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, openssl
-, cmake
-# deps for audio backends
-, alsa-lib
-, libpulseaudio
-, portaudio
-, libjack2
-, SDL2
-, gst_all_1
-, dbus
-, fontconfig
-, libsixel
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  cmake,
+  # deps for audio backends
+  alsa-lib,
+  libpulseaudio,
+  portaudio,
+  libjack2,
+  SDL2,
+  gst_all_1,
+  dbus,
+  fontconfig,
+  libsixel,
 
-# build options
-, withStreaming ? true
-, withDaemon ? true
-, withAudioBackend ? "rodio" # alsa, pulseaudio, rodio, portaudio, jackaudio, rodiojack, sdl
-, withMediaControl ? true
-, withLyrics ? true
-, withImage ? true
-, withNotify ? true
-, withSixel ? true
-, withFuzzy ? true
-, stdenv
-, darwin
-, makeBinaryWrapper
+  # build options
+  withStreaming ? true,
+  withDaemon ? true,
+  withAudioBackend ? "rodio", # alsa, pulseaudio, rodio, portaudio, jackaudio, rodiojack, sdl
+  withMediaControl ? true,
+  withLyrics ? true,
+  withImage ? true,
+  withNotify ? true,
+  withSixel ? true,
+  withFuzzy ? true,
+  stdenv,
+  darwin,
+  makeBinaryWrapper,
 
-# passthru
-, nix-update-script
+  # passthru
+  nix-update-script,
 }:
 
-assert lib.assertOneOf "withAudioBackend" withAudioBackend [ "" "alsa" "pulseaudio" "rodio" "portaudio" "jackaudio" "rodiojack" "sdl" "gstreamer" ];
+assert lib.assertOneOf "withAudioBackend" withAudioBackend [
+  ""
+  "alsa"
+  "pulseaudio"
+  "rodio"
+  "portaudio"
+  "jackaudio"
+  "rodiojack"
+  "sdl"
+  "gstreamer"
+];
 
 rustPlatform.buildRustPackage rec {
   pname = "spotify-player";
@@ -48,38 +59,55 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-VlJ8Bz4EY2rERyOn6ifC7JAL5Mvjt0ZOzlPBOwiH6WA=";
 
-  nativeBuildInputs = [
-    pkg-config
-    cmake
-    rustPlatform.bindgenHook
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    makeBinaryWrapper
-  ];
+  nativeBuildInputs =
+    [
+      pkg-config
+      cmake
+      rustPlatform.bindgenHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      makeBinaryWrapper
+    ];
 
-  buildInputs = [
-    openssl
-    dbus
-    fontconfig
-  ]
+  buildInputs =
+    [
+      openssl
+      dbus
+      fontconfig
+    ]
     ++ lib.optionals withSixel [ libsixel ]
     ++ lib.optionals (withAudioBackend == "alsa") [ alsa-lib ]
     ++ lib.optionals (withAudioBackend == "pulseaudio") [ libpulseaudio ]
     ++ lib.optionals (withAudioBackend == "rodio" && stdenv.hostPlatform.isLinux) [ alsa-lib ]
     ++ lib.optionals (withAudioBackend == "portaudio") [ portaudio ]
     ++ lib.optionals (withAudioBackend == "jackaudio") [ libjack2 ]
-    ++ lib.optionals (withAudioBackend == "rodiojack") [ alsa-lib libjack2 ]
+    ++ lib.optionals (withAudioBackend == "rodiojack") [
+      alsa-lib
+      libjack2
+    ]
     ++ lib.optionals (withAudioBackend == "sdl") [ SDL2 ]
-    ++ lib.optionals (withAudioBackend == "gstreamer") [ gst_all_1.gstreamer gst_all_1.gst-devtools gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && withMediaControl) [ darwin.apple_sdk.frameworks.MediaPlayer ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
-      AppKit
-      AudioUnit
-      Cocoa
-    ]);
+    ++ lib.optionals (withAudioBackend == "gstreamer") [
+      gst_all_1.gstreamer
+      gst_all_1.gst-devtools
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && withMediaControl) [
+      darwin.apple_sdk.frameworks.MediaPlayer
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AppKit
+        AudioUnit
+        Cocoa
+      ]
+    );
 
   buildNoDefaultFeatures = true;
 
-  buildFeatures = [ ]
+  buildFeatures =
+    [ ]
     ++ lib.optionals (withAudioBackend != "") [ "${withAudioBackend}-backend" ]
     ++ lib.optionals withMediaControl [ "media-control" ]
     ++ lib.optionals withImage [ "image" ]
@@ -93,7 +121,7 @@ rustPlatform.buildRustPackage rec {
   # sixel-sys is dynamically linked to libsixel
   postInstall = lib.optionals (stdenv.hostPlatform.isDarwin && withSixel) ''
     wrapProgram $out/bin/spotify_player \
-      --prefix DYLD_LIBRARY_PATH : "${lib.makeLibraryPath [libsixel]}"
+      --prefix DYLD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsixel ]}"
   '';
 
   passthru = {
@@ -106,6 +134,11 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/aome510/spotify-player/releases/tag/v${version}";
     mainProgram = "spotify_player";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dit7ya xyven1 _71zenith caperren ];
+    maintainers = with lib.maintainers; [
+      dit7ya
+      xyven1
+      _71zenith
+      caperren
+    ];
   };
 }


### PR DESCRIPTION
ZHF: #352882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
