### PR TITLE
stl-to-obj: init at 0.3

### DIFF
--- a/pkgs/by-name/st/stl-to-obj/package.nix
+++ b/pkgs/by-name/st/stl-to-obj/package.nix
@@ -1,0 +1,48 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stl-to-obj";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "Neizvestnyj";
+    repo = "stl-to-obj";
+    rev = finalAttrs.version;
+    hash = "sha256-+R7rNpMxKFC7sLYQXZX3Ikb5MqNd57r1M8gma73kCcg=";
+  };
+
+  postPatch = ''
+    # Add missing cstdint include
+    # ref. https://github.com/Neizvestnyj/stl-to-obj/pull/12
+    for filename in \
+      stl2obj/src/mode.cpp \
+      stl2obj/src/obj_to_stl/StlWriter.cpp \
+      stl2obj/src/stl_to_obj/importstl.cpp \
+      stl2obj/src/stl_to_obj/kdtree.h
+    do
+      echo "$(echo '#include <cstdint>'; cat $filename)" > $filename
+    done
+
+    # Install main executable
+    # ref. https://github.com/Neizvestnyj/stl-to-obj/pull/13
+    echo "install(TARGETS stl2obj DESTINATION $""{CMAKE_INSTALL_BINDIR})" >> CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "C++ stl to obj file converter and vice versa";
+    homepage = "https://github.com/Neizvestnyj/stl-to-obj";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "stl2obj";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Hi,

This add the C++ version of https://github.com/Neizvestnyj/stl-to-obj

A python interface is also available, but I don't need it right now, so I did not bother to include it.
But I can easily do that if/when anybody ask

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
