### PR TITLE
nixos/doc/rl-2411: add highlight for the Darwin changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -4,11 +4,6 @@
 
 ## Highlights {#sec-release-24.11-highlights}
 
-- **This will be the last release of Nixpkgs to support macOS Sierra 10.12 to macOS Catalina 10.15.**
-  Starting with release 25.05, the minimum supported version will be macOS Big Sur 11, and we cannot guarantee that packages will continue to work on older versions of macOS.
-  Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
-  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
-
 - Nix was updated to 2.24, which brings a lot of improvements and fixes. See the release notes for
     [2.19](https://nix.dev/manual/nix/latest/release-notes/rl-2.19),
     [2.20](https://nix.dev/manual/nix/latest/release-notes/rl-2.20),
@@ -17,6 +12,16 @@
     [2.23](https://nix.dev/manual/nix/latest/release-notes/rl-2.23),
     [2.24](https://nix.dev/manual/nix/latest/release-notes/rl-2.24).
   Notable changes include improvements to Git fetching, documentation comment support in `nix-repl> :doc`, as well as many quality of life additions.
+
+- There have been significant changes to macOS support.
+  - The build environment has been redesigned to be closer to a native Xcode toolchain, enabling us to provide all SDKs from macOS Sierra 10.12 to macOS Sequoia 15, simplify build definitions, and build more software without hacks or patching.
+    Although compatibility shims for the old SDK scheme are provided, some builds may break, and the old mechanisms will be removed by 25.11 at the latest.
+    See the [Darwin section](https://nixos.org/manual/nixpkgs/stable/#sec-darwin) of the Nixpkgs manual for details of the new scheme and how to use it, and [the announcement on Discourse](https://discourse.nixos.org/t/the-darwin-sdks-have-been-updated/55295) for more information on the changes and benefits.
+
+  - **This will be the last release of Nixpkgs to support macOS Sierra 10.12 to macOS Catalina 10.15.**
+    Starting with release 25.05, the minimum supported version will be macOS Big Sur 11, and we cannot guarantee that packages will continue to work on older versions of macOS.
+    Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
+    If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
 
 - This will be the last release of Nixpkgs to support versions of CUDA prior to CUDA 12.0.
   These versions only work with old compiler versions that will be unsupported by the time of the Nixpkgs 25.05 release.


### PR DESCRIPTION
Since this release contains the biggest change to Darwin support in many years, the changes deprecate mechanisms that will be removed in a release or two, and the compatibility shims for those mechanisms can’t avoid breaking changes for some package definitions (albeit not too many of them in practice), it feels worth having a release highlight to point users to the new documentation and get the word out about the great work that’s been done.

Note that the link to the Nixpkgs manual is currently broken because 24.11 isn’t stable yet, but it will work by the time it matters and it seems better than linking to the unstable manual as 25.05 will implement breaking changes in platform support that affect that manual section (see https://github.com/NixOS/nixpkgs/pull/352129).

The wording here is a draft; I would especially like feedback on it from @reckenrode.

I’ve placed this next to the existing warning of upcoming macOS backwards‐incompatibility since it seems reasonable to expect people to read both of them at once, but if that’s too much Darwin in a row I can move it elsewhere, or perhaps nest both of them under one bullet point. In future releases it might be nice to have a Darwin‐specific release notes section.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
