### PR TITLE
rustc: be extremely principled about cross builds

### DIFF
--- a/pkgs/development/compilers/rust/1_84.nix
+++ b/pkgs/development/compilers/rust/1_84.nix
@@ -36,7 +36,7 @@ let
       {
         enableSharedLibraries = true;
       }
-      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+      // lib.optionalAttrs (pkgSet.stdenv.targetPlatform.useLLVM or false) {
         # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
         stdenv = pkgSet.stdenv.override {
           allowedRequisites = null;


### PR DESCRIPTION
There were a lot of collapsed assumptions about the cross build process in this derivation, especially with the overloaded meanings of useLLVM. This diff splits useLLVM into a value for each of the build, host, and target platforms. We also specify more target-specific configure flags, including passing through the llvm-config-native binary which is built in some cross configurations. This also allows us to clean up some hacky NIX_LDFLAGS code.

This commit was tested with the following build configurations:

* x86_64-freebsd -> x86_64-freebsd -> x86_64-freebsd
* x86_64-freebsd -> x86_64-freebsd -> x86_64-linux
* x86_64-freebsd -> x86_64-linux -> x86_64-linux
* x86_64-freebsd -> x86_64-freebsd -> aarch64-linux
* x86_64-freebsd -> aarch64-linux -> aarch64-linux
* x86_64-linux -> x86_64-linux -> x86_64-linux
* x86_64-linux -> x86_64-linux -> aarch64-linux
* x86_64-linux -> aarch64-linux -> aarch64-linux
* x86_64-linux -> x86_64-linux -> x86_64-freebsd
* x86_64-linux -> x86_64-freebsd -> x86_64-freebsd

Please note that darwin is completely absent from this list. I don't have any apple machines!

This PR has several dependencies. I've submitted them all as separate PRs, but some of them target staging and others master. If you'd like to test this branch, please build [rhelmot:freebsd-staging-test](https://github.com/rhelmot/nixpkgs/tree/freebsd-staging-test).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
