### PR TITLE
desk-exec: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2273,6 +2273,12 @@
     githubId = 206242;
     name = "Andreas Wiese";
   };
+  axertheaxe = {
+    email = "axertheaxe@proton.me";
+    github = "axertheaxe";
+    githubId = 99703210;
+    name = "Katherine Jamison";
+  };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
     github = "hafiz";

--- a/pkgs/by-name/de/desk-exec/package.nix
+++ b/pkgs/by-name/de/desk-exec/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "desk-exec";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "AxerTheAxe";
+    repo = "desk-exec";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bJLdd07IAf+ba++vtS0iSmeQSGygwSVNry2bHTDAgjE=";
+  };
+
+  cargoHash = "sha256-pK1WDtGkpPZgFwEm59TqoH7EkKPQivNuvsiOG0dbum4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    pushd target/${stdenv.hostPlatform.config}/release/dist
+      installShellCompletion desk-exec.{bash,fish}
+      installShellCompletion _desk-exec
+      installManPage desk-exec.1
+    popd
+  '';
+
+  meta = {
+    description = "Execute programs defined in XDG desktop entries directly from the command line";
+    homepage = "https://github.com/AxerTheAxe/desk-exec";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.axertheaxe ];
+    mainProgram = "desk-exec";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hello, I would like to package my program `desk-exec`. 

`desk-exec` is a robust CLI-based application launcher for Linux. It provides an efficient way to search and execute desktop entries directly from the command line, with support for filtering by program names, substrings, mimetypes, and more. Designed for terminal-focused workflows, it follows the XDG Base Directory Specification, ensuring compatibility across Linux distributions.

I created `desk-exec` because I couldn't find a CLI tool that met my needs for launching applications based on desktop entries. Existing tools are either GUI-focused or lack the fine-grained filtering capabilities required for power users. This utility fills that gap while remaining lightweight and fast.

### Unique Features:
- Seamless integration with the XDG Base Directory Specification.
- Advanced filtering options (name, substring, mimetype, etc.).
- Minimal dependencies, making it suitable for a variety of environments.

I believe `desk-exec` is general-purpose and lightweight enough to be included in nixpkgs.

This is my first PR so sorry if I get anything wrong. Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
