### PR TITLE
nixos/netdata: copy apps_groups.conf instead of symlink

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -27,7 +27,7 @@ let
     mkdir $out
     ${concatStringsSep "\n" (mapAttrsToList (path: file: ''
         mkdir -p "$out/$(dirname ${path})"
-        ln -s "${file}" "$out/${path}"
+        ${if path == "apps_groups.conf" then "cp" else "ln -s"} "${file}" "$out/${path}"
       '') cfg.configDir)}
   '';
 

--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -14,6 +14,10 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           services.netdata = {
             enable = true;
             python.recommendedPythonPackages = true;
+
+            configDir."apps_groups.conf" = pkgs.writeText "apps_groups.conf" ''
+              netdata_test: netdata
+            '';
           };
         };
     };
@@ -33,12 +37,20 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     # check if netdata can read disk ops for root owned processes.
     # if > 0, successful. verifies both netdata working and
     # apps.plugin has elevated capabilities.
-    url = "http://localhost:19999/api/v1/data\?chart=user.root_disk_physical_io"
+    url = "http://localhost:19999/api/v1/data?chart=user.root_disk_physical_io"
     filter = '[.data[range(10)][2]] | add | . < 0'
     cmd = f"curl -s {url} | jq -e '{filter}'"
     netdata.wait_until_succeeds(cmd)
 
     # check if the control socket is available
     netdata.succeed("sudo netdatacli ping")
+
+    # check that custom groups in apps_groups.conf are used.
+    # if > 0, successful. verifies that user-specified apps_group.conf
+    # is used.
+    url = "http://localhost:19999/api/v1/data?chart=app.netdata_test_cpu_utilization"
+    filter = '[.data[range(10)][2]] | add | . > 0'
+    cmd = f"curl -s {url} | jq -e '{filter}'"
+    netdata.wait_until_succeeds(cmd, timeout=30)
   '';
 })


### PR DESCRIPTION
Currently, it is not possible to configure `apps.plugin` via NixOS option `services.netdata.configDir."apps_groups.conf"`. This is because `apps.plugin` explicitly does not follow symbolic links when reading its configuration from apps_groups.conf[^ref].

This change will copy that file instead of symlinking to address this.

Fixes #255161

[^ref]: https://github.com/netdata/netdata/blob/3849e70f93d9c13097e80823a5e0a0fa2c6ea39c/src/collectors/apps.plugin/apps_plugin.c#L679


## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
