### PR TITLE
libepoxy: add wayland option to enable egl support

### DIFF
--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -1,60 +1,76 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, meson
-, ninja
-, pkg-config
-, utilmacros
-, python3
-, libGL
-, libX11
-, Carbon
-, OpenGL
-, x11Support ? !stdenv.hostPlatform.isDarwin
-, testers
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  utilmacros,
+  python3,
+  libGL,
+  libX11,
+  Carbon,
+  OpenGL,
+  x11Support ? !stdenv.hostPlatform.isDarwin,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libepoxy";
   version = "1.5.10";
 
-  src = with finalAttrs; fetchFromGitHub {
-    owner = "anholt";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-gZiyPOW2PeTMILcPiUTqPUGRNlMM5mI1z9563v4SgEs=";
-  };
+  src =
+    with finalAttrs;
+    fetchFromGitHub {
+      owner = "anholt";
+      repo = pname;
+      rev = version;
+      sha256 = "sha256-gZiyPOW2PeTMILcPiUTqPUGRNlMM5mI1z9563v4SgEs=";
+    };
 
   patches = [ ./libgl-path.patch ];
 
-  postPatch = ''
-    patchShebangs src/*.py
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace src/dispatch_common.h --replace "PLATFORM_HAS_GLX 0" "PLATFORM_HAS_GLX 1"
-  ''
-  # cgl_core and cgl_epoxy_api fail in darwin sandbox and on Hydra (because it's headless?)
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace test/meson.build \
-      --replace "[ 'cgl_epoxy_api', [ 'cgl_epoxy_api.c' ] ]," ""
-  ''
-  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-    substituteInPlace test/meson.build \
-      --replace "[ 'cgl_core', [ 'cgl_core.c' ] ]," ""
-  '';
+  postPatch =
+    ''
+      patchShebangs src/*.py
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/dispatch_common.h --replace "PLATFORM_HAS_GLX 0" "PLATFORM_HAS_GLX 1"
+    ''
+    # cgl_core and cgl_epoxy_api fail in darwin sandbox and on Hydra (because it's headless?)
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace test/meson.build \
+        --replace "[ 'cgl_epoxy_api', [ 'cgl_epoxy_api.c' ] ]," ""
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+      substituteInPlace test/meson.build \
+        --replace "[ 'cgl_core', [ 'cgl_core.c' ] ]," ""
+    '';
 
-  outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [ meson ninja pkg-config utilmacros python3 ];
-
-  buildInputs = lib.optionals (x11Support && !stdenv.hostPlatform.isDarwin) [
-    libGL
-  ] ++ lib.optionals x11Support [
-    libX11
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    Carbon
-    OpenGL
+  outputs = [
+    "out"
+    "dev"
   ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    utilmacros
+    python3
+  ];
+
+  buildInputs =
+    lib.optionals (x11Support && !stdenv.hostPlatform.isDarwin) [
+      libGL
+    ]
+    ++ lib.optionals x11Support [
+      libX11
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      Carbon
+      OpenGL
+    ];
 
   mesonFlags = [
     "-Degl=${if (x11Support && !stdenv.hostPlatform.isDarwin) then "yes" else "no"}"
@@ -63,7 +79,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dx11=${lib.boolToString x11Support}"
   ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (x11Support && !stdenv.hostPlatform.isDarwin) ''-DLIBGL_PATH="${lib.getLib libGL}/lib"'';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (
+    x11Support && !stdenv.hostPlatform.isDarwin
+  ) ''-DLIBGL_PATH="${lib.getLib libGL}/lib"'';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for handling OpenGL function pointer management";
     homepage = "https://github.com/anholt/libepoxy";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ jwillikers ];
     platforms = platforms.unix;
     pkgConfigModules = [ "epoxy" ];
   };

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -12,6 +12,7 @@
   Carbon,
   OpenGL,
   x11Support ? !stdenv.hostPlatform.isDarwin,
+  waylandSupport ? stdenv.hostPlatform.isLinux,
   testers,
 }:
 
@@ -61,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs =
-    lib.optionals (x11Support && !stdenv.hostPlatform.isDarwin) [
+    lib.optionals ((waylandSupport || x11Support) && !stdenv.hostPlatform.isDarwin) [
       libGL
     ]
     ++ lib.optionals x11Support [
@@ -73,14 +74,14 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   mesonFlags = [
-    "-Degl=${if (x11Support && !stdenv.hostPlatform.isDarwin) then "yes" else "no"}"
+    "-Degl=${if ((waylandSupport || x11Support) && !stdenv.hostPlatform.isDarwin) then "yes" else "no"}"
     "-Dglx=${if x11Support then "yes" else "no"}"
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-Dx11=${lib.boolToString x11Support}"
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    x11Support && !stdenv.hostPlatform.isDarwin
+    (waylandSupport || x11Support) && !stdenv.hostPlatform.isDarwin
   ) ''-DLIBGL_PATH="${lib.getLib libGL}/lib"'';
 
   doCheck = true;

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "anholt";
     repo = "libepoxy";
-    rev = finalAttrs.version;
+    rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-gZiyPOW2PeTMILcPiUTqPUGRNlMM5mI1z9563v4SgEs=";
   };
 

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   meson,
   ninja,
+  nix-update-script,
   pkg-config,
   utilmacros,
   python3,
@@ -88,11 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  passthru.tests = {
-    pkg-config = testers.hasPkgConfigModules {
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
       versionCheck = true;
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -74,10 +74,10 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   mesonFlags = [
-    "-Degl=${if ((waylandSupport || x11Support) && !stdenv.hostPlatform.isDarwin) then "yes" else "no"}"
-    "-Dglx=${if x11Support then "yes" else "no"}"
-    "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
-    "-Dx11=${lib.boolToString x11Support}"
+    (lib.mesonOption "egl" (if ((waylandSupport || x11Support) && !stdenv.hostPlatform.isDarwin) then "yes" else "no"))
+    (lib.mesonOption "glx" (if x11Support then "yes" else "no"))
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
+    (lib.mesonBool "x11" x11Support)
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -92,12 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Library for handling OpenGL function pointer management";
     homepage = "https://github.com/anholt/libepoxy";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jwillikers ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     pkgConfigModules = [ "epoxy" ];
   };
 })

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -22,14 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libepoxy";
   version = "1.5.10";
 
-  src =
-    with finalAttrs;
-    fetchFromGitHub {
-      owner = "anholt";
-      repo = pname;
-      rev = version;
-      sha256 = "sha256-gZiyPOW2PeTMILcPiUTqPUGRNlMM5mI1z9563v4SgEs=";
-    };
+  src = fetchFromGitHub {
+    owner = "anholt";
+    repo = "libepoxy";
+    rev = finalAttrs.version;
+    hash = "sha256-gZiyPOW2PeTMILcPiUTqPUGRNlMM5mI1z9563v4SgEs=";
+  };
 
   patches = [ ./libgl-path.patch ];
 

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -14,6 +14,7 @@
   x11Support ? !stdenv.hostPlatform.isDarwin,
   waylandSupport ? stdenv.hostPlatform.isLinux,
   testers,
+  validatePkgConfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     utilmacros
     python3
+    validatePkgConfig
   ];
 
   buildInputs =
@@ -89,6 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests = {
     pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
+      versionCheck = true;
     };
   };
 


### PR DESCRIPTION
Building the gtk3 package with x11Support disabled and waylandSupport enabled doesn't work.
It passes the x11Support option to libepoxy, which then disables egl support.
Wayland still requires egl support however, causing the build to fail.

Add an option to allow enabling egl.

Format the file, too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
