### PR TITLE
luaPackages: refactor custom busted nlua checkPhases; {busted, nlua}: add meta.mainProgram

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -534,13 +534,12 @@ in
 
   lz-n  = prev.lz-n.overrideAttrs(oa: {
     doCheck = lua.luaversion == "5.1";
-    nativeCheckInputs = [ final.nlua final.busted ];
     checkPhase = ''
       runHook preCheck
       export HOME=$(mktemp -d)
-      busted --lua=nlua
+      ${lib.getExe final.busted} --lua=${lib.getExe final.nlua}
       runHook postCheck
-      '';
+    '';
   });
 
   lze  = prev.lze.overrideAttrs(oa: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -772,15 +772,14 @@ in
       '';
   });
 
-  rustaceanvim  = prev.rustaceanvim.overrideAttrs(oa: {
+  rustaceanvim = prev.rustaceanvim.overrideAttrs (oa: {
     doCheck = lua.luaversion == "5.1";
-    nativeCheckInputs = [ final.nlua final.busted ];
     checkPhase = ''
       runHook preCheck
       export HOME=$(mktemp -d)
-      busted --lua=nlua
+      ${lib.getExe final.busted} --lua=${lib.getExe final.nlua}
       runHook postCheck
-      '';
+    '';
   });
 
   sqlite = prev.sqlite.overrideAttrs (drv: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -575,11 +575,10 @@ in
 
   haskell-tools-nvim  = prev.haskell-tools-nvim.overrideAttrs(oa: {
     doCheck = lua.luaversion == "5.1";
-    nativeCheckInputs = [ final.nlua final.busted ];
     checkPhase = ''
       runHook preCheck
       export HOME=$(mktemp -d)
-      busted --lua=nlua
+      ${lib.getExe final.busted} --lua=${lib.getExe final.nlua}
       runHook postCheck
     '';
   });

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -761,15 +761,14 @@ in
     };
   })) {};
 
-  rtp-nvim  = prev.rtp-nvim.overrideAttrs(oa: {
+  rtp-nvim = prev.rtp-nvim.overrideAttrs (oa: {
     doCheck = lua.luaversion == "5.1";
-    nativeCheckInputs = [ final.nlua final.busted ];
     checkPhase = ''
       runHook preCheck
       export HOME=$(mktemp -d)
-      busted --lua=nlua
+      ${lib.getExe final.busted} --lua=${lib.getExe final.nlua}
       runHook postCheck
-      '';
+    '';
   });
 
   rustaceanvim = prev.rustaceanvim.overrideAttrs (oa: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -104,6 +104,7 @@ in
         --zsh completions/zsh/_busted \
         --bash completions/bash/busted.bash
     '';
+    meta.mainProgram = "busted";
   });
 
   cqueues = prev.cqueues.overrideAttrs (oa: rec {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -703,6 +703,7 @@ in
       sed -i -e "1 s|.*|#\!${coreutils}/bin/env -S ${neovim-unwrapped}/bin/nvim -l|" "$out/bin/nlua"
       '';
     dontPatchShebangs = true;
+    meta.mainProgram = "nlua";
   });
 
   psl = prev.psl.overrideAttrs (drv: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -544,11 +544,10 @@ in
 
   lze  = prev.lze.overrideAttrs(oa: {
     doCheck = lua.luaversion == "5.1";
-    nativeCheckInputs = [ final.nlua final.busted ];
     checkPhase = ''
       runHook preCheck
       export HOME=$(mktemp -d)
-      busted --lua=nlua
+      ${lib.getExe final.busted} --lua=${lib.getExe final.nlua}
       runHook postCheck
     '';
   });


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
While working on https://github.com/NixOS/nixpkgs/pull/352277 I enabled the checkPhase for vimPlugins. I noticed that nativeCheckInputs don't propogate down to vimPlugin's with the luaAttr. Refactoring the checkPhase to carry the store path of the `busted` and `nlua` binaries. 

Breaking this off to remove the noise from the neovimRequireCheckHook diff. 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
