### PR TITLE
{libllvm,isl,libiberty,libmpc}: fix references to /usr/bin/uname on native FreeBSD

### DIFF
--- a/pkgs/by-name/li/libiberty/package.nix
+++ b/pkgs/by-name/li/libiberty/package.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation {
 
   postUnpack = "sourceRoot=\${sourceRoot}/libiberty";
 
+  # needed until config scripts are updated to not use /usr/bin/uname on FreeBSD native
+  # updateAutotoolsGnuConfigScriptsHook doesn't seem to work here
+  postPatch = ''
+    substituteInPlace ../config.guess --replace-fail /usr/bin/uname uname
+  '';
+
   configureFlags = [ "--enable-install-libiberty" ]
     ++ lib.optional (!staticBuild) "--enable-shared";
 

--- a/pkgs/by-name/li/libmpc/package.nix
+++ b/pkgs/by-name/li/libmpc/package.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl
 , gmp, mpfr
+, updateAutotoolsGnuConfigScriptsHook
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -20,6 +21,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [ gmp mpfr ];
+  nativeBuildInputs = [
+    # needed until config scripts are updated to not use /usr/bin/uname on FreeBSD native
+    updateAutotoolsGnuConfigScriptsHook
+  ];
 
   doCheck = true; # not cross;
 

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -24,6 +24,7 @@
 , which
 , sysctl
 , buildLlvmTools
+, updateAutotoolsGnuConfigScriptsHook
 , debugVersion ? false
 , doCheck ? !stdenv.hostPlatform.isAarch32 && (if lib.versionOlder release_version "15" then stdenv.hostPlatform.isLinux else true)
   && (!stdenv.hostPlatform.isx86_32 /* TODO: why */) && (!stdenv.hostPlatform.isMusl)
@@ -112,7 +113,12 @@ stdenv.mkDerivation (finalAttrs: {
     "shadowstack"
   ];
 
-  nativeBuildInputs = [ cmake ]
+  nativeBuildInputs = [
+    cmake
+    # while this is not an autotools build, it still includes a config.guess
+    # this is needed until scripts are updated to not use /usr/bin/uname on FreeBSD native
+    updateAutotoolsGnuConfigScriptsHook
+  ]
     ++ (lib.optional (lib.versionAtLeast release_version "15") ninja)
     ++ [ python ]
     ++ optionals enableManpages [

--- a/pkgs/development/libraries/isl/generic.nix
+++ b/pkgs/development/libraries/isl/generic.nix
@@ -11,6 +11,7 @@
 , gmp
 , autoreconfHook
 , buildPackages
+, updateAutotoolsGnuConfigScriptsHook
 }:
 
 stdenv.mkDerivation {
@@ -25,7 +26,12 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   depsBuildBuild = lib.optionals (lib.versionAtLeast version "0.24") [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isRiscV && lib.versionOlder version "0.24") [ autoreconfHook ];
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isRiscV && lib.versionOlder version "0.24") [
+    autoreconfHook
+  ] ++ [
+    # needed until config scripts are updated to not use /usr/bin/uname on FreeBSD native
+    updateAutotoolsGnuConfigScriptsHook
+  ];
   buildInputs = [ gmp ];
 
   inherit configureFlags;


### PR DESCRIPTION
We've all heard this story before. Old versions of gnu config scripts hardcode the /usr/bin/uname filename in the FreeBSD build system code path. Upgrade them so this stops happening. See https://github.com/NixOS/nixpkgs/pull/313496 for context.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
