### PR TITLE
stdenv/linux: apply default compiler errors from GCC 14

### DIFF
--- a/pkgs/development/compilers/gcc/patches/13/backport-wdeclaration-missing-parameter-type.patch
+++ b/pkgs/development/compilers/gcc/patches/13/backport-wdeclaration-missing-parameter-type.patch
@@ -1,0 +1,37 @@
+Backport `-Wdeclaration-missing-parameter-type`
+
+As a default warning option rather than a `permerror`.
+
+Original author: Florian Weimer <fweimer@redhat.com>
+Original commit: ff9efa3fc48baa1dee7ed376c25ecfcfbc28d35c
+
+diff --git a/gcc/c/c-decl.cc b/gcc/c/c-decl.cc
+index 7dcb1141bf..ef86d5bf35 100644
+--- a/gcc/c/c-decl.cc
++++ b/gcc/c/c-decl.cc
+@@ -8215,7 +8215,9 @@
+     {
+       if (!funcdef_flag)
+ 	{
+-	  pedwarn (input_location, 0, "parameter names (without types) in "
++	  pedwarn (input_location,
++		   OPT_Wdeclaration_missing_parameter_type,
++		   "parameter names (without types) in "
+ 		   "function declaration");
+ 	  arg_info->parms = NULL_TREE;
+ 	}
+diff --git a/gcc/c-family/c.opt b/gcc/c-family/c.opt
+index 0e0c98f5e0..98affb1152 100644
+--- a/gcc/c-family/c.opt
++++ b/gcc/c-family/c.opt
+@@ -571,6 +571,10 @@
+ C ObjC Var(warn_declaration_after_statement) Init(-1) Warning
+ Warn when a declaration is found after a statement.
+ 
++Wdeclaration-missing-parameter-type
++C ObjC Var(warn_declaration_missing_parameter) Warning Init(1)
++Warn for missing parameter types in function declarations.
++
+ Wdelete-incomplete
+ C++ ObjC++ Var(warn_delete_incomplete) Init(1) Warning
+ Warn when deleting a pointer to incomplete type.

--- a/pkgs/development/compilers/gcc/patches/13/backport-wreturn-mismatch.patch
+++ b/pkgs/development/compilers/gcc/patches/13/backport-wreturn-mismatch.patch
@@ -1,0 +1,361 @@
+Backport `-Wreturn-mismatch`
+
+Disabled by default.
+
+Original author: Florian Weimer <fweimer@redhat.com>
+Original commit: 6e312b2b864bf923a9d772429f014375bf9dabc8
+
+diff --git a/gcc/c/c-typeck.cc b/gcc/c/c-typeck.cc
+index a17879698e..ffaf3688ec 100644
+--- a/gcc/c/c-typeck.cc
++++ b/gcc/c/c-typeck.cc
+@@ -11293,17 +11293,11 @@
+       if ((warn_return_type >= 0 || flag_isoc99)
+ 	  && valtype != NULL_TREE && TREE_CODE (valtype) != VOID_TYPE)
+ 	{
+-	  bool warned_here;
+-	  if (flag_isoc99)
+-	    warned_here = pedwarn
+-	      (loc, warn_return_type >= 0 ? OPT_Wreturn_type : 0,
+-	       "%<return%> with no value, in function returning non-void");
+-	  else
+-	    warned_here = warning_at
+-	      (loc, OPT_Wreturn_type,
+-	       "%<return%> with no value, in function returning non-void");
+ 	  no_warning = true;
+-	  if (warned_here)
++	  if (emit_diagnostic (flag_isoc99 ? DK_PEDWARN : DK_WARNING,
++			       loc, OPT_Wreturn_mismatch,
++			       "%<return%> with no value,"
++			       " in function returning non-void"))
+ 	    inform (DECL_SOURCE_LOCATION (current_function_decl),
+ 		    "declared here");
+ 	}
+@@ -11314,7 +11308,7 @@
+       bool warned_here;
+       if (TREE_CODE (TREE_TYPE (retval)) != VOID_TYPE)
+ 	warned_here = pedwarn
+-	  (xloc, warn_return_type >= 0 ? OPT_Wreturn_type : 0,
++	  (xloc, OPT_Wreturn_mismatch,
+ 	   "%<return%> with a value, in function returning void");
+       else
+ 	warned_here = pedwarn
+diff --git a/gcc/c-family/c.opt b/gcc/c-family/c.opt
+index a75038930a..0e0c98f5e0 100644
+--- a/gcc/c-family/c.opt
++++ b/gcc/c-family/c.opt
+@@ -1238,6 +1238,10 @@
+ C++ ObjC++ Var(warn_reorder) Warning LangEnabledBy(C++ ObjC++,Wall)
+ Warn when the compiler reorders code.
+ 
++Wreturn-mismatch
++C ObjC Var(warn_return_mismatch) Warning Init(-1)
++Warn whenever void-returning functions return a non-void expressions, or a return expression is missing in a function not returning void.
++
+ Wreturn-type
+ C ObjC C++ ObjC++ Var(warn_return_type) Warning LangEnabledBy(C ObjC C++ ObjC++,Wall) Init(-1)
+ Warn whenever a function's return type defaults to \"int\" (C), or about inconsistent return types (C++).
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-1.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-1.c
+new file mode 100644
+index 0000000000..3bad847ecf
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-1.c
+@@ -1,0 +1,40 @@
++/* { dg-do compile } */
++/* { dg-options "" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++}
++
++static inline int
++f3 (void)
++{
++  f1 ();
++}
++
++void
++f4 (void)
++{
++  return 1; /* { dg-warning "'return' with a value\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 (); /* { dg-bogus "ISO C" } */
++}
++
++int
++f6 (void)
++{
++  return; /* { dg-warning "'return' with no value\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++}
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-2.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-2.c
+new file mode 100644
+index 0000000000..49eb5a5a95
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-2.c
+@@ -1,0 +1,41 @@
++/* { dg-do compile } */
++/* { dg-options "-Wall" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++} /* { dg-warning "control reaches end of non-void\[^\n\r\]*-Wreturn-type" } */
++
++static inline int
++f3 (void)
++{
++  f1 ();
++} /* { dg-warning "no return statement in function\[^\n\r\]*-Wreturn-type" } */
++
++void
++f4 (void)
++{
++  return 1; /* { dg-warning "with a value,\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 ();
++}
++
++int
++f6 (void)
++{
++  return; /* { dg-warning "with no value,\[^\n\r\]*Wreturn-mismatch" } */
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++} /* { dg-warning "control reaches end of non-void\[^\n\r\]*-Wreturn-type" } */
++
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-3.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-3.c
+new file mode 100644
+index 0000000000..ee77ec6a76
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-3.c
+@@ -1,0 +1,40 @@
++/* { dg-do compile } */
++/* { dg-options "-pedantic-errors" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++}
++
++static inline int
++f3 (void)
++{
++  f1 ();
++}
++
++void
++f4 (void)
++{
++  return 1; /* { dg-error "with a value,\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 (); /* { dg-error "with expression, in function\[^\n\r\]*-Wpedantic" } */
++}
++
++int
++f6 (void)
++{
++  return; /* { dg-error "with no value,\[^\n\r\]*Wreturn-mismatch" }  */
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++}
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-4.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-4.c
+new file mode 100644
+index 0000000000..f73e8a05dc
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-4.c
+@@ -1,0 +1,40 @@
++/* { dg-do compile } */
++/* { dg-options "-std=gnu89" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++}
++
++static inline int
++f3 (void)
++{
++  f1 ();
++}
++
++void
++f4 (void)
++{
++  return 1; /* { dg-warning "with a value,\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 ();
++}
++
++int
++f6 (void)
++{
++  return; /* { dg-bogus "with no value" }  */
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++}
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-5.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-5.c
+new file mode 100644
+index 0000000000..f2fd3294b7
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-5.c
+@@ -1,0 +1,40 @@
++/* { dg-do compile } */
++/* { dg-options "-std=gnu89 -pedantic-errors" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++}
++
++static inline int
++f3 (void)
++{
++  f1 ();
++}
++
++void
++f4 (void)
++{
++  return 1; /* { dg-error "with a value,\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 (); /* { dg-error "with expression\[^\n\r\]*-Wpedantic" } */
++}
++
++int
++f6 (void)
++{
++  return;
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++}
+diff --git a/gcc/testsuite/gcc.dg/Wreturn-mismatch-6.c b/gcc/testsuite/gcc.dg/Wreturn-mismatch-6.c
+new file mode 100644
+index 0000000000..51543fb714
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wreturn-mismatch-6.c
+@@ -1,0 +1,40 @@
++/* { dg-do compile } */
++/* { dg-options "-std=c90 -pedantic-errors -Wreturn-type" } */
++
++void f1 (void);
++
++int
++f2 (void)
++{
++  f1 ();
++} /* { dg-warning "control reaches end of non-void\[^\n\r\]*-Wreturn-type" } */
++
++static __inline__ int
++f3 (void)
++{
++  f1 ();
++} /* { dg-warning "no return statement in function\[^\n\r\]*-Wreturn-type" } */
++
++void
++f4 (void)
++{
++  return 1; /* { dg-error "with a value,\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++void
++f5 (void)
++{
++  return f1 (); /* { dg-error "with expression\[^\n\r\]*-Wpedantic" } */
++}
++
++int
++f6 (void)
++{
++  return; /* { dg-warning "'return' with no value\[^\n\r\]*-Wreturn-mismatch" } */
++}
++
++int
++f7 (void)
++{
++  return f1 (); /* { dg-error "void value not ignored as it ought to be" } */
++} /* { dg-warning "control reaches end of non-void\[^\n\r\]*-Wreturn-type" } */
+diff --git a/gcc/testsuite/gcc.dg/noncompile/pr55976-1.c b/gcc/testsuite/gcc.dg/noncompile/pr55976-1.c
+index d078990bd8..d348b03ad9 100644
+--- a/gcc/testsuite/gcc.dg/noncompile/pr55976-1.c
++++ b/gcc/testsuite/gcc.dg/noncompile/pr55976-1.c
+@@ -1,6 +1,6 @@
+ /* PR c/55976 */
+ /* { dg-do compile } */
+-/* { dg-options "-Werror=return-type" } */
++/* { dg-options "-Werror=return-mismatch" } */
+ /* { dg-prune-output "some warnings being treated as errors" } */
+ 
+ /* Verify warnings for return type become errors.  */
+diff --git a/gcc/testsuite/gcc.dg/noncompile/pr55976-2.c b/gcc/testsuite/gcc.dg/noncompile/pr55976-2.c
+index 0e493d0e8a..d6f07a9572 100644
+--- a/gcc/testsuite/gcc.dg/noncompile/pr55976-2.c
++++ b/gcc/testsuite/gcc.dg/noncompile/pr55976-2.c
+@@ -1,8 +1,8 @@
+ /* PR c/55976 */
+ /* { dg-do compile } */
+-/* { dg-options "-Wno-return-type" } */
++/* { dg-options "-Wno-return-mismatch" } */
+ 
+-/* Verify that -Wno-return-type turns off warnings about function return
++/* Verify that -Wno-return-mismatch turns off warnings about function return
+    type.  */
+ 
+ void t () { return 1; } /* normally generates function returning void */

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -54,6 +54,12 @@ in
 ## 1. Patches relevant to gcc>=12 on every platform ####################################
 
 []
+++ optionals is13 [
+  # Backport GCC 14 warnings to GCC 13.
+  # TODO: Remove these before 25.05.
+  ./13/backport-wreturn-mismatch.patch
+  ./13/backport-wdeclaration-missing-parameter-type.patch
+]
 ++ optional (!atLeast12) ./fix-bug-80431.patch
 ++ optional (targetPlatform != hostPlatform) ./libstdc++-target.patch
 ++ optionals (noSysDirs) (

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -573,6 +573,17 @@ in
         inherit lib;
         inherit (self) stdenvNoCC coreutils gnugrep runtimeShell;
         fortify-headers = self.fortify-headers;
+        # In preparation for GCC 14 becoming the default,
+        # backport the new default errors to GCC 13.
+        # TODO: Remove these before 25.05.
+        nixSupport.cc-cflags = lib.optionals (lib.versionAtLeast prevStage.gcc-unwrapped.version "13") [
+          "-Werror=implicit-int"
+          "-Werror=implicit-function-declaration"
+          "-Werror=declaration-missing-parameter-type"
+          "-Werror=return-mismatch"
+          "-Werror=int-conversion"
+          "-Werror=incompatible-pointer-types"
+        ];
       };
     };
     extraNativeBuildInputs = [


### PR DESCRIPTION
Let’s make sure both OSes get an adequate amount of compiler fun this cycle! This is a version of alyssais’s <https://github.com/NixOS/nixpkgs/pull/344239> that applies to the Linux standard environment’s compiler wrapping rather than the versioned GCC packages themselves.

This is purely a transition mechanism to help us prepare for the GCC 14 update while GCC 14 itself is not yet ready for wide deployment; it will be reverted before 25.05, whether because it becomes obsolete thanks to an upgrade to GCC 14 or because we give up on GCC 14 and deicde to stick with GCC 13 with the vanilla flags.

This approach means that the standard `gcc` will be wrapped correctly, unlike with the previous PR, achieving the primary goal of the change, but `gcc13` will remain as it was before. Currently, I believe the difference between the two is just bootstrapping stage stuff; it’s a bit weird to me to diverge, especially since there is a definition of `gcc` in `all-packages.nix` that looks like it ought to make them equivalent, but it may have the nice property that we can pin especially stubborn packages to GCC 13 without them getting the errors (though I am not sure if this is actually true or not, since I’m not sure how `gcc13Stdenv` actually works).

One downside is that this only applies to Linux, but since this is essentially meant to be a forcing function to get us to deal with the errors early, that seems fine.

Source: https://gcc.gnu.org/gcc-14/porting_to.html

I’ve bootstrapped an earlier version of this but will compile again with the current commits tomorrow.

cc @trofi for review of my sloppily‐modified GCC patches :) I hope `Init(-1)` rather than `Init(0)` is correct!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
