### PR TITLE
[Backport release-24.05] opensc: 0.25.1 -> 0.26.0

### DIFF
--- a/pkgs/tools/security/opensc/0001-Revert-Desctivate-driver-for-MICARDO.patch
+++ b/pkgs/tools/security/opensc/0001-Revert-Desctivate-driver-for-MICARDO.patch
@@ -1,0 +1,33 @@
+From 6b576118c02241c7e366696be2f16850460fac35 Mon Sep 17 00:00:00 2001
+From: Michael Adler <therisen06@gmail.com>
+Date: Wed, 27 Nov 2024 09:23:04 +0100
+Subject: [PATCH] Revert "Desctivate driver for MICARDO"
+
+This reverts commit 13951f633b5f1df14d5c49310cd397a42a467f36.
+---
+ src/libopensc/ctx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libopensc/ctx.c b/src/libopensc/ctx.c
+index 6fbab389c..2316209ee 100644
+--- a/src/libopensc/ctx.c
++++ b/src/libopensc/ctx.c
+@@ -148,6 +148,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
+ 	 * put the muscle driver first to cope with this bug. */
+ 	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
+ 	{ "sc-hsm",	(void *(*)(void)) sc_get_sc_hsm_driver },
++	{ "mcrd",	(void *(*)(void)) sc_get_mcrd_driver },
+ 	{ "setcos",	(void *(*)(void)) sc_get_setcos_driver },
+ 	{ "PIV-II",	(void *(*)(void)) sc_get_piv_driver },
+ 	{ "cac",	(void *(*)(void)) sc_get_cac_driver },
+@@ -175,7 +176,6 @@ static const struct _sc_driver_entry old_card_drivers[] = {
+ 	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
+ 	{ "cyberflex",	(void *(*)(void)) sc_get_cyberflex_driver },
+ 	{ "flex",       (void *(*)(void)) sc_get_cryptoflex_driver },
+-	{ "mcrd",       (void *(*)(void)) sc_get_mcrd_driver },
+ 	{ NULL, NULL }
+ };
+ // clang-format on
+-- 
+2.47.1
+

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -8,14 +8,18 @@
 
 stdenv.mkDerivation rec {
   pname = "opensc";
-  version = "0.25.1";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "OpenSC";
     rev = version;
-    sha256 = "sha256-Ktvp/9Hca87qWmDlQhFzvWsr7TvNpIAvOFS+4zTZbB8=";
+    sha256 = "sha256-EIQ9YpIGwckg/JjpK0S2ZYdFf/0YC4KaWcLXRNRMuzA=";
   };
+
+  patches = [
+    ./0001-Revert-Desctivate-driver-for-MICARDO.patch
+  ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/345666

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
