### PR TITLE
coqPackages: fix serapi & coq-lsp

### DIFF
--- a/pkgs/development/coq-modules/coq-lsp/coq-loader.patch
+++ b/pkgs/development/coq-modules/coq-lsp/coq-loader.patch
@@ -1,0 +1,11 @@
+--- a/coq/loader.ml	2024-11-14 17:54:36.562137810 +0100
++++ b/coq/loader.ml	2024-11-14 17:55:01.485154767 +0100
+@@ -81,7 +81,7 @@
+     Exninfo.iraise iexn
+ 
+ let plugin_handler user_loader =
+-  let loader = Option.default (Fl_dynload.load_packages ~debug:false) user_loader in
++  let loader = Option.default (Fl_dynload.load_packages ?loadfile:None ~debug:false) user_loader in
+   let safe_loader = safe_loader loader in
+   fun fl_pkg ->
+     let _, fl_pkg = Mltop.PluginSpec.repr fl_pkg in

--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -49,4 +49,6 @@
     else
      [ cmdliner ppx_deriving ppx_deriving_yojson ppx_import ppx_sexp_conv
        ppx_compare ppx_hash sexplib ]);
+
+    patches = lib.optional (lib.versions.isEq "0.1.8" o.version) ./coq-loader.patch;
 })

--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -32,7 +32,7 @@
   '';
 
   propagatedBuildInputs =
-    with coq.ocamlPackages; [ dune-build-info menhir uri yojson ];
+    with coq.ocamlPackages; [ dune-build-info menhir result uri yojson ];
 
   meta = with lib; {
     description = "Language Server Protocol and VS Code Extension for Coq";

--- a/pkgs/development/coq-modules/serapi/sertop.patch
+++ b/pkgs/development/coq-modules/serapi/sertop.patch
@@ -1,0 +1,11 @@
+--- a/sertop/sertop_loader.ml	2024-11-14 11:49:00.887576232 +0100
++++ b/sertop/sertop_loader.ml	2024-11-14 11:49:32.433659096 +0100
+@@ -51,7 +51,7 @@
+   else None
+ 
+ let plugin_handler user_handler =
+-  let loader = Option.default (Fl_dynload.load_packages ~debug:false) user_handler in
++  let loader = Option.default (Fl_dynload.load_packages ?loadfile:None ~debug:false) user_handler in
+   fun fl_pkg ->
+     try
+       let _, fl_pkg = Mltop.PluginSpec.repr fl_pkg in

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -10,31 +10,27 @@
 , ounit
 , ounit2
 , ocaml-migrate-parsetree
+, version ?
+  if lib.versionAtLeast ppxlib.version "0.32" then "6.0.3"
+  else if lib.versionAtLeast ppxlib.version "0.20" then "5.2.1"
+  else if lib.versionAtLeast ppxlib.version "0.15" then "5.1"
+  else "5.0"
 }:
 
-let params =
-  if lib.versionAtLeast ppxlib.version "0.32" then {
-    version = "6.0.3";
-    sha256 = "sha256-N0qpezLF4BwJqXgQpIv6IYwhO1tknkRSEBRVrBnJSm0=";
-  } else if lib.versionAtLeast ppxlib.version "0.20" then {
-    version = "5.2.1";
-    sha256 = "11h75dsbv3rs03pl67hdd3lbim7wjzh257ij9c75fcknbfr5ysz9";
-  } else if lib.versionAtLeast ppxlib.version "0.15" then {
-    version = "5.1";
-    sha256 = "1i64fd7qrfzbam5hfbl01r0sx4iihsahcwqj13smmrjlnwi3nkxh";
-  } else {
-    version = "5.0";
-    sha256 = "0fkzrn4pdyvf1kl0nwvhqidq01pnq3ql8zk1jd56hb0cxaw851w3";
-  }
-; in
+let hash = {
+  "6.0.3" = "sha256-N0qpezLF4BwJqXgQpIv6IYwhO1tknkRSEBRVrBnJSm0=";
+  "5.2.1" = "sha256:11h75dsbv3rs03pl67hdd3lbim7wjzh257ij9c75fcknbfr5ysz9";
+  "5.1" = "sha256:1i64fd7qrfzbam5hfbl01r0sx4iihsahcwqj13smmrjlnwi3nkxh";
+  "5.0" = "sha256:0fkzrn4pdyvf1kl0nwvhqidq01pnq3ql8zk1jd56hb0cxaw851w3";
+}."${version}"; in
 
 buildDunePackage rec {
   pname = "ppx_deriving";
-  inherit (params) version;
+  inherit version;
 
   src = fetchurl {
     url = "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v${version}/ppx_deriving-${lib.optionalString (lib.versionOlder version "6.0") "v"}${version}.tbz";
-    inherit (params) sha256;
+    inherit hash;
   };
 
   strictDeps = true;


### PR DESCRIPTION
Fix regressions after updates of `ppx_deriving` and `findlib`.

Tests: https://github.com/coq-community/coq-nix-toolbox/pull/286

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
