### PR TITLE
backblaze-b2: 4.0.1 -> 4.2.0

### DIFF
--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -1,23 +1,24 @@
-{ lib
-, python3Packages
-, fetchFromGitHub
-, installShellFiles
-, testers
-, backblaze-b2
-# executable is renamed to backblaze-b2 by default, to avoid collision with boost's 'b2'
-, execName ? "backblaze-b2"
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  backblaze-b2,
+  # executable is renamed to backblaze-b2 by default, to avoid collision with boost's 'b2'
+  execName ? "backblaze-b2",
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
-  version = "4.0.1";
+  version = "4.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     rev = "refs/tags/v${version}";
-    hash = "sha256-rZUWPSI7CrKOdEKdsSpekwBerbIMf2iiVrWkV8WrqSc=";
+    hash = "sha256-a0XJq8M1yw4GmD5ndIAJtmHFKqS0rYdvYIxK7t7oyZw=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -39,8 +40,6 @@ python3Packages.buildPythonApplication rec {
     tabulate
     tqdm
     platformdirs
-    packaging
-    setuptools
   ];
 
   nativeCheckInputs = with python3Packages; [
@@ -50,10 +49,6 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
     pytest-xdist
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   disabledTestPaths = [
     # Test requires network
@@ -73,32 +68,39 @@ python3Packages.buildPythonApplication rec {
     "test_install_autocomplete"
   ];
 
-  postInstall = lib.optionalString (execName != "b2") ''
-    mv "$out/bin/b2" "$out/bin/${execName}"
-  ''
-  + ''
-    installShellCompletion --cmd ${execName} \
-      --bash <(register-python-argcomplete ${execName}) \
-      --zsh <(register-python-argcomplete ${execName})
-  '';
-
-  passthru.tests.version = (testers.testVersion {
-    package = backblaze-b2;
-    command = "${execName} version --short";
-  }).overrideAttrs (old: {
-    # workaround the error: Permission denied: '/homeless-shelter'
-    # backblaze-b2 fails to create a 'b2' directory under the XDG config path
-    preHook = ''
-      export HOME=$(mktemp -d)
+  postInstall =
+    lib.optionalString (execName != "b2") ''
+      mv "$out/bin/b2" "$out/bin/${execName}"
+    ''
+    + ''
+      installShellCompletion --cmd ${execName} \
+        --bash <(register-python-argcomplete ${execName}) \
+        --zsh <(register-python-argcomplete ${execName})
     '';
-  });
+
+  passthru.tests.version =
+    (testers.testVersion {
+      package = backblaze-b2;
+      command = "${execName} version --short";
+    }).overrideAttrs
+      (old: {
+        # workaround the error: Permission denied: '/homeless-shelter'
+        # backblaze-b2 fails to create a 'b2' directory under the XDG config path
+        preHook = ''
+          export HOME=$(mktemp -d)
+        '';
+      });
 
   meta = with lib; {
     description = "Command-line tool for accessing the Backblaze B2 storage service";
     homepage = "https://github.com/Backblaze/B2_Command_Line_Tool";
     changelog = "https://github.com/Backblaze/B2_Command_Line_Tool/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ hrdinka tomhoule ];
+    maintainers = with maintainers; [
+      hrdinka
+      pmw
+      tomhoule
+    ];
     mainProgram = "backblaze-b2";
   };
 }


### PR DESCRIPTION
Also run `nixfmt` and add myself as a maintainer.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
