### PR TITLE
edrawmax{-cn}: init at 14.0.0

### DIFF
--- a/pkgs/applications/graphics/edrawmax/default.nix
+++ b/pkgs/applications/graphics/edrawmax/default.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  cups,
+  e2fsprogs,
+  freetype,
+  gcc-unwrapped,
+  glib,
+  gtk3,
+  krb5,
+  libmysqlclient,
+  libsForQt5,
+  mesa,
+  pango,
+  postgresql,
+  udev,
+  xkeyboardconfig,
+  xorg,
+  useChineseVersion ? false,
+}:
+
+stdenv.mkDerivation {
+  pname = "edrawmax";
+  version = "14.0.0";
+  src = fetchurl {
+    url =
+      if useChineseVersion then
+        "https://cc-download.wondershare.cc/prd/edrawmax_full5374.deb"
+      else
+        "https://download.wondershare.com/prd/edrawmax_full5371.deb";
+    hash =
+      if useChineseVersion then
+        "sha256-s5oQd6KWI3zZmqXWDFVdsZzqycOwj7BIEVd8pCCovL0="
+      else
+        "sha256-mmlCiVNa5ZLoTbOKvakNu2+wF2/CJMzcAFoITI3B0ok=";
+  };
+
+  unpackCmd = "dpkg -x $src .";
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    cups
+    e2fsprogs
+    glib
+    gtk3
+    krb5
+    libsForQt5.qt5.qt3d
+    libsForQt5.qt5.qtbase
+    libsForQt5.qt5.qtgamepad
+    libsForQt5.qt5.qtsensors
+    libsForQt5.qt5.qtserialport
+    libsForQt5.qt5.qttools
+    libsForQt5.qt5.qtwebengine
+    libmysqlclient
+    mesa
+    pango
+    postgresql
+    udev
+    xorg.libxshmfence
+  ];
+
+  dontWrapQtApps = true;
+
+  runtimeDependencies = map lib.getLib ([
+    cups
+    pango
+    freetype
+    gcc-unwrapped.lib
+  ]);
+
+  installPhase = ''
+    runHook preInstall
+    prefix=$out/opt/apps/edrawmax
+    mkdir -p $out
+    cp -r opt $out
+    cp -r usr/* $out
+    makeWrapper $prefix/EdrawMax $out/bin/EdrawMax \
+      --set QT_QPA_PLATFORM "" \
+      --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb"
+    substituteInPlace $out/share/applications/edrawmax.desktop \
+      --replace "sh /opt/apps/edrawmax/edrawmax.sh" $out/bin/EdrawMax
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    patchelf --add-needed libudev.so.1 $out/opt/apps/edrawmax/lib/libcef.so
+    patchelf --replace-needed libmysqlclient.so.18 libmysqlclient.so $out/opt/apps/edrawmax/lib/sqldrivers/libqsqlmysql.so
+    patchelf --add-rpath "${libmysqlclient}/lib/mariadb" $out/opt/apps/edrawmax/lib/sqldrivers/libqsqlmysql.so
+  '';
+
+  meta = {
+    description = "All-in-One Diagram Software";
+    homepage = "https://www.edrawsoft.com/edraw-max/";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ ltrump ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19249,4 +19249,9 @@ with pkgs;
   tree-from-tags = callPackage ../by-name/tr/tree-from-tags/package.nix {
     ruby = ruby_3_1;
   };
+
+  edrawmax = libsForQt5.callPackage ../applications/graphics/edrawmax { };
+  edrawmax-cn = libsForQt5.callPackage ../applications/graphics/edrawmax {
+    useChineseVersion = true;
+  };
 }


### PR DESCRIPTION
All-in-one diagram software like visio.
Homepage: https://www.edrawsoft.com/edraw-max/

Thanks a lot to the maintainers of package `wpsoffice{-cn}`, I referenced a lot from it as there are a lot of similarities in these two packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
