### PR TITLE
llvm-ez80: init at 0-unstable-2023-12-13

### DIFF
--- a/pkgs/by-name/ll/llvm-ez80/package.nix
+++ b/pkgs/by-name/ll/llvm-ez80/package.nix
@@ -1,0 +1,68 @@
+{
+  stdenv,
+  cmake,
+  python3,
+  lib,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "llvm-ez80";
+  version = "0-unstable";
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  src = fetchFromGitHub {
+    owner = "jacobly0";
+    repo = "llvm-project";
+    rev = "005a99ce2569373524bd881207aa4a1e98a2b238";
+    hash = "sha256-g9AVQF48HvaOzwm6Fr935+2+Ch+nvUV2afygb3iUflw=";
+  };
+
+  patchPhase = ''
+    chmod +w --recursive /build/${finalAttrs.src.name}
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_ENABLE_PROJECTS=clang"
+    "-DLLVM_TARGETS_TO_BUILD="
+    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=Z80"
+  ];
+  buildFlags = [
+    "llvm-link"
+    "clang"
+  ];
+
+  sourceRoot = finalAttrs.src.name + "/llvm";
+
+  doCheck = false;
+
+  installPhase =
+    let
+      binDir = "/build/${finalAttrs.sourceRoot}/build/bin";
+    in
+    ''
+      mkdir -p $out/bin
+      cp ${binDir}/llvm-link $out/bin/ez80-link
+      cp ${binDir}/clang $out/bin/ez80-clang
+    '';
+
+  meta = {
+    description = "A compiler and linker for (e)Z80 targets.";
+    longDescription = ''
+      This package provides a compiler and linker for (e)Z80 targets
+      based on the LLVM toolchain.
+      Originally designed for the TI-84 Plus CE, this also works for the Agon Light.
+
+      This does not provide fasmg or any include files to build the programs.
+      Please install a toolchain, such as the CE C toolchain.
+    '';
+    homepage = "https://github.com/jacobly0/llvm-project";
+    license = lib.licenses.asl20-llvm;
+    maintainers = with lib.maintainers; [ clevor ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
llvm-ez80 is a fork of the LLVM compiler by @jacobly0 that supports compiling for the (e)Z80 targets. It is primarily meant for the TI-84 Plus CE, but is also used by the Agon Light community. it can be found [on jacobly's profile](https://github.com/jacobly0/llvm-project).

Today, I tried to work on [my old PR for it](#321846), but it automatically closed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - ~~In progress as I submit this~~ Done
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - Disabled my disk swap partition, and the OOM killer happened and had to restart my system
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
