### PR TITLE
nixos-rebuild-ng: improve developer experience

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -96,4 +96,10 @@ And use `nixos-rebuild-ng` instead of `nixos-rebuild`.
 - [ ] Improve documentation
 - [ ] `nixos-rebuild repl` (calling old `nixos-rebuild` for now)
 - [ ] `nix` build/bootstrap
-- [ ] Reduce build closure
+- [ ] Generate tab completion via [`shtab`](https://docs.iterative.ai/shtab/)
+- [x] Reduce build closure
+
+## TODON'T
+
+- Reimplement `systemd-run` logic (will be moved to the new
+  [`apply`](https://github.com/NixOS/nixpkgs/pull/344407) script)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -53,6 +53,38 @@ an attempt of the rewrite.
 
 And use `nixos-rebuild-ng` instead of `nixos-rebuild`.
 
+## Development
+
+Run:
+
+```console
+nix-build -A nixos-rebuild-ng.tests.ci
+```
+
+The command above will run the unit tests and linters, and also check if the
+code is formatted. However, sometimes is more convenient to run just a few
+tests to debug, in this case you can run:
+
+```console
+nix-shell -A nixos-rebuild-ng.devShell
+```
+
+The command above should automatically put you inside `src` directory, and you
+can run:
+
+```console
+# run program
+python -m nixos_rebuild
+# run tests
+python -m pytest
+# check types
+mypy .
+# fix lint issues
+ruff check --fix .
+# format code
+ruff format .
+```
+
 ## Current caveats
 
 - For now we will install it in `nixos-rebuild-ng` path by default, to avoid

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -5,20 +5,21 @@
   nix,
   nixos-rebuild,
   python3,
+  python3Packages,
   runCommand,
   withNgSuffix ? true,
 }:
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "nixos-rebuild-ng";
   version = "0.0.0";
   src = ./src;
   pyproject = true;
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     tabulate
   ];
 
@@ -54,7 +55,7 @@ python3.pkgs.buildPythonApplication rec {
       mv $out/bin/nixos-rebuild $out/bin/nixos-rebuild-ng
     '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -7,8 +7,6 @@ import sys
 from subprocess import run
 from typing import assert_never
 
-from tabulate import tabulate
-
 from .models import Action, Flake, NRError, Profile
 from .nix import (
     edit,
@@ -177,6 +175,8 @@ def execute(argv: list[str]) -> None:
             if args.json:
                 print(json.dumps(generations, indent=2))
             else:
+                from tabulate import tabulate
+
                 headers = {
                     "generation": "Generation",
                     "date": "Build-date",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -231,7 +231,3 @@ def main() -> None:
             raise ex
         else:
             sys.exit(str(ex))
-
-
-if __name__ == "__main__":
-    main()

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__main__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -46,9 +46,7 @@ class Action(Enum):
 class Flake:
     path: Path
     attr: str
-    _re: ClassVar[re.Pattern[str]] = re.compile(
-        r"^(?P<path>[^\#]*)\#?(?P<attr>[^\#\"]*)$"
-    )
+    _re: ClassVar = re.compile(r"^(?P<path>[^\#]*)\#?(?P<attr>[^\#\"]*)$")
 
     @override
     def __str__(self) -> str:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -57,11 +57,8 @@ class Flake:
         m = cls._re.match(flake_str)
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
-        if not attr:
-            attr = f"nixosConfigurations.{hostname or "default"}"
-        else:
-            attr = f"nixosConfigurations.{attr}"
-        return Flake(Path(m.group("path")), attr)
+        nixos_attr = f"nixosConfigurations.{attr or hostname or "default"}"
+        return Flake(Path(m.group("path")), nixos_attr)
 
     @classmethod
     def from_arg(cls, flake_arg: Any) -> Flake | None:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Reduce build closure
- Add `nixos-rebuild-ng.devShell` to make it easier to develop
- Add `.version-suffix` update to classic Nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
