### PR TITLE
datadog-integrations-core: 7.38.0 -> 7.50.2

### DIFF
--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -33,7 +33,7 @@
 #
 # [1]: https://github.com/DataDog/integrations-core
 
-{ pkgs, python, extraIntegrations ? {} }:
+{ pkgs, python, extraIntegrations ? { }, }:
 
 let
   inherit (pkgs.lib) attrValues mapAttrs;
@@ -42,18 +42,21 @@ let
     owner = "DataDog";
     repo = "integrations-core";
     rev = version;
-    sha256 = "sha256-CIzuJ97KwsG1k65Y+8IUSka/3JX1pmQKN3hPHzZnGhQ=";
+    sha256 = "sha256-tgY8Jh7N9ot3Xp+JfsA9vEzj62H2OPTEh6b1YzyNGRU=";
   };
-  version = "7.38.0";
+  version = "7.50.2";
 
   # Build helper to build a single datadog integration package.
-  buildIntegration = { pname, ... }@args: python.pkgs.buildPythonPackage (args // {
-    inherit src version;
-    name = "datadog-integration-${pname}-${version}";
+  buildIntegration = { pname, ... }@args:
+    python.pkgs.buildPythonPackage (args // {
+      inherit src version;
+      name = "datadog-integration-${pname}-${version}";
+      pyproject = true;
 
-    sourceRoot = "${src.name}/${args.sourceRoot or pname}";
-    doCheck = false;
-  });
+      sourceRoot = "${src.name}/${args.sourceRoot or pname}";
+      buildInputs = with python.pkgs; [ hatchling setuptools ];
+      doCheck = false;
+    });
 
   # Base package depended on by all other integrations.
   datadog_checks_base = buildIntegration {


### PR DESCRIPTION
[changelog](https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7502)

This brings the integration clients up to date with the current `datadog-agent`, adding some new integrations such as `dcgm` for monitoring GPU metrics.

Between these versions the project switched to `pyproject.toml`, and added hatchling and setuptools build systems, so some derivation updates were necessary.

`datadog-agent` is currently broken in unstable & 24.11, so I think this should be backported to 24.05 if possible. There are some mentions of breaking changes to the integrations, but many of these are just bumping the minimum base check version, which is tracked alongside the integrations.

EDIT: apologies for the label spam, I accidentally pushed a rebase here.

## Things done

Tested building of all default integrations, and several custom integrations. Also rebased and re-tested on nixos-24.05

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
