### PR TITLE
ocamlPackages.luv: fix clang build

### DIFF
--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -15,6 +15,12 @@ buildDunePackage rec {
     sha256 = "sha256-dp9qCIYqSdROIAQ+Jw73F3vMe7hnkDe8BgZWImNMVsA=";
   };
 
+  patches = [
+    # backport of patch to fix incompatible pointer type. remove next update
+    # https://github.com/aantron/luv/commit/ad7f953fccb8732fe4eb9018556e8d4f82abf8f2
+    ./incompatible-pointer-type-fix.diff
+  ];
+
   postConfigure = ''
     for f in src/c/vendor/configure/{ltmain.sh,configure}; do
       substituteInPlace "$f" --replace /usr/bin/file file

--- a/pkgs/development/ocaml-modules/luv/incompatible-pointer-type-fix.diff
+++ b/pkgs/development/ocaml-modules/luv/incompatible-pointer-type-fix.diff
@@ -1,0 +1,87 @@
+addapted from https://github.com/aantron/luv/commit/ad7f953fccb8732fe4eb9018556e8d4f82abf8f2
+diff --git a/src/c/helpers.c b/src/c/helpers.c
+index 7fcd8b6..bc1b926 100755
+--- a/src/c/helpers.c
++++ b/src/c/helpers.c
+@@ -175,7 +175,8 @@ static void luv_getaddrinfo_trampoline(
+ }
+ 
+ static void luv_getnameinfo_trampoline(
+-    uv_getnameinfo_t *c_request, int status, char *hostname, char *service)
++    uv_getnameinfo_t *c_request, int status, const char *hostname,
++    const char *service)
+ {
+     caml_acquire_runtime_system();
+     value callback;
+@@ -407,7 +408,7 @@ uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline()
+     return luv_getaddrinfo_trampoline;
+ }
+ 
+-luv_getnameinfo_cb luv_get_getnameinfo_trampoline()
++uv_getnameinfo_cb luv_get_getnameinfo_trampoline()
+ {
+     return luv_getnameinfo_trampoline;
+ }
+@@ -613,15 +614,6 @@ int luv_fs_poll_start(
+     return uv_fs_poll_start(handle, (uv_fs_poll_cb)poll_cb, path, interval);
+ }
+ 
+-int luv_getnameinfo(
+-    uv_loop_t *loop, uv_getnameinfo_t *req, luv_getnameinfo_cb getnameinfo_cb,
+-    const struct sockaddr *addr, int flags)
+-{
+-    return
+-        uv_getnameinfo(
+-            loop, req, (uv_getnameinfo_cb)getnameinfo_cb, addr, flags);
+-}
+-
+ int luv_read_start(
+     uv_stream_t *stream, uv_alloc_cb alloc_cb, luv_read_cb read_cb)
+ {
+diff --git a/src/c/helpers.h b/src/c/helpers.h
+index f73e32f..2cc1200 100755
+--- a/src/c/helpers.h
++++ b/src/c/helpers.h
+@@ -55,9 +55,6 @@ typedef void (*luv_fs_event_cb)(
+ typedef void (*luv_fs_poll_cb)(
+     uv_fs_poll_t *handle, int status, uv_stat_t *prev, uv_stat_t *curr);
+ 
+-typedef void (*luv_getnameinfo_cb)(
+-    uv_getnameinfo_t *req, int status, char *hostname, char *service);
+-
+ typedef void (*luv_read_cb)(uv_stream_t *stream, ssize_t nread, uv_buf_t *buf);
+ 
+ typedef void (*luv_udp_recv_cb)(
+@@ -78,7 +75,7 @@ uv_fs_cb luv_null_fs_callback_pointer();
+ luv_fs_event_cb luv_get_fs_event_trampoline();
+ luv_fs_poll_cb luv_get_fs_poll_trampoline();
+ uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline();
+-luv_getnameinfo_cb luv_get_getnameinfo_trampoline();
++uv_getnameinfo_cb luv_get_getnameinfo_trampoline();
+ uv_idle_cb luv_get_idle_trampoline();
+ luv_once_cb luv_get_once_trampoline();
+ uv_poll_cb luv_get_poll_trampoline();
+@@ -173,10 +170,6 @@ int luv_fs_poll_start(
+     uv_fs_poll_t *handle, luv_fs_poll_cb poll_cb, const char *path,
+     unsigned int interval);
+ 
+-int luv_getnameinfo(
+-    uv_loop_t *loop, uv_getnameinfo_t *req, luv_getnameinfo_cb getnameinfo_cb,
+-    const struct sockaddr *addr, int flags);
+-
+ int luv_read_start(
+     uv_stream_t *stream, uv_alloc_cb alloc_cb, luv_read_cb read_cb);
+ 
+diff --git a/src/c/luv_c_function_descriptions.ml b/src/c/luv_c_function_descriptions.ml
+index 684a46b..7ac1421 100755
+--- a/src/c/luv_c_function_descriptions.ml
++++ b/src/c/luv_c_function_descriptions.ml
+@@ -1336,7 +1336,7 @@ struct
+           (void @-> returning trampoline)
+ 
+       let getnameinfo =
+-        foreign "luv_getnameinfo"
++        foreign "uv_getnameinfo"
+           (ptr Loop.t @->
+            ptr t @->
+            trampoline @->


### PR DESCRIPTION
<em>needs back port label added</em>

clang build fails with an incompatible pointer type error. Backport a patch from 0.5.14 which fixes this. Can not just update to 0.5.14 as it contains breaking changes and breaks most of luv's consumers.

https://github.com/aantron/luv/commit/ad7f953fccb8732fe4eb9018556e8d4f82abf8f2

https://hydra.nixos.org/build/278533735
ZHF: https://github.com/NixOS/nixpkgs/issues/352882
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
