### PR TITLE
python3Packages.pytest-examples: fixup build flakiness

### DIFF
--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -3,6 +3,7 @@
   black,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   hatchling,
   pytest,
   pytestCheckHook,
@@ -31,6 +32,13 @@ buildPythonPackage rec {
   '';
 
   pythonRemoveDeps = [ "ruff" ];
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/pydantic/pytest-examples/pull/37.patch";
+      hash = "sha256-SISZl2mTDrazQjlwtS9c/dkfY05VKapkdvCmfB0/cQU=";
+    })
+  ];
 
   build-system = [
     hatchling

--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -25,18 +25,14 @@ buildPythonPackage rec {
     hash = "sha256-R0gSWQEGMkJhkeXImyris2wzqjJ0hC3zO0voEdhWLoY=";
   };
 
-  postPatch = ''
-    # ruff binary is used directly, the ruff Python package is not needed
-    substituteInPlace pytest_examples/lint.py \
-      --replace-fail "'ruff'" "'${lib.getExe ruff}'"
-  '';
-
-  pythonRemoveDeps = [ "ruff" ];
-
   patches = [
     (fetchpatch2 {
       url = "https://github.com/pydantic/pytest-examples/pull/37.patch";
       hash = "sha256-SISZl2mTDrazQjlwtS9c/dkfY05VKapkdvCmfB0/cQU=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/pydantic/pytest-examples/pull/41.patch";
+      hash = "sha256-E8j8clAUZEJo0ZXBS8VaaoT4krEVdfPIaVC94kFKO0c=";
     })
   ];
 
@@ -44,7 +40,7 @@ buildPythonPackage rec {
     hatchling
   ];
 
-  buildInputs = [ pytest ];
+  buildInputs = [ pytest ruff ];
 
   dependencies = [ black ];
 


### PR DESCRIPTION
This imports the patch from https://github.com/pydantic/pytest-examples/pull/37 to try to help with build flakiness.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
