### PR TITLE
amulet-map-editor: init at 0.10.37

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -97,6 +97,14 @@ lib.mapAttrs mkLicense ({
     fullName = "Academy of Motion Picture Arts and Sciences BSD";
   };
 
+  amulet = {
+    fullName = "Amulet Team License 1.0.0";
+    url = "https://github.com/Amulet-Team/Amulet-NBT/blob/4.0/LICENSE";
+    free = false;
+    # Amulet Team License is based on Polyform Shield which allows non-competitive distribution
+    redistributable = true;
+  };
+
   aom = {
     fullName = "Alliance for Open Media Patent License 1.0";
     url = "https://aomedia.org/license/patent-license/";

--- a/pkgs/by-name/am/amulet-map-editor/package.nix
+++ b/pkgs/by-name/am/amulet-map-editor/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  nix-update-script,
+  wrapGAppsHook3,
+  gtk3,
+}:
+let
+  version = "0.10.39";
+in
+python3.pkgs.buildPythonApplication {
+  pname = "amulet-map-editor";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-Map-Editor";
+    tag = version;
+    hash = "sha256-6HwASoAi4amPTzAFnUTxn2PCzBRKi0wFXcTN1l10O8U=";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook3 ];
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+    cython
+    versioneer
+    numpy
+  ];
+
+  buildInputs = [ gtk3 ];
+
+  dependencies = with python3.pkgs; [
+    pillow
+    wxpython
+    numpy
+    pyopengl
+    packaging
+    amulet-core
+    amulet-nbt
+    pymctranslate
+    minecraft-resource-pack
+    platformdirs
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "amulet_map_editor" ];
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minecraft world editor and converter that supports all versions since Java 1.12 and Bedrock 1.7";
+    homepage = "https://github.com/Amulet-Team/Amulet-Map-Editor";
+    changelog = "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-core/default.nix
+++ b/pkgs/development/python-modules/amulet-core/default.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  wheel,
+  cython,
+  versioneer,
+  numpy,
+
+  # dependencies
+  amulet-nbt,
+  pymctranslate,
+  portalocker,
+  amulet-leveldb,
+  platformdirs,
+  lz4,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+
+  pytestCheckHook,
+  nix-update-script,
+}:
+let
+  version = "1.9.27";
+in
+buildPythonPackage {
+  pname = "amulet-core";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-Core";
+    tag = version;
+    hash = "sha256-cwk70qg97BIFPTpBnGG5WQElzvS5CYP5HIEIYd0w96I=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'versioneer-518' 'versioneer'
+
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    cython
+    versioneer
+    numpy
+  ];
+
+  dependencies = [
+    numpy
+    amulet-nbt
+    pymctranslate
+    portalocker
+    amulet-leveldb
+    platformdirs
+    lz4
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  pythonImportsCheck = [ "amulet" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    # Required for tests that want to write to the home directory
+    export HOME=$(mktemp -d)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing the Minecraft save formats";
+    homepage = "https://github.com/Amulet-Team/Amulet-Core";
+    changelog = "https://github.com/Amulet-Team/Amulet-Core/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-leveldb/default.nix
+++ b/pkgs/development/python-modules/amulet-leveldb/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  zlib,
+
+  # build-system
+  setuptools,
+  wheel,
+  cython,
+  versioneer,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+
+  pytestCheckHook,
+  nix-update-script,
+}:
+let
+  version = "1.0.2";
+in
+buildPythonPackage {
+  pname = "amulet-leveldb";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-LevelDB";
+    tag = version;
+    hash = "sha256-7VJb5TEa3GcwNEZYrnwP3yMWdpxkHeFcydCCeHiB3+w=";
+
+    postFetch = ''
+      # De-vendor zlib
+      rm -r $out/zlib
+    '';
+    fetchSubmodules = true;
+  };
+
+  disabled = pythonOlder "3.8";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    cython
+    versioneer
+  ];
+
+  buildInputs = [ zlib ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "leveldb" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # FIXME(pluiedev): I... frankly don't know why this fails.
+  # try:
+  #     self.assertTrue(40_000 <= len(list(db.keys())) < 100_000)
+  #     ^ AssertionError: False is not true
+  disabledTests = [ "test_corrupt" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cython wrapper for Mojang's custom LevelDB";
+    homepage = "https://github.com/Amulet-Team/Amulet-LevelDB";
+    changelog = "https://github.com/Amulet-Team/Amulet-LevelDB/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-nbt/default.nix
+++ b/pkgs/development/python-modules/amulet-nbt/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+  cython,
+
+  # dependencies
+  numpy,
+  mutf8,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+
+  pytestCheckHook,
+  nix-update-script,
+}:
+let
+  version = "2.1.3";
+in
+buildPythonPackage {
+  pname = "amulet-nbt";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-NBT";
+    tag = version;
+    hash = "sha256-ucN/CFPYWEPPiqrK9v2VZ1l5s2jf0N0tNuxpYoTZQ4s=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  postPatch = ''
+    # FIXME: Drop for 4.x
+    substituteInPlace pyproject.toml \
+      --replace-fail 'versioneer-518' 'versioneer'
+
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    cython
+    versioneer
+    numpy
+  ];
+
+  dependencies = [
+    numpy
+    mutf8
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "amulet_nbt" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Source files interfere with tests :(
+  preCheck = ''
+    rm -r amulet_nbt
+  '';
+
+  # FIXME: Drop for 4.x, somehow it's just not implemented at all
+  disabledTestPaths = [ "tests/base_type_test.py" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing binary NBT and stringified NBT";
+    homepage = "https://github.com/Amulet-Team/Amulet-NBT";
+    changelog = "https://github.com/Amulet-Team/Amulet-NBT/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/minecraft-resource-pack/default.nix
+++ b/pkgs/development/python-modules/minecraft-resource-pack/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+
+  # dependencies
+  pillow,
+  numpy,
+  amulet-nbt,
+  platformdirs,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+
+  nix-update-script,
+}:
+let
+  version = "1.4.6";
+in
+buildPythonPackage {
+  pname = "minecraft-resource-pack";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gentlegiantJGC";
+    repo = "Minecraft-Model-Reader";
+    tag = version;
+    hash = "sha256-i+c5QSvGQeB5APBzN5JJ6uFohR2volX4D9qkuRQeig4=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    versioneer
+  ];
+
+  dependencies = [
+    pillow
+    numpy
+    amulet-nbt
+    platformdirs
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  pythonImportsCheck = [ "minecraft_model_reader" ];
+
+  # minecraft_model_reader/api/amulet/block.py:132: in __init__
+  #    assert isinstance(properties, dict) and all(
+  #E   AssertionError: {'age': '0', 'east': 'true', 'north': 'true', 'south': 'false', 'up': 'false', 'west': 'false'}
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing binary NBT and stringified NBT";
+    homepage = "https://github.com/Amulet-Team/Amulet-NBT";
+    changelog = "https://github.com/Amulet-Team/Amulet-NBT/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/pymctranslate/default.nix
+++ b/pkgs/development/python-modules/pymctranslate/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+
+  # dependencies
+  numpy,
+  amulet-nbt,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+
+  pytestCheckHook,
+  nix-update-script,
+}:
+let
+  version = "1.2.30";
+in
+buildPythonPackage {
+  pname = "pymctranslate";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gentlegiantJGC";
+    repo = "PyMCTranslate";
+    tag = version;
+    hash = "sha256-ezLByCYaj9OwXXrvpGduQW/E+UhWexK0mFZEnxoy0ZI=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'versioneer-518' 'versioneer'
+
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    versioneer
+  ];
+
+  dependencies = [
+    numpy
+    amulet-nbt
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "PyMCTranslate" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # ¯\_(ツ)_/¯ This uses a nonexistent method for no reason - someone probably just forgot
+  disabledTestPaths = [ "tests/basic_test.py" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minecraft data translation system";
+    homepage = "https://github.com/gentlegiantJGC/PyMCTranslate";
+    changelog = "https://github.com/gentlegiantJGC/PyMCTranslate/releases/tag/${version}";
+    license = with lib.licenses; [ amulet ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8141,6 +8141,8 @@ self: super: with self; {
 
   mindsdb-evaluator = callPackage ../development/python-modules/mindsdb-evaluator { };
 
+  minecraft-resource-pack = callPackage ../development/python-modules/minecraft-resource-pack { };
+
   minexr = callPackage ../development/python-modules/minexr { };
 
   miniaudio = callPackage ../development/python-modules/miniaudio {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11958,6 +11958,8 @@ self: super: with self; {
 
   pymc = callPackage ../development/python-modules/pymc { };
 
+  pymctranslate = callPackage ../development/python-modules/pymctranslate { };
+
   pymdstat = callPackage ../development/python-modules/pymdstat { };
 
   pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -586,6 +586,8 @@ self: super: with self; {
 
   amqtt = callPackage ../development/python-modules/amqtt { };
 
+  amulet-leveldb = callPackage ../development/python-modules/amulet-leveldb { };
+
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };
 
   ancp-bids = callPackage ../development/python-modules/ancp-bids { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -588,6 +588,8 @@ self: super: with self; {
 
   amulet-leveldb = callPackage ../development/python-modules/amulet-leveldb { };
 
+  amulet-nbt = callPackage ../development/python-modules/amulet-nbt { };
+
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };
 
   ancp-bids = callPackage ../development/python-modules/ancp-bids { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -586,6 +586,8 @@ self: super: with self; {
 
   amqtt = callPackage ../development/python-modules/amqtt { };
 
+  amulet-core = callPackage ../development/python-modules/amulet-core { };
+
   amulet-leveldb = callPackage ../development/python-modules/amulet-leveldb { };
 
   amulet-nbt = callPackage ../development/python-modules/amulet-nbt { };


### PR DESCRIPTION
Closes #201016

Got it to work for a brief moment before somehow it just starts to SIGBUS everywhere. Needs further investigation/reproduction
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
