### PR TITLE
nixos/crproxy: init module crproxy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20587,6 +20587,12 @@
     githubId = 1286668;
     name = "Thilo Uttendorfer";
   };
+  SenseT = {
+    email = "tonychee1989@gmail.com";
+    github = "senseab";
+    githubId = 2174238;
+    name = "Tony Chyi";
+  };
   sentientmonkey = {
     email = "swindsor@gmail.com";
     github = "sentientmonkey";

--- a/nixos/modules/services/networking/crproxy.nix
+++ b/nixos/modules/services/networking/crproxy.nix
@@ -1,0 +1,164 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.crproxy;
+
+  allowImageListFile = pkgs.writeTextFile {
+    name = "crproxy-allow-image-list";
+    text = lib.strings.concatLines cfg.allowImageList;
+  };
+  useAllowImageList = (lib.length cfg.allowImageList) != 0;
+  blockIPListFile = pkgs.writeTextFile {
+    name = "crproxy-block-ip-list";
+    text = lib.strings.concatLines cfg.blockIPList;
+  };
+  useBlockIPList = (lib.length cfg.blockIPList) != 0;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    concatStringsSep
+    concatLists
+    optionals
+    literalExpression
+    mkPackageOption
+    ;
+in
+{
+  options.services.crproxy = {
+    enable = mkEnableOption "CRProxy, a generic Docker image proxy";
+
+    package = mkPackageOption pkgs "crproxy" { };
+
+    listenAddress = mkOption {
+      default = ":8080";
+      example = literalExpression ''
+        ":8080"
+      '';
+      type = types.str;
+      description = "Address and port to listen on.";
+    };
+
+    behindProxy = mkOption {
+      default = false;
+      example = literalExpression ''
+        true
+      '';
+      type = types.bool;
+      description = "Behind the reverse proxy such as nginx or caddy, which can receive HTTP headers from fronted nginx or caddy. Enable it when enable nginx or caddy as a reverse proxy server.";
+    };
+
+    userpass = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [ "user1:password@docker.io" "user2:password@ghcr.io" ]
+      '';
+      type = types.listOf types.str;
+      description = "Credentials for registries that require authentication.";
+    };
+
+    allowHostList = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [ "192.168.233.233" "10.233.233.233" "1.1.1.1" ]
+      '';
+      type = types.listOf types.str;
+      description = "Allow host list, specifiy which host(s) can access.";
+    };
+
+    allowImageList = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [
+          "busybox"
+          "hello-world"
+        ]
+      '';
+      type = types.listOf types.str;
+      description = "Docker images to allow.";
+    };
+
+    blockMessage = mkOption {
+      type = types.str;
+      default = "This image is not allowed for my proxy!";
+      example = literalExpression ''
+        "Not allowed"
+      '';
+      description = "Block message for disallowed images.";
+    };
+
+    blockIPList = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "IP addresses which may not access the crproxy.";
+    };
+
+    defaultRegistry = mkOption {
+      type = types.str;
+      default = "docker.io";
+      description = "Default registry used for non full-path docker pull.";
+    };
+
+    simpleAuthUser = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''
+        [ "user1:password" "user2:password" ]
+      '';
+      description = "Users which may access the crproxy. An empty list disables simple authentication.";
+    };
+
+    privilegedIPList = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = "Privileged IP list, which can access the crproxy without limits.";
+    };
+
+    extraOptions = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      example = literalExpression ''
+        [
+          "--retry=3"
+          "--limit-delay"
+        ]
+      '';
+      description = ''
+        See https://github.com/DaoCloud/crproxy/blob/master/cmd/crproxy/main.go for more.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.crproxy = {
+      wantedBy = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        RestartSec = 5;
+        ExecStart = concatStringsSep " " concatLists [
+          [
+            (lib.getExe cfg.package)
+            "--default-registry=${cfg.defaultRegistry}"
+            "--address=${cfg.listenAddress}"
+          ]
+          (optionals cfg.behindProxy [ "--behind" ])
+          (optionals useAllowImageList [ "--allow-image-list-from-file=${allowImageListFile}" ])
+          (optionals useAllowImageList [ "--block-message=${cfg.blockMessage}" ])
+          (optionals useBlockIPList [ "--block-ip-list-from-file=${blockIPListFile}" ])
+          (optionals (cfg.simpleAuthUser != [ ]) [ "--simple-auth" ])
+          (map (e: "--simple-auth-user=${e}") cfg.simpleAuthUser)
+          (map (e: "--allow-host-list=${e}") cfg.allowHostList)
+          (map (e: "--privileged-ip-list=${e}") cfg.privilegedIPList)
+          (map (e: "--user=${e}") cfg.userpass)
+
+          cfg.extraOptions
+        ];
+      };
+    };
+  };
+}

--- a/pkgs/by-name/cr/crproxy/package.nix
+++ b/pkgs/by-name/cr/crproxy/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "crproxy";
+  version = "0.12.4"; # stable
+
+  src = fetchFromGitHub {
+    owner = "DaoCloud";
+    repo = "crproxy";
+    rev = "v${version}";
+    hash = "sha256-jWSp0NzeXQu38fAaZ8eTqVN+uvpn6v5xgoi3N5SCQoc=";
+  };
+
+  vendorHash = "sha256-R78GbtTWgizvMz3HE83ZYxAbZBvCTbsuKLvPBCB5sx4=";
+
+  env.CGO_ENABLED = 0;
+
+  doCheck = true;
+
+  meta = {
+    description = "Generic Docker image proxy";
+    homepage = "https://github.com/DaoCloud/crproxy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SenseT ];
+  };
+}


### PR DESCRIPTION
a generic image proxy for dockerhub, see https://github.com/DaoCloud/crproxy/releases/tag/v0.12.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
