### PR TITLE
nicotine-plus: 3.3.5 -> 3.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1197,6 +1197,12 @@
     name = "alyaeanyx";
     keys = [ { fingerprint = "1F73 8879 5E5A 3DFC E2B3 FA32 87D1 AADC D25B 8DEE"; } ];
   };
+  amadaluzia = {
+    email = "amad@atl.tools";
+    github = "amadaluzia";
+    githubId = 188314694;
+    name = "Artur Manuel";
+  };
   amadejkastelic = {
     email = "amadejkastelic7@gmail.com";
     github = "amadejkastelic";

--- a/pkgs/by-name/ni/nicotine-plus/package.nix
+++ b/pkgs/by-name/ni/nicotine-plus/package.nix
@@ -1,45 +1,57 @@
-{ lib
-, fetchFromGitHub
-, wrapGAppsHook4
-, gdk-pixbuf
-, gettext
-, gobject-introspection
-, gtk4
-, python3Packages
+{
+  lib,
+  fetchFromGitHub,
+  wrapGAppsHook4,
+  gdk-pixbuf,
+  gettext,
+  gobject-introspection,
+  gtk4,
+  glib,
+  python3Packages,
+  libadwaita,
 }:
-
 python3Packages.buildPythonApplication rec {
   pname = "nicotine-plus";
-  version = "3.3.5";
-
+  version = "3.3.6";
+  pyproject = true;
   src = fetchFromGitHub {
     owner = "nicotine-plus";
     repo = "nicotine-plus";
     rev = "refs/tags/${version}";
-    hash = "sha256-6tA3d+QX2ArDH4aeWZNKuIXe3Sk32JaFe8d0C8G9Akc=";
+    hash = "sha256-je3hyxbF9wKW2gvHoDp712EJxBxooS2z0pQM57WDdOk=";
   };
 
-  nativeBuildInputs = [ gettext wrapGAppsHook4 gobject-introspection ];
-
-  propagatedBuildInputs = [
-    gdk-pixbuf
+  nativeBuildInputs = [
+    gettext
+    wrapGAppsHook4
     gobject-introspection
+    glib
+    gdk-pixbuf
     gtk4
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  dependencies = [
     python3Packages.pygobject3
+  ];
+
+  build-system = [
+    python3Packages.setuptools
   ];
 
   postInstall = ''
     ln -s $out/bin/nicotine $out/bin/nicotine-plus
   '';
 
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix XDG_DATA_DIRS : "${gtk4}/share/gsettings-schemas/${gtk4.name}"
-    )
-  '';
+  dontWrapGAppsHook = true;
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+  ];
 
   doCheck = false;
-
   meta = with lib; {
     description = "Graphical client for the SoulSeek peer-to-peer system";
     longDescription = ''
@@ -49,6 +61,9 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://www.nicotine-plus.org";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ klntsky ];
+    maintainers = with maintainers; [
+      klntsky
+      amadaluzia
+    ];
   };
 }


### PR DESCRIPTION
I have done some refactoring in the nicotine-plus package to fix libadwaita being an issue, (you may test this with running nicotine-plus with NICOTINE_LIBADWAITA="1") and updated the package from 3.3.5 to 3.3.6.

You may read about changes made in 3.3.6 here: https://nicotine-plus.org/NEWS.html

This introduces a renderer change which may affect some computers.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
