### PR TITLE
docker-init: init at v1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2474,6 +2474,13 @@
     githubId = 6987136;
     keys = [ { fingerprint = "2C6D 37D4 6AA1 DCDA BE8D  F346 43E2 CF4C 01B9 4940"; } ];
   };
+  BastianAsmussen = {
+    name = "Bastian Asmussen";
+    email = "bastian@asmussen.tech";
+    github = "BastianAsmussen";
+    githubId = 76102128;
+    keys = [ { fingerprint = "3B11 7469 0893 85E7 16C2  7CD9 0FE5 A355 DBC9 2568"; } ];
+  };
   basvandijk = {
     email = "v.dijk.bas@gmail.com";
     github = "basvandijk";

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -8,12 +8,12 @@ rec {
       , runcRev, runcHash
       , containerdRev, containerdHash
       , tiniRev, tiniHash
-      , buildxSupport ? true, composeSupport ? true, sbomSupport ? false
+      , buildxSupport ? true, composeSupport ? true, sbomSupport ? false, initSupport ? false
       # package dependencies
       , stdenv, fetchFromGitHub, fetchpatch, buildGoModule
       , makeWrapper, installShellFiles, pkg-config, glibc
       , go-md2man, go, containerd, runc, tini, libtool
-      , sqlite, iproute2, docker-buildx, docker-compose, docker-sbom
+      , sqlite, iproute2, docker-buildx, docker-compose, docker-sbom, docker-init
       , iptables, e2fsprogs, xz, util-linux, xfsprogs, gitMinimal
       , procps, rootlesskit, slirp4netns, fuse-overlayfs, nixosTests
       , clientOnly ? !stdenv.hostPlatform.isLinux, symlinkJoin
@@ -179,7 +179,8 @@ rec {
 
     plugins = lib.optional buildxSupport docker-buildx
       ++ lib.optional composeSupport docker-compose
-      ++ lib.optional sbomSupport docker-sbom;
+      ++ lib.optional sbomSupport docker-sbom
+      ++ lib.optional initSupport docker-init;
     pluginsRef = symlinkJoin { name = "docker-plugins"; paths = plugins; };
   in
   buildGoModule (lib.optionalAttrs (!clientOnly) {

--- a/pkgs/by-name/do/docker-init/package.nix
+++ b/pkgs/by-name/do/docker-init/package.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  fetchurl,
+  zstd,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "docker-init";
+  version = "v1.3.0";
+  tag = "157355";
+
+  src = fetchurl {
+    url = "https://desktop.docker.com/linux/main/amd64/${finalAttrs.tag}/docker-desktop-x86_64.pkg.tar.zst";
+    hash = "sha256-ysZorPBmoUvTJFFKDbZgQxPamONJKcXezmMrpZSVpwY=";
+  };
+
+  nativeBuildInputs = [
+    zstd
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    tar --zstd -xvf $src
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,libexec/docker/cli-plugins}
+
+    cp usr/lib/docker/cli-plugins/docker-init $out/libexec/docker/cli-plugins
+    ln -s $out/libexec/docker/cli-plugins/docker-init $out/bin/docker-init
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Creates Docker-related starter files for your project";
+    homepage = "https://docs.docker.com/reference/cli/docker/init";
+    downloadPage = "https://docs.docker.com/desktop/release-notes/#4320";
+    mainProgram = "docker-init";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    badPlatforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ BastianAsmussen ];
+  };
+})


### PR DESCRIPTION
I added the [docker-init CLI plugin](https://docs.docker.com/reference/cli/docker/init) found in Docker Desktop as a togglable attribute in the docker package like [other docker CLI plugins](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/virtualization/docker/sbom.nix).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
