### PR TITLE
mpvScripts.autosub: init at 2021-06-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16185,6 +16185,13 @@
     github = "octodi";
     githubId = 127038896;
   };
+  octvs = {
+    name = "octvs";
+    email = "octvs@posteo.de";
+    matrix = "@octvs:matrix.org";
+    github = "octvs";
+    githubId = 42993892;
+  };
   oddlama = {
     email = "oddlama@oddlama.org";
     github = "oddlama";

--- a/pkgs/applications/video/mpv/scripts/autosub.nix
+++ b/pkgs/applications/video/mpv/scripts/autosub.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  python3Packages,
+}:
+buildLua {
+  pname = "mpv-autosub";
+  version = "0-unstable-2021-06-29";
+  scriptPath = "autosub.lua";
+
+  src = fetchFromGitHub {
+    owner = "davidde";
+    repo = "mpv-autosub";
+    rev = "35115355bd339681f97d067538356c29e5b14afa";
+    hash = "sha256-BKT/Tzwl5ZA4fbdc/cxz0+CYc1zyY/KOXc58x5GYow0=";
+  };
+
+  preInstall = ''
+    substituteInPlace autosub.lua --replace-fail \
+      "local subliminal = '/home/david/.local/bin/subliminal'" \
+      "local subliminal = '${lib.getExe' python3Packages.subliminal "subliminal"}'"
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Fully automatic subtitle downloading for the MPV media player";
+    homepage = "https://github.com/davidde/mpv-autosub";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.octvs ];
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -98,6 +98,7 @@ let
         ;
 
       buildLua = callPackage ./buildLua.nix { };
+      autosub = callPackage ./autosub.nix { };
       autosubsync-mpv = callPackage ./autosubsync-mpv.nix { };
       chapterskip = callPackage ./chapterskip.nix { };
       convert = callPackage ./convert.nix { };


### PR DESCRIPTION
Add `mpvScripts.autosub`, resolves #336986.

Took the discussion over at the linked issue, and other mpvScripts as basis.
~~Couple of questions to whom might review this:~~

- ~~There are usage of `passthru.updateScript` on other scripts, what is the best
practice for this?~~
- ~~In a similar manner I saw uses of `lib.getExe` for dependencies on
`substituteInPlace` like [here][1]. What is the point of using it rather than a
direct path?~~
  - ~~The latter seems more safe (or exact) _to me_, therefore I opted for using
  it. But I would like to know if there is a best practice and/or the logic
  behind using `lib.getExe`.~~

Cheers!

_Credits to @jcaesar for supplying an initial version at the discussion_

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[1]: https://github.com/NixOS/nixpkgs/blob/70548b93f05d02cb6e90750272e3b6531ee26d7d/pkgs/applications/video/mpv/scripts/videoclip.nix#L28-L29
