### PR TITLE
gtk3, gtk4: only include libxkbcommon dependency when Wayland is enabled

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -51,6 +51,14 @@
 , testers
 }:
 
+assert lib.assertMsg (builtins.any (x: x) [
+  stdenv.hostPlatform.isDarwin
+  stdenv.hostPlatform.isWindows
+  broadwaySupport
+  waylandSupport
+  x11Support
+]) "At least one backend must be enabled";
+
 let
 
   gtkCleanImmodulesCache = substituteAll {

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -117,13 +117,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    libxkbcommon
     (libepoxy.override { inherit x11Support; })
     isocodes
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     AppKit
   ] ++ lib.optionals trackerSupport [
     tinysparql
+  ] ++ lib.optionals waylandSupport [
+    libxkbcommon
   ];
   #TODO: colord?
 

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -168,6 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dbroadway_backend=${lib.boolToString broadwaySupport}"
     "-Dx11_backend=${lib.boolToString x11Support}"
     "-Dquartz_backend=${lib.boolToString (stdenv.hostPlatform.isDarwin && !x11Support)}"
+    "-Dwayland_backend=${lib.boolToString waylandSupport}"
     "-Dintrospection=${lib.boolToString withIntrospection}"
   ];
 

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ finalAttrs.setupHooks;
 
   buildInputs = [
-    libxkbcommon
     libpng
     libtiff
     libjpeg
@@ -136,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     tinysparql
   ] ++ lib.optionals waylandSupport [
     libGL
+    libxkbcommon
     wayland
     wayland-protocols
   ] ++ lib.optionals xineramaSupport [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -58,6 +58,14 @@
 , darwinMinVersionHook
 }:
 
+assert lib.assertMsg (!builtins.any (x: x) [
+  stdenv.hostPlatform.isDarwin
+  stdenv.hostPlatform.isWindows
+  broadwaySupport
+  waylandSupport
+  x11Support
+]) "At least one backend must be enabled";
+
 let
 
   gtkCleanImmodulesCache = substituteAll {

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -177,6 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "broadway-backend" broadwaySupport)
     (lib.mesonEnable "vulkan" vulkanSupport)
     (lib.mesonEnable "print-cups" cupsSupport)
+    (lib.mesonBool "wayland-backend" waylandSupport)
     (lib.mesonBool "x11-backend" x11Support)
   ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAarch64) [
     "-Dmedia-gstreamer=disabled" # requires gstreamer-gl


### PR DESCRIPTION
The `libxkbcommon` dependency is only used when Wayland support is enabled: https://gitlab.gnome.org/GNOME/gtk/-/blame/gtk-3-24/meson.build?ref_type=heads#L441

Also, Wayland support is always enabled by default when not on Windows or macOS, so disabling Wayland support doesn't actually work since the option isn't passed to Meson.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
