### PR TITLE
flutter_rust_bridge_codegen: init a 2.6.0

### DIFF
--- a/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
+++ b/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  flutter,
+  cargo-expand,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "flutter_rust_bridge_codegen";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "fzyzcjy";
+    repo = "flutter_rust_bridge";
+    rev = "v${version}";
+    hash = "sha256-U7Z349D3U83YLrcwSh2zMTNPScxtXpEM2n/H/S0RqhY=";
+  };
+
+  cargoHash = "sha256-b+duVR3vn1HrhUcVucHfzjTDhbru3+IYVNS3ji6LGto=";
+  cargoTestFlags = "--package ${pname}";
+  cargoBuildFlags = "--package ${pname}";
+
+  nativeBuildInputs = [ cargo-expand ];
+  buildInputs = [ flutter ];
+
+  # needed to run text (see https://github.com/fzyzcjy/flutter_rust_bridge/blob/ae970bfafdf80b9eb283a2167b972fb2e6504511/frb_codegen/src/library/utils/logs.rs#L43)
+  logLevel = "debug";
+  checkFlags = [
+    # Disabled because these tests need a different version of anyhow than the package itself
+    "--skip=tests::test_execute_generate_on_frb_example_dart_minimal"
+    "--skip=tests::test_execute_generate_on_frb_example_pure_dart"
+  ];
+
+  meta = {
+    description = "Flutter/Dart <-> Rust binding generator, feature-rich, but seamless and simple";
+    homepage = "https://fzyzcjy.github.io/flutter_rust_bridge/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.eymeric ];
+  };
+}


### PR DESCRIPTION
Add the package flutter_rust_bridge_codegen

## Things done

Add flutter_rust_bridge_codegen

For the details on the disabled tests, I get this error when they are run
```
[2024-11-14T11:25:18.293Z WARN frb_codegen/src/library/commands/command_runner.rs:153] command=cd "/build/source/frb_example/pure_dart/rust" && RUSTFLAGS="--cfg frb_expand" "cargo" "expand" "--lib" "--theme=none" "--ugly" "--features" "internal_feature_for_testing" stdout= stderr=error: failed to select a version for the requirement `anyhow = "^1.0.64"` (locked to 1.0.75)
candidate versions found which didn't match: 1.0.86
location searched: directory source `/build/flutter_rust_bridge_codegen-2.6.0-vendor.tar.gz` (which is replacing registry `crates-io`)
required by package `frb_example_pure_dart v0.1.0 (/build/source/frb_example/pure_dart/rust)`
perhaps a crate was updated and forgotten to be re-vendored?

Error: cargo expand returned empty output
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
