### PR TITLE
nixos/k3s: use same k3s package in multi-node test

### DIFF
--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -116,6 +116,7 @@ import ../make-test-python.nix (
           services.k3s = {
             inherit tokenFile;
             enable = true;
+            package = k3s;
             serverAddr = "https://192.168.1.1:6443";
             clusterInit = false;
             extraFlags = builtins.toString [
@@ -161,6 +162,7 @@ import ../make-test-python.nix (
             inherit tokenFile;
             enable = true;
             role = "agent";
+            package = k3s;
             serverAddr = "https://192.168.1.3:6443";
             extraFlags = lib.concatStringsSep " " [
               "--pause-image"


### PR DESCRIPTION
nixos/k3s: use same k3s package in multi-node test

Cherry-picks commit 4dd7c2fe6a8813f2b71ee8d9509baa9f77096f37

From #355230

CC @NixOS/k3s 