### PR TITLE
mitra: Init at 3.9.0

### DIFF
--- a/pkgs/by-name/mi/mitra/package.nix
+++ b/pkgs/by-name/mi/mitra/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mitra";
+  version = "3.9.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "silverpill";
+    repo = "mitra";
+    rev = "v${version}";
+    hash = "sha256-reBG9h3jI4ONxYIwM2QdXlTC8ohmSrPm18sLOeI/2wY=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-WoJzFhxBDHuUNGaNsqieev93hg0Eo604tAM0HZJv9tA=";
+
+  # MEMO: mitra v3.9.0 tests failed with cargo option, "--offline"
+  doCheck = false;
+
+  RUSTFLAGS = [
+    # MEMO: mitra use ammonia crate with unstable rustc flag
+    "--cfg=ammonia_unstable"
+  ];
+
+  buildFeatures = [
+    "production"
+  ];
+
+  meta = {
+    description = "Federated micro-blogging platform";
+    homepage = "https://codeberg.org/silverpill/mitra";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ haruki7049 ];
+    mainProgram = "mitra";
+  };
+}


### PR DESCRIPTION
Federated micro-blogging platform and content subscription service
https://codeberg.org/silverpill/mitra

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
