### PR TITLE
systemd: 256.7 -> 256.8

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -185,7 +185,7 @@ assert withBootloader -> withEfi;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "256.7";
+  version = "256.8";
 
   # Use the command below to update `releaseTimestamp` on every (major) version
   # change. More details in the commentary at mesonFlags.
@@ -203,7 +203,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "systemd";
     repo = "systemd";
     rev = "v${version}";
-    hash = "sha256-x214fOhEWLoiexRrN4lGx4Pqx2+jYN94w9GzntVRcZ4=";
+    hash = "sha256-L/MCsCCMVvK7LgxlaLFpnmsJuTu33cPaiMxIpHU7Tzg=";
   };
 
   # On major changes, or when otherwise required, you *must* :


### PR DESCRIPTION
# Changes
https://github.com/systemd/systemd/compare/v256.7...v256.8

# Tests
The switchTest, systemd-journal, and systemd-journal-upload tests all pass. The systemd-journal-gateway test is already broken due to https://github.com/NixOS/nixpkgs/pull/297870.