### PR TITLE
cargo-tauri: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/Cargo.lock
+++ b/pkgs/by-name/ca/cargo-tauri/Cargo.lock
@@ -8994,7 +8994,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -15,13 +15,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tauri";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = "tauri";
     rev = "refs/tags/tauri-v${version}";
-    hash = "sha256-n1rSffVef9G9qtLyheuK5k6anAHsZANSu0C73QDdg2o=";
+    hash = "sha256-HPmViOowP1xAjDJ89YS0BTjNnKI1P0L777ywkqAhhc4=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -9,7 +9,6 @@
   nix-update-script,
   openssl,
   pkg-config,
-  testers,
   webkitgtk_4_1,
 }:
 
@@ -49,7 +48,6 @@ rustPlatform.buildRustPackage rec {
 
     tests = {
       hook = callPackage ./test-app.nix { };
-      version = testers.testVersion { package = cargo-tauri; };
     };
 
     updateScript = nix-update-script {

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  rustPlatform,
   cargo-tauri,
   glib-networking,
   libayatana-appindicator,
@@ -9,28 +8,27 @@
   openssl,
   pkg-config,
   pnpm_9,
+  rustPlatform,
   webkitgtk_4_1,
   wrapGAppsHook4,
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  pnpm = pnpm_9;
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "test-app";
   inherit (cargo-tauri) version src;
-
-  cargoLock = {
-    inherit (cargo-tauri.cargoDeps) lockFile;
-    outputHashes = {
-      "schemars_derive-0.8.21" = "sha256-AmxBKZXm2Eb+w8/hLQWTol5f22uP8UqaIh+LVLbS20g=";
-    };
-  };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
       --replace "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
-  pnpmDeps = pnpm_9.fetchDeps {
-    inherit
+  inherit (cargo-tauri) cargoDeps;
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs)
       pname
       version
       src
@@ -44,7 +42,9 @@ rustPlatform.buildRustPackage rec {
 
     nodejs
     pkg-config
-    pnpm_9.configHook
+    pnpm.configHook
+    rustPlatform.cargoCheckHook
+    rustPlatform.cargoSetupHook
     wrapGAppsHook4
   ];
 
@@ -70,4 +70,4 @@ rustPlatform.buildRustPackage rec {
   meta = {
     inherit (cargo-tauri.hook.meta) platforms;
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
       --replace "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -3,7 +3,6 @@
   stdenv,
   rustPlatform,
   cargo-tauri,
-  darwin,
   glib-networking,
   libayatana-appindicator,
   nodejs,
@@ -55,9 +54,6 @@ rustPlatform.buildRustPackage rec {
       glib-networking
       libayatana-appindicator
       webkitgtk_4_1
-    ]
-    ++ lib.optionals stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.WebKit
     ];
 
   buildAndTestSubdir = "examples/api/src-tauri";


### PR DESCRIPTION
Changelog: https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.1.1
Diff: https://github.com/tauri-apps/tauri/compare/tauri-v2.1.0...tauri-v2.1.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
