### PR TITLE
decasify: init at 0.8.0

### DIFF
--- a/pkgs/by-name/de/decasify/package.nix
+++ b/pkgs/by-name/de/decasify/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  # nativeBuildInputs
+  zstd,
+  pkg-config,
+  jq,
+  cargo,
+  rustc,
+  rustPlatform,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "decasify";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/alerque/decasify/releases/download/v${finalAttrs.version}/decasify-${finalAttrs.version}.tar.zst";
+    hash = "sha256-HTUAb/yL3H4B/n/Ecd/fDpnTYiqwco/E07sa6pFIIU4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    nativeBuildInputs = [ zstd ];
+    # so the cargo fetcher won't try to run the `./configure` script
+    dontConfigure = true;
+    hash = "sha256-bD8MYufI87j//7dIAnCzmp4yoOaT81Zv1i7rjWpjPlc=";
+  };
+
+  nativeBuildInputs = [
+    zstd
+    pkg-config
+    jq
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  outputs = [
+    "out"
+    "doc"
+    "man"
+    "dev"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Utility to change the case of prose strings following natural language style guides";
+    longDescription = ''
+      A CLI utility to cast strings to title-case (and other cases) according
+      to locale specific style guides including Turkish support.
+    '';
+    homepage = "https://github.com/alerque/decasify";
+    changelog = "https://github.com/alerque/decasify/raw/v${finalAttrs.version}/CHANGELOG.md";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alerque
+    ];
+    license = lib.licenses.lgpl3Only;
+    mainProgram = "decasify";
+  };
+})

--- a/pkgs/by-name/gi/git-warp-time/package.nix
+++ b/pkgs/by-name/gi/git-warp-time/package.nix
@@ -13,7 +13,6 @@
 
   # buildInputs
   libgit2,
-  typos,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,14 +21,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/alerque/git-warp-time/releases/download/v${finalAttrs.version}/git-warp-time-${finalAttrs.version}.tar.zst";
-    sha256 = "sha256-Xh30nA77cJ7+UfKlIslnyD+93AtnQ+8P3sCFsG0DAUk=";
+    hash = "sha256-Xh30nA77cJ7+UfKlIslnyD+93AtnQ+8P3sCFsG0DAUk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     nativeBuildInputs = [ zstd ];
+    # so the cargo fetcher won't try to run the `./configure` script
     dontConfigure = true;
-    hash = "sha256-ozy8Mfl5fTJL2Sr22tCSnK30SOKaC9cL+g4lX6ivi9Q=";
+    hash = "sha256-bmClqtH1xU2KOKVbCOrgN14jpLKiA2ZMzWwrOiufwnQ=";
   };
 
   nativeBuildInputs = [
@@ -43,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libgit2
-    typos
   ];
 
   env = {

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -18,8 +18,6 @@
   icu,
   fontconfig,
   libiconv,
-  stylua,
-  typos,
   # FONTCONFIG_FILE
   makeFontsConf,
   gentium,
@@ -35,14 +33,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${finalAttrs.version}/sile-${finalAttrs.version}.tar.zst";
-    sha256 = "sha256-PjU6Qfn+FTL3vt66mkIAn/uXWMPPlH8iK6B264ekIis=";
+    hash = "sha256-PjU6Qfn+FTL3vt66mkIAn/uXWMPPlH8iK6B264ekIis=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     nativeBuildInputs = [ zstd ];
+    # so the cargo fetcher won't try to run the `./configure` script
     dontConfigure = true;
-    hash = "sha256-m21SyGtHwVCz+77pYq48Gjnrf/TLCLCf/IQ7AnZk+fo=";
+    hash = "sha256-iPkXEUC4U1m/ComIDo/J5kwkmM1QdowioNtnSnmMhJ0=";
   };
 
   nativeBuildInputs = [
@@ -63,8 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     icu
     fontconfig
     libiconv
-    stylua
-    typos
   ];
 
   configureFlags =


### PR DESCRIPTION
New package for [decasify](https://github.com/alerque/decasify). For now this is just packaging the CLI tool. In the future there is a possibility of packaging some of the other iterations of tooling in the same repository. For example the Lua module may become a dependency for sile. Also there is a NeoVIM plugin as well.

The package derivation is almost identical for the one for [git-warp-time](https://github.com/alerque/git-warp-time) recently merged in #354046.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
