### PR TITLE
autoconf-archive: fix quoting of m4_fatal

### DIFF
--- a/pkgs/by-name/au/autoconf-archive/0001-ax_check_gl.m4-properly-quote-m4_fatal.patch
+++ b/pkgs/by-name/au/autoconf-archive/0001-ax_check_gl.m4-properly-quote-m4_fatal.patch
@@ -1,0 +1,38 @@
+From 427e226a2fe3980388abffd6de25ed6b9591cce3 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Sat, 19 Oct 2024 21:51:30 -0400
+Subject: [PATCH 1/3] ax_check_gl.m4: properly quote m4_fatal
+
+It needs to only run as an argument of m4_if, not all the time.
+
+Fixes: 753493bf7e251997f02559b98fc599d4a337d8cd
+Bug: https://bugs.gentoo.org/941845
+---
+ m4/ax_check_gl.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/m4/ax_check_gl.m4 b/m4/ax_check_gl.m4
+index 850d407..4c2e4ef 100644
+--- a/m4/ax_check_gl.m4
++++ b/m4/ax_check_gl.m4
+@@ -85,7 +85,7 @@
+ #   modified version of the Autoconf Macro, you may extend this special
+ #   exception to the GPL to apply to your modified version as well.
+ 
+-#serial 23
++#serial 24
+ 
+ # example gl program
+ m4_define([_AX_CHECK_GL_PROGRAM],
+@@ -187,7 +187,7 @@ AC_DEFUN([_AX_CHECK_GL_LINK_CV],
+ AC_DEFUN([_AX_CHECK_GL_MANUAL_LIBS_GENERIC], [
+   AS_IF([test -n "$GL_LIBS"],[], [
+     ax_check_gl_manual_libs_generic_extra_libs="$1"
+-    m4_if($1, [], m4_fatal([$0: argument must not be empty]))
++    m4_if($1, [], [m4_fatal([$0: argument must not be empty])])
+ 
+     _AX_CHECK_GL_SAVE_FLAGS([CFLAGS])
+     AC_SEARCH_LIBS([glBegin],[$ax_check_gl_manual_libs_generic_extra_libs], [
+-- 
+2.46.1
+

--- a/pkgs/by-name/au/autoconf-archive/0002-ax_check_glx.m4-properly-quote-m4_fatal.patch
+++ b/pkgs/by-name/au/autoconf-archive/0002-ax_check_glx.m4-properly-quote-m4_fatal.patch
@@ -1,0 +1,37 @@
+From e25f8d9e3ead52f998535b86c763065c5b45cc59 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Sat, 19 Oct 2024 21:57:16 -0400
+Subject: [PATCH 2/3] ax_check_glx.m4: properly quote m4_fatal
+
+It needs to only run as an argument of m4_if, not all the time.
+
+Fixes: 40ca66e7e52bb63e3eee2514855fcf3ad2df7673
+---
+ m4/ax_check_glx.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/m4/ax_check_glx.m4 b/m4/ax_check_glx.m4
+index c7890d9..b5027f9 100644
+--- a/m4/ax_check_glx.m4
++++ b/m4/ax_check_glx.m4
+@@ -61,7 +61,7 @@
+ #   modified version of the Autoconf Macro, you may extend this special
+ #   exception to the GPL to apply to your modified version as well.
+ 
+-#serial 9
++#serial 10
+ 
+ # example program
+ m4_define([_AX_CHECK_GLX_PROGRAM],
+@@ -183,7 +183,7 @@ AC_DEFUN([_AX_CHECK_GLX_HEADERS],
+ AC_DEFUN([_AX_CHECK_GLX_MANUAL_LIBS_GENERIC],
+ [dnl
+  ax_check_glx_manual_libs_generic_extra_libs="$1"
+- m4_if($1, [], m4_fatal([$0: argument must not be empty]))
++ m4_if($1, [], [m4_fatal([$0: argument must not be empty])])
+ 
+  AC_LANG_PUSH([C])
+  _AX_CHECK_GLX_SAVE_FLAGS()
+-- 
+2.46.1
+

--- a/pkgs/by-name/au/autoconf-archive/0003-ax_switch_flags.m4-properly-quote-m4_fatal.patch
+++ b/pkgs/by-name/au/autoconf-archive/0003-ax_switch_flags.m4-properly-quote-m4_fatal.patch
@@ -1,0 +1,32 @@
+From 3a23daa3da0eb1a256fda631867e19345d5f6e3a Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Sat, 19 Oct 2024 21:58:52 -0400
+Subject: [PATCH 3/3] ax_switch_flags.m4: properly quote m4_fatal
+
+It needs to only run as an argument of m4_if, not all the time.
+
+Fixes: 2adff78e224c908fd58df91852c8301c25777a8f
+---
+ m4/ax_switch_flags.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/m4/ax_switch_flags.m4 b/m4/ax_switch_flags.m4
+index dc79d1e..777aeb0 100644
+--- a/m4/ax_switch_flags.m4
++++ b/m4/ax_switch_flags.m4
+@@ -36,10 +36,10 @@
+ #   and this notice are preserved. This file is offered as-is, without any
+ #   warranty.
+ 
+-#serial 5
++#serial 6
+ 
+ AC_DEFUN([AX_SWITCH_FLAGS], [
+-  m4_if($1, [], m4_fatal([$0: namespace is empty]))
++  m4_if($1, [], [m4_fatal([$0: namespace is empty])])
+   AC_REQUIRE(AX_SAVE_FLAGS)
+   AC_REQUIRE(AX_RESTORE_FLAGS)
+   AX_SAVE_FLAGS($1[])
+-- 
+2.46.1
+

--- a/pkgs/by-name/au/autoconf-archive/package.nix
+++ b/pkgs/by-name/au/autoconf-archive/package.nix
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-e81dABkW86UO10NvT3AOPSsbrePtgDIZxZLWJQKlc2M=";
   };
 
+  patches = [
+    # cherry-picked changes from
+    # https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=commit;h=fadde164479a926d6b56dd693ded2a4c36ed89f0
+    # can be removed on next release
+    ./0001-ax_check_gl.m4-properly-quote-m4_fatal.patch
+    ./0002-ax_check_glx.m4-properly-quote-m4_fatal.patch
+    ./0003-ax_switch_flags.m4-properly-quote-m4_fatal.patch
+  ];
+
   strictDeps = true;
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This fixes the `cava` package, and could potentially fix others.  I tested this as an override in `cava` and it worked, but I haven't built this in staging.

I believe it was broken by 59b91bae8c9f855411d9f4cb847a6d17e73284b5.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
