### PR TITLE
xtreemfs: fix, format

### DIFF
--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -1,20 +1,21 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, fetchpatch
-, makeWrapper
-, stripJavaArchivesHook
-, ant
-, attr
-, boost
-, cmake
-, file
-, fuse
-, jdk8
-, openssl
-, python3
-, valgrind
-, which
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  makeWrapper,
+  stripJavaArchivesHook,
+  ant,
+  attr,
+  boost,
+  cmake,
+  file,
+  fuse,
+  jdk8,
+  openssl,
+  python3,
+  valgrind,
+  which,
 }:
 
 stdenv.mkDerivation {
@@ -29,8 +30,15 @@ stdenv.mkDerivation {
     sha256 = "1hjmd32pla27zf98ghzz6r5ml8ry86m9dsryv1z01kxv5l95b3m0";
   };
 
-  nativeBuildInputs = [ makeWrapper python3 stripJavaArchivesHook ];
-  buildInputs = [ which attr ];
+  nativeBuildInputs = [
+    makeWrapper
+    python3
+    stripJavaArchivesHook
+  ];
+  buildInputs = [
+    which
+    attr
+  ];
 
   patches = [
     (fetchpatch {
@@ -107,7 +115,10 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Distributed filesystem";
-    maintainers = with lib.maintainers; [ raskin matejc ];
+    maintainers = with lib.maintainers; [
+      raskin
+      matejc
+    ];
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
   };

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation {
     makeWrapper
     python3
     stripJavaArchivesHook
+    which
   ];
   buildInputs = [
-    which
     attr
   ];
 

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -74,8 +74,8 @@ stdenv.mkDerivation {
     substituteInPlace cpp/CMakeLists.txt \
       --replace '"/lib64" "/usr/lib64"' '"${attr.out}/lib" "${lib.getLib fuse}/lib"'
 
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${fuse}/include"
-    export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -L${fuse}/lib"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${lib.getDev fuse}/include"
+    export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -L${lib.getLib fuse}/lib"
 
     export DESTDIR=$out
 


### PR DESCRIPTION
Fuse derivation is split into more outputs, need to grab the `dev` output for headers. Also, reformats using `nixfmt`.

Closes #356723.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
