### PR TITLE
scalene: 1.5.46 -> 1.5.47

### DIFF
--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -39,7 +39,7 @@ in
 
 buildPythonPackage rec {
   pname = "scalene";
-  version = "1.5.46";
+  version = "1.5.47";
   pyproject = true;
   disabled = pythonOlder "3.9";
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     owner = "plasma-umass";
     repo = "scalene";
     rev = "v${version}";
-    hash = "sha256-G+fX0D70aGOmXr/SqaBKkOz3CEHpGqClFFdTeOzRpaw=";
+    hash = "sha256-NrXXwzp+NYdie7p5xsJa7lMGgKED3FCzeAjO7x+USHU=";
   };
 
   patches = [


### PR DESCRIPTION
Version bump to bugfix release. Confirmed that required dependencies heap-layers and printf were unchanged.

[Fixes memory leak tracking and VS Code integration](https://github.com/plasma-umass/scalene/releases/tag/v1.5.47)
Repository: [plasma-umass/scalene](https://github.com/plasma-umass/scalene) · Tag: [v1.5.47](https://github.com/plasma-umass/scalene/tree/v1.5.47) · Commit: [3eecd59](https://github.com/plasma-umass/scalene/commit/3eecd59e878acc9727089d40a99da8a32bc7fc25) · Released by: [emeryberger](https://github.com/emeryberger)

What's Changed
Fixed memory leak issues by [@sternj](https://github.com/sternj) in https://github.com/plasma-umass/scalene/pull/879
Fixed integration with Visual Studio Code: updated logic to ensure HTML files are output as requested (with --outfile) by [@emeryberger](https://github.com/emeryberger) in https://github.com/plasma-umass/scalene/pull/881
Full Changelog: [v1.5.46...v1.5.47](https://github.com/plasma-umass/scalene/compare/v1.5.46...v1.5.47)

Replaces #355281 after a terrible rebase error. (Sorry) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
