### PR TITLE
bitwarden-desktop: 2024.9.0 -> 2024.11.1

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
@@ -1,7 +1,7 @@
-diff --git a/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts b/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
-index e2428d9d12..de4e9e1e62 100644
---- a/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
-+++ b/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
+diff --git a/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts b/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
+index 8962e7f3ec..a7291420f2 100644
+--- a/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
++++ b/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
 @@ -109,7 +109,7 @@ export default class BiometricUnixMain implements OsBiometricService {
      // The user needs to manually set up the polkit policy outside of the sandbox
      // since we allow access to polkit via dbus for the sandboxed clients, the authentication works from

--- a/pkgs/by-name/bi/bitwarden-desktop/skip-afterpack.diff
+++ b/pkgs/by-name/bi/bitwarden-desktop/skip-afterpack.diff
@@ -1,0 +1,39 @@
+diff --git a/apps/desktop/scripts/after-pack.js b/apps/desktop/scripts/after-pack.js
+index fd16cd5ffb..05a2325ee1 100644
+--- a/apps/desktop/scripts/after-pack.js
++++ b/apps/desktop/scripts/after-pack.js
+@@ -13,25 +13,6 @@ async function run(context) {
+   console.log("## After pack");
+   // console.log(context);
+ 
+-  if (context.packager.platform.nodeName !== "darwin" || context.arch === builder.Arch.universal) {
+-    await addElectronFuses(context);
+-  }
+-
+-  if (context.electronPlatformName === "linux") {
+-    console.log("Creating memory-protection wrapper script");
+-    const appOutDir = context.appOutDir;
+-    const oldBin = path.join(appOutDir, context.packager.executableName);
+-    const newBin = path.join(appOutDir, "bitwarden-app");
+-    fse.moveSync(oldBin, newBin);
+-    console.log("Moved binary to bitwarden-app");
+-
+-    const wrapperScript = path.join(__dirname, "../resources/memory-dump-wrapper.sh");
+-    const wrapperBin = path.join(appOutDir, context.packager.executableName);
+-    fse.copyFileSync(wrapperScript, wrapperBin);
+-    fse.chmodSync(wrapperBin, "755");
+-    console.log("Copied memory-protection wrapper script");
+-  }
+-
+   if (["darwin", "mas"].includes(context.electronPlatformName)) {
+     const is_mas = context.electronPlatformName === "mas";
+     const is_mas_dev = context.targets.some((e) => e.name === "mas-dev");
+@@ -140,6 +121,8 @@ function getIdentities() {
+  * @param {import("electron-builder").AfterPackContext} context
+  */
+ async function addElectronFuses(context) {
++  return;
++
+   const platform = context.packager.platform.nodeName;
+ 
+   const ext = {


### PR DESCRIPTION
Diff: https://github.com/bitwarden/clients/compare/desktop-v2024.9.0...desktop-v2024.11.1

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2024.11.1

- This includes update to node-argon2 that removes the need for our fix.
- Upstream now also attempts to modify the "fuses" of bin/electron, but
  that fails for us as we are wrapping the read-only electron. So simply
  skip that in the afterpack. Also, in afterpack, skip creating the
  wrapper script since we don't use it anyway (again, we wrap electron
  directly passing the asar).
- Update biometric patch as file was moved upstream.
- Beware that Bitwarden 2024.10.x was unfree, hence having skipped a few
  versions, see https://github.com/bitwarden/clients/issues/11611


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
