### PR TITLE
nixos/hypridle: make systemd user service only run under Hyprland

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -870,6 +870,8 @@
 - `services.localtimed.enable = true` will now set `time.timeZone = null`.
   This is to avoid silently shadowing a user's explicitly defined timezone without recognition on the user's part.
 
+- `services.hypridle` will only start if `XDG_CURRENT_DESKTOP=Hyprland` is detected.
+
 - `qgis` and `qgis-ltr` are now built without `grass` by default. `grass` support can be enabled with `qgis.override { withGrass = true; }`.
 
 - `virtualisation.incus` module gained new `incus-user.service` and `incus-user.socket` systemd units. It is now possible to add a user to `incus` group instead of `incus-admin` for increased security.

--- a/nixos/modules/services/wayland/hypridle.nix
+++ b/nixos/modules/services/wayland/hypridle.nix
@@ -19,12 +19,15 @@ in
 
     systemd = {
       packages = [ cfg.package ];
-      user.services.hypridle.wantedBy = [ "graphical-session.target" ];
-      user.services.hypridle.path = [
-        config.programs.hyprland.package
-        config.programs.hyprlock.package
-        pkgs.procps
-      ];
+      user.services.hypridle = {
+        wantedBy = [ "graphical-session.target" ];
+        path = [
+          config.programs.hyprland.package
+          config.programs.hyprlock.package
+          pkgs.procps
+        ];
+        unitConfig.ConditionEnvironment = "XDG_CURRENT_DESKTOP=Hyprland";
+      };
     };
   };
 


### PR DESCRIPTION
I have both KDE Plasma 6 and Hyprland enabled on my system, and since the service doesn't have any sort of condition to check the environment, the service also starts under KDE Plasma 6.

The change simply checks that `XDG_CURRENT_DESKTOP`, which is part of the freedesktop desktop entry specification, is set to `Hyprland`, which is done by Hyprland.

- <https://github.com/hyprwm/Hyprland/blob/7affc34ab43c5d5cbf670759b839a9e990d8bbea/src/config/ConfigManager.cpp#L1450>
- <https://github.com/hyprwm/Hyprland/blob/7affc34ab43c5d5cbf670759b839a9e990d8bbea/src/Compositor.cpp#L330>

> If there is a better way to implement some check to have the service only run under Hyprland, or if there is a reason as to why this wouldn't be a good idea or isn't needed, please do say.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
