### PR TITLE
home-assistant-custom-components.dreame-vacuum: init at 1.0.4, python312Packages.py-mini-racer: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/py-mini-racer/default.nix
+++ b/pkgs/development/python-modules/py-mini-racer/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+}:
+
+buildPythonPackage rec {
+  pname = "py-mini-racer";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "sqreen";
+    repo = "PyMiniRacer";
+    rev = "v${version}";
+    sha256 = "sha256-r6ghH1uPbnM4cruxgcOkHv3HsC29p3fILtH3Mzpy8yQ=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PyMiniRacer is a V8 bridge in Python";
+    homepage = "https://github.com/sqreen/PyMiniRacer";
+    license = licenses.isc;
+    maintainers = with maintainers; [ baksa ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/dreame-vacuum/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/dreame-vacuum/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  python312Packages,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "Tasshack";
+  domain = "dreame_vacuum";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "dreame-vacuum";
+    rev = "v${version}";
+    hash = "sha256-LeKD2dIeC/TsOl3Q2TLFQy7RjzbRwYmvKUUm3JVsz8E=";
+  };
+
+  propagatedBuildInputs = with python312Packages; [
+    pillow
+    numpy
+    pybase64
+    requests
+    pycryptodome
+    python-miio
+    py-mini-racer
+    tzlocal
+    paho-mqtt
+  ];
+
+  meta = with lib; {
+    description = "Home Assistant integration for Dreame robot vacuums with map support";
+    homepage = "https://github.com/Tasshack/dreame-vacuum";
+    changelog = "https://github.com/Tasshack/dreame-vacuum/releases/tag/${version}";
+    maintainers = with maintainers; [ baksa ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11895,6 +11895,8 @@ self: super: with self; {
 
   pymilter = callPackage ../development/python-modules/pymilter { };
 
+  py-mini-racer = callPackage ../development/python-modules/py-mini-racer { };
+
   pymilvus = callPackage ../development/python-modules/pymilvus { };
 
   pymitv = callPackage ../development/python-modules/pymitv { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds dreame-vacuum custom component for controlling Dreame Robots.
Also adds py-mini-racer python library which is required by dreame-vacuum.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
