### PR TITLE
protonmail-desktop: 1.0.6 -> 1.5.1 / fix update-script

### DIFF
--- a/pkgs/by-name/pr/protonmail-desktop/package.nix
+++ b/pkgs/by-name/pr/protonmail-desktop/package.nix
@@ -72,8 +72,6 @@ stdenv.mkDerivation {
     ];
     platforms = [
       "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
 

--- a/pkgs/by-name/pr/protonmail-desktop/package.nix
+++ b/pkgs/by-name/pr/protonmail-desktop/package.nix
@@ -1,80 +1,58 @@
 {
+  asar,
   lib,
   stdenv,
   fetchurl,
   makeWrapper,
   dpkg,
   electron,
-  unzip,
 }:
-
 let
   mainProgram = "proton-mail";
-  srcHashes = {
-    # Upstream info: It's intended to stay like this in further releases
-    # https://github.com/NixOS/nixpkgs/pull/326152#discussion_r1679558135
-    universal-darwin = "sha256-6b+CNCvrkIA1CvSohSJZq/veZZNsA3lyhVv5SsBlJlw=";
-    x86_64-linux = "sha256-v8ufnQQEqTT5cr7fq8Fozje/NDlBzaCeKIzE6yU/biE=";
-  };
+  version = "1.5.1";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "protonmail-desktop";
-  # Upstream info: "v"-prefix got dropped
-  version = "1.0.6";
+  inherit version;
 
   src = fetchurl {
-    url =
-      if stdenv.hostPlatform.isDarwin then
-        "https://github.com/ProtonMail/inbox-desktop/releases/download/${version}/Proton.Mail-darwin-universal-${version}.zip"
-      else
-        "https://github.com/ProtonMail/inbox-desktop/releases/download/${version}/proton-mail_${version}_amd64.deb";
-    sha256 =
-      {
-        x86_64-linux = srcHashes.x86_64-linux;
-        x86_64-darwin = srcHashes.universal-darwin;
-        aarch64-darwin = srcHashes.universal-darwin;
-      }
-      .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
+    url = "https://proton.me/download/mail/linux/${version}/ProtonMail-desktop-beta.deb";
+    sha256 = "sha256-PkxJUzSmSeIf/WjXCj5Pne5DHrXnTRib1IqHtbe3lNA=";
   };
-
-  sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin ".";
 
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs =
-    [
-      makeWrapper
-    ]
-    ++ lib.optional stdenv.hostPlatform.isLinux dpkg ++ lib.optional stdenv.hostPlatform.isDarwin unzip;
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    asar
+  ];
 
-  installPhase =
-    let
-      darwin = ''
-        mkdir -p $out/{Applications,bin}
-        cp -r "Proton Mail.app" $out/Applications/
-        makeWrapper $out/Applications/"Proton Mail.app"/Contents/MacOS/Proton\ Mail $out/bin/protonmail-desktop
-      '';
-      linux = ''
-        runHook preInstall
-        mkdir -p $out
-        cp -r usr/share/ $out/
-        cp -r usr/lib/proton-mail/resources/app.asar $out/share/
-      '';
+  # Rebuild the ASAR archive, hardcoding the resourcesPath
+  preInstall = ''
+    asar extract usr/lib/proton-mail/resources/app.asar tmp
+    rm usr/lib/proton-mail/resources/app.asar
+    substituteInPlace tmp/.webpack/main/index.js \
+      --replace-fail "process.resourcesPath" "'$out/share/proton-mail'"
+    asar pack tmp/ usr/lib/proton-mail/resources/app.asar
+    rm -fr tmp
+  '';
 
-    in
-    ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      ${if stdenv.hostPlatform.isDarwin then darwin else linux}
+    mkdir -p $out/share/proton-mail
+    cp -r usr/share/ $out/
+    cp -r usr/lib/proton-mail/resources/* $out/share/proton-mail/
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
   preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     makeWrapper ${lib.getExe electron} $out/bin/${mainProgram} \
-      --add-flags $out/share/app.asar \
+      --add-flags $out/share/proton-mail/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
@@ -85,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Desktop application for Mail and Calendar, made with Electron";
-    homepage = "https://github.com/ProtonMail/inbox-desktop";
+    homepage = "https://github.com/ProtonMail/WebClients";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       rsniezek
@@ -98,6 +76,7 @@ stdenv.mkDerivation rec {
       "aarch64-darwin"
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     inherit mainProgram;
   };
 }

--- a/pkgs/by-name/pr/protonmail-desktop/update.sh
+++ b/pkgs/by-name/pr/protonmail-desktop/update.sh
@@ -5,25 +5,7 @@
 
 set -eu -o pipefail
 
-latestVersion=$(curl https://api.github.com/repos/ProtonMail/inbox-desktop/releases/latest | jq -r '.tag_name')
-
-declare -A platforms
-platforms[x86_64-linux]="amd64"
-platforms[x86_64-darwin]="universal"
-
-for platform in "${!platforms[@]}"
-do
-  arch=${platforms[$platform]}
-  os=$(echo "$platform" | cut -d "-" -f2)
-
-  if [[ "$os" == "linux" ]]; then
-    downloadUrl="https://github.com/ProtonMail/inbox-desktop/releases/download/${latestVersion}/proton-mail_${latestVersion}_${arch}.deb"
-  else
-    downloadUrl="https://github.com/ProtonMail/inbox-desktop/releases/download/${latestVersion}/Proton.Mail-${os}-${arch}-${latestVersion}.zip"
-  fi
-  echo "$downloadUrl"
-
-  latestSha=$(nix store prefetch-file "$downloadUrl" --json | jq -r '.hash')
-
-  update-source-version "protonmail-desktop" "$latestVersion" "$latestSha" --system="$platform" --ignore-same-version --file=./pkgs/by-name/pr/protonmail-desktop/package.nix
-done
+latestVersion=$(curl https://proton.me/download/mail/linux/version.json | jq -r 'first(.Releases[])|.Version')
+downloadUrl="https://proton.me/download/mail/linux/${latestVersion}/ProtonMail-desktop-beta.deb"
+latestSha=$(nix store prefetch-file "$downloadUrl" --json | jq -r '.hash')
+update-source-version "protonmail-desktop" "$latestVersion" "$latestSha" --ignore-same-version --file=./pkgs/by-name/pr/protonmail-desktop/package.nix


### PR DESCRIPTION
Updated protonmail-desktop to latest release, copied the approach from @massix (kudos 👍🏻) for resources-issue for loading/offline page

Fixed update-script as the sources are now official part of https://github.com/ProtonMail/WebClients and releases not provided via github anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
