### PR TITLE
lib.generators.toPlist: escape XML syntax in strings & keys

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -70,6 +70,7 @@ let
     split
     toJSON
     typeOf
+    escapeXML
     ;
 
   ## -- HELPER FUNCTIONS & DEFAULTS --
@@ -548,13 +549,17 @@ in rec {
 
     # Inputs
 
-    Options
-    : Empty set, there may be configuration options in the future
+    Structured function argument
+
+    : escape (optional, default: `false`)
+      : If this option is true, XML special characters are escaped in string values and keys
 
     Value
       : The value to be converted to Plist
   */
-  toPlist = {}: v: let
+  toPlist = {
+    escape ? false
+  }: v: let
     expr = ind: x:
       if x == null  then "" else
       if isBool x   then bool ind x else
@@ -568,10 +573,12 @@ in rec {
 
     literal = ind: x: ind + x;
 
+    maybeEscapeXML = if escape then escapeXML else x: x;
+
     bool = ind: x: literal ind  (if x then "<true/>" else "<false/>");
     int = ind: x: literal ind "<integer>${toString x}</integer>";
-    str = ind: x: literal ind "<string>${x}</string>";
-    key = ind: x: literal ind "<key>${x}</key>";
+    str = ind: x: literal ind "<string>${maybeEscapeXML x}</string>";
+    key = ind: x: literal ind "<key>${maybeEscapeXML x}</key>";
     float = ind: x: literal ind "<real>${toString x}</real>";
 
     indent = ind: expr "\t${ind}";
@@ -597,7 +604,10 @@ in rec {
       (expr "\t${ind}" value)
     ]) x));
 
-  in ''<?xml version="1.0" encoding="UTF-8"?>
+  in
+  # TODO: As discussed in #356502, deprecated functionality should be removed sometime after 25.11.
+  lib.warnIf (!escape && lib.oldestSupportedReleaseIsAtLeast 2505) "Using `lib.generators.toPlist` without `escape = true` is deprecated"
+  ''<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 ${expr "" v}

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1635,7 +1635,7 @@ runTests {
     expected  = "«foo»";
   };
 
-  testToPlist = {
+  testToPlistUnescaped = {
     expr = mapAttrs (const (generators.toPlist { })) {
       value = {
         nested.values = {
@@ -1651,10 +1651,34 @@ runTests {
           emptylist = [];
           attrs = { foo = null; "foo b/ar" = "baz"; };
           emptyattrs = {};
+          "keys are not <escaped>" = "and < neither are string values";
         };
       };
     };
-    expected = { value = builtins.readFile ./test-to-plist-expected.plist; };
+    expected = { value = builtins.readFile ./test-to-plist-unescaped-expected.plist; };
+  };
+
+  testToPlistEscaped = {
+    expr = mapAttrs (const (generators.toPlist { escape = true; })) {
+      value = {
+        nested.values = {
+          int = 42;
+          float = 0.1337;
+          bool = true;
+          emptystring = "";
+          string = "fn\${o}\"r\\d";
+          newlinestring = "\n";
+          path = /. + "/foo";
+          null_ = null;
+          list = [ 3 4 "test" ];
+          emptylist = [];
+          attrs = { foo = null; "foo b/ar" = "baz"; };
+          emptyattrs = {};
+          "keys are <escaped>" = "and < so are string values";
+        };
+      };
+    };
+    expected = { value = builtins.readFile ./test-to-plist-escaped-expected.plist; };
   };
 
   testToLuaEmptyAttrSet = {

--- a/lib/tests/test-to-plist-escaped-expected.plist
+++ b/lib/tests/test-to-plist-escaped-expected.plist
@@ -27,6 +27,8 @@
 			<real>0.133700</real>
 			<key>int</key>
 			<integer>42</integer>
+			<key>keys are &lt;escaped&gt;</key>
+			<string>and &lt; so are string values</string>
 			<key>list</key>
 			<array>
 				<integer>3</integer>
@@ -39,7 +41,7 @@
 			<key>path</key>
 			<string>/foo</string>
 			<key>string</key>
-			<string>fn${o}"r\d</string>
+			<string>fn${o}&quot;r\d</string>
 		</dict>
 	</dict>
 </dict>

--- a/lib/tests/test-to-plist-unescaped-expected.plist
+++ b/lib/tests/test-to-plist-unescaped-expected.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>nested</key>
+	<dict>
+		<key>values</key>
+		<dict>
+			<key>attrs</key>
+			<dict>
+				<key>foo b/ar</key>
+				<string>baz</string>
+			</dict>
+			<key>bool</key>
+			<true/>
+			<key>emptyattrs</key>
+			<dict>
+
+			</dict>
+			<key>emptylist</key>
+			<array>
+
+			</array>
+			<key>emptystring</key>
+			<string></string>
+			<key>float</key>
+			<real>0.133700</real>
+			<key>int</key>
+			<integer>42</integer>
+			<key>keys are not <escaped></key>
+			<string>and < neither are string values</string>
+			<key>list</key>
+			<array>
+				<integer>3</integer>
+				<integer>4</integer>
+				<string>test</string>
+			</array>
+			<key>newlinestring</key>
+			<string>
+</string>
+			<key>path</key>
+			<string>/foo</string>
+			<key>string</key>
+			<string>fn${o}"r\d</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Before this patch, code like this would break generate invalid XML.

    lib.generators.toPlist {} "ab<cd"

That's obviously bad, since the call to toPlist often happens through indirection, as is the case in e.g. the nix-darwin project.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
