### PR TITLE
containerd: 1.7.23 -> 2.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -35,6 +35,10 @@
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)
   for more information.
 
+- `containerd` has been updated to v2, which contains breaking changes. See the [containerd
+  2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for more
+  details.
+
 - the notmuch vim plugin now lives in a separate output of the `notmuch`
   package. Installing `notmuch` will not bring the notmuch vim package anymore,
   add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the

--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -67,7 +67,7 @@ in
     systemd.services.containerd = {
       description = "containerd - container runtime";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network.target" "local-fs.target" "dbus.service" ];
       path = with pkgs; [
         containerd
         runc

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -53,6 +53,9 @@ rec {
       pname = "docker-containerd";
       inherit version;
 
+      # We only need binaries
+      outputs = [ "out" ];
+
       src = fetchFromGitHub {
         owner = "containerd";
         repo = "containerd";
@@ -62,6 +65,9 @@ rec {
 
       buildInputs = oldAttrs.buildInputs
         ++ lib.optionals withSeccomp [ libseccomp ];
+
+      # See above
+      installTargets = "install";
     });
 
     docker-tini = tini.overrideAttrs {

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -86,6 +86,7 @@ buildGoModule rec {
       offline
       vdemeester
     ];
+    mainProgram = "containerd";
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -8,6 +8,7 @@
   nix-update-script,
   nixosTests,
   util-linux,
+  btrfsSupport ? btrfs-progs != null,
 }:
 
 buildGoModule rec {
@@ -32,9 +33,9 @@ buildGoModule rec {
     util-linux
   ];
 
-  buildInputs = [ btrfs-progs ];
+  buildInputs = lib.optional btrfsSupport btrfs-progs;
 
-  tags = lib.optionals (btrfs-progs == null) [ "no_btrfs" ];
+  tags = lib.optional (!btrfsSupport) "no_btrfs";
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "containerd";
-  version = "1.7.23";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
     rev = "v${version}";
-    hash = "sha256-vuOefU1cZr1pKCYHKyDBx/ohghgPlXhK3a38PQKH0pc=";
+    hash = "sha256-DFAP+zjBYP2SpyD8KXGvI3i/PUZ6d4jdzGyFfr1lzj4=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   go-md2man,
   kubernetes,
+  nix-update-script,
   nixosTests,
   util-linux,
 }:
@@ -61,9 +62,13 @@ buildGoModule rec {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) docker;
-  } // kubernetes.tests;
+  passthru = {
+    tests = {
+      inherit (nixosTests) docker;
+    } // kubernetes.tests;
+
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Daemon to control runC";

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -16,13 +16,15 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-DFAP+zjBYP2SpyD8KXGvI3i/PUZ6d4jdzGyFfr1lzj4=";
   };
 
   postPatch = "patchShebangs .";
 
   vendorHash = null;
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     go-md2man
@@ -63,15 +65,15 @@ buildGoModule rec {
     inherit (nixosTests) docker;
   } // kubernetes.tests;
 
-  meta = with lib; {
-    changelog = "https://github.com/containerd/containerd/releases/tag/${src.rev}";
-    homepage = "https://containerd.io/";
+  meta = {
     description = "Daemon to control runC";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    homepage = "https://containerd.io/";
+    changelog = "https://github.com/containerd/containerd/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       offline
       vdemeester
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, fetchFromGitHub
-, buildGoModule
-, btrfs-progs
-, go-md2man
-, installShellFiles
-, util-linux
-, nixosTests
-, kubernetes
+{
+  lib,
+  btrfs-progs,
+  buildGoModule,
+  fetchFromGitHub,
+  go-md2man,
+  installShellFiles,
+  kubernetes,
+  nixosTests,
+  util-linux,
 }:
 
 buildGoModule rec {
@@ -22,7 +23,11 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  nativeBuildInputs = [ go-md2man installShellFiles util-linux ];
+  nativeBuildInputs = [
+    go-md2man
+    installShellFiles
+    util-linux
+  ];
 
   buildInputs = [ btrfs-progs ];
 
@@ -43,14 +48,19 @@ buildGoModule rec {
     runHook postInstall
   '';
 
-  passthru.tests = { inherit (nixosTests) docker; } // kubernetes.tests;
+  passthru.tests = {
+    inherit (nixosTests) docker;
+  } // kubernetes.tests;
 
   meta = with lib; {
     changelog = "https://github.com/containerd/containerd/releases/tag/${src.rev}";
     homepage = "https://containerd.io/";
     description = "Daemon to control runC";
     license = licenses.asl20;
-    maintainers = with maintainers; [ offline vdemeester ];
+    maintainers = with maintainers; [
+      offline
+      vdemeester
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  pkgsCross,
   btrfs-progs,
   buildGoModule,
   fetchFromGitHub,
@@ -69,9 +70,18 @@ buildGoModule rec {
   '';
 
   passthru = {
-    tests = {
-      inherit (nixosTests) docker;
-    } // kubernetes.tests;
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux (
+      {
+        cross =
+          let
+            systemString = if stdenv.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform";
+          in
+          pkgsCross.${systemString}.containerd;
+
+        inherit (nixosTests) docker;
+      }
+      // kubernetes.tests
+    );
 
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   btrfs-progs,
   buildGoModule,
   fetchFromGitHub,
@@ -9,6 +10,7 @@
   nixosTests,
   util-linux,
   btrfsSupport ? btrfs-progs != null,
+  withMan ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 buildGoModule rec {
@@ -18,8 +20,7 @@ buildGoModule rec {
   outputs = [
     "out"
     "doc"
-    "man"
-  ];
+  ] ++ lib.optional withMan "man";
 
   src = fetchFromGitHub {
     owner = "containerd";
@@ -35,9 +36,8 @@ buildGoModule rec {
   strictDeps = true;
 
   nativeBuildInputs = [
-    go-md2man
     util-linux
-  ];
+  ] ++ lib.optional withMan go-md2man;
 
   buildInputs = lib.optional btrfsSupport btrfs-progs;
 
@@ -54,8 +54,7 @@ buildGoModule rec {
   installTargets = [
     "install"
     "install-doc"
-    "install-man"
-  ];
+  ] ++ lib.optional withMan "install-man";
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -15,6 +15,12 @@ buildGoModule rec {
   pname = "containerd";
   version = "2.0.0";
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -85,6 +85,7 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [
       offline
       vdemeester
+      getchoo
     ];
     mainProgram = "containerd";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Closes #356474

Diff: https://github.com/containerd/containerd/compare/v1.7.23...v2.0.0

Changelog: https://github.com/containerd/containerd/releases/tag/v2.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
