### PR TITLE
treewide: fix sed -ie and friends

### DIFF
--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -219,7 +219,7 @@ let
           succeed(
               'echo \'${postData}\'> /tmp/data.json'
           )
-          succeed('sed -ie "s DATE $(date +%s) " /tmp/data.json')
+          succeed('sed -i -e "s DATE $(date +%s) " /tmp/data.json')
           succeed(
               "curl -sSfH 'Content-Type: application/json' -X POST --data @/tmp/data.json localhost:9103/collectd"
           )

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -28,12 +28,12 @@ stdenv.mkDerivation rec {
     # /etc/{resolv.conf,hosts}, replace all references to `localhost'
     # by their IPv4 equivalent.
     find . \( -name \*.c -or -name \*.conf \) | \
-      xargs sed -ie 's|\<localhost\>|127.0.0.1|g'
+      xargs sed -i -e 's|\<localhost\>|127.0.0.1|g'
 
     # Make sure the tests don't rely on `/tmp', for the sake of chroot
     # builds.
     find . \( -iname \*test\*.c -or -name \*.conf \) | \
-      xargs sed -ie "s|/tmp|$TMPDIR|g"
+      xargs sed -i -e "s|/tmp|$TMPDIR|g"
   '';
 
   # unfortunately, there's still a few failures with impure tests

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -147,14 +147,14 @@ in stdenv.mkDerivation (finalAttrs: {
 
   #bad configure.ac and Makefile.in everywhere
   preConfigure = ''
-    sed -ie 's;-L/usr/local/lib -R/usr/local/lib;;g' \
+    sed -i -e 's;-L/usr/local/lib -R/usr/local/lib;;g' \
       main/Makefile.in \
       tool/mlfc/Makefile.in \
       tool/mlimgloader/Makefile.in \
       tool/mlconfig/Makefile.in \
       uitoolkit/libtype/Makefile.in \
       uitoolkit/libotl/Makefile.in
-    sed -ie 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' \
+    sed -i -e 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' \
       tool/mlconfig/po/Makefile.in.in
     #utmp and mlterm-fb
     substituteInPlace configure.in \

--- a/pkgs/by-name/ar/arangodb/package.nix
+++ b/pkgs/by-name/ar/arangodb/package.nix
@@ -51,7 +51,7 @@ gcc10Stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   postPatch = ''
-    sed -ie 's!/bin/echo!echo!' 3rdParty/V8/gypfiles/*.gypi
+    sed -i -e 's!/bin/echo!echo!' 3rdParty/V8/gypfiles/*.gypi
 
     # with nixpkgs, it has no sense to check for a version update
     substituteInPlace js/client/client.js --replace "require('@arangodb').checkAvailableVersions();" ""

--- a/pkgs/by-name/bc/bcftools/package.nix
+++ b/pkgs/by-name/bc/bcftools/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   preCheck = ''
     patchShebangs misc/
     patchShebangs test/
-    sed -ie 's|/bin/bash|${bash}/bin/bash|' test/test.pl
+    sed -i -e 's|/bin/bash|${bash}/bin/bash|' test/test.pl
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/be/bear/package.nix
+++ b/pkgs/by-name/be/bear/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # /usr/bin/env is used in test commands and embedded scripts.
     find test -name '*.sh' \
-      -exec sed -ie 's|/usr/bin/env|${coreutils}/bin/env|g' {} +
+      -exec sed -i -e 's|/usr/bin/env|${coreutils}/bin/env|g' {} +
   '';
 
   # Functional tests use loopback networking.

--- a/pkgs/by-name/ca/canon-cups-ufr2/package.nix
+++ b/pkgs/by-name/ca/canon-cups-ufr2/package.nix
@@ -52,20 +52,20 @@ stdenv.mkDerivation rec {
     (
       cd $sourceRoot
       tar -xf Sources/cnrdrvcups-lb-${version}-1.${suffix2}.tar.xz
-      sed -ie "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-common-${version}/allgen.sh
-      sed -ie "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-common-${version}/allgen.sh
-      sed -ie "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-common-${version}/allgen.sh
-      sed -ie "s@/usr@$out@" cnrdrvcups-common-${version}/{{backend,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h}
-      sed -ie "s@etc/cngplp@$out/etc/cngplp@" cnrdrvcups-common-${version}/cngplp/Makefile.am
-      sed -ie "s@usr/share/cngplp@$out/usr/share/cngplp@" cnrdrvcups-common-${version}/cngplp/src/Makefile.am
+      sed -i -e "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-common-${version}/allgen.sh
+      sed -i -e "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-common-${version}/allgen.sh
+      sed -i -e "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-common-${version}/allgen.sh
+      sed -i -e "s@/usr@$out@" cnrdrvcups-common-${version}/{{backend,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h}
+      sed -i -e "s@etc/cngplp@$out/etc/cngplp@" cnrdrvcups-common-${version}/cngplp/Makefile.am
+      sed -i -e "s@usr/share/cngplp@$out/usr/share/cngplp@" cnrdrvcups-common-${version}/cngplp/src/Makefile.am
       patchShebangs cnrdrvcups-common-${version}
 
-      sed -ie "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -ie "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -ie "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -ie '/^cd \.\.\/cngplp/,/^cd files/{/^cd files/!{d}}' cnrdrvcups-lb-${version}/allgen.sh
-      sed -ie "s@cd \.\./pdftocpca@cd pdftocpca@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -ie "s@/usr@$out@" cnrdrvcups-lb-${version}/pdftocpca/Makefile.am
+      sed -i -e "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-lb-${version}/allgen.sh
+      sed -i -e "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-lb-${version}/allgen.sh
+      sed -i -e "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-lb-${version}/allgen.sh
+      sed -i -e '/^cd \.\.\/cngplp/,/^cd files/{/^cd files/!{d}}' cnrdrvcups-lb-${version}/allgen.sh
+      sed -i -e "s@cd \.\./pdftocpca@cd pdftocpca@" cnrdrvcups-lb-${version}/allgen.sh
+      sed -i -e "s@/usr@$out@" cnrdrvcups-lb-${version}/pdftocpca/Makefile.am
       sed -i "/CNGPLPDIR/d" cnrdrvcups-lb-${version}/Makefile
       patchShebangs cnrdrvcups-lb-${version}
     )

--- a/pkgs/by-name/ct/ctpp2/package.nix
+++ b/pkgs/by-name/ct/ctpp2/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # include <unistd.h> to fix undefined getcwd
-    sed -ie 's/<stdlib.h>/<stdlib.h>\n#include <unistd.h>/' src/CTPP2FileSourceLoader.cpp
+    sed -i -e 's/<stdlib.h>/<stdlib.h>\n#include <unistd.h>/' src/CTPP2FileSourceLoader.cpp
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/da/daemontools/package.nix
+++ b/pkgs/by-name/da/daemontools/package.nix
@@ -24,12 +24,12 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     cd daemontools-${version}
 
-    sed -ie '1 s_$_ -include ${glibc.dev}/include/errno.h_' src/conf-cc
+    sed -i -e '1 s_$_ -include ${glibc.dev}/include/errno.h_' src/conf-cc
 
     substituteInPlace src/Makefile \
       --replace '/bin/sh' '${bash}/bin/bash -oxtrace'
 
-    sed -ie "s_^PATH=.*_PATH=$src/daemontools-${version}/compile:''${PATH}_" src/rts.tests
+    sed -i -e "s_^PATH=.*_PATH=$src/daemontools-${version}/compile:''${PATH}_" src/rts.tests
 
     cat ${glibc.dev}/include/errno.h
   '';

--- a/pkgs/by-name/gs/gsimplecal/package.nix
+++ b/pkgs/by-name/gs/gsimplecal/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    sed -ie '/sys\/sysctl.h/d' src/Unique.cpp
+    sed -i -e '/sys\/sysctl.h/d' src/Unique.cpp
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ho/hol/package.nix
+++ b/pkgs/by-name/ho/hol/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
       substituteInPlace $f --replace "\"/usr/bin/dot\"" "\"${graphviz}/bin/dot\""
     done
 
-    #sed -ie "/compute/,999 d" tools/build-sequence # for testing
+    #sed -i -e "/compute/,999 d" tools/build-sequence # for testing
 
     poly < tools/smart-configure.sml
 

--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     # The Addon generation (AsyncRequest and a others checked) seems to have
     # trouble with building on Virtual machines. Disabling them until it
     # can be fully investigated.
-    sed -ie \
+    sed -i -e \
           "s/add_subdirectory(addons)/#add_subdirectory(addons)/g" \
           CMakeLists.txt
     # Bind Libs STATIC to avoid a segfault when relinking

--- a/pkgs/by-name/ju/jumpnbump/package.nix
+++ b/pkgs/by-name/ju/jumpnbump/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     make -C menu PREFIX=$out all install
     cp -r ${data}/* $out/share/jumpnbump/
     rm $out/share/applications/jumpnbump-menu.desktop
-    sed -ie 's+Exec=jumpnbump+Exec=jumpnbump-menu+' $out/share/applications/jumpnbump.desktop
+    sed -i -e 's+Exec=jumpnbump+Exec=jumpnbump-menu+' $out/share/applications/jumpnbump.desktop
   '';
 
   pythonPath = with python3Packages; [ pygobject3 pillow ];

--- a/pkgs/by-name/ju/justbuild/package.nix
+++ b/pkgs/by-name/ju/justbuild/package.nix
@@ -87,8 +87,8 @@ stdenv.mkDerivation rec {
 
   postPatch =
     ''
-      sed -ie 's|\./bin/just-mr.py|${python3}/bin/python3 ./bin/just-mr.py|' bin/bootstrap.py
-      sed -ie 's|#!/usr/bin/env python3|#!${python3}/bin/python3|' bin/parallel-bootstrap-traverser.py
+      sed -i -e 's|\./bin/just-mr.py|${python3}/bin/python3 ./bin/just-mr.py|' bin/bootstrap.py
+      sed -i -e 's|#!/usr/bin/env python3|#!${python3}/bin/python3|' bin/parallel-bootstrap-traverser.py
       jq '.repositories.protobuf.pkg_bootstrap.local_path = "${protobuf}"' etc/repos.json > etc/repos.json.patched
       mv etc/repos.json.patched etc/repos.json
       jq '.repositories.com_github_grpc_grpc.pkg_bootstrap.local_path = "${grpc}"' etc/repos.json > etc/repos.json.patched
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
       mv etc/toolchain/CC/TARGETS.patched etc/toolchain/CC/TARGETS
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      sed -ie 's|-Wl,-z,stack-size=8388608|-Wl,-stack_size,0x800000|' bin/bootstrap.py
+      sed -i -e 's|-Wl,-z,stack-size=8388608|-Wl,-stack_size,0x800000|' bin/bootstrap.py
     '';
 
   /*

--- a/pkgs/by-name/ko/koules/package.nix
+++ b/pkgs/by-name/ko/koules/package.nix
@@ -37,13 +37,13 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # We do not want to depend on that particular font to be available in the
     # xserver, hence substitute it by a font which is always available
-    sed -ie 's:-schumacher-clean-bold-r-normal--8-80-75-75-c-80-\*iso\*:fixed:' xlib/init.c
+    sed -i -e 's:-schumacher-clean-bold-r-normal--8-80-75-75-c-80-\*iso\*:fixed:' xlib/init.c
   '';
 
   preBuild = ''
     cp xkoules.6 xkoules.man  # else "make" will not succeed
-    sed -ie "s:^SOUNDDIR\s*=.*:SOUNDDIR=$out/lib:" Makefile
-    sed -ie "s:^KOULESDIR\s*=.*:KOULESDIR=$out:" Makefile
+    sed -i -e "s:^SOUNDDIR\s*=.*:SOUNDDIR=$out/lib:" Makefile
+    sed -i -e "s:^KOULESDIR\s*=.*:KOULESDIR=$out:" Makefile
   '';
 
   installPhase = ''

--- a/pkgs/by-name/mo/molden/package.nix
+++ b/pkgs/by-name/mo/molden/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
      substituteInPlace ambfor/makefile --replace 'FFLAGS =' 'FFLAGS = -fallow-argument-mismatch'
 
-     sed -in '/^# DO NOT DELETE THIS LINE/q;' surf/Makefile
+     sed -i '/^# DO NOT DELETE THIS LINE/q;' surf/Makefile
   '';
 
   preInstall = ''

--- a/pkgs/by-name/nu/nuweb/package.nix
+++ b/pkgs/by-name/nu/nuweb/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ texliveMedium ];
 
   patchPhase = ''
-    sed -ie 's|nuweb -r|./nuweb -r|' Makefile
+    sed -i -e 's|nuweb -r|./nuweb -r|' Makefile
   '';
 
   # Workaround build failure on -fno-common toolchains like upstream

--- a/pkgs/by-name/pu/pugixml/package.nix
+++ b/pkgs/by-name/pu/pugixml/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # Enable long long support (required for filezilla)
-    sed -ire '/PUGIXML_HAS_LONG_LONG/ s/^\/\///' src/pugiconfig.hpp
+    sed -i -e '/PUGIXML_HAS_LONG_LONG/ s/^\/\///' src/pugiconfig.hpp
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ro/rosie/package.nix
+++ b/pkgs/by-name/ro/rosie/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
     # Part of the same Makefile target which calls git to update submodules
     ln -s src submodules/lua/include
     # ldconfig is irrelevant, disable it inside `make installforce`.
-    sed -iE 's/ldconfig/echo skippin ldconfig/' Makefile
-    sed -iE '/ld.so.conf.d/d' Makefile
+    sed -i 's/ldconfig/echo skippin ldconfig/' Makefile
+    sed -i '/ld.so.conf.d/d' Makefile
   '';
 
   preInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/sh/sherpa/package.nix
+++ b/pkgs/by-name/sh/sherpa/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = lib.optionalString (stdenv.hostPlatform.libc == "glibc") ''
-    sed -ie '/sys\/sysctl.h/d' ATOOLS/Org/Run_Parameter.C
+    sed -i -e '/sys\/sysctl.h/d' ATOOLS/Org/Run_Parameter.C
   '';
 
   nativeBuildInputs = [ autoconf gfortran ];

--- a/pkgs/by-name/sl/slang/package.nix
+++ b/pkgs/by-name/sl/slang/package.nix
@@ -21,10 +21,10 @@ stdenv.mkDerivation rec {
 
   # Fix some wrong hardcoded paths
   preConfigure = ''
-    sed -ie "s|/usr/lib/terminfo|${ncurses.out}/lib/terminfo|" configure
-    sed -ie "s|/usr/lib/terminfo|${ncurses.out}/lib/terminfo|" src/sltermin.c
-    sed -ie "s|/bin/ln|ln|" src/Makefile.in
-    sed -ie "s|-ltermcap|-lncurses|" ./configure
+    sed -i -e "s|/usr/lib/terminfo|${ncurses.out}/lib/terminfo|" configure
+    sed -i -e "s|/usr/lib/terminfo|${ncurses.out}/lib/terminfo|" src/sltermin.c
+    sed -i -e "s|/bin/ln|ln|" src/Makefile.in
+    sed -i -e "s|-ltermcap|-lncurses|" ./configure
   '';
 
   configureFlags = [

--- a/pkgs/by-name/sp/sparkleshare/package.nix
+++ b/pkgs/by-name/sp/sparkleshare/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # SparkleShare's default desktop file falls back to flatpak.
-    sed -ie "s_^Exec=.*_Exec=$out/bin/sparkleshare_" SparkleShare/Linux/SparkleShare.Autostart.desktop
+    sed -i -e "s_^Exec=.*_Exec=$out/bin/sparkleshare_" SparkleShare/Linux/SparkleShare.Autostart.desktop
 
     # Nix will manage the icon cache.
     echo '#!/bin/sh' >scripts/post-install.sh

--- a/pkgs/by-name/sw/swaylock-effects/package.nix
+++ b/pkgs/by-name/sw/swaylock-effects/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    sed -iE "s/version: '1\.3',/version: '${version}',/" meson.build
+    sed -i "s/version: '1\.3',/version: '${version}',/" meson.build
   '';
 
   strictDeps = true;

--- a/pkgs/by-name/tc/tcpkali/package.nix
+++ b/pkgs/by-name/tc/tcpkali/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "09ky3cccaphcqc6nhfs00pps99lasmzc2pf5vk0gi8hlqbbhilxf";
   };
   postPatch = ''
-    sed -ie '/sys\/sysctl\.h/d' src/tcpkali_syslimits.c
+    sed -i -e '/sys\/sysctl\.h/d' src/tcpkali_syslimits.c
   '';
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ bison];

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -27,17 +27,17 @@ stdenv.mkDerivation rec {
 
   # remove tests which call out to https://tsduck.io/download/test/...
   postPatch = ''
-    sed -i"" \
+    sed -i \
       -e '/TSUNIT_TEST(testMasterPlaylist);/ d' \
       -e '/TSUNIT_TEST(testMasterPlaylistWithAlternate);/ d' \
       -e '/TSUNIT_TEST(testMediaPlaylist);/ d' \
       src/utest/utestHLS.cpp
 
-    sed -i"" \
+    sed -i \
       -e '/TSUNIT_TEST(testBetterSystemRandomGenerator);/ d' \
       src/utest/utestSystemRandomGenerator.cpp
 
-    sed -i"" \
+    sed -i \
       -e '/TSUNIT_ASSERT(request.downloadBinaryContent/ d' \
       -e '/TSUNIT_ASSERT(!request.downloadBinaryContent/ d' \
       -e '/TSUNIT_TEST(testGitHub);/ d' \
@@ -46,11 +46,11 @@ stdenv.mkDerivation rec {
       -e '/TSUNIT_TEST(testReadMeFile);/ d' \
       src/utest/utestWebRequest.cpp
 
-    sed -i"" \
+    sed -i \
       -e '/TSUNIT_TEST(testHomeDirectory);/ d' \
       src/utest/utestSysUtils.cpp
 
-    sed -i"" \
+    sed -i \
       -e '/TSUNIT_TEST(testIPv4Address);/ d' \
       -e '/TSUNIT_TEST(testIPv4AddressConstructors);/ d' \
       -e '/TSUNIT_TEST(testIPv4SocketAddressConstructors);/ d' \

--- a/pkgs/by-name/vk/vk-bootstrap/package.nix
+++ b/pkgs/by-name/vk/vk-bootstrap/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Upstream uses cmake FetchContent to resolve glfw and catch2
     # needed for examples and tests
-    sed -iE 's=add_subdirectory(ext)==g' CMakeLists.txt
-    sed -iE 's=Catch2==g' tests/CMakeLists.txt
+    sed -i 's=add_subdirectory(ext)==g' CMakeLists.txt
+    sed -i 's=Catch2==g' tests/CMakeLists.txt
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
   postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     ln -s ${mktable}/bin/mktable mktable
     # stop make from recompiling mktable
-    sed -ie 's!mktable.*:.*!mktable:!' Makefile.in
+    sed -i -e 's!mktable.*:.*!mktable:!' Makefile.in
   '';
 
   # updateAutotoolsGnuConfigScriptsHook necessary to build on FreeBSD native pending inclusion of

--- a/pkgs/by-name/wi/wifish/package.nix
+++ b/pkgs/by-name/wi/wifish/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postPatch = ''
-    sed -ie 's|/var/lib/wifish|${placeholder "out"}/var/lib/wifish|' wifish
+    sed -i -e 's|/var/lib/wifish|${placeholder "out"}/var/lib/wifish|' wifish
   '';
 
   dontConfigure = true;

--- a/pkgs/by-name/x2/x2goserver/package.nix
+++ b/pkgs/by-name/x2/x2goserver/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     done
     # We're patching @INC of the setgid wrapper, because we can't mix
     # the perl wrapper (for PERL5LIB) with security.wrappers (for setgid)
-    sed -ie "s,.\+bin/perl,#!${perl}/bin/perl -I ${perlEnv}/lib/perl5/site_perl," \
+    sed -i -e "s,.\+bin/perl,#!${perl}/bin/perl -I ${perlEnv}/lib/perl5/site_perl," \
       $out/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl
   '';
 

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -94,11 +94,11 @@ let
     env.LC_ALL = "en_US.UTF-8";
 
     postPatch = ''
-      sed -ie 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
-      sed -ie 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
+      sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
+      sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
 
       for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
-        sed -ie 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
+        sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
       done
       patchShebangs .
     '';

--- a/pkgs/development/compilers/factor-lang/factor99.nix
+++ b/pkgs/development/compilers/factor-lang/factor99.nix
@@ -106,13 +106,13 @@ stdenv.mkDerivation {
   buildInputs = runtimeLibs;
 
   postPatch = ''
-    sed -ie '4i GIT_LABEL = heads/master-${rev}' GNUmakefile
+    sed -i -e '4i GIT_LABEL = heads/master-${rev}' GNUmakefile
 
     # There is no ld.so.cache in NixOS so we patch out calls to that completely.
     # This should work as long as no application code relies on `find-library*`
     # to return a match, which currently is the case and also a justified assumption.
 
-    sed -ie "s#/sbin/ldconfig -p#cat $out/lib/factor/ld.so.cache#g" \
+    sed -i -e "s#/sbin/ldconfig -p#cat $out/lib/factor/ld.so.cache#g" \
       basis/alien/libraries/finder/linux/linux.factor
 
     # Some other hard-coded paths to fix:
@@ -123,7 +123,7 @@ stdenv.mkDerivation {
       extra/terminfo/terminfo.factor
 
     # De-memoize xdg-* functions, otherwise they break the image.
-    sed -ie 's/^MEMO:/:/' basis/xdg/xdg.factor
+    sed -i -e 's/^MEMO:/:/' basis/xdg/xdg.factor
 
     # update default paths in factor-listener.el for fuel mode
     substituteInPlace misc/fuel/fuel-listener.el \

--- a/pkgs/development/compilers/scala-runners/default.nix
+++ b/pkgs/development/compilers/scala-runners/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/bin $out/lib
-    sed -ie "s| cs | ${coursier}/bin/cs |" scala-runner
+    sed -i -e "s| cs | ${coursier}/bin/cs |" scala-runner
     cp scala-runner $out/lib
     ln -s $out/lib/scala-runner $out/bin/scala
     ln -s $out/lib/scala-runner $out/bin/scalac

--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = common.src;
 
   postPatch = ''
-    sed -ie '/sys\/sysctl.h/d' source/Irrlicht/COSOperator.cpp
+    sed -i -e '/sys\/sysctl.h/d' source/Irrlicht/COSOperator.cpp
   '' + lib.optionalString stdenv.hostPlatform.isAarch64 ''
     substituteInPlace source/Irrlicht/Makefile \
       --replace "-DIRRLICHT_EXPORTS=1" "-DIRRLICHT_EXPORTS=1 -DPNG_ARM_NEON_OPT=0"

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck = ''
     # Since `localhost' can't be resolved in a chroot, work around it.
-    sed -ie 's/localhost/127.0.0.1/g' src/test*/*.[ch]
+    sed -i -e 's/localhost/127.0.0.1/g' src/test*/*.[ch]
   '';
 
   # Disabled because the tests can time-out.

--- a/pkgs/development/libraries/wxsqliteplus/default.nix
+++ b/pkgs/development/libraries/wxsqliteplus/default.nix
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    sed -ie 's|all: $(LIBPREFIX)wxsqlite$(LIBEXT)|all: |g' Makefile
-    sed -ie 's|wxsqliteplus$(EXEEXT): $(WXSQLITEPLUS_OBJECTS) $(LIBPREFIX)wxsqlite$(LIBEXT)|wxsqliteplus$(EXEEXT):  $(WXSQLITEPLUS_OBJECTS) |g' Makefile
-    sed -ie 's|-lwxsqlite |-lwxcode_${if stdenv.hostPlatform.isDarwin then "osx_cocoau_wxsqlite3-3.2.0" else "gtk3u_wxsqlite3-3.2"} |g' Makefile
+    sed -i -e 's|all: $(LIBPREFIX)wxsqlite$(LIBEXT)|all: |g' Makefile
+    sed -i -e 's|wxsqliteplus$(EXEEXT): $(WXSQLITEPLUS_OBJECTS) $(LIBPREFIX)wxsqlite$(LIBEXT)|wxsqliteplus$(EXEEXT):  $(WXSQLITEPLUS_OBJECTS) |g' Makefile
+    sed -i -e 's|-lwxsqlite |-lwxcode_${if stdenv.hostPlatform.isDarwin then "osx_cocoau_wxsqlite3-3.2.0" else "gtk3u_wxsqlite3-3.2"} |g' Makefile
   '';
 
   installPhase = ''

--- a/pkgs/development/python-modules/baselines/default.nix
+++ b/pkgs/development/python-modules/baselines/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage {
     # Needed for the atari wrapper, but the gym-atari package is not supported
     # in nixos anyways. Since opencv-python is not currently packaged, we
     # disable it.
-    sed -ie '/opencv-python/d' setup.py
+    sed -i -e '/opencv-python/d' setup.py
   '';
 
   # fails to create a daemon, probably because of sandboxing

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
 
   # fix packaging.ParserSyntaxError, which can't handle comments
   postPatch = ''
-    sed -ie "s/ #.*$//g" requirements*.txt
+    sed -i -e "s/ #.*$//g" requirements*.txt
 
     # they bundle deps?
     rm -rf venv/

--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -59,8 +59,8 @@ buildPythonPackage rec {
     mkdir vendor/printf
     cp ${printf-src}/printf.c vendor/printf/printf.cpp
     cp -r ${printf-src}/* vendor/printf
-    sed -i"" 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h
-    sed -i"" 's/^#define vsnprintf vsnprintf_/\/\/&/' vendor/printf/printf.h
+    sed -i 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h
+    sed -i 's/^#define vsnprintf vsnprintf_/\/\/&/' vendor/printf/printf.h
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/coreboot-toolchain/update.sh
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update.sh
@@ -33,6 +33,6 @@ done
 
 echo ']' >>"$tmp"
 
-sed -ie 's/https\:\/\/ftpmirror\.gnu\.org/mirror\:\/\/gnu/g' "$tmp"
+sed -i -e 's/https\:\/\/ftpmirror\.gnu\.org/mirror\:\/\/gnu/g' "$tmp"
 
 mv "$tmp" "${pkg_dir}/sources.nix"

--- a/pkgs/games/doom-ports/zandronum/alpha/default.nix
+++ b/pkgs/games/doom-ports/zandronum/alpha/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ln -s ${sqlite}/* sqlite/
-    sed -ie 's| restrict| _restrict|g' dumb/include/dumb.h \
+    sed -i -e 's| restrict| _restrict|g' dumb/include/dumb.h \
                                        dumb/src/it/*.c
   '' + lib.optionalString (!serverOnly) ''
     sed -i \

--- a/pkgs/games/doom-ports/zandronum/default.nix
+++ b/pkgs/games/doom-ports/zandronum/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ln -s ${sqlite}/* sqlite/
-    sed -ie 's| restrict| _restrict|g' dumb/include/dumb.h \
+    sed -i -e 's| restrict| _restrict|g' dumb/include/dumb.h \
                                        dumb/src/it/*.c
   '' + lib.optionalString (!serverOnly) ''
     sed -i \

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8829,9 +8829,9 @@ with self; {
       hash = "sha256-F2+gJ3H1QqTvsdvCpMko6PQ5G/QHhHO9YEDY8RrbDsE=";
     };
     preCheck = if stdenv.hostPlatform.isCygwin then ''
-      sed -i"" -e "s@plan tests => 13@plan tests => 10@" t/env.t
-      sed -i"" -e "s@ok(env(\"\\\x@#ok(env(\"\\\x@" t/env.t
-      sed -i"" -e "s@ok(\$ENV{\"\\\x@#ok(\$ENV{\"\\\x@" t/env.t
+      sed -i -e "s@plan tests => 13@plan tests => 10@" t/env.t
+      sed -i -e "s@ok(env(\"\\\x@#ok(env(\"\\\x@" t/env.t
+      sed -i -e "s@ok(\$ENV{\"\\\x@#ok(\$ENV{\"\\\x@" t/env.t
     '' else null;
     meta = {
       description = "Determine the locale encoding";
@@ -24443,7 +24443,7 @@ with self; {
       perl_lib = "${host_perl}/lib/perl5/${host_perl.version}";
       self_lib = "${host_self}/lib/perl5/site_perl/${host_perl.version}";
     in ''
-      sed -ie 's|"-I$(INST_ARCHLIB)"|"-I${perl_lib}" "-I${self_lib}"|g' Makefile
+      sed -i -e 's|"-I$(INST_ARCHLIB)"|"-I${perl_lib}" "-I${self_lib}"|g' Makefile
     '');
 
     # TermReadKey uses itself in the build process
@@ -28499,7 +28499,7 @@ with self; {
     };
     buildInputs = [ pkgs.xorg.libXext pkgs.xorg.libXScrnSaver pkgs.xorg.libX11 ];
     propagatedBuildInputs = [ InlineC ];
-    patchPhase = "sed -ie 's,-L/usr/X11R6/lib/,-L${pkgs.xorg.libX11.out}/lib/ -L${pkgs.xorg.libXext.out}/lib/ -L${pkgs.xorg.libXScrnSaver}/lib/,' IdleTime.pm";
+    patchPhase = "sed -i -e 's,-L/usr/X11R6/lib/,-L${pkgs.xorg.libX11.out}/lib/ -L${pkgs.xorg.libXext.out}/lib/ -L${pkgs.xorg.libXScrnSaver}/lib/,' IdleTime.pm";
     meta = {
       description = "Get the idle time of X11";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -28833,7 +28833,7 @@ with self; {
     postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
       substituteInPlace Expat/Makefile.PL --replace 'use English;' '#'
     '' + lib.optionalString stdenv.hostPlatform.isCygwin ''
-      sed -i"" -e "s@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. \$Config{_exe};@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. (\$^O eq 'cygwin' ? \"\" : \$Config{_exe});@" inc/Devel/CheckLib.pm
+      sed -i -e "s@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. \$Config{_exe};@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. (\$^O eq 'cygwin' ? \"\" : \$Config{_exe});@" inc/Devel/CheckLib.pm
     '';
     makeMakerFlags = [ "EXPATLIBPATH=${pkgs.expat.out}/lib" "EXPATINCPATH=${pkgs.expat.dev}/include" ];
     propagatedBuildInputs = [ LWP ];


### PR DESCRIPTION
GNU sed's man page has this to say about "-i":

> Because -i takes an optional argument, it should not be followed by
> other short options:
> [..]
> sed -iE '...' FILE
>   This is equivalent to --in-place=E, creating FILEE as backup of FILE

This means all "-iX" did not have the intended effect X, so we can instead remove them.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
