### PR TITLE
plausible: 2.0.0 -> 2.1.4

### DIFF
--- a/nixos/modules/services/web-apps/plausible.md
+++ b/nixos/modules/services/web-apps/plausible.md
@@ -15,15 +15,6 @@ After that, `plausible` can be deployed like this:
 {
   services.plausible = {
     enable = true;
-    adminUser = {
-      # activate is used to skip the email verification of the admin-user that's
-      # automatically created by plausible. This is only supported if
-      # postgresql is configured by the module. This is done by default, but
-      # can be turned off with services.plausible.database.postgres.setup.
-      activate = true;
-      email = "admin@localhost";
-      passwordFile = "/run/secrets/plausible-admin-pwd";
-    };
     server = {
       baseUrl = "http://analytics.example.org";
       # secretKeybaseFile is a path to the file which contains the secret generated

--- a/nixos/tests/plausible.nix
+++ b/nixos/tests/plausible.nix
@@ -1,18 +1,13 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }: {
+import ./make-test-python.nix ({ lib, ... }: {
   name = "plausible";
-  meta = with lib.maintainers; {
-    maintainers = [ ];
+  meta = {
+    maintainers = lib.teams.cyberus.members;
   };
 
   nodes.machine = { pkgs, ... }: {
     virtualisation.memorySize = 4096;
     services.plausible = {
       enable = true;
-      adminUser = {
-        email = "admin@example.org";
-        passwordFile = "${pkgs.writeText "pwd" "foobar"}";
-        activate = true;
-      };
       server = {
         baseUrl = "http://localhost:8000";
         secretKeybaseFile = "${pkgs.writeText "dont-try-this-at-home" "nannannannannannannannannannannannannannannannannannannan_batman!"}";
@@ -32,21 +27,5 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     machine.succeed("curl -f localhost:8000 >&2")
 
     machine.succeed("curl -f localhost:8000/js/script.js >&2")
-
-    csrf_token = machine.succeed(
-        "curl -c /tmp/cookies localhost:8000/login | grep '_csrf_token' | sed -E 's,.*value=\"(.*)\".*,\\1,g'"
-    )
-
-    machine.succeed(
-        f"curl -b /tmp/cookies -f -X POST localhost:8000/login -F email=admin@example.org -F password=foobar -F _csrf_token={csrf_token.strip()} -D headers"
-    )
-
-    # By ensuring that the user is redirected to the dashboard after login, we
-    # also make sure that the automatic verification of the module works.
-    machine.succeed(
-        "[[ $(grep 'location: ' headers | cut -d: -f2- | xargs echo) == /sites* ]]"
-    )
-
-    machine.shutdown()
   '';
 })

--- a/pkgs/servers/web-apps/plausible/default.nix
+++ b/pkgs/servers/web-apps/plausible/default.nix
@@ -1,35 +1,51 @@
-{ lib
-, beamPackages
-, buildNpmPackage
-, fetchFromGitHub
-, nodejs
-, nixosTests
-, ...
+{
+  lib,
+  beamPackages,
+  buildNpmPackage,
+  rustPlatform,
+  fetchFromGitHub,
+  nodejs,
+  runCommand,
+  nixosTests,
+  npm-lockfile-fix,
+  brotli,
+  tailwindcss,
+  esbuild,
+  ...
 }:
 
 let
   pname = "plausible";
-  version = "2.0.0";
+  version = "2.1.4";
+  mixEnv = "ce";
 
   src = fetchFromGitHub {
     owner = "plausible";
     repo = "analytics";
     rev = "v${version}";
-    hash = "sha256-yrTwxBguAZbfEKucUL+w49Hr6D7v9/2OjY1h27+w5WI=";
-  };
-
-  # TODO consider using `mix2nix` as soon as it supports git dependencies.
-  mixFodDeps = beamPackages.fetchMixDeps {
-    pname = "${pname}-deps";
-    inherit src version;
-    hash = "sha256-CAyZLpjmw1JreK3MopqI0XsWhP+fJEMpXlww7CibSaM=";
+    hash = "sha256-wV2zzRKJM5pQ06pF8vt1ieFqv6s3HvCzNT5Hed29Owk=";
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/assets/package-lock.json
+      sed -ie '
+        /defp deps do/ {
+          n
+          /\[/ a\
+            \{:rustler, ">= 0.0.0", optional: true \},
+          }
+      ' $out/mix.exs
+      cat >> $out/config/config.exs <<EOF
+      config :mjml, Mjml.Native,
+        crate: :mjml_nif,
+        skip_compilation?: true
+      EOF
+    '';
   };
 
   assets = buildNpmPackage {
     pname = "${pname}-assets";
     inherit version;
     src = "${src}/assets";
-    npmDepsHash = "sha256-2t1M6RQhBjZxx36qawVUVC+ob9SvQIq5dy4HgVeY2Eo=";
+    npmDepsHash = "sha256-Rf1+G9F/CMK09KEh022vHe02FADJtARKX4QEVbmvSqk=";
     dontNpmBuild = true;
     installPhase = ''
       runHook preInstall
@@ -42,7 +58,7 @@ let
     pname = "${pname}-tracker";
     inherit version;
     src = "${src}/tracker";
-    npmDepsHash = "sha256-y09jVSwUrxF0nLpLqS1yQweYL+iMF6jVx0sUdQtvrpc=";
+    npmDepsHash = "sha256-ng0YpBZc0vcg5Bsr1LmgXtzNCtNV6hJIgLt3m3yRdh4=";
     dontNpmBuild = true;
     installPhase = ''
       runHook preInstall
@@ -50,37 +66,92 @@ let
       runHook postInstall
     '';
   };
+
+  mixFodDeps = beamPackages.fetchMixDeps {
+    inherit
+      pname
+      version
+      src
+      mixEnv
+      ;
+    hash = "sha256-N6cYlYwNss2FPYcljANJYbXobmLFauZ64F7Sf/+7Ctg=";
+  };
+
+  mjmlNif = rustPlatform.buildRustPackage {
+    pname = "mjml-native";
+    version = "";
+    src = "${mixFodDeps}/mjml/native/mjml_nif";
+    cargoHash = "sha256-W4r8W+JGTE6j4gDogL5Yulr0mbaXjDbwDTwhzMbbDcQ=";
+    doCheck = false;
+
+    env = {
+      RUSTLER_PRECOMPILED_FORCE_BUILD_ALL = "true";
+      RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH = "unused-but-required";
+    };
+  };
+
+  patchedMixFodDeps = runCommand mixFodDeps.name { } ''
+    mkdir $out
+    cp -r --no-preserve=mode ${mixFodDeps}/. $out
+
+    mkdir -p $out/mjml/priv/native
+    for lib in ${mjmlNif}/lib/*
+    do
+      # normalies suffix to .so, otherswise build would fail on darwin
+      file=''${lib##*/}
+      base=''${file%.*}
+      ln -s "$lib" $out/mjml/priv/native/$base.so
+    done
+  '';
+
 in
-beamPackages.mixRelease {
-  inherit pname version src mixFodDeps;
+beamPackages.mixRelease rec {
+  inherit
+    pname
+    version
+    src
+    mixEnv
+    ;
 
   nativeBuildInputs = [
     nodejs
+    brotli
   ];
 
+  mixFodDeps = patchedMixFodDeps;
+
   passthru = {
-    tests = { inherit (nixosTests) plausible; };
+    tests = {
+      inherit (nixosTests) plausible;
+    };
     updateScript = ./update.sh;
+    inherit assets tracker;
   };
 
-  postPatch = ''
-    substituteInPlace lib/plausible_release.ex --replace 'defp prepare do' 'def prepare do'
-  '';
+  env = {
+    APP_VERSION = version;
+    RUSTLER_PRECOMPILED_FORCE_BUILD_ALL = "true";
+    RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH = "unused-but-required";
+  };
 
   preBuild = ''
     rm -r assets tracker
-    cp -r ${assets} assets
+    cp --no-preserve=mode -r ${assets} assets
     cp -r ${tracker} tracker
+
+    cat >> config/config.exs <<EOF
+    config :tailwind, path: "${lib.getExe tailwindcss}"
+    config :esbuild, path: "${lib.getExe esbuild}"
+    EOF
   '';
 
   postBuild = ''
-    export NODE_OPTIONS=--openssl-legacy-provider # required for webpack compatibility with OpenSSL 3 (https://github.com/webpack/webpack/issues/14532)
-    npm run deploy --prefix ./assets
     npm run deploy --prefix ./tracker
 
     # for external task you need a workaround for the no deps check flag
     # https://github.com/phoenixframework/phoenix/issues/2690
-    mix do deps.loadpaths --no-deps-check, phx.digest
+    mix do deps.loadpaths --no-deps-check, assets.deploy
+    mix do deps.loadpaths --no-deps-check, phx.digest priv/static
   '';
 
   meta = with lib; {

--- a/pkgs/servers/web-apps/plausible/update.sh
+++ b/pkgs/servers/web-apps/plausible/update.sh
@@ -1,62 +1,14 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq nix-prefetch-github yarn yarn2nix-moretea.yarn2nix moreutils
-
-# NOTE: please check on new releases which steps aren't necessary anymore!
-# Currently the following things are done:
-#
-# * Add correct `name`/`version` field to `package.json`, otherwise `yarn2nix` fails to
-#   find required dependencies.
-# * Adjust `file:`-dependencies a bit for the structure inside a Nix build.
-# * Update hashes for the tarball & the fixed-output drv with all `mix`-dependencies.
-# * Generate `yarn.lock` & `yarn.nix` in a temporary directory.
+#!nix-shell -i bash -p nix-update jq elixir npm-lockfile-fix nixfmt-rfc-style
 
 set -euxo pipefail
 
-dir="$(realpath $(dirname "$0"))"
-export latest="$(curl -q https://api.github.com/repos/plausible/analytics/releases/latest \
-  | jq -r '.tag_name')"
-nix_version="$(cut -c2- <<< "$latest")"
+nix-update plausible
 
-if [[ "$(nix-instantiate -A plausible.version --eval --json | jq -r)" = "$nix_version" ]];
-then
-  echo "Already using version $latest, skipping"
-  exit 0
-fi
+version="$(nix-instantiate -A plausible.version --eval --json | jq -r)"
+source_url="$(nix-instantiate -A plausible.src.url --eval --json | jq -r)"
 
-SRC="https://raw.githubusercontent.com/plausible/analytics/${latest}"
+nix-update --url "$source_url" --version "$version" plausible.tracker
+nix-update --url "$source_url" --version "$version" plausible.assets
 
-package_json="$(curl -qf "$SRC/assets/package.json")"
 
-echo "$package_json" \
-  | jq '. + {"name":"plausible","version": $ENV.latest}' \
-  | sed -e 's,../deps/,../../tmp/deps/,g' \
-  > $dir/package.json
-
-tarball_meta="$(nix-prefetch-github plausible analytics --rev "$latest")"
-tarball_hash="$(jq -r '.hash' <<< "$tarball_meta")"
-tarball_path="$(nix-build -E 'with import ./. {}; { p }: fetchFromGitHub (builtins.fromJSON p)' --argstr p "$tarball_meta")"
-fake_hash="$(nix-instantiate --eval -A lib.fakeHash | xargs echo)"
-
-sed -i "$dir/default.nix" \
-  -e 's,version = ".*",version = "'"$nix_version"'",' \
-  -e '/^  src = fetchFromGitHub/,+4{;s#hash = "\(.*\)"#hash = "'"$tarball_hash"'"#}' \
-  -e '/^  mixFodDeps =/,+3{;s#hash = "\(.*\)"#hash = "'"$fake_hash"'"#}'
-
-mix_hash="$(nix-build -A plausible.mixFodDeps 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
-
-sed -i "$dir/default.nix" -e '/^  mixFodDeps =/,+3{;s#hash = "\(.*\)"#hash = "'"$mix_hash"'"#}'
-
-tmp_setup_dir="$(mktemp -d)"
-trap "rm -rf $tmp_setup_dir" EXIT
-
-cp -r $tarball_path/* $tmp_setup_dir/
-cp -r "$(nix-build -A plausible.mixFodDeps)" "$tmp_setup_dir/deps"
-chmod -R u+rwx "$tmp_setup_dir"
-
-pushd $tmp_setup_dir/assets
-yarn
-yarn2nix > "$dir/yarn.nix"
-cp yarn.lock "$dir/yarn.lock"
-popd
-
-nix-build -A plausible

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1955,8 +1955,8 @@ with pkgs;
   lukesmithxyz-bible-kjv = callPackage ../applications/misc/kjv/lukesmithxyz-kjv.nix { };
 
   plausible = callPackage ../servers/web-apps/plausible {
-    elixir = elixir_1_14;
-    beamPackages = beamPackages.extend (self: super: { elixir = elixir_1_14; });
+    elixir = elixir_1_17;
+    beamPackages = beamPackages.extend (self: super: { elixir = elixir_1_17; });
   };
 
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace { };


### PR DESCRIPTION
Changelog: https://github.com/plausible/analytics/blob/v2.1.4/CHANGELOG.md

This upgrade was quite the undertaking, the major source of headaches was that plausible now has a dependency that makes use of rustler, tooling to call rust from elixir.

As the newer plausible version drop support for admin user reaction via env var in favour of a first install wizard, this can be backported to stable. This first install wizard is also the reason why the nixos test was reduces, as this new installed is based on phoenix live views, we can simply interact with it using `curl` and `grep` :/

I'm yet to deploy this onto a production installation of plausible, but looking at the web UI in a simple test installation everything look fine.

Closes: #314768

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
