### PR TITLE
sydbox: 2.2.0 -> 3.28.3

### DIFF
--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -7,6 +7,8 @@
   pkg-config,
   rustPlatform,
   scdoc,
+  sydbox,
+  testers,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -64,6 +66,11 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru = {
+    tests.version = testers.testVersion {
+      package = sydbox;
+      command = "syd -V";
+    };
+
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -62,11 +62,13 @@ rustPlatform.buildRustPackage rec {
     make $makeFlags install-{man,vim}
   '';
 
-  meta = with lib; {
-    homepage = "https://sydbox.exherbo.org/";
+  meta = {
     description = "seccomp-based application sandbox";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ mvs ];
+    homepage = "https://sydbox.exherbo.org/";
+    changelog = "https://gitlab.exherbo.org/sydbox/sydbox/-/blob/v${version}/ChangeLog.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ mvs ];
+    mainProgram = "syd";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "seccomp-based application sandbox";
-    homepage = "https://sydbox.exherbo.org/";
+    homepage = "https://gitlab.exherbo.org/sydbox/sydbox";
     changelog = "https://gitlab.exherbo.org/sydbox/sydbox/-/blob/v${version}/ChangeLog.md";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -1,93 +1,71 @@
 {
   lib,
-  stdenv,
-  autoreconfHook,
-  docbook_xml_dtd_42,
-  docbook_xsl,
-  fetchurl,
-  gnumake,
+  fetchFromGitLab,
   libseccomp,
-  libunwind,
-  libxslt,
-  perl,
+  mandoc,
   pkg-config,
-  python3,
-  which,
-  debugBuild ? false,
-  installTests ? true,
+  rustPlatform,
+  scdoc,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "sydbox-1";
-  version = "2.2.0";
+rustPlatform.buildRustPackage rec {
+  pname = "sydbox";
+  version = "3.28.3";
 
   outputs = [
     "out"
-    "dev"
     "man"
-    "doc"
-  ] ++ lib.optional installTests "installedTests";
-
-  src = fetchurl {
-    url = "https://git.exherbo.org/${pname}.git/snapshot/${pname}-${version}.tar.xz";
-    sha256 = "0664myrrzbvsw73q5b7cqwgv4hl9a7vkm642s1r96gaxm16jk0z7";
-  };
-
-  nativeBuildInputs = [
-    pkg-config
-    autoreconfHook
-    python3
-    perl
-    libxslt.bin
-    docbook_xsl
-    docbook_xml_dtd_42
   ];
 
-  buildInputs =
-    [
-      libseccomp
-    ]
-    ++ lib.optional debugBuild libunwind
-    ++ lib.optionals installTests [
-      gnumake
-      python3
-      perl
-      which
-    ];
+  src = fetchFromGitLab {
+    domain = "gitlab.exherbo.org";
+    owner = "Sydbox";
+    repo = "sydbox";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-9IegNFkOWYt+jdpN0rk4S/qyD/NSPaSqmFnMmCl/3Tk=";
+  };
 
-  enableParallelBuilding = true;
+  cargoHash = "sha256-6/D//mkPDRW01SCLmQGWwFCClZ84aJUPhleWGVCJaKM=";
 
-  configureFlags =
-    [ ]
-    ++ lib.optionals installTests [
-      "--enable-installed-tests"
-      "--libexecdir=${placeholder "installedTests"}/libexec"
-    ]
-    ++ lib.optional debugBuild "--enable-debug";
+  nativeBuildInputs = [
+    mandoc
+    pkg-config
+    scdoc
+  ];
 
-  makeFlags = [ "SYD_INCLUDEDIR=${stdenv.cc.libc.dev}/include" ];
+  buildInputs = [ libseccomp ];
 
-  doCheck = true;
-  checkPhase = ''
-    # Many of the regular test cases in t/ do not work inside the build sandbox
-    make -C syd check
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  checkFlags = [
+    # rm -rf tmpdir: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+    "--skip=fs::tests::test_relative_symlink_resolution"
+    # Failed to write C source file!: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
+    "--skip=proc::tests::test_proc_set_at_secure_test_32bit_dynamic"
+    # /bin/false: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+    "--skip=syd_test"
+
+    # Endlessly stall. Maybe a sandbox issue?
+    "--skip=caps"
+    "--skip=landlock::compat::Compatible::set_compatibility"
+    "--skip=landlock::fs::PathBeneath"
+    "--skip=landlock::fs::PathFd"
+    "--skip=landlock::fs::path_beneath_rules"
+    "--skip=proc::proc_cmdline"
+    "--skip=proc::proc_comm"
+  ];
+
+  # TODO: Have these directories be created upstream similar to the vim files
+  postInstall = ''
+    mkdir -p $out/share/man/man{1,2,5,7}
+
+    make $makeFlags install-{man,vim}
   '';
-
-  postInstall =
-    if installTests then
-      ''
-        moveToOutput bin/syd-test $installedTests
-      ''
-    else
-      ''
-        # Tests are installed despite --disable-installed-tests
-        rm -r $out/bin/syd-test $out/libexec
-      '';
 
   meta = with lib; {
     homepage = "https://sydbox.exherbo.org/";
     description = "seccomp-based application sandbox";
-    license = licenses.gpl2Only;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ mvs ];
   };

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -1,24 +1,32 @@
-{ lib
-, stdenv
-, fetchurl
-, pkg-config
-, autoreconfHook
-, python3
-, perl
-, libxslt
-, docbook_xsl
-, docbook_xml_dtd_42
-, libseccomp
-, installTests ? true, gnumake, which
-, debugBuild ? false, libunwind
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  docbook_xml_dtd_42,
+  docbook_xsl,
+  fetchurl,
+  gnumake,
+  libseccomp,
+  libunwind,
+  libxslt,
+  perl,
+  pkg-config,
+  python3,
+  which,
+  debugBuild ? false,
+  installTests ? true,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sydbox-1";
   version = "2.2.0";
 
-  outputs = [ "out" "dev" "man" "doc" ]
-    ++ lib.optional installTests "installedTests";
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "doc"
+  ] ++ lib.optional installTests "installedTests";
 
   src = fetchurl {
     url = "https://git.exherbo.org/${pname}.git/snapshot/${pname}-${version}.tar.xz";
@@ -35,9 +43,11 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_42
   ];
 
-  buildInputs = [
-    libseccomp
-  ] ++ lib.optional debugBuild libunwind
+  buildInputs =
+    [
+      libseccomp
+    ]
+    ++ lib.optional debugBuild libunwind
     ++ lib.optionals installTests [
       gnumake
       python3
@@ -47,9 +57,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = [ ]
-    ++ lib.optionals installTests [ "--enable-installed-tests"
-      "--libexecdir=${placeholder "installedTests"}/libexec" ]
+  configureFlags =
+    [ ]
+    ++ lib.optionals installTests [
+      "--enable-installed-tests"
+      "--libexecdir=${placeholder "installedTests"}/libexec"
+    ]
     ++ lib.optional debugBuild "--enable-debug";
 
   makeFlags = [ "SYD_INCLUDEDIR=${stdenv.cc.libc.dev}/include" ];
@@ -60,12 +73,16 @@ stdenv.mkDerivation rec {
     make -C syd check
   '';
 
-  postInstall = if installTests then ''
-    moveToOutput bin/syd-test $installedTests
-  '' else ''
-    # Tests are installed despite --disable-installed-tests
-    rm -r $out/bin/syd-test $out/libexec
-  '';
+  postInstall =
+    if installTests then
+      ''
+        moveToOutput bin/syd-test $installedTests
+      ''
+    else
+      ''
+        # Tests are installed despite --disable-installed-tests
+        rm -r $out/bin/syd-test $out/libexec
+      '';
 
   meta = with lib; {
     homepage = "https://sydbox.exherbo.org/";

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitLab,
   libseccomp,
   mandoc,
+  nix-update-script,
   pkg-config,
   rustPlatform,
   scdoc,
@@ -61,6 +62,10 @@ rustPlatform.buildRustPackage rec {
 
     make $makeFlags install-{man,vim}
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "seccomp-based application sandbox";

--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -79,7 +79,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://sydbox.exherbo.org/";
     changelog = "https://gitlab.exherbo.org/sydbox/sydbox/-/blob/v${version}/ChangeLog.md";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ mvs ];
+    maintainers = with lib.maintainers; [
+      mvs
+      getchoo
+    ];
     mainProgram = "syd";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/356580

Changelog: https://gitlab.exherbo.org/sydbox/sydbox/-/blob/v3.28.3/ChangeLog.md?ref_type=tags#3283

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
