### PR TITLE
nixos/hyprland: adds programs.hyprland.withUWSM option

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.hyprland;
@@ -13,29 +18,39 @@ in
       A configuration file will be generated in {file}`~/.config/hypr/hyprland.conf`.
       See <https://wiki.hyprland.org> for more information'';
 
-    package = lib.mkPackageOption pkgs "hyprland" {
-      extraDescription = ''
-        If the package is not overridable with `enableXWayland`, then the module option
-        {option}`xwayland` will have no effect.
-      '';
-    } // {
-      apply = p: wayland-lib.genFinalPackage p {
-        enableXWayland = cfg.xwayland.enable;
+    package =
+      lib.mkPackageOption pkgs "hyprland" {
+        extraDescription = ''
+          If the package is not overridable with `enableXWayland`, then the module option
+          {option}`xwayland` will have no effect.
+        '';
+      }
+      // {
+        apply =
+          p:
+          wayland-lib.genFinalPackage p {
+            enableXWayland = cfg.xwayland.enable;
+          };
       };
-    };
 
-    portalPackage = lib.mkPackageOption pkgs "xdg-desktop-portal-hyprland" {
-      extraDescription = ''
-        If the package is not overridable with `hyprland`, then the Hyprland package
-        used by the portal may differ from the one set in the module option {option}`package`.
-      '';
-    } // {
-      apply = p: wayland-lib.genFinalPackage p {
-        hyprland = cfg.package;
+    portalPackage =
+      lib.mkPackageOption pkgs "xdg-desktop-portal-hyprland" {
+        extraDescription = ''
+          If the package is not overridable with `hyprland`, then the Hyprland package
+          used by the portal may differ from the one set in the module option {option}`package`.
+        '';
+      }
+      // {
+        apply =
+          p:
+          wayland-lib.genFinalPackage p {
+            hyprland = cfg.package;
+          };
       };
-    };
 
-    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
+    xwayland.enable = lib.mkEnableOption "XWayland" // {
+      default = true;
+    };
 
     systemd.setPath.enable = lib.mkEnableOption null // {
       default = lib.versionOlder cfg.package.version "0.41.2";
@@ -49,46 +64,52 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (lib.mkMerge [
-    {
-      environment.systemPackages = [ cfg.package ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
 
-      # To make a Hyprland session available if a display manager like SDDM is enabled:
-      services.displayManager.sessionPackages = [ cfg.package ];
+        # To make a Hyprland session available if a display manager like SDDM is enabled:
+        services.displayManager.sessionPackages = [ cfg.package ];
 
-      xdg.portal = {
-        enable = true;
-        extraPortals = [ cfg.portalPackage ];
-        configPackages = lib.mkDefault [ cfg.package ];
-      };
+        xdg.portal = {
+          enable = true;
+          extraPortals = [ cfg.portalPackage ];
+          configPackages = lib.mkDefault [ cfg.package ];
+        };
 
-      systemd = lib.mkIf cfg.systemd.setPath.enable {
-        user.extraConfig = ''
-          DefaultEnvironment="PATH=/run/wrappers/bin:/etc/profiles/per-user/%u/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
-        '';
-      };
-    }
+        systemd = lib.mkIf cfg.systemd.setPath.enable {
+          user.extraConfig = ''
+            DefaultEnvironment="PATH=/run/wrappers/bin:/etc/profiles/per-user/%u/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
+          '';
+        };
+      }
 
-    (import ./wayland-session.nix {
-      inherit lib pkgs;
-      enableXWayland = cfg.xwayland.enable;
-      enableWlrPortal = lib.mkDefault false; # Hyprland has its own portal, wlr is not needed
-    })
-  ]);
+      (import ./wayland-session.nix {
+        inherit lib pkgs;
+        enableXWayland = cfg.xwayland.enable;
+        enableWlrPortal = lib.mkDefault false; # Hyprland has its own portal, wlr is not needed
+      })
+    ]
+  );
 
   imports = [
-    (lib.mkRemovedOptionModule
-      [ "programs" "hyprland" "xwayland" "hidpi" ]
-      "XWayland patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland"
-    )
-    (lib.mkRemovedOptionModule
-      [ "programs" "hyprland" "enableNvidiaPatches" ]
-      "Nvidia patches are no longer needed"
-    )
-    (lib.mkRemovedOptionModule
-      [ "programs" "hyprland" "nvidiaPatches" ]
-      "Nvidia patches are no longer needed"
-    )
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "hyprland"
+      "xwayland"
+      "hidpi"
+    ] "XWayland patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland")
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "hyprland"
+      "enableNvidiaPatches"
+    ] "Nvidia patches are no longer needed")
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "hyprland"
+      "nvidiaPatches"
+    ] "Nvidia patches are no longer needed")
   ];
 
   meta.maintainers = with lib.maintainers; [ fufexan ];


### PR DESCRIPTION
Upstream recommends using UWSM for better compatibility with systemd integration.
https://wiki.hyprland.org/Useful-Utilities/Systemd-start/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
