### PR TITLE
ciscoPacketTracer8: fix script modules

### DIFF
--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -1,17 +1,18 @@
-{ stdenvNoCC
-, lib
-, alsa-lib
-, autoPatchelfHook
-, copyDesktopItems
-, dbus
-, dpkg
-, expat
-, fontconfig
-, glib
-, makeDesktopItem
-, makeWrapper
-, qt5
-, requireFile
+{
+  stdenvNoCC,
+  lib,
+  alsa-lib,
+  autoPatchelfHook,
+  copyDesktopItems,
+  dbus,
+  dpkg,
+  expat,
+  fontconfig,
+  glib,
+  makeDesktopItem,
+  makeWrapper,
+  qt5,
+  requireFile,
 }:
 
 let
@@ -91,7 +92,11 @@ stdenvNoCC.mkDerivation (args: {
       desktopName = "Cisco Packet Tracer 8";
       icon = "ciscoPacketTracer8";
       exec = "packettracer8 %f";
-      mimeTypes = [ "application/x-pkt" "application/x-pka" "application/x-pkz" ];
+      mimeTypes = [
+        "application/x-pkt"
+        "application/x-pka"
+        "application/x-pkz"
+      ];
     })
   ];
 

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -13,6 +13,7 @@
   makeWrapper,
   qt5,
   requireFile,
+  version ? "8.2.2",
 }:
 
 let
@@ -28,14 +29,14 @@ let
   };
 in
 
-stdenvNoCC.mkDerivation (args: {
+stdenvNoCC.mkDerivation {
   pname = "ciscoPacketTracer8";
 
-  version = "8.2.2";
+  inherit version;
 
   src = requireFile {
-    name = names.${args.version};
-    hash = hashes.${args.version};
+    name = names.${version};
+    hash = hashes.${version};
     url = "https://www.netacad.com";
   };
 
@@ -117,4 +118,4 @@ stdenvNoCC.mkDerivation (args: {
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-})
+}

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -25,6 +25,7 @@
   copyDesktopItems,
   makeDesktopItem,
   version ? "8.2.2",
+  packetTracerSource ? null,
 }:
 
 let
@@ -43,11 +44,15 @@ let
     name = "ciscoPacketTracer8-unwrapped";
     inherit version;
 
-    src = requireFile {
-      name = names.${version};
-      hash = hashes.${version};
-      url = "https://www.netacad.com";
-    };
+    src =
+      if (packetTracerSource != null) then
+        packetTracerSource
+      else
+        requireFile {
+          name = names.${version};
+          hash = hashes.${version};
+          url = "https://www.netacad.com";
+        };
 
     buildInputs =
       [

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -111,7 +111,9 @@ stdenvNoCC.mkDerivation (args: {
     homepage = "https://www.netacad.com/courses/packet-tracer";
     license = lib.licenses.unfree;
     mainProgram = "packettracer8";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -106,13 +106,13 @@ stdenvNoCC.mkDerivation (args: {
     inherit hashes;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Network simulation tool from Cisco";
     homepage = "https://www.netacad.com/courses/packet-tracer";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ ];
-    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
     mainProgram = "packettracer8";
+    maintainers = with lib.maintainers; [ ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes https://github.com/NixOS/nixpkgs/issues/291445

As the bug got introduced with a refactor that moved away from `buildFHSEnv`, the only fix I found is moving back to it.

This PR is mostly a revert of https://github.com/NixOS/nixpkgs/commit/2920b6fc16a9ed5d51429e94238b28306ceda79e with additional refactors and the addition of `wayland` for newer versions of packet tracer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
