### PR TITLE
postgresqlPackages: enable update scripts and update many packages

### DIFF
--- a/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
+++ b/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
@@ -60,70 +60,88 @@
   lib,
   stdenv,
   postgresql,
+  nix-update-script,
 }:
 
 args:
 
 let
-  buildPostgresqlExtension = finalAttrs: prevAttrs: {
-    buildInputs = [ postgresql ] ++ prevAttrs.buildInputs or [ ];
+  buildPostgresqlExtension =
+    finalAttrs:
+    {
+      enableUpdateScript ? true,
+      ...
+    }@prevAttrs:
+    {
+      passthru =
+        prevAttrs.passthru or { }
+        // lib.optionalAttrs enableUpdateScript {
+          updateScript =
+            prevAttrs.passthru.updateScript or (nix-update-script (
+              lib.optionalAttrs (lib.hasInfix "unstable" prevAttrs.version) {
+                extraArgs = [ "--version=branch" ];
+              }
+            ));
+        };
 
-    installFlags = [
-      "DESTDIR=${placeholder "out"}"
-    ] ++ prevAttrs.installFlags or [ ];
+      buildInputs = [ postgresql ] ++ prevAttrs.buildInputs or [ ];
 
-    postInstall =
-      ''
-        # DESTDIR + pg_config install the files into
-        # /nix/store/<extension>/nix/store/<postgresql>/...
-        # We'll now remove the /nix/store/<postgresql> part:
-        if [[ -d "$out${postgresql}" ]]; then
-            cp -alt "$out" "$out${postgresql}"/*
-            rm -r "$out${postgresql}"
-        fi
+      installFlags = [
+        "DESTDIR=${placeholder "out"}"
+      ] ++ prevAttrs.installFlags or [ ];
 
-        if [[ -d "$out${postgresql.dev}" ]]; then
-            mkdir -p "''${dev:-$out}"
-            cp -alt "''${dev:-$out}" "$out${postgresql.dev}"/*
-            rm -r "$out${postgresql.dev}"
-        fi
+      postInstall =
+        ''
+          # DESTDIR + pg_config install the files into
+          # /nix/store/<extension>/nix/store/<postgresql>/...
+          # We'll now remove the /nix/store/<postgresql> part:
+          if [[ -d "$out${postgresql}" ]]; then
+              cp -alt "$out" "$out${postgresql}"/*
+              rm -r "$out${postgresql}"
+          fi
 
-        if [[ -d "$out${postgresql.lib}" ]]; then
-            mkdir -p "''${lib:-$out}"
-            cp -alt "''${lib:-$out}" "$out${postgresql.lib}"/*
-            rm -r "$out${postgresql.lib}"
-        fi
+          if [[ -d "$out${postgresql.dev}" ]]; then
+              mkdir -p "''${dev:-$out}"
+              cp -alt "''${dev:-$out}" "$out${postgresql.dev}"/*
+              rm -r "$out${postgresql.dev}"
+          fi
 
-        if [[ -d "$out${postgresql.doc}" ]]; then
-            mkdir -p "''${doc:-$out}"
-            cp -alt "''${doc:-$out}" "$out${postgresql.doc}"/*
-            rm -r "$out${postgresql.doc}"
-        fi
+          if [[ -d "$out${postgresql.lib}" ]]; then
+              mkdir -p "''${lib:-$out}"
+              cp -alt "''${lib:-$out}" "$out${postgresql.lib}"/*
+              rm -r "$out${postgresql.lib}"
+          fi
 
-        if [[ -d "$out${postgresql.man}" ]]; then
-            mkdir -p "''${man:-$out}"
-            cp -alt "''${man:-$out}" "$out${postgresql.man}"/*
-            rm -r "$out${postgresql.man}"
-        fi
+          if [[ -d "$out${postgresql.doc}" ]]; then
+              mkdir -p "''${doc:-$out}"
+              cp -alt "''${doc:-$out}" "$out${postgresql.doc}"/*
+              rm -r "$out${postgresql.doc}"
+          fi
 
-        # In some cases (postgis) parts of the install script
-        # actually work "OK", before we add DESTDIR, so some
-        # files end up in
-        # /nix/store/<extension>/nix/store/<extension>/...
-        if [[ -d "$out$out" ]]; then
-            cp -alt "$out" "$out$out"/*
-            rm -r "$out$out"
-        fi
+          if [[ -d "$out${postgresql.man}" ]]; then
+              mkdir -p "''${man:-$out}"
+              cp -alt "''${man:-$out}" "$out${postgresql.man}"/*
+              rm -r "$out${postgresql.man}"
+          fi
 
-        if [[ -d "$out/nix/store" ]]; then
-            if ! rmdir "$out/nix/store" "$out/nix"; then
-              find "$out/nix"
-              nixErrorLog 'Found left-overs in $out/nix/store, make sure to move them into $out properly.'
-              exit 1
-            fi
-        fi
-      ''
-      + prevAttrs.postInstall or "";
-  };
+          # In some cases (postgis) parts of the install script
+          # actually work "OK", before we add DESTDIR, so some
+          # files end up in
+          # /nix/store/<extension>/nix/store/<extension>/...
+          if [[ -d "$out$out" ]]; then
+              cp -alt "$out" "$out$out"/*
+              rm -r "$out$out"
+          fi
+
+          if [[ -d "$out/nix/store" ]]; then
+              if ! rmdir "$out/nix/store" "$out/nix"; then
+                find "$out/nix"
+                nixErrorLog 'Found left-overs in $out/nix/store, make sure to move them into $out properly.'
+                exit 1
+              fi
+          fi
+        ''
+        + prevAttrs.postInstall or "";
+    };
 in
 stdenv.mkDerivation (lib.extends buildPostgresqlExtension (lib.toFunction args))

--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -28,6 +28,7 @@ buildPostgresqlExtension rec {
     "PERL=${perl}/bin/perl"
   ];
 
+  enableUpdateScript = false;
   passthru.tests = stdenv.mkDerivation {
     inherit version src;
 

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -36,6 +36,7 @@ buildPostgresqlExtension (finalAttrs: {
     runHook postPatch
   '';
 
+  enableUpdateScript = false;
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;
     sql = ''

--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -9,13 +9,13 @@
 
 buildPostgresqlExtension rec {
   pname = "citus";
-  version = "12.1.2";
+  version = "12.1.6";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "citus";
     rev = "v${version}";
-    hash = "sha256-0uYNMLAYigtGlDRvOEkQeC5i58QfXcdSVjTQwWVFX+8=";
+    hash = "sha256-PYABH4e5Wp5hMvEQMRHjPL7gDVu8Wud6d+BzrBBMjIQ=";
   };
 
   buildInputs = [
@@ -30,7 +30,7 @@ buildPostgresqlExtension rec {
     broken = versionOlder postgresql.version "14" ||
       # PostgreSQL 17 support issue upstream: https://github.com/citusdata/citus/issues/7708
       # Check after next package update.
-      (versionAtLeast postgresql.version "17" && version == "12.1.2");
+      (versionAtLeast postgresql.version "17" && version == "12.1.6");
     description = "Distributed PostgreSQL as an extension";
     homepage = "https://www.citusdata.com/";
     changelog = "https://github.com/citusdata/citus/blob/${src.rev}/CHANGELOG.md";

--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -2,7 +2,7 @@
 
 buildPostgresqlExtension rec {
   pname = "cstore_fdw";
-  version = "unstable-2022-03-08";
+  version = "1.7.0-unstable-2021-03-08";
 
   nativeBuildInputs = [ protobufc ];
 

--- a/pkgs/servers/sql/postgresql/ext/h3-pg.nix
+++ b/pkgs/servers/sql/postgresql/ext/h3-pg.nix
@@ -10,21 +10,24 @@
 
 buildPostgresqlExtension (finalAttrs: {
   pname = "h3-pg";
-  version = "4.1.3";
+  version = "4.1.4";
 
   src = fetchFromGitHub {
     owner = "zachasme";
     repo = "h3-pg";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-nkaDZ+JuMtsGUJVx70DD2coLrmc/T8/cNov7pfNF1Eg=";
+    hash = "sha256-uZ4XI/VXRr636CI1r24D6ykPQqO5qZNxNQLUQKmoPtg=";
   };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace "add_subdirectory(cmake/h3)" "include_directories(${lib.getDev h3_4}/include/h3)"
+      --replace-fail "add_subdirectory(cmake/h3)" "include_directories(${lib.getDev h3_4}/include/h3)"
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace cmake/AddPostgreSQLExtension.cmake \
-      --replace "INTERPROCEDURAL_OPTIMIZATION TRUE" ""
+      --replace-fail "INTERPROCEDURAL_OPTIMIZATION TRUE" ""
+    # Commented upstream: https://github.com/zachasme/h3-pg/pull/141/files#r1844970927
+    substituteInPlace cmake/FindPostgreSQL.cmake \
+      --replace-fail 'list(APPEND PostgreSQL_INCLUDE_DIRS "/usr/local/include")' ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
+++ b/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
@@ -2,7 +2,7 @@
 
 buildPostgresqlExtension rec {
   pname = "jsonb_deep_sum";
-  version = "unstable-2021-12-24";
+  version = "0-unstable-2021-12-24";
 
   src = fetchFromGitHub {
     owner = "furstenheim";

--- a/pkgs/servers/sql/postgresql/ext/lantern.nix
+++ b/pkgs/servers/sql/postgresql/ext/lantern.nix
@@ -10,13 +10,13 @@
 
 buildPostgresqlExtension (finalAttrs: {
   pname = "postgresql-lantern";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "lanterndata";
     repo = "lantern";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-V8W61hELXeaVvNZgRUcckFlCMWis7NENlRKySxsK/L8=";
+    hash = "sha256-IsDD/um5pVvbzin8onf45DQVszl+Id/pJSQ2iijgHmg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -2,13 +2,13 @@
 
 buildPostgresqlExtension rec {
   pname = "periods";
-  version = "1.2.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "xocolatl";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ezt+MtDqPM8OmJCD6oQTS644l+XHZoxuivq0PUIXOY8=";
+    sha256 = "sha256-97v6+WNDcYb/KivlE/JBlRIZ3gYHj68AlK0fylp1cPo=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -2,22 +2,14 @@
 
 buildPostgresqlExtension rec {
   pname = "pg_bigm";
-  version = "1.2-20200228";
+  version = "1.2-20240606";
 
   src = fetchFromGitHub {
     owner = "pgbigm";
     repo = "pg_bigm";
     rev = "v${version}";
-    hash = "sha256-3lspEglVWzEUTiRIWqW0DpQe8gDn9R/RxsWuI9znYc8=";
+    hash = "sha256-5Uy1DmGZR4WdtRUvNdZ5b9zBHJUb9idcEzW20rkreBs=";
   };
-
-  patches = [
-    # Fix compatibility with PostgreSQL 16. Remove with the next release.
-    (fetchpatch {
-      url = "https://github.com/pgbigm/pg_bigm/commit/2a9d783c52a1d7a2eb414da6f091f6035da76edf.patch";
-      hash = "sha256-LuMpSUPnT8cPChQfA9sJEKP4aGpsbN5crfTKLnDzMN8=";
-    })
-  ];
 
   makeFlags = [ "USE_PGXS=1" ];
 

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -44,6 +44,8 @@ buildPostgresqlExtension {
     substituteInPlace Makefile --replace "LDFLAGS+=-Wl,--build-id" ""
   '';
 
+  enableUpdateScript = false;
+
   meta = with lib; {
     description = "Extension to tweak PostgreSQL execution plans using so-called 'hints' in SQL comments";
     homepage = "https://github.com/ossc-db/pg_hint_plan";

--- a/pkgs/servers/sql/postgresql/ext/pg_net.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_net.nix
@@ -2,7 +2,7 @@
 
 buildPostgresqlExtension rec {
   pname = "pg_net";
-  version = "0.8.0";
+  version = "0.13.0";
 
   buildInputs = [ curl ];
 
@@ -10,7 +10,7 @@ buildPostgresqlExtension rec {
     owner  = "supabase";
     repo   = pname;
     rev    = "refs/tags/v${version}";
-    hash   = "sha256-ZPsRPWV1G3lMM2mT+H139Wvgoy8QnmeUbzEnGeDJmZA=";
+    hash   = "sha256-FRaTZPCJQPYAFmsJg22hYJJ0+gH1tMdDQoCQgiqEnaA=";
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -9,7 +9,7 @@
 
 buildPostgresqlExtension (finalAttrs: {
   pname = "pg_repack";
-  version = "1.5.0";
+  version = "1.5.1";
 
   buildInputs = postgresql.buildInputs;
 
@@ -17,7 +17,7 @@ buildPostgresqlExtension (finalAttrs: {
     owner = "reorg";
     repo = "pg_repack";
     rev = "ver_${finalAttrs.version}";
-    sha256 = "sha256-do80phyMxwcRIkYyUt9z02z7byNQhK+pbSaCUmzG+4c=";
+    sha256 = "sha256-wJwy4qIt6/kgWqT6HbckUVqDayDkixqHpYiC1liLERw=";
   };
 
   passthru.tests = {

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, postgresql, unstableGitUpdater, buildPostgresqlExtension }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, postgresql, buildPostgresqlExtension }:
 
 buildPostgresqlExtension {
   pname = "pg_similarity";
-  version = "1.0-unstable-2021-01-12";
+  version = "pg_similarity_1_0-unstable-2021-01-12";
 
   src = fetchFromGitHub {
     owner = "eulerto";
@@ -22,8 +22,6 @@ buildPostgresqlExtension {
   ];
 
   makeFlags = [ "USE_PGXS=1" ];
-
-  passthru.updateScript = unstableGitUpdater {};
 
   meta = {
     description = "Extension to support similarity queries on PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -1,16 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension, buildPostgresqlExtension }:
+{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension, buildPostgresqlExtension, nix-update-script }:
 
 buildPostgresqlExtension (finalAttrs: {
   pname = "pg_squeeze";
-  version = "1.7.0";
+  version = "${builtins.replaceStrings ["_"] ["."] (lib.strings.removePrefix "REL" finalAttrs.src.rev)}";
 
   src = fetchFromGitHub {
     owner = "cybertec-postgresql";
     repo = "pg_squeeze";
-    rev = "REL${builtins.replaceStrings ["."] ["_"] finalAttrs.version}";
+    rev = "REL1_7_0";
     hash = "sha256-Kh1wSOvV5Rd1CG/na3yzbWzvaR8SJ6wmTZOnM+lbgik=";
   };
 
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=REL(.*)" ]; };
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;
     postgresqlExtraSettings = ''

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -7,13 +7,13 @@
 
 buildPostgresqlExtension rec {
   pname = "pg_uuidv7";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "fboulnois";
     repo = "pg_uuidv7";
     rev = "v${version}";
-    hash = "sha256-oVyRtjl3KsD3j96qvQb8bFLMhoWO81OudOL4wVXrjzI=";
+    hash = "sha256-lG6dCnbLALnfQc4uclqXXXfYjK/WXLV0lo5I8l1E5p4=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -43,6 +43,8 @@ buildPostgresqlExtension {
 
   makeFlags = [ "USE_PGXS=1" ];
 
+  enableUpdateScript = false;
+
   meta = with lib; {
     description = "Open Source PostgreSQL Audit Logging";
     homepage = "https://github.com/pgaudit/pgaudit";

--- a/pkgs/servers/sql/postgresql/ext/pgmq.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgmq.nix
@@ -8,13 +8,13 @@
 
 buildPostgresqlExtension rec {
   pname = "pgmq";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "tembo-io";
     repo = "pgmq";
     rev = "v${version}";
-    hash = "sha256-z+8/BqIlHwlMnuIzMz6eylmYbSmhtsNt7TJf/CxbdVw=";
+    hash = "sha256-ynco5t/z7+IPEynuY1wtSaoVloMr6z7UYn4byZecOhg=";
   };
 
   sourceRoot = "${src.name}/pgmq-extension";

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -2,13 +2,13 @@
 
 buildPostgresqlExtension rec {
   pname = "pgroonga";
-  version = "3.2.3";
+  version = "3.2.4";
 
   src = fetchFromGitHub {
     owner = "pgroonga";
     repo = "pgroonga";
     rev = "${version}";
-    hash = "sha256-bDCDfb78r/HUa7LuZZrwrSZEFcevA1pwSy8/tcCh/oE=";
+    hash = "sha256-ZHACMsQ+hneU68Y2jOpz16Mo0jzgXKaVSCZ/qAqCDdI=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -1,18 +1,21 @@
-{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, groonga, buildPostgresqlExtension }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, postgresql, msgpack-c, groonga, buildPostgresqlExtension, xxHash }:
 
 buildPostgresqlExtension rec {
   pname = "pgroonga";
   version = "3.2.3";
 
-  src = fetchurl {
-    url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
-    hash = "sha256-k9+DgiLzU2cA3jvw3pMF7/FmDGxsCYtAOaUtf2LMTnw=";
+  src = fetchFromGitHub {
+    owner = "pgroonga";
+    repo = "pgroonga";
+    rev = "${version}";
+    hash = "sha256-bDCDfb78r/HUa7LuZZrwrSZEFcevA1pwSy8/tcCh/oE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ msgpack-c groonga ];
+  buildInputs = [ msgpack-c groonga xxHash ];
 
   makeFlags = [
+    "HAVE_XXHASH=1"
     "HAVE_MSGPACK=1"
     "MSGPACK_PACKAGE_NAME=msgpack-c"
   ];

--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -2,7 +2,7 @@
 
 buildPostgresqlExtension rec {
   pname = "pgrouting";
-  version = "3.6.3";
+  version = "3.7.0";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ boost ];
@@ -11,7 +11,7 @@ buildPostgresqlExtension rec {
     owner  = "pgRouting";
     repo   = "pgrouting";
     rev    = "v${version}";
-    hash   = "sha256-VCoapUM7Vh4W1DUE/gWQ9YIRLbw63XlOWsgajJW+XNU=";
+    hash   = "sha256-IwH8bEdyJyPMFYtCfWLRr+jVmS5sOr5QFOhGykGPYh4=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
@@ -2,13 +2,13 @@
 
 buildPostgresqlExtension rec {
   pname = "pgsql-http";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "pramsey";
     repo = "pgsql-http";
     rev = "v${version}";
-    hash = "sha256-CPHfx7vhWfxkXsoKTzyFuTt47BPMvzi/pi1leGcuD60=";
+    hash = "sha256-C8eqi0q1dnshUAZjIsZFwa5FTYc7vmATF3vv2CReWPM=";
   };
 
   buildInputs = [ curl ];

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -2,13 +2,13 @@
 
 buildPostgresqlExtension rec {
   pname = "pgvector";
-  version = "0.6.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "pgvector";
     repo = "pgvector";
     rev = "v${version}";
-    hash = "sha256-r+TpFJg6WrMn0L2B7RpmSRvw3XxpHzMRtpFWDCzLvgs=";
+    hash = "sha256-JsZV+I4eRMypXTjGmjCtMBXDVpqTIPHQa28ogXncE/Q=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
@@ -2,13 +2,13 @@
 
 buildPostgresqlExtension (finalAttrs: {
   pname = "plpgsql-check";
-  version = "2.7.5";
+  version = "2.7.12";
 
   src = fetchFromGitHub {
     owner = "okbob";
     repo = "plpgsql_check";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-CD/G/wX6o+mC6gowlpFe1DdJWyh3cB9wxSsW2GXrENE=";
+    hash = "sha256-sLakN4595z+Smt7oaK7IPIJZp/JIGwL5UB4OXQek7JU=";
   };
 
   passthru.tests.extension = postgresqlTestExtension {

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -2,12 +2,12 @@
 
 buildPostgresqlExtension rec {
   pname = "plr";
-  version = "8.4.7";
+  version = "${builtins.replaceStrings ["_"] ["."] (lib.strings.removePrefix "REL" src.rev)}";
 
   src = fetchFromGitHub {
     owner = "postgres-plr";
     repo = "plr";
-    rev = "REL${builtins.replaceStrings ["."] ["_"] version}";
+    rev = "REL8_4_7";
     sha256 = "sha256-PdvFEmtKfLT/xfaf6obomPR5hKC9F+wqpfi1heBphRk=";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -1,5 +1,5 @@
 {
-  fetchurl,
+  fetchFromGitHub,
   lib,
   stdenv,
   perl,
@@ -22,6 +22,10 @@
   jitSupport,
   llvm,
   buildPostgresqlExtension,
+  autoconf,
+  automake,
+  libtool,
+  which,
 }:
 
 let
@@ -36,9 +40,11 @@ buildPostgresqlExtension (finalAttrs: {
     "doc"
   ];
 
-  src = fetchurl {
-    url = "https://download.osgeo.org/postgis/source/postgis-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ymmKIswrKzRnrE4GO0OihBPzAE3dUFvczddMVqZH9RA=";
+  src = fetchFromGitHub {
+    owner = "postgis";
+    repo = "postgis";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-wh7Lav2vnKzGWuSvvMFvAaGV7ynD+KgPsFUgujdtzlA=";
   };
 
   buildInputs = [
@@ -51,8 +57,12 @@ buildPostgresqlExtension (finalAttrs: {
     pcre2.dev
   ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
   nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
     perl
     pkg-config
+    which
   ] ++ lib.optional jitSupport llvm;
   dontDisableStatic = true;
 
@@ -70,7 +80,7 @@ buildPostgresqlExtension (finalAttrs: {
 
   setOutputFlags = false;
   preConfigure = ''
-    sed -i 's@/usr/bin/file@${file}/bin/file@' configure
+    ./autogen.sh
   '';
 
   configureFlags = [

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -10,13 +10,13 @@
 
 buildPostgresqlExtension rec {
   pname = "repmgr";
-  version = "5.4.1";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "EnterpriseDB";
     repo = "repmgr";
     rev = "v${version}";
-    sha256 = "sha256-OaEoP1BajVW9dt8On9Ppf8IXmAk47HHv8zKw3WlsLHw=";
+    sha256 = "sha256-8G2CzzkWTKEglpUt1Gr7d/DuHJvCIEjsbYDMl3Zt3cs=";
   };
 
   nativeBuildInputs = [ flex ];
@@ -29,9 +29,6 @@ buildPostgresqlExtension rec {
     license = licenses.postgresql;
     platforms = postgresql.meta.platforms;
     maintainers = with maintainers; [ zimbatm ];
-    # PostgreSQL 17 support issue upstream: https://github.com/EnterpriseDB/repmgr/issues/856
-    # Check after next package update.
-    broken = versionAtLeast postgresql.version "17" && version == "5.4.1";
   };
 }
 

--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -8,12 +8,14 @@
 
 buildPostgresqlExtension rec {
   pname = "wal2json";
-  version = "2.6";
+  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
+    lib.strings.removePrefix "wal2json_" src.rev
+  )}";
 
   src = fetchFromGitHub {
     owner = "eulerto";
     repo = "wal2json";
-    rev = "wal2json_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    rev = "wal2json_2_6";
     sha256 = "sha256-+QoACPCKiFfuT2lJfSUmgfzC5MXf75KpSoc2PzPxKyM=";
   };
 
@@ -24,7 +26,7 @@ buildPostgresqlExtension rec {
   meta = with lib; {
     description = "PostgreSQL JSON output plugin for changeset extraction";
     homepage = "https://github.com/eulerto/wal2json";
-    changelog = "https://github.com/eulerto/wal2json/releases/tag/wal2json_${version}";
+    changelog = "https://github.com/eulerto/wal2json/releases/tag/${src.rev}";
     maintainers = with maintainers; [ euank ];
     platforms = postgresql.meta.platforms;
     license = licenses.bsd3;


### PR DESCRIPTION
Enables update script per default via `postgresqlBuildExtension`. Extensions must opt out actively if they don't support the update script.

To make the update script work, some extensions had to be changed to pull their code from GitHub instead. Those with PostgreSQL-style version tags (REL_X_Y) had to be changed to make `src.rev` the source of truth instead of `version`.

Updating 15 postgresql extensions along the way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
