### PR TITLE
ocamlPackages.dune-configurator: workaround clang arg order bug

### DIFF
--- a/pkgs/development/ocaml-modules/dune-configurator/clang-arg-order-workaround.patch
+++ b/pkgs/development/ocaml-modules/dune-configurator/clang-arg-order-workaround.patch
@@ -1,0 +1,53 @@
+From 3e9f115a8e931452d74e37da6f279e8bdd057088 Mon Sep 17 00:00:00 2001
+From: Reno Dakota <paparodeo@proton.me>
+Date: Thu, 14 Nov 2024 23:27:41 +0000
+Subject: [PATCH] configurator: c file name is last in compiler args
+
+Re-order the compiler arguments so the c file name is last. This works
+around a clang bug which will suppress errors for unsupported flags if
+linker arguments come after the c file name. This suppression is a
+problem because it indicates that some argument is supported when it is
+not which can result in build errors.
+
+`https://github.com/llvm/llvm-project/issues/116278`
+
+eg: on aarch64 darwin and clang > 16 `-mpopcnt` will generate an error
+
+```
+$ clang -mpopcnt hello.c
+clang: error: unsupported option '-mpopcnt' for target 'aarch64-apple-darwin'
+$ echo $?
+1
+```
+
+however, if appending `-lpthread`:
+
+```
+$ clang -mpopcnt hello.c -lpthread
+$ echo $?
+0
+```
+
+Which is a problem as code will assume `-mpopcnt` is supported and will
+then break later when compiling with the unsupported flag
+
+Signed-off-by: Reno Dakota <paparodeo@proton.me>
+---
+ otherlibs/configurator/src/v1.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/otherlibs/configurator/src/v1.ml b/otherlibs/configurator/src/v1.ml
+index ddd8446fb14..0bfd8ab4071 100644
+--- a/otherlibs/configurator/src/v1.ml
++++ b/otherlibs/configurator/src/v1.ml
+@@ -418,9 +418,9 @@ let compile_and_link_c_prog t ?(c_flags = []) ?(link_flags = []) code =
+          [ c_flags
+          ; [ "-I"; t.stdlib_dir ]
+          ; output_flag
+-         ; [ c_fname ]
+          ; t.c_libraries
+          ; link_flags
++         ; [ c_fname ]
+          ])
+   in
+   if ok then Ok () else Error ()

--- a/pkgs/development/ocaml-modules/dune-configurator/default.nix
+++ b/pkgs/development/ocaml-modules/dune-configurator/default.nix
@@ -3,7 +3,13 @@
 buildDunePackage rec {
   pname = "dune-configurator";
 
-  inherit (dune_3) src version patches;
+  inherit (dune_3) src version;
+
+  patches = dune_3.patches or [] ++ [
+    # https://github.com/ocaml/dune/pull/11123
+    # https://github.com/llvm/llvm-project/issues/116278
+    ./clang-arg-order-workaround.patch
+  ];
 
   # This fixes finding csexp
   postPatch = ''


### PR DESCRIPTION
reorder compiler arguments so the c code file name is last. this works around a bug in clang which can indicate the compiler supports an argument when it does not.

https://github.com/ocaml/dune/pull/11123
https://github.com/llvm/llvm-project/issues/116278

this will allow various ocaml modules to build using clang-17 and greater.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
