### PR TITLE
mojave-gtk-theme: 2023-08-04 -> 2024-11-15

### DIFF
--- a/pkgs/by-name/mo/mojave-gtk-theme/package.nix
+++ b/pkgs/by-name/mo/mojave-gtk-theme/package.nix
@@ -22,13 +22,13 @@
 let
 
   pname = "mojave-gtk-theme";
-  version = "2023-08-04";
+  version = "2024-11-15";
 
   main_src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    hash = "sha256-boS/GPjuJV5lZjyHW7tG74T6a3SASQVGnSz++5HkCuw=";
+    hash = "sha256-uL4lO6aWiDfOQkhpTnr/iVx1fI7n/fx7WYr5jDWPfYM=";
   };
 
   wallpapers_src = fetchFromGitHub {
@@ -97,13 +97,13 @@ stdenvNoCC.mkDerivation rec {
     do
       patchShebangs $f
       substituteInPlace $f \
-        --replace /usr/bin/inkscape ${inkscape}/bin/inkscape \
-        --replace /usr/bin/optipng ${optipng}/bin/optipng
+        --replace-fail /usr/bin/inkscape ${inkscape}/bin/inkscape \
+        --replace-fail /usr/bin/optipng ${optipng}/bin/optipng
     done
 
     ${lib.optionalString wallpapers ''
       for f in ../${wallpapers_src.name}/Mojave{,-timed}.xml; do
-        substituteInPlace $f --replace /usr $out
+        substituteInPlace $f --replace-fail /usr $out
       done
     ''}
   '';
@@ -119,6 +119,8 @@ stdenvNoCC.mkDerivation rec {
       ${lib.optionalString (themeVariants != []) "--theme " + builtins.toString themeVariants} \
       --icon nixos \
       --dest $out/share/themes
+
+    rm $out/share/themes/*/COPYING
 
     ${lib.optionalString wallpapers ''
       mkdir -p $out/share/backgrounds/Mojave
@@ -137,11 +139,11 @@ stdenvNoCC.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     description = "Mac OSX Mojave like theme for GTK based desktop environments";
     homepage = "https://github.com/vinceliuice/Mojave-gtk-theme";
-    license = licenses.gpl3Only;
-    platforms = platforms.unix;
-    maintainers = [ maintainers.romildo ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
Update to version [2024-11-15](https://github.com/vinceliuice/Mojave-gtk-theme/releases/tag/2024-11-15)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
