### PR TITLE
python3Packages.sphinx: add graphviz to the check inputs make checks pass

### DIFF
--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -36,6 +36,7 @@
   html5lib,
   pytestCheckHook,
   pytest-xdist,
+  graphviz
 }:
 
 buildPythonPackage rec {
@@ -93,6 +94,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-xdist
     typing-extensions
+    graphviz
   ];
 
   preCheck = ''


### PR DESCRIPTION
Many other packages depend on sphinx and are currently broken/not cached.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).