### PR TITLE
bisq2: init at 2.1.2

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -1,0 +1,169 @@
+{
+  stdenvNoCC,
+  lib,
+  makeWrapper,
+  runtimeShell,
+  fetchurl,
+  makeDesktopItem,
+  copyDesktopItems,
+  imagemagick,
+  jdk23,
+  dpkg,
+  writeShellScript,
+  bash,
+  tor,
+  zip,
+  gnupg,
+}:
+
+let
+  version = "2.1.2";
+
+  jdk = jdk23.override { enableJavaFX = true; };
+
+  bisq-launcher =
+    args:
+    writeShellScript "bisq-launcher" ''
+      # This is just a comment to convince Nix that Tor is a
+      # runtime dependency; The Tor binary is in a *.jar file,
+      # whereas Nix only scans for hashes in uncompressed text.
+      # ${lib.getExe' tor "tor"}
+
+      rm -fR $HOME/.local/share/Bisq2/tor
+
+      exec "${lib.getExe jdk}" -Djpackage.app-version=@version@ -classpath @out@/lib/app/desktop-app-launcher.jar:@out@/lib/app/* ${args} bisq.desktop_app_launcher.DesktopAppLauncher "$@"
+    '';
+
+  # A given release will be signed by either Alejandro Garcia or Henrik Jannsen
+  # as indicated in the file
+  # https://github.com/bisq-network/bisq2/releases/download/v${version}/signingkey.asc
+  publicKey =
+    {
+      "E222AA02" = fetchurl {
+        url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/E222AA02.asc";
+        sha256 = "sha256-31uBpe/+0QQwFyAsoCt1TUWRm0PHfCFOGOx1M16efoE=";
+      };
+
+      "387C8307" = fetchurl {
+        url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/387C8307.asc";
+        sha256 = "sha256-PrRYZLT0xv82dUscOBgQGKNf6zwzWUDhriAffZbNpmI=";
+      };
+    }
+    ."387C8307";
+in
+stdenvNoCC.mkDerivation rec {
+  inherit version;
+
+  pname = "bisq2";
+
+  src = fetchurl {
+    url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/Bisq-${version}.deb";
+    sha256 = "0zgv70xlz3c9mrwmiaa1dgagbc441ppk2vrkgard8zjrvk8rg7va";
+
+    # Verify the upstream Debian package prior to extraction.
+    # See https://bisq.wiki/Bisq_2#Installation
+    # This ensures that a successful build of this Nix package requires the Debian
+    # package to pass verification.
+    nativeBuildInputs = [ gnupg ];
+    downloadToTemp = true;
+
+    postFetch = ''
+      pushd $(mktemp -d)
+      export GNUPGHOME=./gnupg
+      mkdir -m 700 -p $GNUPGHOME
+      ln -s $downloadedFile ./Bisq-${version}.deb
+      ln -s ${signature} ./signature.asc
+      gpg --import ${publicKey}
+      gpg --batch --verify signature.asc Bisq-${version}.deb
+      popd
+      mv $downloadedFile $out
+    '';
+  };
+
+  signature = fetchurl {
+    url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/Bisq-${version}.deb.asc";
+    sha256 = "sha256-WZhI8RDmb7nQqpCQJM86vrp8qQNg+mvRVdSPcDqgzxE=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    dpkg
+    imagemagick
+    makeWrapper
+    zip
+    gnupg
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bisq2";
+      exec = "bisq2";
+      icon = "bisq2";
+      desktopName = "Bisq 2";
+      genericName = "Decentralized bitcoin exchange";
+      categories = [
+        "Network"
+        "P2P"
+      ];
+    })
+
+    (makeDesktopItem {
+      name = "bisq2-hidpi";
+      exec = "bisq2-hidpi";
+      icon = "bisq2";
+      desktopName = "Bisq 2 (HiDPI)";
+      genericName = "Decentralized bitcoin exchange";
+      categories = [
+        "Network"
+        "P2P"
+      ];
+    })
+  ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  buildPhase = ''
+    # Replace the Tor binary embedded in tor.jar (which is in the zip archive tor.zip)
+    # with the Tor binary from Nixpkgs.
+
+    makeWrapper ${lib.getExe' tor "tor"} ./tor
+    zip tor.zip ./tor
+    zip opt/bisq2/lib/app/tor.jar tor.zip
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin
+    cp -r opt/bisq2/lib/app $out/lib
+
+    install -D -m 777 ${bisq-launcher ""} $out/bin/bisq2
+    substituteAllInPlace $out/bin/bisq2
+
+    install -D -m 777 ${bisq-launcher "-Dglass.gtk.uiScale=2.0"} $out/bin/bisq2-hidpi
+    substituteAllInPlace $out/bin/bisq2-hidpi
+
+    for n in 16 24 32 48 64 96 128 256; do
+      size=$n"x"$n
+      magick convert opt/bisq2/lib/Bisq2.png -resize $size bisq2.png
+      install -Dm644 -t $out/share/icons/hicolor/$size/apps bisq2.png
+    done;
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Decentralized bitcoin exchange network";
+    homepage = "https://bisq.network";
+    mainProgram = "bisq2";
+    sourceProvenance = with sourceTypes; [
+      binaryBytecode
+    ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ emmanuelrosa ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
This PR adds [Bisq 2](https://bisq.wiki/Bisq_2), a decentralized bitcoin exchange that allows anyone to buy and sell bitcoin in exchange for national currencies or other cryptocurrencies.

This is a continuation of [#347160](https://github.com/NixOS/nixpkgs/pull/347160), which was rolled back on https://github.com/NixOS/nixpkgs/pull/352550

The package now uses JDK 23.

## Verification
It is customary to verify the downloaded Bisq application by importing upstream's GPG key and verifying the signature of the downloaded package.

This Nix package includes build-time verification of the downloaded Debian package. This is to give users of this package a greater level of confirmation --compared to verification by the maintainer, (me)-- that the package has been signed by upstream. In short, if this package builds, then it's also verified.

## QR code scanning
There's a bundled "webcam app" which is used for webcam access to scan QR codes. This app does not work on NixOS due to bundled libraries which need to be patchelf'ed. I already made two attempts to add support for this "webcam app" and failed. I will not be making another attempt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
