### PR TITLE
haskellPackages: cleanup overrides after linked pulls made it to hackage

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -19,8 +19,8 @@ in
 with haskellLib;
 
 self: super: {
-  # enable list-transformer, jailbreaking is necessary until next release >0.13.0: https://github.com/ivanperez-keera/dunai/issues/427
-  dunai = doJailbreak (addBuildDepend self.list-transformer (enableCabalFlag "list-transformer" super.dunai));
+  # https://github.com/ivanperez-keera/dunai/issues/427
+  dunai = addBuildDepend self.list-transformer (enableCabalFlag "list-transformer" super.dunai);
 
   # Make sure that Cabal_* can be built as-is
   Cabal_3_10_3_0 = doDistribute (super.Cabal_3_10_3_0.override {
@@ -238,13 +238,7 @@ self: super: {
   # currently, cabal-plan seems to get not much maintenance
   cabal-plan = doJailbreak super.cabal-plan;
 
-  # test dependency has incorrect upper bound but still supports the newer dependency
-  # https://github.com/fused-effects/fused-effects/issues/451
-  # https://github.com/fused-effects/fused-effects/pull/452
-  fused-effects = doJailbreak super.fused-effects;
-
   # support for transformers >= 0.6
-  fused-effects-random = doJailbreak super.fused-effects-random;
   fused-effects-readline = doJailbreak super.fused-effects-readline;
 
   leveldb-haskell = overrideCabal (drv: {
@@ -882,9 +876,6 @@ self: super: {
   # https://github.com/nomeata/tasty-expected-failure/issues/21
   tasty-expected-failure = dontCheck super.tasty-expected-failure;
 
-  # Waiting on https://github.com/RaphaelJ/friday/pull/36
-  friday = doJailbreak super.friday;
-
   # Won't compile with recent versions of QuickCheck.
   inilist = dontCheck super.inilist;
 
@@ -1233,9 +1224,6 @@ self: super: {
   # dontCheck can be removed on the next package set bump
   vulkan-utils = dontCheck (addExtraLibrary pkgs.vulkan-headers super.vulkan-utils);
 
-  # https://github.com/dmwit/encoding/pull/3
-  encoding = doJailbreak (appendPatch ./patches/encoding-Cabal-2.0.patch super.encoding);
-
   # Work around overspecified constraint on github ==0.18.
   github-backup = doJailbreak super.github-backup;
 
@@ -1341,10 +1329,6 @@ self: super: {
     (dontCheckIf (!pkgs.postgresql.doCheck))
   ];
 
-  # Requires pqueue <1.5 but it works fine with pqueue-1.5.0.0
-  # https://github.com/haskell-beam/beam/pull/705
-  beam-migrate = doJailbreak super.beam-migrate;
-
   users-postgresql-simple = addTestToolDepends [
     pkgs.postgresql
     pkgs.postgresqlTestHook
@@ -1428,10 +1412,6 @@ self: super: {
 
   # https://github.com/erikd/hjsmin/issues/32
   hjsmin = dontCheck super.hjsmin;
-
-  # too strict bounds on text in the test suite
-  # https://github.com/audreyt/string-qq/pull/3
-  string-qq = doJailbreak super.string-qq;
 
   # Remove for hail > 0.2.0.0
   hail = overrideCabal (drv: {
@@ -1895,10 +1875,6 @@ self: super: {
 
   hercules-ci-agent = self.generateOptparseApplicativeCompletions [ "hercules-ci-agent" ] super.hercules-ci-agent;
 
-  # Test suite doesn't compile with aeson 2.0
-  # https://github.com/hercules-ci/hercules-ci-agent/pull/387
-  hercules-ci-api-agent = dontCheck super.hercules-ci-api-agent;
-
   hercules-ci-cli = lib.pipe super.hercules-ci-cli [
     unmarkBroken
     (overrideCabal (drv: { hydraPlatforms = super.hercules-ci-cli.meta.platforms; }))
@@ -1913,9 +1889,6 @@ self: super: {
     relative = "pipes-aeson";
     sha256 = "sha256-kFV6CcwKdMq+qSgyc+eIApnaycq5A++pEEVr2A9xvts=";
   }) super.pipes-aeson;
-
-  # 2024-09-18: transformers <0.6  https://github.com/Gabriella439/Haskell-Pipes-Extras-Library/pull/19
-  pipes-extras = assert super.pipes-extras.version == "1.0.15"; doJailbreak super.pipes-extras;
 
   moto-postgresql = appendPatches [
     # https://gitlab.com/k0001/moto/-/merge_requests/3
@@ -2038,10 +2011,6 @@ self: super: {
   #   https://github.com/noinia/hgeometry/commit/a6abecb1ce4a7fd96b25cc1a5c65cd4257ecde7a#commitcomment-49282301
   hgeometry-combinatorial = dontCheck (doJailbreak super.hgeometry-combinatorial);
 
-  # Too strict version bounds on ansi-terminal
-  # https://github.com/kowainik/co-log/pull/218
-  co-log = doJailbreak super.co-log;
-
   # Test suite has a too strict bound on base
   # https://github.com/jswebtools/language-ecmascript/pull/88
   # Test suite doesn't compile anymore
@@ -2069,16 +2038,13 @@ self: super: {
   # Need https://github.com/obsidiansystems/cli-extras/pull/12 and more
   cli-extras = doJailbreak super.cli-extras;
 
-  cli-git = lib.pipe super.cli-git [
-    doJailbreak
-    (addBuildTool pkgs.git)
-  ];
+  cli-git = addBuildTool pkgs.git super.cli-git;
 
   # Need https://github.com/obsidiansystems/cli-nix/pull/5 and more
   cli-nix = addBuildTools [
     pkgs.nix
     pkgs.nix-prefetch-git
-  ] (doJailbreak super.cli-nix);
+  ] super.cli-nix;
 
   nix-thunk = doJailbreak super.nix-thunk;
 
@@ -2404,8 +2370,6 @@ self: super: {
   # Invalid CPP in test suite: https://github.com/cdornan/memory-cd/issues/1
   memory-cd = dontCheck super.memory-cd;
 
-  # https://github.com/haskell/fgl/pull/99
-  fgl = doJailbreak super.fgl;
   fgl-arbitrary = doJailbreak super.fgl-arbitrary;
 
   # raaz-0.3 onwards uses backpack and it does not play nicely with
@@ -2478,9 +2442,6 @@ self: super: {
   # 2023-07-18: https://github.com/srid/ema/issues/156
   ema = doJailbreak super.ema;
 
-  # 2024-03-02: base <=4.18.0.0  https://github.com/srid/url-slug/pull/2
-  url-slug = doJailbreak super.url-slug;
-
   glirc = super.glirc.override {
     vty = self.vty_6_2;
     vty-unix = super.vty-unix.override {
@@ -2527,7 +2488,6 @@ self: super: {
   system-fileio = doJailbreak (dontCheck super.system-fileio);
 
   # Bounds too strict on base and ghc-prim: https://github.com/tibbe/ekg-core/pull/43 (merged); waiting on hackage release
-  ekg-core = assert super.ekg-core.version == "0.1.1.7"; doJailbreak super.ekg-core;
   hasura-ekg-core = doJailbreak super.hasura-ekg-core;
 
   # Test suite doesn't support hspec 2.8
@@ -2749,7 +2709,6 @@ self: super: {
 
   heist-extra = doJailbreak super.heist-extra;  # base <4.18.0.0.0
   unionmount = doJailbreak super.unionmount;  # base <4.18
-  path-tree = doJailbreak super.path-tree;  # base <4.18  https://github.com/srid/pathtree/pull/1
   tailwind = doJailbreak super.tailwind;  # base <=4.17.0.0
   tagtree = doJailbreak super.tagtree;  # base <=4.17  https://github.com/srid/tagtree/issues/1
   commonmark-wikilink = doJailbreak super.commonmark-wikilink; # base <4.18.0.0.0
@@ -2825,18 +2784,6 @@ self: super: {
   swagger2 = doJailbreak super.swagger2;
 
   html-charset = dontCheck super.html-charset;
-
-  # true-name-0.1.0.4 has been tagged, but has not been released to Hackage.
-  # Also, beyond 0.1.0.4 an additional patch is required to make true-name
-  # compatible with current versions of template-haskell
-  # https://github.com/liyang/true-name/pull/4
-  true-name = appendPatch (fetchpatch {
-    url = "https://github.com/liyang/true-name/compare/0.1.0.3...nuttycom:true-name:update_template_haskell.patch";
-    hash = "sha256-ZMBXGGc2X5AKXYbqgkLXkg5BhEwyj022E37sUEWahtc=";
-  }) (overrideCabal (drv: {
-    revision = null;
-    editedCabalFile = null;
-  }) super.true-name);
 
   # 2024-08-15: primitive >=0.9 && <0.10
   posix-api = doJailbreak super.posix-api;
@@ -2986,10 +2933,6 @@ self: super: {
   # https://github.com/isovector/type-errors/issues/9
   type-errors = dontCheck super.type-errors;
 
-  # 2024-05-15: Hackage distribution is missing files needed for tests
-  # https://github.com/isovector/cornelis/issues/150
-  cornelis = dontCheck super.cornelis;
-
   lzma = doJailbreak (super.lzma.overrideScope (self: super: {
     tasty = super.tasty_1_5_2;
   }));
@@ -3012,9 +2955,6 @@ self: super: {
   # 2024-07-09: zinza has bumped their QuickCheck and tasty dependencies beyond stackage lts.
   # Can possibly be removed once QuickCheck >= 2.15 and tasty >= 1.5
   zinza = dontCheck super.zinza;
-
-  # Doesn't officially support hedgehog > 1.3 yet: https://github.com/coot/free-algebras/pull/33
-  free-algebras = doJailbreak super.free-algebras;
 
   pdftotext = overrideCabal (drv: {
       postPatch = ''

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1533,7 +1533,6 @@ broken-packages:
   - enchant # failure in job https://hydra.nixos.org/build/233196992 at 2023-09-02
   - Encode # failure in job https://hydra.nixos.org/build/252712962 at 2024-03-16
   - encode-string # failure in job https://hydra.nixos.org/build/233251833 at 2023-09-02
-  - encoding # failure in job https://hydra.nixos.org/build/233216476 at 2023-09-02
   - encoding-io # failure in job https://hydra.nixos.org/build/233208714 at 2023-09-02
   - encryptable # failure in job https://hydra.nixos.org/build/233215911 at 2023-09-02
   - endo # failure in job https://hydra.nixos.org/build/233222561 at 2023-09-02
@@ -6236,7 +6235,6 @@ broken-packages:
   - trivia # failure in job https://hydra.nixos.org/build/233234176 at 2023-09-02
   - tropical # failure in job https://hydra.nixos.org/build/233212835 at 2023-09-02
   - tropical-geometry # failure in job https://hydra.nixos.org/build/234465815 at 2023-09-13
-  - true-name # failure in job https://hydra.nixos.org/build/252712188 at 2024-03-16
   - trust-chain # failure in job https://hydra.nixos.org/build/233252622 at 2023-09-02
   - tsession # failure in job https://hydra.nixos.org/build/233259005 at 2023-09-02
   - tslib # failure in job https://hydra.nixos.org/build/233225813 at 2023-09-02


### PR DESCRIPTION
All build both under 9.6 and 9.8 - can test easily with
```
$ NIXPKGS_ALLOW_BROKEN=1 nix-build --keep-going -E 'with (import ./. {}).haskell.packages.ghc96; [beam-migrate cli-git cli-nix co-log cornelis ekg-core encoding fgl free-algebras fused-effects fused-effects-random hercules-ci-api-agent path-tree pipes-extras string-qq true-name url-slug]'
```
`NIXPKGS_ALLOW_BROKEN=1` since `regenerate-haskell-packages.sh` is currently borked.

I wrote a little bash snippet with some `grep` and `sed` that'd grab everything shaped like a github pull url and curl the API to see whether it was closed so I could have a list of worth-trying removals rather than brute-force.

Turns out this was almost useless because many PRs are merged (sometimes years ago) but not propagated to hackage.
Another thing I noticed is that most remaining overrides with an yet unmerged PR in comment are for unmaintained repos and thus a merge is unlikely to ever happen (e.g. vincent libs). 

Perhaps we should float those to a separate section at the start of the file and jailbreak them by default?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
