### PR TITLE
nixos/i18n: add `extraLocales` option

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -344,6 +344,11 @@
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.05-notable-changes}
 
+- `i18n` module improvements:
+  - `i18n.extraLocales` should now be the preferred way to install additional locales.
+  - `i18n.supportedLocales` is now considered an implementation detail and will be hidden from the documentation. But the option will still continue to work.
+  - `i18n.supportedLocales` will now trigger a warning when it omits any locale set in `i18n.defaultLocale`, `i18n.extraLocales` or `i18n.extraLocaleSettings`.
+
 - `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs []{#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed}.
 
 - androidenv has been improved:

--- a/nixos/doc/manual/configuration/profiles/minimal.section.md
+++ b/nixos/doc/manual/configuration/profiles/minimal.section.md
@@ -1,6 +1,6 @@
 # Minimal {#sec-profile-minimal}
 
 This profile defines a small NixOS configuration. It does not contain any
-graphical stuff. It's a very short file that sets [](#opt-i18n.supportedLocales)
+graphical stuff. It's a very short file that sets the supported locales
 to only support the user-selected locale, and
 [disables packages' documentation](#opt-documentation.enable).

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -103,6 +103,29 @@
   ###### implementation
 
   config = {
+    warnings =
+      lib.optional
+        (
+          (lib.subtractLists config.i18n.supportedLocales (
+            builtins.map
+              (l: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] l) + "/UTF-8")
+              (
+                [ config.i18n.defaultLocale ]
+                ++ config.i18n.extraLocales
+                ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
+              )
+          )) != [ ]
+        )
+        ''
+          `i18n.supportedLocales` is deprecated in favor of `i18n.extraLocales`,
+          and it seems you are using `i18n.supportedLocales` and forgot to
+          include some locales specified in `i18n.defaultLocale`,
+          `i18n.extraLocales` or `i18n.extraLocaleSettings`.
+
+          If you're trying to install additional locales not specified in
+          `i18n.defaultLocale` or `i18n.extraLocaleSettings`, consider adding
+          only those locales to `i18n.extraLocales`.
+        '';
 
     environment.systemPackages =
       # We increase the priority a little, so that plain glibc in systemPackages can't win.

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -69,6 +69,7 @@
 
       supportedLocales = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        visible = false;
         default = lib.unique (
           builtins.map
             (l: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] l) + "/UTF-8")
@@ -82,21 +83,6 @@
               ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
             )
         );
-        defaultText = lib.literalExpression ''
-          lib.unique (
-            builtins.map
-              (l: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] l) + "/UTF-8")
-              (
-                [
-                  "C.UTF-8"
-                  "en_US.UTF-8"
-                  config.i18n.defaultLocale
-                ]
-                ++ config.i18n.extraLocales
-                ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
-              )
-          )
-        '';
         example = [
           "en_US.UTF-8/UTF-8"
           "nl_NL.UTF-8/UTF-8"

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -42,6 +42,17 @@
         '';
       };
 
+      extraLocales = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "nl_NL.UTF-8" ];
+        description = ''
+          Additional locales that the system should support, besides the ones
+          configured with {option}`i18n.defaultLocale` and
+          {option}`i18n.extraLocaleSettings`.
+        '';
+      };
+
       extraLocaleSettings = lib.mkOption {
         type = lib.types.attrsOf lib.types.str;
         default = { };
@@ -67,18 +78,24 @@
                 "en_US.UTF-8"
                 config.i18n.defaultLocale
               ]
+              ++ config.i18n.extraLocales
               ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
             )
         );
         defaultText = lib.literalExpression ''
-          lib.unique
-            (builtins.map (l: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] l) + "/UTF-8") (
-              [
-                "C.UTF-8"
-                "en_US.UTF-8"
-                config.i18n.defaultLocale
-              ] ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
-            ))
+          lib.unique (
+            builtins.map
+              (l: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] l) + "/UTF-8")
+              (
+                [
+                  "C.UTF-8"
+                  "en_US.UTF-8"
+                  config.i18n.defaultLocale
+                ]
+                ++ config.i18n.extraLocales
+                ++ (lib.attrValues (lib.filterAttrs (n: v: n != "LANGUAGE") config.i18n.extraLocaleSettings))
+              )
+          )
         '';
         example = [
           "en_US.UTF-8/UTF-8"


### PR DESCRIPTION
This adds a new `i18n.extraLocales` setting for installing additional locales not specified in `i18n.defaultLocale` or `i18n.extraLocaleSettings`. This is useful when you need to run isolated applications that requires a specific locale not used by the rest of the system, for example when running certain Japanese games in a wine prefix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
