### PR TITLE
treewide: remove deprecations up until 24.11 (staging part)

### DIFF
--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -210,43 +210,6 @@ class Driver:
         name: Optional[str] = None,
         keep_vm_state: bool = False,
     ) -> Machine:
-        # Legacy args handling
-        # FIXME: remove after 24.05
-        if isinstance(start_command, dict):
-            if name is not None or keep_vm_state:
-                raise TypeError(
-                    "Dictionary passed to create_machine must be the only argument"
-                )
-
-            args = start_command
-            start_command = args.pop("startCommand", SENTINEL)
-
-            if start_command is SENTINEL:
-                raise TypeError(
-                    "Dictionary passed to create_machine must contain startCommand"
-                )
-
-            if not isinstance(start_command, str):
-                raise TypeError(
-                    f"startCommand must be a string, got: {repr(start_command)}"
-                )
-
-            name = args.pop("name", None)
-            keep_vm_state = args.pop("keep_vm_state", False)
-
-            if args:
-                raise TypeError(
-                    f"Unsupported arguments passed to create_machine: {args}"
-                )
-
-            self.logger.warning(
-                Fore.YELLOW
-                + Style.BRIGHT
-                + "WARNING: Using create_machine with a single dictionary argument is deprecated and will be removed in NixOS 24.11"
-                + Style.RESET_ALL
-            )
-        # End legacy args handling
-
         tmp_dir = get_tmp_dir()
 
         cmd = NixStartScript(start_command)

--- a/pkgs/by-name/e2/e2fsprogs/package.nix
+++ b/pkgs/by-name/e2/e2fsprogs/package.nix
@@ -23,13 +23,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withFuse [ fuse3 ];
 
   patches = [
-    # Avoid trouble with older systems like NixOS 23.05.
-    # TODO: most likely drop this at some point, e.g. when 23.05 loses support.
-    (fetchurl {
-      name = "mke2fs-avoid-incompatible-features.patch";
-      url = "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/plain/debian/patches/disable-metadata_csum_seed-and-orphan_file-by-default?h=debian/master&id=3fb3d18baba90e5d48d94f4c0b79b2d271b0c913";
-      hash = "sha256-YD11K4s2bqv0rvzrxtaiodzLp3ztULlOlPUf1XcpxRY=";
-    })
     (fetchurl {
       name = "SIZEOF_SIZE_T.patch";
       url = "https://lore.kernel.org/linux-ext4/20240527074121.2767083-1-hi@alyssa.is/raw";


### PR DESCRIPTION
Same as #356732, but with changes causing a few rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
