### PR TITLE
diffpdf: fix homepage path typo in meta

### DIFF
--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -49,7 +49,7 @@ mkDerivation rec {
     '';
 
   meta = {
-    homepage = "http://www.qtrac.eu/diffpdfc.html";
+    homepage = "http://www.qtrac.eu/diffpdf.html";
     description = "Tool for diffing pdf files visually or textually";
     mainProgram = "diffpdf";
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
The file name of the homepage url has either changed or had a typo and is fixed in this PR