### PR TITLE
cfv: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10892,6 +10892,11 @@
     githubId = 691552;
     name = "Jamie McClymont";
   };
+  jjtt = {
+    github = "jjtt";
+    githubId = 3908945;
+    name = "Juho Törmä";
+  };
   jk = {
     email = "hello+nixpkgs@j-k.io";
     matrix = "@j-k:matrix.org";

--- a/pkgs/by-name/cf/cfv/package.nix
+++ b/pkgs/by-name/cf/cfv/package.nix
@@ -24,6 +24,7 @@ python3.pkgs.buildPythonApplication rec {
   checkPhase = ''
     runHook preCheck
     cd test
+    ulimit -n 4096
     python3 test.py
     runHook postCheck
   '';

--- a/pkgs/by-name/cf/cfv/package.nix
+++ b/pkgs/by-name/cf/cfv/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  pkgs,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cfv";
+  version = "3.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cfv-project";
+    repo = "cfv";
+    tag = "v${version}";
+    sha256 = "1wxf30gsijsdvhv5scgkq0bqi8qi4dgs9dwppdrca5wxgy7a8sn5";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    cd test
+    python3 test.py
+    runHook postCheck
+  '';
+
+  nativeCheckInputs = [
+    pkgs.cksfv
+  ];
+
+  meta = {
+    description = "Utility to verify and create a wide range of checksums";
+    homepage = "https://github.com/cfv-project/cfv";
+    changelog = "https://github.com/cfv-project/cfv/releases/tag/v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ jjtt ];
+    mainProgram = "cfv";
+  };
+}


### PR DESCRIPTION
cfv – Command-line File Verify

cfv is a utility to test and create a wide range of checksum verification files. It currently supports testing and creating sfv, sfvmd5, csv, csv2, csv4, md5, bsdmd5, sha1, sha224, sha256, sha384, sha512, torrent and crc files. Test-only support is available for par, par2.

cfv was originally written by Matthew Mueller. Version in GitHub (https://github.com/cfv-project/cfv) is a friendly fork of cfv maintained by David Lisa Gnedt.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
