### PR TITLE
rPackages.curl: fixed build on darwin

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1135,6 +1135,7 @@ let
 
     curl = old.curl.overrideAttrs (attrs: {
       preConfigure = "patchShebangs configure";
+      patches = [ ./patches/curl-darwin.patch ];
     });
 
     Cyclops = old.Cyclops.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/patches/curl-darwin.patch
+++ b/pkgs/development/r-modules/patches/curl-darwin.patch
@@ -1,0 +1,63 @@
+diff --git a/R/options.R b/R/options.R
+index 1879286..0e4ead3 100644
+--- a/R/options.R
++++ b/R/options.R
+@@ -1,8 +1,8 @@
+ #' List curl version and options.
+ #'
+-#' \code{curl_version()} shows the versions of libcurl, libssl and zlib and
+-#' supported protocols. \code{curl_options()} lists all options available in
+-#' the current version of libcurl.  The dataset \code{curl_symbols} lists all
++#' `curl_version()` shows the versions of libcurl, libssl and zlib and
++#' supported protocols. `curl_options()` lists all options available in
++#' the current version of libcurl.  The dataset `curl_symbols` lists all
+ #' symbols (including options) provides more information about the symbols,
+ #' including when support was added/removed from libcurl.
+ #'
+@@ -22,21 +22,23 @@ curl_options <- function(filter = ""){
+   opts[m]
+ }
+ 
+-option_table <- (function(){
+-  env <- new.env()
+-  if(file.exists("tools/option_table.txt")){
+-    source("tools/option_table.txt", env)
+-  } else if(file.exists("../tools/option_table.txt")){
+-    source("../tools/option_table.txt", env)
+-  } else {
+-    stop("Failed to find 'tools/option_table.txt' from:", getwd())
+-  }
+-
+-  option_table <- unlist(as.list(env))
+-  names(option_table) <- sub("^curlopt_", "", tolower(names(option_table)))
+-  option_table[order(names(option_table))]
+-})()
++# Remove this when RHEL-8 is EOL
++option_table_legacy <- if(.Platform$OS.type == "unix" && grepl("^7", libcurlVersion())){
++  (function(){
++    env <- new.env()
++    if(file.exists("tools/option_table.txt")){
++      source("tools/option_table.txt", env)
++    } else if(file.exists("../tools/option_table.txt")){
++      source("../tools/option_table.txt", env)
++    } else {
++      stop("Failed to find 'tools/option_table.txt' from:", getwd())
++    }
+ 
++    option_table <- unlist(as.list(env))
++    names(option_table) <- sub("^curlopt_", "", tolower(names(option_table)))
++    option_table[order(names(option_table))]
++  })()
++}
+ 
+ #' @useDynLib curl R_option_types
+ make_option_type_table <- function(){
+@@ -57,7 +59,7 @@ curl_options_list <- local({
+         structure(option_type_table$value, names = option_type_table$name)
+       } else {
+         # Fallback method: extracted from headers at build-time
+-        option_table
++        option_table_legacy
+       }
+     }
+     return(cache)


### PR DESCRIPTION
rPackages.curl fails on Darwin since today with:

```
       > installing to /nix/store/q1lpsi4qhjsrpl93fr6dwyixsc3lig8k-r-curl-5.2.1/library/00LOCK-curl/00new/curl/libs
       > ** R
       > ** inst
       > ** byte-compile and prepare package for lazy loading
       > Error in source("tools/option_table.txt", env) :
       >   tools/option_table.txt:23:20: entrée inattendue
       > 22:   CURLOPT_HTTPHEADER = 10000 + 23
       > 23:   CURLOPT_HTTPPOST _
       >                        ^
       > Erreur : impossible de charger le code R depuis le package ‘curl’
       > Exécution arrêtée
       > ERROR: lazy loading failed for package ‘curl’
       > * removing ‘/nix/store/q1lpsi4qhjsrpl93fr6dwyixsc3lig8k-r-curl-5.2.1/library/curl’
       For full logs, run 'nix log /nix/store/vs12110cgipc0lryl98jrzlxhkamfbdx-r-curl-5.2.1.drv'.
```

the current version of the package on CRAN handles this, so I backported the code while we wait for the r tree bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
