### PR TITLE
nixos/soteria: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -103,6 +103,8 @@
 
 - [Hatsu](https://github.com/importantimport/hatsu), a self-hosted bridge that interacts with Fediverse on behalf of your static site. Available as [services.hatsu](options.html#opt-services.hatsu.enable).
 
+- [Soteria](https://github.com/ImVaskel/soteria), a polkit authentication agent to handle elevated prompts for any desktop environment. Normally this should only be used on DEs or WMs that do not provide a graphical polkit frontend on their own. Available as [`security.soteria`](#opt-security.soteria.enable).
+
 - [Flood](https://flood.js.org/), a beautiful WebUI for various torrent clients. Available as [services.flood](options.html#opt-services.flood.enable).
 
 - [Niri](https://github.com/YaLTeR/niri), a scrollable-tiling Wayland compositor. Available as [programs.niri](options.html#opt-programs.niri.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -362,6 +362,7 @@
   ./security/polkit.nix
   ./security/rngd.nix
   ./security/rtkit.nix
+  ./security/soteria.nix
   ./security/sudo.nix
   ./security/sudo-rs.nix
   ./security/systemd-confinement.nix

--- a/nixos/modules/security/soteria.nix
+++ b/nixos/modules/security/soteria.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.security.soteria;
+in
+{
+  options.security.soteria = {
+    enable = lib.mkEnableOption null // {
+      description = ''
+        Whether to enable Soteria, a Polkit authentication agent
+        for any desktop environment.
+
+        ::: {.note}
+        You should only enable this if you are on a Desktop Environment that
+        does not provide a graphical polkit authentication agent, or you are on
+        a standalone window manager or Wayland compositor.
+        :::
+      '';
+    };
+    package = lib.mkPackageOption pkgs "soteria" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.polkit.enable = true;
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.user.services.polkit-soteria = {
+      description = "Soteria, Polkit authentication agent for any desktop environment";
+
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+
+      script = lib.getExe cfg.package;
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = 1;
+        TimeoutStopSec = 10;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+}


### PR DESCRIPTION
This adds a `security.soteria.enable` option.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - Tested with my own configuration
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
