### PR TITLE
nixos/oci-containers: add systemd backend

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -439,6 +439,7 @@ in {
   livebook-service = handleTest ./livebook-service.nix {};
   pyload = handleTest ./pyload.nix {};
   oci-containers = handleTestOn ["aarch64-linux" "x86_64-linux"] ./oci-containers.nix {};
+  oci-containers-systemd = handleTestOn ["x86_64-linux"] ./oci-containers-systemd.nix {};
   odoo = handleTest ./odoo.nix {};
   odoo17 = handleTest ./odoo.nix { package = pkgs.odoo17; };
   odoo16 = handleTest ./odoo.nix { package = pkgs.odoo16; };

--- a/nixos/tests/oci-containers-systemd.nix
+++ b/nixos/tests/oci-containers-systemd.nix
@@ -1,0 +1,45 @@
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../.. { inherit system config; },
+  lib ? pkgs.lib,
+}:
+
+let
+
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+
+in
+makeTest {
+  name = "oci-containers-systemd";
+
+  meta.maintainers =
+    lib.teams.serokell.members
+    ++ (with lib.maintainers; [
+      benley
+      mkaito
+    ]);
+
+  nodes = {
+    server = {
+      virtualisation.oci-containers = {
+        backend = "systemd";
+        containers.nginx = {
+          # ports = ["8182:80"]; # this driver always uses host networking
+          image = "nginx";
+          imageFile = pkgs.dockerTools.pullImage {
+            imageName = "nginx";
+            imageDigest = "sha256:a8f1c6d64295f107da7319cc1af9b7d0ce4d34d347390589223091e05137c9df";
+            sha256 = "sha256-69/y0icMlThWCt2J7SS3Pg1mmdB4M90+PtYs+N5CAMo=";
+          };
+        };
+      };
+    };
+  };
+  testScript = ''
+    start_all()
+    server.wait_for_unit("systemd-nginx.service")
+    server.wait_for_open_port(80)
+    server.wait_until_succeeds("curl -f http://server:80 | grep 'Welcome to nginx!'")
+  '';
+}

--- a/pkgs/build-support/docker/extract-image.py
+++ b/pkgs/build-support/docker/extract-image.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from argparse import ArgumentParser
+from tempfile import TemporaryDirectory
+from tarfile import TarFile
+import json
+import shlex
+import stat
+import shutil
+
+parser = ArgumentParser(description="Extracts the layers of a OCI container")
+parser.add_argument("image", type=Path)
+parser.add_argument("output", type=Path)
+parser.add_argument("--generate-wrapper-args", type=Path)
+parser.add_argument("--generate-entrypoint", type=Path)
+
+wrapper_args = []
+
+args = parser.parse_args()
+print('args', args)
+
+with TemporaryDirectory() as td:
+    td = Path(td)
+    with TarFile.open(args.image, 'r') as image:
+        image.extractall(td)
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert len(manifest) == 1
+    manifest = manifest[0]
+    config = json.loads((td / manifest['Config']).read_text())
+    config = config['config']
+    for layer in manifest['Layers']:
+        with TarFile.open(td / layer) as layer:
+            layer.extractall(args.output)
+    print('config', config)
+
+if args.generate_wrapper_args is not None:
+    with args.generate_wrapper_args.open('w') as f:
+        for arg in wrapper_args:
+            print(arg, file=f)
+
+if args.generate_entrypoint is not None:
+    with args.generate_entrypoint.open('w') as f:
+        def write_line(*args):
+            print(*args, file=f)
+        write_line(f"#!/usr/bin/env {shutil.which('bash')}")
+        for env in config['Env']:
+            k, *v = env.split('=')
+            v = '='.join(v)
+            write_line(f"export {k}={shlex.quote(v)}")
+        working_dir = config.get('WorkingDir', '/')
+        write_line(f'cd "{shlex.quote(working_dir)}"')
+        write_line('args=()')
+        for arg in config['Entrypoint']:
+            write_line(f'args+=({shlex.quote(arg)})')
+        write_line('if [[ $# == 0 ]]; then')
+        for arg in config['Cmd']:
+            write_line(f'args+=({shlex.quote(arg)})')
+        write_line('fi')
+        write_line('echo exec "${args[@]}" "$@"')
+        write_line('exec "${args[@]}" "$@"')
+    filename = args.generate_entrypoint
+    filename.chmod(filename.stat().st_mode | stat.S_IEXEC)


### PR DESCRIPTION
- **nixos/oci-containers: introducing systemd backend**

Today, oci-containers may require some manual intervention to keep containers updated,
 and it's possible to run containerized stuff using features already available in systemd.

Right now you can consider this a workaround that is not stable or secure for most of
the workloads.

What I want to achieve is to run OCI containers without an OCI runtime, and also learn
some systemd in the process.

I am submitting this PR early to gather feedback around it. I already have a hacky implementation
of a way to extract the layers of an OCI image then generate a wrapper script tho.

Suggestions to make it better are welcome!

## TODO
- [ ] Port forwarding, network isolation (current: host networking)
- [ ] Allow the module to override Cmd and Entrypoint (current: get from the image)
- [x] Allow the module to override environment variables
- [ ] Support for containers generated by Nix (somehow a path that has nix/store in it can't be written)
- [ ] Volumes (right now /nix/store:ro, / as tmpfs with symllinks from the extracted image by lndir)
- [x] NixOS tests
  - [x] Basic nginx based on bookworm from Docker Hub

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
