### PR TITLE
[24.05] postgresql: 12.20 -> 12.21, 13.16 -> 13.17, 14.13 -> 14.14, 15.8 -> 15.9

### DIFF
--- a/pkgs/servers/sql/postgresql/12.nix
+++ b/pkgs/servers/sql/postgresql/12.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "12.20";
-  hash = "sha256-LVQ68wCf7H/VrzX3pwyVCF0+72tQjlF6qUk+mbFenqk=";
+  version = "12.21";
+  hash = "sha256-bHEVUKwcx4KIZeWCPZ9Ffjva1vQyAXcWn5DkGb4MJ/I=";
 }

--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "13.16";
-  hash = "sha256-ycu7YSnwIyggSCgGa7N4XACoXIyo/TKcKopTwfXNiGU=";
+  version = "13.17";
+  hash = "sha256-AisKbnvDdKd37s4zcIiV17YMrgfUkrKGspaknXOV14s=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "14.13";
-  hash = "sha256-Wao8S0lasmqexp860KAijFHw/m+s82NN+tTRGX1hOlY=";
+  version = "14.14";
+  hash = "sha256-hHJ/vM29Hv4B2N5kvBszCV23c60kV8787cLYJY68CdY=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "15.8";
-  hash = "sha256-RANRX5pp7rPv68mPMLjGlhIr/fiV6Ss7I/W452nty2o=";
+  version = "15.9";
+  hash = "sha256-dPLUVlA18M9ynssFmUn6rxECy9k3WbNZgi+Y+CGYx4M=";
 }

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -119,7 +119,7 @@ let
         src = ./patches/locale-binary-path.patch;
         locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
       })
-    ] ++ lib.optionals (atLeast "14") [
+    ] ++ lib.optionals (atLeast "15") [
       # TODO: Remove this with the next set of minor releases
       (fetchpatch ({
           url = "https://github.com/postgres/postgres/commit/b27622c90869aab63cfe22159a459c57768b0fa4.patch";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -119,23 +119,13 @@ let
         src = ./patches/locale-binary-path.patch;
         locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
       })
-
+    ] ++ lib.optionals (atLeast "14") [
       # TODO: Remove this with the next set of minor releases
-      (fetchpatch (
-        if atLeast "14" then {
+      (fetchpatch ({
           url = "https://github.com/postgres/postgres/commit/b27622c90869aab63cfe22159a459c57768b0fa4.patch";
           hash = "sha256-7G+BkJULhyx6nlMEjClcr2PJg6awgymZHr2JgGhXanA=";
           excludes = [ "doc/*" ];
-        } else if atLeast "13" then {
-          url = "https://github.com/postgres/postgres/commit/b28b9b19bbe3410da4a805ef775e0383a66af314.patch";
-          hash = "sha256-meFFskNWlcc/rv4BWo6fNR/tTFgQRgXGqTkJkoX7lHU=";
-          excludes = [ "doc/*" ];
-        } else {
-          url = "https://github.com/postgres/postgres/commit/205813da4c264d80db3c3215db199cc119e18369.patch";
-          hash = "sha256-L8/ns/fxTh2ayfDQXtBIKaArFhMd+v86UxVFWQdmzUw=";
-          excludes = [ "doc/*" ];
-        })
-      )
+        }))
     ] ++ lib.optionals stdenv'.hostPlatform.isMusl (
       # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
       map fetchurl (lib.attrValues muslPatches)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -119,7 +119,7 @@ let
         src = ./patches/locale-binary-path.patch;
         locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
       })
-    ] ++ lib.optionals (atLeast "15") [
+    ] ++ lib.optionals (atLeast "16") [
       # TODO: Remove this with the next set of minor releases
       (fetchpatch ({
           url = "https://github.com/postgres/postgres/commit/b27622c90869aab63cfe22159a459c57768b0fa4.patch";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of #355965

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
