### PR TITLE
python3Packages.fitter, fitter: init at 1.8.0

### DIFF
--- a/pkgs/by-name/fi/fitter/package.nix
+++ b/pkgs/by-name/fi/fitter/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication fitter

--- a/pkgs/development/python-modules/fitter/default.nix
+++ b/pkgs/development/python-modules/fitter/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  click,
+  joblib,
+  loguru,
+  matplotlib,
+  numpy,
+  pandas,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-timeout,
+  pytest-xdist,
+  rich-click,
+  scipy,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "fitter";
+  version = "1.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cokelaer";
+    repo = "fitter";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-RNcI8N2Eiemu37pbkWen681ZVsmuEHqY5GmmF522kDo=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    click
+    joblib
+    loguru
+    matplotlib
+    numpy
+    pandas
+    rich-click
+    scipy
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-mock
+    pytest-timeout
+    pytest-xdist
+  ];
+
+  # There's no obvious reason to assert NumPy 1.x
+  dontCheckRuntimeDeps = true;
+
+  pythonImportsCheck = [
+    "fitter"
+  ];
+
+  meta = {
+    description = "Fit data to many distributions";
+    homepage = "https://github.com/cokelaer/fitter";
+    changelog = "https://github.com/cokelaer/fitter/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "fitter";
+  };
+}

--- a/pkgs/development/python-modules/fitter/default.nix
+++ b/pkgs/development/python-modules/fitter/default.nix
@@ -57,6 +57,13 @@ buildPythonPackage (finalAttrs: {
     pytest-xdist
   ];
 
+  env = {
+    # Use the non-interactive matplotlib backend Agg.
+    # Matplotlib doesn't switch backends smartly on Darwin builders
+    # and aborts in the sandbox after WindowServer connection failed.
+    MPLBACKEND = "Agg";
+  };
+
   pythonImportsCheck = [
     "fitter"
   ];

--- a/pkgs/development/python-modules/fitter/default.nix
+++ b/pkgs/development/python-modules/fitter/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-timeout,
+  pytest-xdist,
+  writableTmpDirAsHomeHook,
+  click,
+  joblib,
+  loguru,
+  matplotlib,
+  numpy,
+  pandas,
+  rich-click,
+  scipy,
+  tqdm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "fitter";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cokelaer";
+    repo = "fitter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TwCyP71fYJuF40KqbTyBtRY+NTDXF7WdqVR2hZY00oA=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    click
+    joblib
+    loguru
+    matplotlib
+    numpy
+    pandas
+    rich-click
+    scipy
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-mock
+    pytest-timeout
+    pytest-xdist
+  ];
+
+  pythonImportsCheck = [
+    "fitter"
+  ];
+
+  meta = {
+    description = "Fit data to many distributions";
+    homepage = "https://github.com/cokelaer/fitter";
+    changelog = "https://github.com/cokelaer/fitter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "fitter";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4916,6 +4916,8 @@ self: super: with self; {
 
   fitfile = callPackage ../development/python-modules/fitfile { };
 
+  fitter = callPackage ../development/python-modules/fitter { };
+
   fivem-api = callPackage ../development/python-modules/fivem-api { };
 
   fixerio = callPackage ../development/python-modules/fixerio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6093,6 +6093,8 @@ self: super: with self; {
 
   fitparse = callPackage ../development/python-modules/fitparse { };
 
+  fitter = callPackage ../development/python-modules/fitter { };
+
   fivem-api = callPackage ../development/python-modules/fivem-api { };
 
   fixerio = callPackage ../development/python-modules/fixerio { };


### PR DESCRIPTION
Package [Fitter](https://github.com/cokelaer/fitter), a Python package and command-line utility for fitting various distributions available under `scipy.stats`.

The upstream test cases cover the library and the executable. Once the package is built successfully, updates and changes should be ready to go.

I used Claude Opus to find the `env.MPLBACKEND = "Agg"` fix and make the tests work on Darwin.
I wrote the comment myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
