### PR TITLE
podman: 5.2.3 -> 5.3.0

### DIFF
--- a/pkgs/by-name/po/podman/hardcode-paths.patch
+++ b/pkgs/by-name/po/podman/hardcode-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/vendor/github.com/containers/common/pkg/config/default.go b/vendor/github.com/containers/common/pkg/config/default.go
-index 3a6d804ad..5628e2bf6 100644
+index 02ff128..d3254ba 100644
 --- a/vendor/github.com/containers/common/pkg/config/default.go
 +++ b/vendor/github.com/containers/common/pkg/config/default.go
-@@ -366,75 +366,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
+@@ -378,75 +378,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	c.Retry = 3
  	c.OCIRuntimes = map[string][]string{
  		"crun": {
@@ -88,7 +88,7 @@ index 3a6d804ad..5628e2bf6 100644
  		},
  	}
  	c.PlatformToOCIRuntime = map[string]string{
-@@ -445,26 +404,12 @@ func defaultEngineConfig() (*EngineConfig, error) {
+@@ -457,26 +416,12 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	// Needs to be called after populating c.OCIRuntimes.
  	c.OCIRuntime = c.findRuntime()
  

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -66,13 +66,13 @@ let
 in
 buildGoModule rec {
   pname = "podman";
-  version = "5.2.3";
+  version = "5.3.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    hash = "sha256-2FnUijeQhre7B4utsGGEGbMuuMVZlPDoM2di3z1d4vs=";
+    hash = "sha256-v7srZ1S4qnEOgXvhj+61tSWqzx9qFv0m3iBEUoMu7+U=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman/rm-podman-mac-helper-msg.patch
+++ b/pkgs/by-name/po/podman/rm-podman-mac-helper-msg.patch
@@ -1,22 +1,22 @@
 diff --git a/pkg/machine/machine_common.go b/pkg/machine/machine_common.go
-index 1afc3d15b..a8aafcaae 100644
+index d2ba418..5098cdc 100644
 --- a/pkg/machine/machine_common.go
 +++ b/pkg/machine/machine_common.go
-@@ -33,13 +33,8 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
+@@ -34,13 +34,8 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
  // WaitAPIAndPrintInfo prints info about the machine and does a ping test on the
  // API socket
  func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, rootful bool) {
 -	suffix := ""
  	var fmtString string
  
--	if name != DefaultMachineName {
+-	if name != define.DefaultMachineName {
 -		suffix = " " + name
 -	}
 -
  	if forwardState == NoForwarding {
  		return
  	}
-@@ -61,14 +56,6 @@ address can't be used by podman. `
+@@ -62,14 +57,6 @@ address can't be used by podman. `
  
  				if len(helper) < 1 {
  					fmt.Print(fmtString)


### PR DESCRIPTION
Updating podman to [5.3.0](https://github.com/containers/podman/releases/tag/v5.3.0) mainly due to https://github.com/containers/podman/issues/23712 which fixes compatibility with some Docker API.

Additionally, one of the patches must be updated due to https://github.com/containers/podman/commit/9febd2c27ad6708f1b49326ab00758e499a66617.

This is my first PR in nixpkgs, please bear with me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
