### PR TITLE
ghc_filesystem: pin apple-sdk to v11; modernize; adopt

### DIFF
--- a/pkgs/by-name/gh/ghc_filesystem/package.nix
+++ b/pkgs/by-name/gh/ghc_filesystem/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cmake, fetchFromGitHub }:
+{ stdenv, lib, apple-sdk_11, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "filesystem";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
   meta = with lib; {
     description = "header-only single-file C++ std::filesystem compatible helper library";

--- a/pkgs/by-name/gh/ghc_filesystem/package.nix
+++ b/pkgs/by-name/gh/ghc_filesystem/package.nix
@@ -1,4 +1,10 @@
-{ stdenv, lib, apple-sdk_11, cmake, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  apple-sdk_11,
+  cmake,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation rec {
   pname = "filesystem";

--- a/pkgs/by-name/gh/ghc_filesystem/package.nix
+++ b/pkgs/by-name/gh/ghc_filesystem/package.nix
@@ -1,19 +1,20 @@
 {
-  stdenv,
   lib,
+  stdenv,
   apple-sdk_11,
   cmake,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "filesystem";
   version = "1.5.14";
 
   src = fetchFromGitHub {
     owner = "gulrak";
     repo = "filesystem";
-    rev = "v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-XZ0IxyNIAs2tegktOGQevkLPbWHam/AOFT+M6wAWPFg=";
   };
 
@@ -21,10 +22,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
 
-  meta = with lib; {
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "header-only single-file C++ std::filesystem compatible helper library";
     homepage = "https://github.com/gulrak/filesystem";
-    license = licenses.mit;
-    maintainers = with maintainers; [ bbjubjub ];
+    changelog = "https://github.com/gulrak/filesystem/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bbjubjub ];
   };
-}
+})

--- a/pkgs/by-name/gh/ghc_filesystem/package.nix
+++ b/pkgs/by-name/gh/ghc_filesystem/package.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/gulrak/filesystem";
     changelog = "https://github.com/gulrak/filesystem/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ bbjubjub ];
+    maintainers = with lib.maintainers; [
+      bbjubjub
+      getchoo
+    ];
   };
 })


### PR DESCRIPTION
Fixes a build failure on x86_64-darwin that appeared in https://hydra.nixos.org/build/275198284. ZHF https://github.com/NixOS/nixpkgs/issues/352882


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
