### PR TITLE
Remove rane as maintainer and member of Xen team

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18180,12 +18180,6 @@
     githubId = 5653911;
     name = "Rampoina";
   };
-  rane = {
-    email = "rane+nix@junkyard.systems";
-    github = "digitalrane";
-    githubId = 1829286;
-    name = "Rane";
-  };
   ranfdev = {
     email = "ranfdev@gmail.com";
     name = "Lorenzo Miglietta";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1076,7 +1076,6 @@ with lib.maintainers;
     members = [
       hehongbo
       lach
-      rane
       sigmasquadron
     ];
     scope = "Maintain the Xen Project Hypervisor and the related tooling ecosystem.";


### PR DESCRIPTION
This is a simple MR to remove myself from the Xen maintainer team and as a maintainer in nixpkgs in general.
I'm not using NixOS or Nix any longer and find myself spending my time on other projects more.
Thanks!

## Things done

 - Removed `rane` from maintainers list
 - Removed `rane` from Xen packaging team

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
