### PR TITLE
python3Packages.spacy-models: fix model builds

### DIFF
--- a/pkgs/development/python-modules/curated-tokenizers/default.nix
+++ b/pkgs/development/python-modules/curated-tokenizers/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  setuptools,
+  regex,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "curated-tokenizers";
+  version = "0.0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "curated-tokenizers";
+    tag = "v${version}";
+    hash = "sha256-P8kpPnaU3el7sc/vUn4waQN+JV7F9b49i6BtC4BFfIg=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  dependencies = [
+    regex
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Explicitly set the path to avoid running vendored
+  # sentencepiece tests.
+  pytestFlagsArray = [ "tests" ];
+
+  preCheck = ''
+    # avoid local paths, relative imports wont resolve correctly
+    mv curated_tokenizers/tests tests
+    rm -r curated_tokenizers
+  '';
+
+  pythonImportsCheck = [ "curated_tokenizers" ];
+
+  meta = with lib; {
+    description = "Lightweight piece tokenization library";
+    homepage = "https://github.com/explosion/curated-tokenizers";
+    changelog = "https://github.com/explosion/curated-tokenizers/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/curated-transformers/default.nix
+++ b/pkgs/development/python-modules/curated-transformers/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "curated-transformers";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "curated-transformers";
+    tag = "v${version}";
+    hash = "sha256-QhJZnQIa9TilwdQCUlxnQCEc6Suj669cht6WHUAr/Gw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ torch ];
+
+  # Unit tests are hard to use, since most tests rely on downloading
+  # models from Hugging Face Hub.
+  pythonImportCheck = [ "curated_transformers" ];
+
+  meta = with lib; {
+    description = "PyTorch library of curated Transformer models and their composable components";
+    homepage = "https://github.com/explosion/curated-transformers";
+    changelog = "https://github.com/explosion/curated-transformers/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/spacy-curated-transformers/default.nix
+++ b/pkgs/development/python-modules/spacy-curated-transformers/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  curated-tokenizers,
+  curated-transformers,
+  spacy,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "spacy-curated-transformers";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "explosion";
+    repo = "spacy-curated-transformers";
+    tag = "release-v${version}";
+    hash = "sha256-3LL0ofVsyacMzLJtttg0Tl9SlkPex7TwWL/HVF4WkfI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    curated-tokenizers
+    curated-transformers
+    spacy
+    torch
+  ];
+
+  # Unit tests are hard to use, since most tests rely on downloading
+  # models from Hugging Face Hub.
+  pythonImportCheck = [ "spacy_curated_transformers" ];
+
+  meta = with lib; {
+    description = "spaCy entry points for Curated Transformers";
+    homepage = "https://github.com/explosion/spacy-curated-transformers";
+    changelog = "https://github.com/explosion/spacy-curated-transformers/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -69,9 +69,8 @@ let
           # Uses numpy 2.x, while the rest of the dependencies still uses
           # numpy 1.x. Remove once all spaCy packages are updated for
           # numpy 2.x.
-          cat meta.json
           substituteInPlace meta.json \
-          --replace-fail "spacy-pkuseg>=1.0.0,<2.0.0" "spacy-pkuseg"
+            --replace-fail "spacy-pkuseg>=1.0.0,<2.0.0" "spacy-pkuseg"
         '';
 
       nativeBuildInputs = [ setuptools ] ++ lib.optionals requires-protobuf [ protobuf ];

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -9,7 +9,10 @@
   setuptools,
   spacy,
   spacy-pkuseg,
-  spacy-transformers,
+  spacy-curated-transformers,
+  sudachipy,
+  sudachidict-core,
+  transformers,
   writeScript,
   stdenv,
   jq,
@@ -27,7 +30,10 @@ let
 
     let
       lang = builtins.substring 0 2 pname;
-      requires-protobuf = pname == "fr_dep_news_trf" || pname == "uk_core_news_trf";
+      requires-protobuf =
+        pname == "fr_dep_news_trf" || pname == "sl_core_news_trf" || pname == "uk_core_news_trf";
+      requires-sentencepiece = pname == "fr_dep_news_trf" || pname == "sl_core_news_trf";
+      requires-transformers = pname == "uk_core_news_trf";
     in
     buildPythonPackage {
       inherit pname version;
@@ -40,19 +46,33 @@ let
 
       propagatedBuildInputs =
         [ spacy ]
-        ++ lib.optionals (lib.hasSuffix "_trf" pname) [ spacy-transformers ]
+        ++ lib.optionals (lib.hasSuffix "_trf" pname) [ spacy-curated-transformers ]
+        ++ lib.optionals requires-transformers [ transformers ]
+        ++ lib.optionals (lang == "ja") [
+          sudachidict-core
+          sudachipy
+        ]
         ++ lib.optionals (lang == "ru") [ pymorphy3 ]
         ++ lib.optionals (lang == "uk") [
           pymorphy3
           pymorphy3-dicts-uk
         ]
         ++ lib.optionals (lang == "zh") [ spacy-pkuseg ]
-        ++ lib.optionals (pname == "fr_dep_news_trf") [ sentencepiece ];
+        ++ lib.optionals requires-sentencepiece [ sentencepiece ];
 
-      postPatch = lib.optionalString requires-protobuf ''
-        substituteInPlace meta.json \
-          --replace "protobuf<3.21.0" "protobuf"
-      '';
+      postPatch =
+        lib.optionalString requires-protobuf ''
+          substituteInPlace meta.json \
+            --replace-fail "protobuf<3.21.0" "protobuf"
+        ''
+        + lib.optionalString (lang == "zh") ''
+          # Uses numpy 2.x, while the rest of the dependencies still uses
+          # numpy 1.x. Remove once all spaCy packages are updated for
+          # numpy 2.x.
+          cat meta.json
+          substituteInPlace meta.json \
+          --replace-fail "spacy-pkuseg>=1.0.0,<2.0.0" "spacy-pkuseg"
+        '';
 
       nativeBuildInputs = [ setuptools ] ++ lib.optionals requires-protobuf [ protobuf ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2793,6 +2793,8 @@ self: super: with self; {
 
   curated-tokenizers = callPackage ../development/python-modules/curated-tokenizers { };
 
+  curated-transformers = callPackage ../development/python-modules/curated-transformers { };
+
   customtkinter = callPackage ../development/python-modules/customtkinter { };
 
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2791,6 +2791,8 @@ self: super: with self; {
 
   cu2qu = callPackage ../development/python-modules/cu2qu { };
 
+  curated-tokenizers = callPackage ../development/python-modules/curated-tokenizers { };
+
   customtkinter = callPackage ../development/python-modules/customtkinter { };
 
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15055,6 +15055,8 @@ self: super: with self; {
 
   spacy-alignments = callPackage ../development/python-modules/spacy-alignments { };
 
+  spacy-curated-transformers = callPackage ../development/python-modules/spacy-curated-transformers { };
+
   spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
 
   spacy-loggers = callPackage ../development/python-modules/spacy-loggers { };


### PR DESCRIPTION
Fix various issues with building spaCy models. The largest change is that spaCy 3.7.x has switched to using `spacy-curated-transformers` for transformer models in place of `spacy-transformers`. This change adds `spacy-curated-transformers` along with its dependensies `curated-transformers` and `curated-tokenizers`.

Besides that, this PR makes some smaller changes to `spacy-models` to make all models build again:

- Transformer models now use `spacy-curated-transformers`.
- `sl_core_news_trf` requires `protobuf` and `sentencepiece`.
- `ja` models require `sudachipy` and `sudachidict-core`
- Loosen the `pkuseg` requirement for `zh` models (0.3 -> 1.0 does not have API changes).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
