### PR TITLE
libhydrogen: init at 0-unstable-2024-11-04

### DIFF
--- a/pkgs/by-name/li/libhydrogen/package.nix
+++ b/pkgs/by-name/li/libhydrogen/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  testers,
+}:
+let
+  static = stdenv.hostPlatform.isStatic;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libhydrogen";
+  version = "0-unstable-2024-11-04";
+
+  src = fetchFromGitHub {
+    owner = "jedisct1";
+    repo = "libhydrogen";
+    rev = "576a38bfd14357326a9727f977b46014363eeec8";
+    hash = "sha256-C8e3qsG9u9QQQ8hm8rLxL0CDA20SdcO9ChqhBFVQ7oE=";
+  };
+
+  doCheck = true;
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  # by default upstream builds a static library, but we want both (unless isStatic)
+  mesonFlags = lib.optional (!static) [ "--default-library=both" ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+  postInstall = ''
+    mkdir -p $dev/lib/
+    mv $out/lib/libhydrogen.a $dev/lib/
+    mv $out/lib/pkgconfig $dev/lib/
+  '';
+
+  meta = {
+    description = "Small, easy-to-use, hard-to-misuse cryptographic library";
+    homepage = "https://libhydrogen.org";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ramblurr ];
+    pkgConfigModules = [ "libhydrogen" ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
About this library:

The hydrogen library  ([source](https://github.com/jedisct1/libhydrogen/))  is a small, easy-to-use, hard-to-misuse cryptographic library. 

* It was created and is currently maintained by [Frank Denis](https://github.com/jedisct1) the creator and maintainer of libsodium ([homepage](https://doc.libsodium.org/)/[nixpkg pkg](https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/development/libraries/libsodium/default.nix))
* It is released direct from git and has no version number


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
