### PR TITLE
meilisearch: 1.11.1 → 1.11.3

### DIFF
--- a/pkgs/servers/search/meilisearch/Cargo.lock
+++ b/pkgs/servers/search/meilisearch/Cargo.lock
@@ -472,7 +472,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmarks"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "time",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "dump"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "big_s",
@@ -1835,7 +1835,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "file-store"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "insta",
  "nom",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "criterion",
  "serde_json",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "fuzzers"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "arbitrary",
  "clap",
@@ -2553,7 +2553,7 @@ checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "index-scheduler"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "arroy",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "criterion",
  "serde_json",
@@ -3366,7 +3366,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "meili-snap"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "insta",
  "md5",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-auth"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "base64 0.22.1",
  "enum-iterator",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-types"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "meilitool"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "arroy",
  "big_s",
@@ -3991,7 +3991,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "permissive-json-pointer"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "big_s",
  "serde_json",
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.11.1"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "build-info",

--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "1.11.1";
+  version = "1.11.3";
 in
 rustPlatform.buildRustPackage {
   pname = "meilisearch";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
     owner = "meilisearch";
     repo = "meiliSearch";
     rev = "refs/tags/v${version}";
-    hash = "sha256-SxmN6CDgS4QrCdJPF36RyljvKXXhCuYzaJnpqROSY5U=";
+    hash = "sha256-CVofke9tOGeDEhRHEt6EYwT52eeAYNqlEd9zPpmXQ2U=";
   };
 
   cargoBuildFlags = [ "--package=meilisearch" ];


### PR DESCRIPTION
Update Meilisearch

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
