### PR TITLE
treewide: stdenv.is -> stdenv.hostPlatform.is

### DIFF
--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -57,7 +57,7 @@ rec {
       throwUnsupportedGuestSystem = guestMap:
         throw "Unsupported guest system ${guestSystem} for host ${hostSystem}, supported: ${lib.concatStringsSep ", " (lib.attrNames guestMap)}";
     in
-    if hostStdenv.isLinux then
+    if hostStdenv.hostPlatform.isLinux then
       linuxHostGuestMatrix.${guestSystem} or "${qemuPkg}/bin/qemu-kvm"
     else
       let

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -69,48 +69,50 @@ stdenv.mkDerivation (finalAttrs: {
     wrapQtAppsHook
   ];
 
-  buildInputs = [
-    airspy
-    airspyhf
-    aptdec
-    boost
-    cm256cc
-    codec2
-    dab_lib
-    dsdcc
-    faad2
-    ffmpeg
-    fftwFloat
-    flac
-    glew
-    hackrf
-    hidapi
-    libbladeRF
-    libiio
-    libopus
-    libpulseaudio
-    libusb1
-    limesuite
-    mbelib
-    opencv4
-    qt5compat
-    qtcharts
-    qtdeclarative
-    qtlocation
-    qtmultimedia
-    qtscxml
-    qtserialport
-    qtspeech
-    qttools
-    qtwebsockets
-    qtwebengine
-    rtl-sdr
-    serialdv
-    sgp4
-    soapysdr-with-plugins
-    uhd
-    zlib
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland ] ++ lib.optionals withSDRplay [ sdrplay ];
+  buildInputs =
+    [
+      airspy
+      airspyhf
+      aptdec
+      boost
+      cm256cc
+      codec2
+      dab_lib
+      dsdcc
+      faad2
+      ffmpeg
+      fftwFloat
+      flac
+      glew
+      hackrf
+      hidapi
+      libbladeRF
+      libiio
+      libopus
+      libpulseaudio
+      libusb1
+      limesuite
+      mbelib
+      opencv4
+      qt5compat
+      qtcharts
+      qtdeclarative
+      qtlocation
+      qtmultimedia
+      qtscxml
+      qtserialport
+      qtspeech
+      qttools
+      qtwebsockets
+      qtwebengine
+      rtl-sdr
+      serialdv
+      sgp4
+      soapysdr-with-plugins
+      uhd
+      zlib
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland ] ++ lib.optionals withSDRplay [ sdrplay ];
 
   cmakeFlags = [
     "-DAPT_DIR=${aptdec}"

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     soapysdr-with-plugins
     uhd
     zlib
-  ] ++ lib.optionals stdenv.isLinux [ qtwayland ] ++ lib.optionals withSDRplay [ sdrplay ];
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland ] ++ lib.optionals withSDRplay [ sdrplay ];
 
   cmakeFlags = [
     "-DAPT_DIR=${aptdec}"

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -230,7 +230,7 @@ stdenv.mkDerivation rec {
 
   # workaround for
   # https://github.com/root-project/root/issues/14778
-  env.NIX_LDFLAGS = lib.optionalString (!stdenv.isDarwin) "--version-script,${writeText "version.map" "ROOT { global: *; };"}";
+  env.NIX_LDFLAGS = lib.optionalString (!stdenv.hostPlatform.isDarwin) "--version-script,${writeText "version.map" "ROOT { global: *; };"}";
 
   # To use the debug information on the fly (without installation)
   # add the outPath of root.debug into NIX_DEBUG_INFO_DIRS (in PATH-like format)

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -104,7 +104,7 @@ assert useSysroot -> !(args.doCheck or true);
 
 stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "cargoLock" ]) // lib.optionalAttrs useSysroot {
   RUSTFLAGS = "--sysroot ${sysroot} " + (args.RUSTFLAGS or "");
-} // lib.optionalAttrs (stdenv.isDarwin && buildType == "debug") {
+} // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
   RUSTFLAGS =
     "-C split-debuginfo=packed "
     + lib.optionalString useSysroot "--sysroot ${sysroot} "

--- a/pkgs/by-name/al/almo/package.nix
+++ b/pkgs/by-name/al/almo/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   makeFlags = [ "all" ];
 
   # remove darwin-only linker flag on linux
-  postPatch = lib.optionalString (!stdenv.isDarwin) ''
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace scripts/pybind.sh \
       --replace-fail " -undefined dynamic_lookup" ""
   '';

--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -28,8 +28,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =
     [ sqlite ]
-    ++ lib.optionals stdenv.isLinux [ openssl ]
-    ++ lib.optionals stdenv.isDarwin (
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk.frameworks;
       [
         CoreServices

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -51,7 +51,7 @@ buildGoModule {
         [
           "TestServeIndex" # Fails with handler returned wrong content encoding
         ]
-        ++ lib.optionals stdenv.isDarwin [
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
           "TestBackup" # relies on ionice
         ];
     in

--- a/pkgs/by-name/bi/binsider/package.nix
+++ b/pkgs/by-name/bi/binsider/package.nix
@@ -18,9 +18,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-EGqoHMkBPIhKV/PozArQ62bH/Gqc92S6ZabTjmIbQeE=";
 
-  buildNoDefaultFeatures = !stdenv.isLinux;
+  buildNoDefaultFeatures = !stdenv.hostPlatform.isLinux;
 
-  buildInputs = lib.optionals stdenv.isDarwin (
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin (
     with darwin.apple_sdk.frameworks;
     [
       AppKit

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -167,7 +167,7 @@ in buildNpmPackage rec {
 
     mkdir $out
 
-    pushd apps/desktop/dist/linux-${lib.optionalString stdenv.isAarch64 "arm64-"}unpacked
+    pushd apps/desktop/dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked
     mkdir -p $out/opt/Bitwarden
     cp -r locales resources{,.pak} $out/opt/Bitwarden
     popd

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [ openssl ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       glib-networking
       libayatana-appindicator
       webkitgtk_4_1

--- a/pkgs/by-name/ch/chatd/package.nix
+++ b/pkgs/by-name/ch/chatd/package.nix
@@ -34,7 +34,7 @@ buildNpmPackage rec {
     makeWrapper
     electron
     pkg-config
-  ] ++ lib.optional stdenv.isLinux autoPatchelfHook; # for onnx libs
+  ] ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook; # for onnx libs
 
   buildInputs = [
     (lib.getLib stdenv.cc.cc) # for libstdc++.so, required by onnxruntime

--- a/pkgs/by-name/co/conserve/package.nix
+++ b/pkgs/by-name/co/conserve/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-IP9x3n5RdI+TKOhMBWEfw9P2CROcC0SmEsmMVaXjiDE=";
 
-  buildInputs = lib.optionals (stdenv.isDarwin) [
+  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin) [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/by-name/co/copycat/package.nix
+++ b/pkgs/by-name/co/copycat/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-oNX1MUpOjRG02FHOU7zpktLAYKu/1+R2d96jC/VA0co=";
 
-  buildInputs = lib.optionals (stdenv.isDarwin) [
+  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin) [
     darwin.apple_sdk_11_0.frameworks.AppKit
   ];
 

--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
       bison
       libsrs2
     ]
-    ++ lib.optionals stdenv.isLinux [ libcap ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap ]
     ++ lib.optionals (enableHttp || enableCalalarmd || enableJMAP) [
       brotli.dev
       libical.dev
@@ -130,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
           cyrus_sasl
         ]
         # Darwin doesn't have libuuid, try to build without it
-        ++ lib.optional (!stdenv.isDarwin) libuuid;
+        ++ lib.optional (!stdenv.hostPlatform.isDarwin) libuuid;
       imapLibs = managesieveLibs ++ [ pcre2 ];
       mkLibsString = lib.strings.concatMapStringsSep " " (l: "-L${lib.getLib l}/lib");
     in

--- a/pkgs/by-name/du/dut/package.nix
+++ b/pkgs/by-name/du/dut/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = {
     platforms = lib.platforms.all;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     description = "A disk usage calculator for Linux";
     homepage = "https://codeberg.org/201984/dut";
     license = lib.licenses.gpl3;

--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -62,7 +62,7 @@ buildGoModule {
 
   passthru = {
     # only works on linux, see comment above about ENTE_CLI_SECRETS_PATH on darwin
-    tests.version = lib.optionalAttrs stdenv.isLinux (
+    tests.version = lib.optionalAttrs stdenv.hostPlatform.isLinux (
       testers.testVersion {
         package = ente-cli;
         command = ''

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -7,7 +7,10 @@
 let
   arch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
   release =
-    if stdenv.hostPlatform.isDarwin then "macos-${arch}-apple-darwin" else "linux-${arch}-unknown-linux-gnu";
+    if stdenv.hostPlatform.isDarwin then
+      "macos-${arch}-apple-darwin"
+    else
+      "linux-${arch}-unknown-linux-gnu";
 
   hashes = {
     linux-aarch64-unknown-linux-gnu = "sha256-vWMrq/uFU/uyuDnsxZK0ZyvtraVCZwvGjzO1a5QjR8g=";

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -5,9 +5,9 @@
   autoPatchelfHook,
 }:
 let
-  arch = if stdenv.isAarch64 then "aarch64" else "x86_64";
+  arch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
   release =
-    if stdenv.isDarwin then "macos-${arch}-apple-darwin" else "linux-${arch}-unknown-linux-gnu";
+    if stdenv.hostPlatform.isDarwin then "macos-${arch}-apple-darwin" else "linux-${arch}-unknown-linux-gnu";
 
   hashes = {
     linux-aarch64-unknown-linux-gnu = "sha256-vWMrq/uFU/uyuDnsxZK0ZyvtraVCZwvGjzO1a5QjR8g=";

--- a/pkgs/by-name/ex/exo/package.nix
+++ b/pkgs/by-name/ex/exo/package.nix
@@ -63,7 +63,7 @@ python3Packages.buildPythonApplication {
   ];
 
   # Tests require `mlx` which is not supported on linux.
-  doCheck = stdenv.isDarwin;
+  doCheck = stdenv.hostPlatform.isDarwin;
 
   passthru = {
     updateScript = unstableGitUpdater {

--- a/pkgs/by-name/fi/fido2-manage/package.nix
+++ b/pkgs/by-name/fi/fido2-manage/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       pkg-config
       cmake
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       copyDesktopItems
       imagemagick
     ];
@@ -60,12 +60,12 @@ stdenv.mkDerivation rec {
       openssl
       zlib
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       xterm
       udev
       pcsclite
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       libuv
       libsolv
       libcouchbase
@@ -80,23 +80,23 @@ stdenv.mkDerivation rec {
       substituteInPlace ./src/libfido2.pc.in \
         --replace-fail "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@"
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace ./CMakeLists.txt \
         --replace-fail "/\''${CMAKE_INSTALL_LIBDIR}" "/lib"
     '';
 
   postInstall =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       install $src/fido2-manage.sh $out/bin/fido2-manage
       magick ${icon} -background none -gravity center -extent 512x512 token2.png
       install -Dm444 token2.png $out/share/icons/hicolor/512x512/apps/token2.png
       install $src/gui.py $out/bin/fido2-manage-gui
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install $src/fido2-manage-mac.sh $out/bin/fido2-manage
     '';
 
-  desktopItems = lib.optionals stdenv.isLinux [
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem rec {
       desktopName = "Fido2 Manager";
       name = "fido2-manage";
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
         --replace-fail "./fido2-manage.sh" "fido2-manage" \
         --replace-fail "awk" "${gawk}/bin/awk"
     ''
-    + lib.optionalString stdenv.isLinux ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace $out/bin/fido2-manage-gui \
         --replace-fail "./fido2-manage.sh" "$out/bin/fido2-manage" \
         --replace-fail "x-terminal-emulator" "${xterm}/bin/xterm" \
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
 
       sed -i '1i #!${pythonEnv.interpreter}' $out/bin/fido2-manage-gui
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace $out/bin/fido2-manage \
         --replace-fail "ggrep" "${gnugrep}/bin/grep"
     '';

--- a/pkgs/by-name/ga/gapcast/package.nix
+++ b/pkgs/by-name/ga/gapcast/package.nix
@@ -37,6 +37,6 @@ buildGoModule rec {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "gapcast";
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/gm/gmt/package.nix
+++ b/pkgs/by-name/gm/gmt/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_CFLAGS_COMPILE =
       lib.optionalString stdenv.cc.isClang "-Wno-implicit-function-declaration "
       + lib.optionalString (
-        stdenv.isDarwin
+        stdenv.hostPlatform.isDarwin
         && lib.versionOlder (darwin.apple_sdk.MacOSX-SDK.version or darwin.apple_sdk.sdk.version) "13.3"
       ) "-D__LAPACK_int=int";
   };
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
       gshhg-gmt
     ]
     ++ (
-      if stdenv.isDarwin then
+      if stdenv.hostPlatform.isDarwin then
         with darwin.apple_sdk.frameworks;
         [
           Accelerate
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "GMT_INSTALL_MODULE_LINKS" false)
       (lib.cmakeFeature "LICENSE_RESTRICTED" "LGPL")
     ]
-    ++ (lib.optionals (!stdenv.isDarwin) [
+    ++ (lib.optionals (!stdenv.hostPlatform.isDarwin) [
       (lib.cmakeFeature "FFTW3_ROOT" "${fftwSinglePrec.dev}")
       (lib.cmakeFeature "LAPACK_LIBRARY" "${lib.getLib lapack}/lib/liblapack.so")
       (lib.cmakeFeature "BLAS_LIBRARY" "${lib.getLib blas}/lib/libblas.so")

--- a/pkgs/by-name/go/gomanagedocker/package.nix
+++ b/pkgs/by-name/go/gomanagedocker/package.nix
@@ -23,8 +23,8 @@ buildGoModule {
   vendorHash = "sha256-M/jfQWCBrv7hZm450yLBmcjWtNSCziKOpfipxI6U9ak=";
 
   buildInputs =
-    lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
-    ++ lib.optionals stdenv.isLinux [ xorg.libX11 ];
+    lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ xorg.libX11 ];
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/im/imhex/package.nix
+++ b/pkgs/by-name/im/imhex/package.nix
@@ -39,7 +39,7 @@ let
     let
       baseStdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     in
-    if stdenv.isDarwin then overrideSDK baseStdenv "11.0" else baseStdenv;
+    if stdenv.hostPlatform.isDarwin then overrideSDK baseStdenv "11.0" else baseStdenv;
 
   patterns_src = fetchFromGitHub {
     name = "ImHex-Patterns-source-${patterns_version}";
@@ -75,7 +75,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ];
 
   # Comment out fixup_bundle in PostprocessBundle.cmake as we are not building a standalone application
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace cmake/modules/PostprocessBundle.cmake \
       --replace-fail "fixup_bundle" "#fixup_bundle"
   '';
@@ -89,8 +89,8 @@ stdenv'.mkDerivation (finalAttrs: {
       pkg-config
       rsync
     ]
-    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ]
-    ++ lib.optionals stdenv.isDarwin [ makeWrapper ];
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeWrapper ];
 
   buildInputs = [
     capstone
@@ -105,12 +105,12 @@ stdenv'.mkDerivation (finalAttrs: {
     mbedtls
     nlohmann_json
     yara
-  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk_11_0.frameworks.UniformTypeIdentifiers ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk_11_0.frameworks.UniformTypeIdentifiers ];
 
   # autoPatchelfHook only searches for *.so and *.so.*, and won't find *.hexpluglib
   # however, we will append to RUNPATH ourselves
-  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.isLinux [ "*.hexpluglib" ];
-  appendRunpaths = lib.optionals stdenv.isLinux [
+  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.hostPlatform.isLinux [ "*.hexpluglib" ];
+  appendRunpaths = lib.optionals stdenv.hostPlatform.isLinux [
     (lib.makeLibraryPath [ libGL ])
     "${placeholder "out"}/lib/imhex/plugins"
   ];
@@ -118,7 +118,7 @@ stdenv'.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "IMHEX_OFFLINE_BUILD" true)
     (lib.cmakeBool "IMHEX_COMPRESS_DEBUG_INFO" false) # avoids error: cannot compress debug sections (zstd not enabled)
-    (lib.cmakeBool "IMHEX_GENERATE_PACKAGE" stdenv.isDarwin)
+    (lib.cmakeBool "IMHEX_GENERATE_PACKAGE" stdenv.hostPlatform.isDarwin)
     (lib.cmakeBool "USE_SYSTEM_CAPSTONE" true)
     (lib.cmakeBool "USE_SYSTEM_CURL" true)
     (lib.cmakeBool "USE_SYSTEM_FMT" true)
@@ -129,12 +129,12 @@ stdenv'.mkDerivation (finalAttrs: {
 
   # rsync is used here so we can not copy the _schema.json files
   postInstall =
-    if stdenv.isLinux then
+    if stdenv.hostPlatform.isLinux then
       ''
         mkdir -p $out/share/imhex
         rsync -av --exclude="*_schema.json" ${patterns_src}/{constants,encodings,includes,magic,nodes,patterns} $out/share/imhex
       ''
-    else if stdenv.isDarwin then
+    else if stdenv.hostPlatform.isDarwin then
       ''
         mkdir -p $out/Applications
         mv $out/imhex.app $out/Applications

--- a/pkgs/by-name/im/imhex/package.nix
+++ b/pkgs/by-name/im/imhex/package.nix
@@ -92,20 +92,24 @@ stdenv'.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeWrapper ];
 
-  buildInputs = [
-    capstone
-    curl
-    dbus
-    file
-    fmt
-    glfw3
-    gtk3
-    jansson
-    libGLU
-    mbedtls
-    nlohmann_json
-    yara
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk_11_0.frameworks.UniformTypeIdentifiers ];
+  buildInputs =
+    [
+      capstone
+      curl
+      dbus
+      file
+      fmt
+      glfw3
+      gtk3
+      jansson
+      libGLU
+      mbedtls
+      nlohmann_json
+      yara
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk_11_0.frameworks.UniformTypeIdentifiers
+    ];
 
   # autoPatchelfHook only searches for *.so and *.so.*, and won't find *.hexpluglib
   # however, we will append to RUNPATH ourselves

--- a/pkgs/by-name/in/intelli-shell/package.nix
+++ b/pkgs/by-name/in/intelli-shell/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     openssl
     sqlite
     zlib
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -45,20 +45,20 @@ buildNpmPackage rec {
       zip
       makeWrapper
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       wayland-scanner
       copyDesktopItems
     ];
 
   buildInputs =
-    lib.optionals stdenv.isLinux [
+    lib.optionals stdenv.hostPlatform.isLinux [
       libxkbcommon
       libX11
       libXtst
       libXi
       wayland
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_11
     ];
 
@@ -69,7 +69,7 @@ buildNpmPackage rec {
     # use our own node headers since we skip downloading them
     NIX_CFLAGS_COMPILE = "-I${nodejs}/include/node";
     # disable code signing on Darwin
-    CSC_IDENTITY_AUTO_DISCOVERY = lib.optionalString stdenv.isDarwin "false";
+    CSC_IDENTITY_AUTO_DISCOVERY = lib.optionalString stdenv.hostPlatform.isDarwin "false";
   };
 
   postConfigure = ''
@@ -103,7 +103,7 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
-    ${lib.optionalString stdenv.isLinux ''
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/kando
       cp -r out/*/{locales,resources{,.pak}} $out/share/kando
 
@@ -115,7 +115,7 @@ buildNpmPackage rec {
           --inherit-argv0
     ''}
 
-    ${lib.optionalString stdenv.isDarwin ''
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications
       cp -r out/*/Kando.app $out/Applications
       makeWrapper $out/Applications/Kando.app/Contents/MacOS/Kando $out/bin/kando

--- a/pkgs/by-name/kt/kty/package.nix
+++ b/pkgs/by-name/kt/kty/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
     [
       openssl
     ]
-    ++ lib.optionals stdenv.isDarwin (
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk;
       [
         frameworks.SystemConfiguration

--- a/pkgs/by-name/ku/kubetui/package.nix
+++ b/pkgs/by-name/ku/kubetui/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=workers::kube::store::tests::kubeconfigからstateを生成"
   ];
 
-  buildInputs = lib.optionals (stdenv.isDarwin) (
+  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin) (
     with darwin.apple_sdk;
     [
       frameworks.CoreGraphics

--- a/pkgs/by-name/la/LAStools/package.nix
+++ b/pkgs/by-name/la/LAStools/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     "format"
   ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-Wno-narrowing";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isAarch64 "-Wno-narrowing";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/li/lilv/package.nix
+++ b/pkgs/by-name/li/lilv/package.nix
@@ -37,12 +37,12 @@ stdenv.mkDerivation rec {
     (lib.mesonEnable "tests" (!stdenv.hostPlatform.isStatic))
   ] # Add nix and NixOS specific lv2 paths
     # The default values are from: https://github.com/lv2/lilv/blob/master/src/lilv_config.h
-    ++ lib.optional stdenv.isDarwin  (lib.mesonOption "default_lv2_path"
+    ++ lib.optional stdenv.hostPlatform.isDarwin  (lib.mesonOption "default_lv2_path"
       "~/.lv2:~/Library/Audio/Plug-Ins/LV2:"
       + "/usr/local/lib/lv2:/usr/lib/lv2:"
       + "/Library/Audio/Plug-Ins/LV2:"
       + "~/.nix-profile/lib/lv2")
-    ++ lib.optional stdenv.isLinux  (lib.mesonOption "default_lv2_path"
+    ++ lib.optional stdenv.hostPlatform.isLinux  (lib.mesonOption "default_lv2_path"
       "~/.lv2:/usr/local/lib/lv2:/usr/lib/lv2:"
       + "~/.nix-profile/lib/lv2:/run/current-system/sw/lib/lv2");
 

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
   # Stop build scripts from searching global include paths
   LSOF_INCLUDE = "${lib.getDev stdenv.cc.libc}/include";
   configurePhase = let genericFlags = "LSOF_CC=$CC LSOF_AR=\"$AR cr\" LSOF_RANLIB=$RANLIB";
-    linuxFlags = lib.optionalString stdenv.isLinux "LINUX_CONF_CC=$CC_FOR_BUILD";
-    freebsdFlags = lib.optionalString stdenv.isFreeBSD "FREEBSD_SYS=${freebsd.sys.src}/sys";
+    linuxFlags = lib.optionalString stdenv.hostPlatform.isLinux "LINUX_CONF_CC=$CC_FOR_BUILD";
+    freebsdFlags = lib.optionalString stdenv.hostPlatform.isFreeBSD "FREEBSD_SYS=${freebsd.sys.src}/sys";
     in "${genericFlags} ${linuxFlags} ${freebsdFlags} ./Configure -n ${dialect}";
 
   preBuild = ''

--- a/pkgs/by-name/lu/luaformatter/package.nix
+++ b/pkgs/by-name/lu/luaformatter/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    stdenv.isDarwin && stdenv.isx86_64
+    stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
   ) "-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION=1";
 
   meta = with lib; {

--- a/pkgs/by-name/ma/matrix-authentication-service/package.nix
+++ b/pkgs/by-name/ma/matrix-authentication-service/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     npmHooks.npmConfigHook
     nodejs
     (python3.withPackages (ps: [ ps.setuptools ])) # Used by gyp
-  ] ++ lib.optional stdenv.isDarwin cctools; # libtool used by gyp;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin cctools; # libtool used by gyp;
 
   buildInputs =
     [

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm.configHook
     makeWrapper
     python3
-  ] ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild.xcrun ];
 
   # https://nixos.org/manual/nixpkgs/unstable/#javascript-pnpm
   pnpmDeps = pnpm.fetchDeps {

--- a/pkgs/by-name/mk/mkuimage/package.nix
+++ b/pkgs/by-name/mk/mkuimage/package.nix
@@ -35,7 +35,7 @@ buildGoModule {
   # Notice that due to some legacy/bug in buildGoModule, the build isn't
   # failing even the tests are, as we get a false-positive the output
   # filtering: https://github.com/NixOS/nixpkgs/issues/349468
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isLinux;
 
   # The tests want to copy /bin/bash and /bin/ls, but we don't have those.
   # As these are interesting e2e tests to check if things work, we substitute

--- a/pkgs/by-name/nc/nchat/package.nix
+++ b/pkgs/by-name/nc/nchat/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       sqlite
       zlib
     ]
-    ++ lib.optionals stdenv.isDarwin (
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk.frameworks;
       [
         AppKit

--- a/pkgs/by-name/nc/ncmpcpp/package.nix
+++ b/pkgs/by-name/nc/ncmpcpp/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     ''
       ./autogen.sh
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # std::result_of was removed in c++20 and unusable for clang16
       substituteInPlace ./configure \
         --replace-fail "std=c++20" "std=c++17"

--- a/pkgs/by-name/ni/nix-serve/package.nix
+++ b/pkgs/by-name/ni/nix-serve/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.eelco ];
     license = licenses.lgpl21;
     # See https://github.com/edolstra/nix-serve/issues/57
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     platforms = nix.meta.platforms;
     mainProgram = "nix-serve";
   };

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -62,6 +62,6 @@ rustPlatform.buildRustPackage rec {
       atemu
     ];
     # Failing tests on Darwin.
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/op/openvi/package.nix
+++ b/pkgs/by-name/op/openvi/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses
     perl
-  ] ++ lib.optionals stdenv.isDarwin [ apple-sdk_11 ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_11 ];
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/by-name/ot/otel-desktop-viewer/package.nix
+++ b/pkgs/by-name/ot/otel-desktop-viewer/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  buildInputs = lib.optional stdenv.isDarwin apple-sdk_12;
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin apple-sdk_12;
 
   passthru.tests.version = testers.testVersion {
     inherit version;

--- a/pkgs/by-name/pa/packetry/package.nix
+++ b/pkgs/by-name/pa/packetry/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
       gtk4
       pango
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_11
     ];
 

--- a/pkgs/by-name/pd/pdfarranger/package.nix
+++ b/pkgs/by-name/pd/pdfarranger/package.nix
@@ -22,9 +22,9 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-94qziqJaKW8/L/6+U1yojxdG8BmeAStn+qbfGemTrVA=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ] ++ lib.optionals stdenv.isDarwin [ gettext ];
+  nativeBuildInputs = [ wrapGAppsHook3 ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ gettext ];
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     LINTL="${lib.getLib gettext}/lib/libintl.8.dylib"
     substituteInPlace pdfarranger/pdfarranger.py --replace-fail \
       "return 'libintl.8.dylib'" \

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   inherit version pname;
 
   src =
-    if stdenv.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.dmg";
         hash = "sha256-5Ym42InDgFLGdZk0LYV1H0eC5WzmsYToG1KLdiGgTto=";

--- a/pkgs/by-name/q2/q2pro/package.nix
+++ b/pkgs/by-name/q2/q2pro/package.nix
@@ -21,8 +21,8 @@
   wayland-scanner,
   makeWrapper,
   versionCheckHook,
-  x11Support ? stdenv.isLinux,
-  waylandSupport ? stdenv.isLinux,
+  x11Support ? stdenv.hostPlatform.isLinux,
+  waylandSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     (lib.mesonBool "variable-fps" true)
     (lib.mesonEnable "wayland" waylandSupport)
     (lib.mesonEnable "x11" x11Support)
-    (lib.mesonEnable "icmp-errors" stdenv.isLinux)
+    (lib.mesonEnable "icmp-errors" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "windows-crash-dumps" false)
   ];
 

--- a/pkgs/by-name/ra/rainfrog/package.nix
+++ b/pkgs/by-name/ra/rainfrog/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-L0gXxV/3+5oRV/Ipm4sRqr9dh9AEChWhtILO3PaNxYY=";
 
-  buildInputs = lib.optionals stdenv.isDarwin (
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin (
     with darwin.apple_sdk.frameworks;
     [
       AppKit

--- a/pkgs/by-name/rq/rqbit/package.nix
+++ b/pkgs/by-name/rq/rqbit/package.nix
@@ -47,13 +47,13 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-esDUzzVm5J8fKftBfk5StJzN1YzLa1p0t7BsoxzrowI=";
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     pkg-config
   ];
 
   buildInputs =
-    lib.optionals stdenv.isLinux [ openssl ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
+    lib.optionals stdenv.hostPlatform.isLinux [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   preConfigure = ''
     mkdir -p crates/librqbit/webui/dist

--- a/pkgs/by-name/sa/sasquatch/package.nix
+++ b/pkgs/by-name/sa/sasquatch/package.nix
@@ -23,7 +23,7 @@ let
       hash = "sha256-0itva+j5WMKvueiUaO253UQ1S6W29xgtFvV4i3yvMtU=";
     };
 
-    patches = lib.optional stdenv.isDarwin ./darwin.patch;
+    patches = lib.optional stdenv.hostPlatform.isDarwin ./darwin.patch;
 
     strictDeps = true;
     nativeBuildInputs = [ which ];

--- a/pkgs/by-name/sc/scopehal-apps/package.nix
+++ b/pkgs/by-name/sc/scopehal-apps/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
       shaderc
       spirv-tools
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       wrapGAppsHook4
     ];
 
@@ -66,13 +66,13 @@ stdenv.mkDerivation {
       yaml-cpp
       zstd
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       ffts
       gtkmm3
       libtirpc
     ]
     ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_11
       (darwinMinVersionHook "10.15")
       moltenvk
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
       --replace-fail '"/share/' '"/../share/'
   '';
 
-  cmakeFlags = lib.optionals stdenv.isDarwin [
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "-DCMAKE_INSTALL_RPATH=${lib.strings.makeLibraryPath [ vulkan-loader ]}"
   ];
 

--- a/pkgs/by-name/si/sioyek/package.nix
+++ b/pkgs/by-name/si/sioyek/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall =
-    if stdenv.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       ''
         cp -r pdf_viewer/shaders sioyek.app/Contents/MacOS/shaders
         cp pdf_viewer/{prefs,prefs_user,keys,key_user}.config tutorial.pdf sioyek.app/Contents/MacOS/

--- a/pkgs/by-name/sn/snakemake/package.nix
+++ b/pkgs/by-name/sn/snakemake/package.nix
@@ -121,7 +121,7 @@ python3Packages.buildPythonApplication rec {
       "test_output_file_cache_storage"
       "test_storage"
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Unclear failure:
       # AssertionError: expected successful execution
       # `__darwinAllowLocalNetworking` doesn't help

--- a/pkgs/by-name/sq/sql-studio/package.nix
+++ b/pkgs/by-name/sq/sql-studio/package.nix
@@ -42,6 +42,6 @@ rustPlatform.buildRustPackage {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.frectonz ];
     platforms = lib.platforms.all;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     rust-jemalloc-sys
-  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.CoreServices ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.CoreServices ];
 
   # Patch the tests to find the binary
   postPatch = ''

--- a/pkgs/by-name/st/styluslabs-write/package.nix
+++ b/pkgs/by-name/st/styluslabs-write/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
       atemu
     ];
     platforms = with lib.platforms; linux ++ darwin ++ windows;
-    broken = !stdenv.isLinux;
+    broken = !stdenv.hostPlatform.isLinux;
     mainProgram = "Write";
   };
 })

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     [
       openssl
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.SystemConfiguration
     ];

--- a/pkgs/by-name/te/termscp/package.nix
+++ b/pkgs/by-name/te/termscp/package.nix
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage rec {
       "--skip=cli::remote::test::test_should_make_remote_args_from_two_bookmarks_and_local_dir"
       "--skip=cli::remote::test::test_should_make_remote_args_from_two_remotes_and_local_dir"
     ]
-    ++ lib.optionals stdenvNoCC.isDarwin [
+    ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
       "--skip=system::watcher::test::should_poll_file_removed"
       "--skip=system::watcher::test::should_poll_file_update"
     ];

--- a/pkgs/by-name/ve/veryl/package.nix
+++ b/pkgs/by-name/ve/veryl/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     [
       dbus
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.CoreFoundation
       darwin.apple_sdk.frameworks.CoreServices
       darwin.apple_sdk.frameworks.Security

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
       llvmPackages.libcxx
       llvmPackages.libunwind
     ]
-    ++ lib.optionals (stdenv.isLinux) [
+    ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       musl # not used, but requires extra work to remove
       xorg.libX11 # for the clipboardy package
     ];
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
       nodejs
       pnpm_9.configHook
     ]
-    ++ lib.optionals (stdenv.isLinux) [
+    ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       autoPatchelfHook
     ];
 

--- a/pkgs/by-name/x4/x4/package.nix
+++ b/pkgs/by-name/x4/x4/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
       openssl
       zlib
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
     ];
 

--- a/pkgs/by-name/zv/zvbi/package.nix
+++ b/pkgs/by-name/zv/zvbi/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     validatePkgConfig
   ];
 
-  buildInputs = lib.optional stdenv.isDarwin libiconv;
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
   outputs = [
     "out"

--- a/pkgs/development/compilers/elm/packages/node/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node/node-composition.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ../../../../node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -58,7 +58,7 @@ in stdenv.mkDerivation {
   patchPhase = ''
     sed -i '/^PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
     echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
-  '' + lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Locate standard headers like <unistd.h>
     substituteInPlace base/runtime/config/gen-posix-names.sh \
       --replace "\$SDK_PATH/usr" "${Libsystem}"

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -356,7 +356,7 @@ let
       swift-driver
       swift-system
       swift-tools-support-core
-    ] ++ lib.optionals stdenv.isDarwin [ (darwinMinVersionHook "10.15.4") ];
+    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ (darwinMinVersionHook "10.15.4") ];
 
     cmakeFlags = [
       "-DUSE_CMAKE_INSTALL=ON"
@@ -386,7 +386,7 @@ in stdenv.mkDerivation (commonAttrs // {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       CryptoKit
       LocalAuthentication
-  ] ++ lib.optionals stdenv.isDarwin [ (darwinMinVersionHook "10.15.4") ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ (darwinMinVersionHook "10.15.4") ];
 
   configurePhase = generated.configure + ''
     # Functionality provided by Xcode XCTest, but not available in

--- a/pkgs/development/interpreters/gauche/boot.nix
+++ b/pkgs/development/interpreters/gauche/boot.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       mbedtls
       cacert
     ]
-    ++ lib.optionals (stdenv.isDarwin) [
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       darwin.apple_sdk_11_0.frameworks.CoreServices
     ];
 

--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
-  ] ++ lib.optionals stdenv.isDarwin [ (lib.cmakeBool "CAPSTONE_BUILD_MACOS_THIN" true) ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ (lib.cmakeBool "CAPSTONE_BUILD_MACOS_THIN" true) ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/librasterlite2/default.nix
+++ b/pkgs/development/libraries/librasterlite2/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     proj
     sqlite
     zstd
-  ] ++ lib.optional stdenv.isDarwin ApplicationServices;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin ApplicationServices;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/physics/geant4/default.nix
+++ b/pkgs/development/libraries/physics/geant4/default.nix
@@ -4,7 +4,7 @@
 , enableQt             ? enableQT
 , enableXM             ? false
 , libGLX
-, enableOpenGLX11      ? !stdenv.isDarwin
+, enableOpenGLX11      ? !stdenv.hostPlatform.isDarwin
 , enablePython         ? false
 , enableRaytracerX11   ? false
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: ({
       [ libinput ]
       ++ lib.optional withGtk3 gtk3
     )
-    ++ lib.optional stdenv.isDarwin darwinVersionInputs
+    ++ lib.optional stdenv.hostPlatform.isDarwin darwinVersionInputs
     ++ lib.optional developerBuild gdb
     ++ lib.optional (cups != null) cups
     ++ lib.optional (mysqlSupport) libmysqlclient

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -28,7 +28,7 @@ mkDerivation (args // {
   buildInputs =
     args.buildInputs or [ ]
     # Per https://doc.qt.io/qt-5/macos.html#supported-versions
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_13
       (darwinMinVersionHook "10.13")
     ];

--- a/pkgs/development/libraries/unicorn/default.nix
+++ b/pkgs/development/libraries/unicorn/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       cmake
       pkg-config
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools
     ];
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -561,7 +561,7 @@ in
   });
 
   neotest  = prev.neotest.overrideAttrs(oa: {
-    doCheck = stdenv.isLinux;
+    doCheck = stdenv.hostPlatform.isLinux;
     nativeCheckInputs = oa.nativeCheckInputs ++ [
       final.nlua final.busted neovim-unwrapped
     ];

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -101,7 +101,7 @@ buildPythonPackage rec {
   ];
 
   # Tests segfault on darwin
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "arviz" ];
 

--- a/pkgs/development/python-modules/berkeleydb/default.nix
+++ b/pkgs/development/python-modules/berkeleydb/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   # Every test currently fails with:
   # berkeleydb.db.DBRunRecoveryError: (-30973, 'BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery -- BDB1546 unable to join the environment')
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   checkPhase = ''
     ${python.interpreter} test.py

--- a/pkgs/development/python-modules/botorch/default.nix
+++ b/pkgs/development/python-modules/botorch/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
       # stuck tests on hydra
       "test_moo_predictive_entropy_search"
     ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.isAarch64) [
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
       # Numerical error slightly above threshold
       # AssertionError: Tensor-likes are not close!
       "test_model_list_gpytorch_model"

--- a/pkgs/development/python-modules/cleanvision/default.nix
+++ b/pkgs/development/python-modules/cleanvision/default.nix
@@ -74,6 +74,6 @@ buildPythonPackage rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     # Fatal Python error: Aborted
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   # Workaround for https://github.com/ethanfurman/dbf/issues/48
-  patches = lib.optional python.stdenv.isDarwin ./darwin.patch;
+  patches = lib.optional python.stdenv.hostPlatform.isDarwin ./darwin.patch;
 
   propagatedBuildInputs = [ aenum ];
 

--- a/pkgs/development/python-modules/hf-transfer/default.nix
+++ b/pkgs/development/python-modules/hf-transfer/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     [
       openssl
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.SystemConfiguration
       libiconv

--- a/pkgs/development/python-modules/jaraco-functools/default.nix
+++ b/pkgs/development/python-modules/jaraco-functools/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   # test is flaky on darwin
-  disabledTests = if stdenv.isDarwin then [ "test_function_throttled" ] else null;
+  disabledTests = if stdenv.hostPlatform.isDarwin then [ "test_function_throttled" ] else null;
 
   pythonNamespaces = [ "jaraco" ];
 

--- a/pkgs/development/python-modules/mss/default.nix
+++ b/pkgs/development/python-modules/mss/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     hash = "sha256-yWpOxzIk2n2yK8B+88+qGPi4aQDRhy4pETu87wCToh4=";
   };
 
-  patches = lib.optionals stdenv.isLinux [
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
     (substituteAll {
       src = ./linux-paths.patch;
       x11 = "${xorg.libX11}/lib/libX11.so";
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isLinux;
 
   nativeCheckInputs = [
     lsof

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -117,7 +117,7 @@ buildPythonPackage rec {
       "test_save"
     ];
 
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # Crashes the interpreter
     "Tests/test_imagetk.py"
   ];

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage {
       polarsMemoryAllocator
       (pkgs.__splicedPackages.zstd or pkgs.zstd)
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.AppKit
       darwin.apple_sdk.frameworks.IOKit
       darwin.apple_sdk.frameworks.Security

--- a/pkgs/development/python-modules/pydantic-extra-types/default.nix
+++ b/pkgs/development/python-modules/pydantic-extra-types/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ];
 
   # PermissionError accessing '/etc/localtime'
-  disabledTestPaths = lib.optionals stdenv.isDarwin [ "tests/test_pendulum_dt.py" ];
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_pendulum_dt.py" ];
 
   meta = with lib; {
     changelog = "https://github.com/pydantic/pydantic-extra-types/blob/${src.rev}/HISTORY.md";

--- a/pkgs/development/python-modules/pyvirtualdisplay/default.nix
+++ b/pkgs/development/python-modules/pyvirtualdisplay/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     hash = "sha256-CXVbw86263JfsH7KVCX0PyNY078I4A0qm3kqGu3RYVk=";
   };
 
-  patches = lib.optionals stdenv.isLinux [
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
     (substituteAll {
       src = ./paths.patch;
       xauth = lib.getExe xorg.xauth;
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isLinux;
 
   nativeCheckInputs = [
     easyprocess

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -98,7 +98,7 @@ beamPackages.mixRelease rec {
             vips
             glib.dev
           ]
-          ++ lib.optionals stdenv.isDarwin [
+          ++ lib.optionals stdenv.hostPlatform.isDarwin [
             darwin.apple_sdk.frameworks.Foundation
             darwin.apple_sdk.frameworks.AppKit
             darwin.apple_sdk.frameworks.Kerberos

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Test requires running Jitsi Videobridge and Jicofo which are Linux-only
-  passthru.tests = lib.optionalAttrs stdenv.isLinux {
+  passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     "--with-working-dir=/var/lib/bacula"
     "--mandir=\${out}/share/man"
   ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes"
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # bacula’s `configure` script fails to detect CoreFoundation correctly,
       # but these symbols are available in the nixpkgs CoreFoundation framework.
       "gt_cv_func_CFLocaleCopyCurrent=yes"

--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   nativeCheckInputs = [ python3 ];
 
-  passthru.tests = lib.optionalAttrs stdenv.isLinux {
+  passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     restic = nixosTests.restic;
   };
 

--- a/pkgs/tools/misc/lighthouse-steamvr/default.nix
+++ b/pkgs/tools/misc/lighthouse-steamvr/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ dbus ] ++ lib.optionals stdenv.isDarwin [ AppKit ];
+  buildInputs = [ dbus ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ AppKit ];
 
   meta = with lib; {
     description = "VR Lighthouse power state management";

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -267,7 +267,7 @@ core-big = stdenv.mkDerivation {
   ''
   # force XeTeX to use fontconfig instead of Core Text, so that fonts can be made available via FONTCONFIG_FILE,
   # by tricking configure into thinking that the relevant test result is already in the config cache
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     export kpse_cv_have_ApplicationServices=no
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9511,7 +9511,7 @@ with pkgs;
 
   gst_all_1 = recurseIntoAttrs (callPackage ../development/libraries/gstreamer {
     callPackage = newScope gst_all_1;
-    stdenv = if stdenv.isDarwin then overrideSDK stdenv "12.3" else stdenv;
+    stdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "12.3" else stdenv;
     inherit (darwin.apple_sdk_12_3.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL Security SystemConfiguration VideoToolbox;
     inherit (darwin.apple_sdk_12_3.libs) xpc;
   });
@@ -10490,7 +10490,7 @@ with pkgs;
     else callPackage ../development/libraries/ncurses {
       # ncurses is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
       stdenv =
-        if stdenv.isDarwin then
+        if stdenv.hostPlatform.isDarwin then
           darwin.bootstrapStdenv
         else
           stdenv;


### PR DESCRIPTION
Commands ran:
```
fd --type f "\.nix" | xargs sd --fixed-strings "stdenv.is" "stdenv.hostPlatform.is"
fd --type f "\.nix" | xargs sd --fixed-strings "stdenv'.is" "stdenv'.hostPlatform.is"
fd --type f "\.nix" | xargs sd --fixed-strings "clangStdenv.is" "clangStdenv.hostPlatform.is"
fd --type f "\.nix" | xargs sd --fixed-strings "gccStdenv.is" "gccStdenv.hostPlatform.is"
fd --type f "\.nix" | xargs sd --fixed-strings "stdenvNoCC.is" "stdenvNoCC.hostPlatform.is"
fd --type f "\.nix" | xargs sd --fixed-strings "inherit (stdenv) is" "inherit (stdenv.hostPlatform) is"
fd --type f "\.nix" | xargs sd  "buildStdenv.is" "buildStdenv.hostPlatform.is"
fd --type f "\.nix" | xargs sd  "effectiveStdenv.is" "effectiveStdenv.hostPlatform.is"
fd --type f "\.nix" | xargs sd  "originalStdenv.is" "originalStdenv.hostPlatform.is"
```

Following https://github.com/NixOS/nixpkgs/pull/341407

~`stdenv.isLinux` -> `stdenv.hostPlatform.isLinux`, is pretty much easy expansion of alias. This should cause no rebuilds.~

~However some packages have stdenv.isLinux in `doCheck`, meaning package tests have to be run when building in linux. So instead of `hostPlatform` there use `buildPlatform` there. This could cause some rebuilds.~

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
