### PR TITLE
mptcpd: init at 0.13

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1104,6 +1104,7 @@
   ./services/networking/lxd-image-server.nix
   ./services/networking/magic-wormhole-mailbox-server.nix
   ./services/networking/matterbridge.nix
+  ./services/networking/mptcpd.nix
   ./services/networking/microsocks.nix
   ./services/networking/mihomo.nix
   ./services/networking/minidlna.nix

--- a/nixos/modules/services/networking/mptcpd.nix
+++ b/nixos/modules/services/networking/mptcpd.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+
+  cfg = config.services.mptcpd;
+
+in
+
+{
+
+  options = {
+
+    services.mptcpd = {
+
+      enable = lib.mkEnableOption "the Multipath TCP path management daemon";
+
+      package = lib.mkPackageOption pkgs "mptcpd" { };
+
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.packages = [ cfg.package ];
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ nim65s ];
+}

--- a/pkgs/by-name/mp/mptcpd/package.nix
+++ b/pkgs/by-name/mp/mptcpd/package.nix
@@ -1,0 +1,79 @@
+{
+  autoreconfHook,
+  autoconf-archive,
+  doxygen,
+  ell,
+  fetchFromGitHub,
+  fontconfig,
+  graphviz,
+  lib,
+  pandoc,
+  perl,
+  pkg-config,
+  stdenv,
+  systemd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mptcpd";
+  version = "0.13";
+
+  src = fetchFromGitHub {
+    owner = "multipath-tcp";
+    repo = "mptcpd";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-gPXtYmCLJ8eL6VfCi3kpDA7lNn38WB6J4FXefdu2D7M=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    doxygen
+    graphviz
+    pandoc
+    perl
+    pkg-config
+  ];
+
+  # ref. https://github.com/multipath-tcp/mptcpd/blob/main/README.md#bootstrapping
+  preConfigure = "./bootstrap";
+
+  # fix: 'To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"'
+  postConfigure = "doxygen -u";
+
+  configureFlags = [
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  # fix: 'Fontconfig error: Cannot load default config file: No such file: (null)'
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  buildInputs = [
+    ell
+    systemd
+  ];
+
+  # fix: 'Fontconfig error: No writable cache directories'
+  preBuild = "export XDG_CACHE_HOME=$(mktemp -d)";
+
+  # build and install doc
+  postBuild = "make doxygen-doc";
+  postInstall = "mv doc $doc";
+
+  doCheck = true;
+
+  meta = {
+    description = "Daemon for Linux that performs Multipath TCP path management related operations in the user space";
+    homepage = "https://github.com/multipath-tcp/mptcpd";
+    changelog = "https://github.com/multipath-tcp/mptcpd/blob/${finalAttrs.src.rev}/NEWS";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "mptcpize";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Hi,

This add https://github.com/multipath-tcp/mptcpd

And take some inspiration from @teto in https://github.com/teto/mptcp-flake/blob/main/pkgs/mptcpd/default.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
