### PR TITLE
asciinema_3: init at 3.0.0-rc.3

### DIFF
--- a/pkgs/by-name/as/asciinema_3/package.nix
+++ b/pkgs/by-name/as/asciinema_3/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  rustPlatform,
+  testers,
+}:
+
+let
+  self = rustPlatform.buildRustPackage {
+    pname = "asciinema";
+    version = "3.0.0-rc.3";
+
+    src = fetchFromGitHub {
+      name = "asciinema-source-${self.version}";
+      owner = "asciinema";
+      repo = "asciinema";
+      rev = "v${self.version}";
+      hash = "sha256-TYJ17uVj8v1u630MTb033h0X3aYRXY9d89GjAxG8muk=";
+    };
+
+    cargoHash = "sha256-CYDy0CedwG/ThTV+XOfOg8ncxF3tdTEGakmu4MXfiE4=";
+
+    nativeCheckInputs = [ python3 ];
+
+    checkFlags = [
+      # ---- pty::tests::exec_quick stdout ----
+      # thread 'pty::tests::exec_quick' panicked at src/pty.rs:494:10:
+      # called `Result::unwrap()` on an `Err` value: EBADF: Bad file number
+      "--skip=pty::tests::exec_quick"
+    ];
+
+    strictDeps = true;
+
+    passthru = {
+      tests.version = testers.testVersion {
+        package = self;
+        command = "asciinema --version";
+      };
+    };
+
+    meta = {
+      homepage = "https://asciinema.org/";
+      description = "Terminal session recorder and the best companion of asciinema.org";
+      longDescription = ''
+        asciinema is a suite of tools for recording, replaying, and sharing
+        terminal sessions. It is free and open-source software (FOSS), created
+        by Marcin Kulik.
+
+        Its typical use cases include creating tutorials, demonstrating
+        command-line tools, and sharing reproducible bug reports. It focuses on
+        simplicity and interoperability, which makes it a popular choice among
+        computer users working with the command-line, such as developers or
+        system administrators.
+      '';
+      license = with lib.licenses; [ gpl3Plus ];
+      mainProgram = "asciinema";
+      maintainers = with lib.maintainers; [ jiriks74 ];
+    };
+  };
+in
+self


### PR DESCRIPTION
This PR is a sucessor to NixOS/nixpkgs#342425 part 2 of 2. Part 1: NixOS/nixpkgs#356055

> [!Note]
> I've split the PR based on packages as it makes more sense to me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
