### PR TITLE
nixos/mopidy: test & cleanup

### DIFF
--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -13,7 +13,7 @@ let
     pathsToLink = [ "/${pkgs.mopidyPackages.python.sitePackages}" ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
-      makeWrapper ${pkgs.mopidy}/bin/mopidy $out/bin/mopidy \
+      makeWrapper ${lib.getExe pkgs.mopidy} $out/bin/mopidy \
         --prefix PYTHONPATH : $out/${pkgs.mopidyPackages.python.sitePackages}
     '';
   };

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -1,24 +1,20 @@
 { config, lib, pkgs, ... }:
-
-with pkgs;
-with lib;
-
 let
   uid = config.ids.uids.mopidy;
   gid = config.ids.gids.mopidy;
   cfg = config.services.mopidy;
 
-  mopidyConf = writeText "mopidy.conf" cfg.configuration;
+  mopidyConf = pkgs.writeText "mopidy.conf" cfg.configuration;
 
-  mopidyEnv = buildEnv {
-    name = "mopidy-with-extensions-${mopidy.version}";
+  mopidyEnv = pkgs.buildEnv {
+    name = "mopidy-with-extensions-${pkgs.mopidy.version}";
     ignoreCollisions = true;
-    paths = closePropagation cfg.extensionPackages;
-    pathsToLink = [ "/${mopidyPackages.python.sitePackages}" ];
-    nativeBuildInputs = [ makeWrapper ];
+    paths = lib.closePropagation cfg.extensionPackages;
+    pathsToLink = [ "/${pkgs.mopidyPackages.python.sitePackages}" ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
-      makeWrapper ${mopidy}/bin/mopidy $out/bin/mopidy \
-        --prefix PYTHONPATH : $out/${mopidyPackages.python.sitePackages}
+      makeWrapper ${pkgs.mopidy}/bin/mopidy $out/bin/mopidy \
+        --prefix PYTHONPATH : $out/${pkgs.mopidyPackages.python.sitePackages}
     '';
   };
 in {
@@ -27,49 +23,47 @@ in {
 
     services.mopidy = {
 
-      enable = mkEnableOption "Mopidy, a music player daemon";
+      enable = lib.mkEnableOption "Mopidy, a music player daemon";
 
-      dataDir = mkOption {
+      dataDir = lib.mkOption {
         default = "/var/lib/mopidy";
-        type = types.str;
+        type = lib.types.str;
         description = ''
           The directory where Mopidy stores its state.
         '';
       };
 
-      extensionPackages = mkOption {
+      extensionPackages = lib.mkOption {
         default = [];
-        type = types.listOf types.package;
-        example = literalExpression "[ pkgs.mopidy-spotify ]";
+        type = lib.types.listOf lib.types.package;
+        example = lib.literalExpression "[ pkgs.mopidy-spotify ]";
         description = ''
           Mopidy extensions that should be loaded by the service.
         '';
       };
 
-      configuration = mkOption {
+      configuration = lib.mkOption {
         default = "";
-        type = types.lines;
+        type = lib.types.lines;
         description = ''
           The configuration that Mopidy should use.
         '';
       };
 
-      extraConfigFiles = mkOption {
+      extraConfigFiles = lib.mkOption {
         default = [];
-        type = types.listOf types.str;
+        type = lib.types.listOf lib.types.str;
         description = ''
           Extra config file read by Mopidy when the service starts.
           Later files in the list overrides earlier configuration.
         '';
       };
-
     };
-
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.tmpfiles.settings."10-mopidy".${cfg.dataDir}.d = {
       user = "mopidy";
@@ -82,7 +76,7 @@ in {
       wants = [ "network-online.target" ];
       description = "mopidy music player daemon";
       serviceConfig = {
-        ExecStart = "${mopidyEnv}/bin/mopidy --config ${concatStringsSep ":" ([mopidyConf] ++ cfg.extraConfigFiles)}";
+        ExecStart = "${mopidyEnv}/bin/mopidy --config ${lib.concatStringsSep ":" ([mopidyConf] ++ cfg.extraConfigFiles)}";
         User = "mopidy";
       };
     };
@@ -90,7 +84,7 @@ in {
     systemd.services.mopidy-scan = {
       description = "mopidy local files scanner";
       serviceConfig = {
-        ExecStart = "${mopidyEnv}/bin/mopidy --config ${concatStringsSep ":" ([mopidyConf] ++ cfg.extraConfigFiles)} local scan";
+        ExecStart = "${mopidyEnv}/bin/mopidy --config ${lib.concatStringsSep ":" ([mopidyConf] ++ cfg.extraConfigFiles)} local scan";
         User = "mopidy";
         Type = "oneshot";
       };
@@ -105,7 +99,5 @@ in {
     };
 
     users.groups.mopidy.gid = gid;
-
   };
-
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -619,6 +619,7 @@ in {
   mongodb = handleTest ./mongodb.nix {};
   moodle = handleTest ./moodle.nix {};
   moonraker = handleTest ./moonraker.nix {};
+  mopidy = handleTest ./mopidy.nix {};
   morph-browser = handleTest ./morph-browser.nix { };
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};

--- a/nixos/tests/mopidy.nix
+++ b/nixos/tests/mopidy.nix
@@ -1,12 +1,17 @@
-import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "mopidy";
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "mopidy";
 
-  nodes.machine = { ... }: {
-    services.mopidy.enable = true;
-  };
+    nodes.machine =
+      { ... }:
+      {
+        services.mopidy.enable = true;
+      };
 
-  testScript = ''
-    machine.wait_for_unit("mopidy")
-    machine.wait_for_open_port(6680)
-  '';
-})
+    testScript = ''
+      machine.wait_for_unit("mopidy")
+      machine.wait_for_open_port(6680)
+    '';
+  }
+)

--- a/nixos/tests/mopidy.nix
+++ b/nixos/tests/mopidy.nix
@@ -1,0 +1,12 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "mopidy";
+
+  nodes.machine = { ... }: {
+    services.mopidy.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("mopidy")
+    machine.wait_for_open_port(6680)
+  '';
+})

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -35,9 +35,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs =
-    [
-      gobject-introspection
-    ]
+    [ gobject-introspection ]
     ++ (
       with pythonPackages;
       [
@@ -51,14 +49,14 @@ pythonPackages.buildPythonApplication rec {
       ++ lib.optional (!stdenv.hostPlatform.isDarwin) dbus-python
     );
 
-  propagatedNativeBuildInputs = [
-    gobject-introspection
-  ];
+  propagatedNativeBuildInputs = [ gobject-introspection ];
 
   # There are no tests
   doCheck = false;
 
-  passthru.tests = { inherit (nixosTests) mopidy; };
+  passthru.tests = {
+    inherit (nixosTests) mopidy;
+  };
 
   meta = with lib; {
     homepage = "https://www.mopidy.com/";

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -8,6 +8,7 @@
   glib-networking,
   gobject-introspection,
   pipewire,
+  nixosTests,
 }:
 
 pythonPackages.buildPythonApplication rec {
@@ -56,6 +57,8 @@ pythonPackages.buildPythonApplication rec {
 
   # There are no tests
   doCheck = false;
+
+  passthru.tests = { inherit (nixosTests) mopidy; };
 
   meta = with lib; {
     homepage = "https://www.mopidy.com/";


### PR DESCRIPTION
adding test and cleanup

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
