### PR TITLE
nixos/doc/rl-2505: fix quotes, add more comments about ordering

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -1,4 +1,4 @@
-# Release 25.05 ("Warbler”, 2025.05/??) {#sec-release-25.05}
+# Release 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -1,23 +1,35 @@
 # Release 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
 
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
-
 ## Highlights {#sec-release-25.05-highlights}
 
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
 - Create the first release note entry in this section!
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}
 
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
 - Create the first release note entry in this section!
 
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - `kanata` was updated to v1.7.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)
   for more information.
 
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
 ## Other Notable Changes {#sec-release-25.05-notable-changes}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - Create the first release note entry in this section!
 


### PR DESCRIPTION
This looks a little ridiculous right now, but my experience is that it’s common to find the beginning or end of a section and add more things there without seeing the comments. We should probably move to a one file per release note system, but in the meantime this is a low‐cost way to help reduce merge conflicts.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
