### PR TITLE
siketyan-ghr: init at 0.4.4

### DIFF
--- a/pkgs/by-name/si/siketyan-ghr/package.nix
+++ b/pkgs/by-name/si/siketyan-ghr/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  libgit2,
+  openssl,
+  stdenv,
+  zlib,
+  zstd,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ghr";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "siketyan";
+    repo = "ghr";
+    rev = "v${version}";
+    hash = "sha256-L9+rcdt+MGZSCOJyCE4t/TT6Fjtxvfr9LBJYyRrx208=";
+  };
+
+  cargoHash = "sha256-HBVMDR+3UB+zWmvZXBph36bajTOAnvVGTGYooJtk9Zg=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+    zstd
+  ];
+
+  postInstall =
+    let
+      ghr = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/ghr";
+    in
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      installShellCompletion --cmd ghr \
+        --bash <(${ghr} shell --completion bash) \
+        --fish <(${ghr} shell --completion fish)
+    '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  meta = with lib; {
+    description = "Yet another repository management with auto-attaching profiles";
+    homepage = "https://github.com/siketyan/ghr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sei40kr ];
+    mainProgram = "ghr";
+  };
+}


### PR DESCRIPTION
Yet another repository management with auto-attaching profiles.
https://github.com/siketyan/ghr

> [ghq](https://github.com/x-motemen/ghq) is the most famous solution to resolve stress of our repository management currently. However, I wanted to customise the git configuration by some rules, such as using my company email in their repositories.
> 
> To achieve that, ghq was not enough for me. So I have rewritten them as simple, in Rust, the robust and modern language today.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
