### PR TITLE
gcc: gcc13 -> gcc14 (again)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -10,6 +10,9 @@
   Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
   If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
 
+- GCC has been updated from GCC 13 to GCC 14.
+  This introduces some backwards‐incompatible changes; see the [upstream porting guide](https://gcc.gnu.org/gcc-14/porting_to.html) for details.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -184,7 +184,13 @@ pipe ((callFile ./common/builder.nix {}) ({
   inherit version;
 
   src = fetchurl {
-    url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
+    url = "mirror://gcc/${
+      # TODO: Remove this before 25.05.
+      if version == "14-20241116" then
+        "snapshots/"
+      else
+        "releases/gcc-"
+    }${version}/gcc-${version}.tar.xz";
     ${if is10 || is11 || is13 then "hash" else "sha256"} =
       gccVersions.srcHashForVersion version;
   };
@@ -205,6 +211,29 @@ pipe ((callFile ./common/builder.nix {}) ({
     for configureScript in $configureScripts; do
       patchShebangs $configureScript
     done
+  ''
+  # Copy the precompiled `gcc/gengtype-lex.cc` from the 14.2.0 tarball.
+  # Since the `gcc/gengtype-lex.l` file didn’t change between 14.2.0
+  # and 14-2024116, this is safe. If it changes and we update the
+  # snapshot, we might need to vendor the compiled output in Nixpkgs.
+  #
+  # TODO: Remove this before 25.05.
+  + optionalString (version == "14-20241116") ''
+    cksum -c <<EOF
+    SHA256 (gcc/gengtype-lex.l) = 05acceeda02e673eaef47d187d3a68a1632508112fbe31b5dc2b0a898998d7ec
+    EOF
+
+    (XZ_OPT="--threads=$NIX_BUILD_CORES" xz -d < ${fetchurl {
+      url = "mirror://gcc/releases/gcc-14.2.0/gcc-14.2.0.tar.xz";
+      hash = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
+    }}; true) | tar xf - \
+      --mode=+w \
+      --warning=no-timestamp \
+      --strip-components=1 \
+      gcc-14.2.0/gcc/gengtype-lex.cc
+
+    # Make sure Make knows it’s up‐to‐date.
+    touch gcc/gengtype-lex.cc
   ''
   # This should kill all the stdinc frameworks that gcc and friends like to
   # insert into default search paths.

--- a/pkgs/development/compilers/gcc/patches/14/fixup-gcc-14-darwin-aarch64-support.patch
+++ b/pkgs/development/compilers/gcc/patches/14/fixup-gcc-14-darwin-aarch64-support.patch
@@ -1,0 +1,181 @@
+This patch was produced by manually merging:
+
+* <https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=74bfca7360910ae640c2c9c362fe9a4c0ebcc3ba>
+* <https://github.com/iains/gcc-14-branch/tree/gcc-14.2-darwin-r2>
+
+and then taking the diff between the result and the upstream GCC
+commit, and excerpting only the files that have conflicts when
+naively applying the branch’s diff to the snapshot. (This is
+more files than the two that actually needed manual merge work –
+`gcc/config/aarch64/aarch64-tune.md` and `libgcc/config.host` –
+because `patch(1)` can’t do a three‐way merge using ancestor
+information.)
+
+diff --git a/gcc/config/aarch64/aarch64-tune.md b/gcc/config/aarch64/aarch64-tune.md
+index 35b27ddb88..8ce2a93168 100644
+--- a/gcc/config/aarch64/aarch64-tune.md
++++ b/gcc/config/aarch64/aarch64-tune.md
+@@ -1,5 +1,5 @@
+ ;; -*- buffer-read-only: t -*-
+ ;; Generated automatically by gentune.sh from aarch64-cores.def
+ (define_attr "tune"
+-	"cortexa34,cortexa35,cortexa53,cortexa57,cortexa72,cortexa73,thunderx,thunderxt88p1,thunderxt88,octeontx,octeontxt81,octeontxt83,thunderxt81,thunderxt83,ampere1,ampere1a,ampere1b,emag,xgene1,falkor,qdf24xx,exynosm1,phecda,thunderx2t99p1,vulcan,thunderx2t99,cortexa55,cortexa75,cortexa76,cortexa76ae,cortexa77,cortexa78,cortexa78ae,cortexa78c,cortexa65,cortexa65ae,cortexx1,cortexx1c,neoversen1,ares,neoversee1,octeontx2,octeontx2t98,octeontx2t96,octeontx2t93,octeontx2f95,octeontx2f95n,octeontx2f95mm,a64fx,fujitsu_monaka,tsv110,thunderx3t110,neoversev1,zeus,neoverse512tvb,saphira,cortexa57cortexa53,cortexa72cortexa53,cortexa73cortexa35,cortexa73cortexa53,cortexa75cortexa55,cortexa76cortexa55,cortexr82,cortexa510,cortexa520,cortexa710,cortexa715,cortexa720,cortexa725,cortexx2,cortexx3,cortexx4,cortexx925,neoversen2,cobalt100,neoversen3,neoversev2,grace,neoversev3,neoversev3ae,demeter,generic,generic_armv8_a,generic_armv9_a"
++	"cortexa34,cortexa35,cortexa53,cortexa57,cortexa72,cortexa73,thunderx,thunderxt88p1,thunderxt88,octeontx,octeontxt81,octeontxt83,thunderxt81,thunderxt83,ampere1,ampere1a,ampere1b,emag,xgene1,falkor,qdf24xx,exynosm1,phecda,thunderx2t99p1,vulcan,thunderx2t99,cortexa55,cortexa75,cortexa76,cortexa76ae,cortexa77,cortexa78,cortexa78ae,cortexa78c,cortexa65,cortexa65ae,cortexx1,cortexx1c,neoversen1,ares,neoversee1,octeontx2,octeontx2t98,octeontx2t96,octeontx2t93,octeontx2f95,octeontx2f95n,octeontx2f95mm,a64fx,fujitsu_monaka,tsv110,thunderx3t110,neoversev1,zeus,neoverse512tvb,saphira,cortexa57cortexa53,cortexa72cortexa53,cortexa73cortexa35,cortexa73cortexa53,cortexa75cortexa55,cortexa76cortexa55,cortexr82,applea12,applem1,applem2,applem3,cortexa510,cortexa520,cortexa710,cortexa715,cortexa720,cortexa725,cortexx2,cortexx3,cortexx4,cortexx925,neoversen2,cobalt100,neoversen3,neoversev2,grace,neoversev3,neoversev3ae,demeter,generic,generic_armv8_a,generic_armv9_a"
+ 	(const (symbol_ref "((enum attr_tune) aarch64_tune)")))
+diff --git a/gcc/config/darwin.h b/gcc/config/darwin.h
+index 0d8886c026..5370511bec 100644
+--- a/gcc/config/darwin.h
++++ b/gcc/config/darwin.h
+@@ -42,6 +42,7 @@
+ 
+ #define DARWIN_X86 0
+ #define DARWIN_PPC 0
++#define DARWIN_ARM64 0
+ 
+ #define OBJECT_FORMAT_MACHO 1
+ 
+@@ -373,7 +374,8 @@
+ */
+ 
+ #define DARWIN_NOCOMPACT_UNWIND \
+-" %:version-compare(>= 10.6 mmacosx-version-min= -no_compact_unwind) "
++"%{!fuse-ld=lld: \
++    %:version-compare(>= 10.6 mmacosx-version-min= -no_compact_unwind)}"
+ 
+ /* In Darwin linker specs we can put -lcrt0.o and ld will search the library
+    path for crt0.o or -lcrtx.a and it will search for libcrtx.a.  As for
+@@ -397,7 +399,8 @@
+     LINK_PLUGIN_SPEC \
+     "%{flto*:%<fcompare-debug*} \
+      %{flto} %{fno-lto} %{flto=*} \
+-    %l " \
++     %l \
++     %{fuse-ld=*:-fuse-ld=%*} " \
+     DARWIN_PLATFORM_ID \
+     LINK_COMPRESS_DEBUG_SPEC \
+    "%X %{s} %{t} %{Z} %{u*} \
+@@ -979,7 +982,12 @@
+   { "apple_kext_compatibility", 0, 0, false, true, false, false,	     \
+     darwin_handle_kext_attribute, NULL },				     \
+   { "weak_import", 0, 0, true, false, false, false,			     \
+-    darwin_handle_weak_import_attribute, NULL }
++    darwin_handle_weak_import_attribute, NULL },			     \
++  { "availability", 0, -1, true, false, false, false,			     \
++    darwin_handle_availability_attribute, NULL }
++
++#undef TARGET_ATTRIBUTE_TAKES_IDENTIFIER_P
++#define TARGET_ATTRIBUTE_TAKES_IDENTIFIER_P darwin_attribute_takes_identifier_p
+ 
+ /* Make local constant labels linker-visible, so that if one follows a
+    weak_global constant, ld64 will be able to separate the atoms.  */
+@@ -1227,6 +1235,10 @@
+ #define TARGET_N_FORMAT_TYPES 1
+ #define TARGET_FORMAT_TYPES darwin_additional_format_types
+ 
++/* We want __builtin_unreachable to be expanded as a trap instruction.  */
++#undef TARGET_UNREACHABLE_SHOULD_TRAP
++#define TARGET_UNREACHABLE_SHOULD_TRAP darwin_unreachable_traps_p
++
+ #ifndef USED_FOR_TARGET
+ extern void darwin_driver_init (unsigned int *,struct cl_decoded_option **);
+ #define GCC_DRIVER_HOST_INITIALIZATION \
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 7332903704..ae4c91dee3 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -82,7 +82,7 @@
+         cpu_type=m32c
+ 	tmake_file=t-fdpbit
+         ;;
+-aarch64*-*-*)
++aarch64*-*-* | arm64*-*-*)
+ 	cpu_type=aarch64
+ 	;;
+ alpha*-*-*)
+@@ -236,22 +236,25 @@
+   esac
+   tmake_file="$tmake_file t-slibgcc-darwin"
+   case ${host} in
++    x86_64-*-darwin2[0-2]*)
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
++      ;;
+     *-*-darwin2*)
+       tmake_file="t-darwin-min-11 $tmake_file"
+       ;;
+     *-*-darwin1[89]*)
+-      tmake_file="t-darwin-min-8 $tmake_file"
++      tmake_file="t-darwin-min-8 t-darwin-libgccs1 $tmake_file"
+       ;;
+     *-*-darwin9* | *-*-darwin1[0-7]*)
+-      tmake_file="t-darwin-min-5 $tmake_file"
++      tmake_file="t-darwin-min-5 t-darwin-libgccs1 $tmake_file"
+       ;;
+     *-*-darwin[4-8]*)
+-      tmake_file="t-darwin-min-1 $tmake_file"
++      tmake_file="t-darwin-min-1 t-darwin-libgccs1 $tmake_file"
+       ;;
+     *)
+       # Fall back to configuring for the oldest system known to work with
+       # all archs and the current sources.
+-      tmake_file="t-darwin-min-5 $tmake_file"
++      tmake_file="t-darwin-min-5 t-darwin-libgccs1 $tmake_file"
+       echo "Warning: libgcc configured to support macOS 10.5" 1>&2
+       ;;
+   esac
+@@ -277,7 +280,7 @@
+   if test "x$enable_darwin_at_rpath" = "xyes"; then
+     tmake_file="$tmake_file t-darwin-rpath "
+   fi
+-  extra_parts="crt3.o libd10-uwfef.a crttms.o crttme.o libemutls_w.a"
++  extra_parts="crt3.o crttms.o crttme.o libemutls_w.a "
+   ;;
+ *-*-dragonfly*)
+   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip"
+@@ -421,6 +424,15 @@
+ 	tmake_file="${tmake_file} t-dfprules"
+ 	md_unwind_header=aarch64/aarch64-unwind.h
+ 	;;
++aarch64*-*-darwin*)
++	extra_parts="$extra_parts crtfastmath.o libheapt_w.a"
++	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
++	tmake_file="${tmake_file} ${cpu_type}/t-lse"
++	tmake_file="${tmake_file} t-crtfm t-dfprules"
++	tmake_file="${tmake_file} ${cpu_type}/t-softfp t-softfp"
++	tmake_file="${tmake_file} ${cpu_type}/t-heap-trampoline"
++	md_unwind_header=aarch64/aarch64-unwind.h
++	;;
+ aarch64*-*-freebsd*)
+ 	extra_parts="$extra_parts crtfastmath.o"
+ 	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
+@@ -728,14 +740,14 @@
+ 	tmake_file="$tmake_file i386/t-crtpc t-crtfm i386/t-msabi"
+ 	tm_file="$tm_file i386/darwin-lib.h"
+ 	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o"
+-	extra_parts="$extra_parts crtfastmath.o libheapt_w.a"
++	extra_parts="$extra_parts crtfastmath.o libd10-uwfef.a libheapt_w.a"
+ 	tmake_file="${tmake_file} i386/t-heap-trampoline"
+ 	;;
+ x86_64-*-darwin*)
+ 	tmake_file="$tmake_file i386/t-crtpc t-crtfm i386/t-msabi"
+ 	tm_file="$tm_file i386/darwin-lib.h"
+ 	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o"
+-	extra_parts="$extra_parts crtfastmath.o libheapt_w.a"
++	extra_parts="$extra_parts crtfastmath.o libd10-uwfef.a libheapt_w.a"
+ 	tmake_file="${tmake_file} i386/t-heap-trampoline"
+ 	;;
+ i[34567]86-*-elfiamcu)
+@@ -1218,12 +1230,14 @@
+ 	# We build the darwin10 EH shim for Rosetta (running on x86 machines).
+ 	tm_file="$tm_file i386/darwin-lib.h"
+ 	tmake_file="$tmake_file rs6000/t-ppc64-fp rs6000/t-ibm-ldouble"
++	extra_parts="$extra_parts libd10-uwfef.a "
+ 	extra_parts="$extra_parts crt2.o crt3_2.o libef_ppc.a dw_ppc.o"
+ 	;;
+ powerpc64-*-darwin*)
+ 	# We build the darwin10 EH shim for Rosetta (running on x86 machines).
+ 	tm_file="$tm_file i386/darwin-lib.h"
+ 	tmake_file="$tmake_file rs6000/t-darwin64 rs6000/t-ibm-ldouble"
++	extra_parts="$extra_parts libd10-uwfef.a "
+ 	extra_parts="$extra_parts crt2.o crt3_2.o libef_ppc.a dw_ppc.o"
+ 	;;
+ powerpc*-*-freebsd*)

--- a/pkgs/development/compilers/gcc/patches/14/libgcc-darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/patches/14/libgcc-darwin-detection.patch
@@ -1,12 +1,13 @@
-diff -u a/libgcc/config.host b/libgcc/config.host
---- a/libgcc/config.host	2023-11-05 11:01:55.778638446 -0500
-+++ b/libgcc/config.host	2023-11-05 11:07:29.405103979 -0500
-@@ -227,7 +227,7 @@
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 7332903704..27a8b5bedb 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -236,7 +236,7 @@
+   esac
    tmake_file="$tmake_file t-slibgcc-darwin"
-   # newer toolsets produce warnings when building for unsupported versions.
    case ${host} in
--    *-*-darwin1[89]* | *-*-darwin2* )
-+    *-*-darwin1[89]* | *-*-darwin2* | *-*-darwin)
-       tmake_file="t-darwin-min-8 $tmake_file"
+-    *-*-darwin2*)
++    *-*-darwin2* | *-*-darwin)
+       tmake_file="t-darwin-min-11 $tmake_file"
        ;;
-     *-*-darwin9* | *-*-darwin1[0-7]*)
+     *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -138,13 +138,23 @@ in
 # We only apply this patch when building a native toolchain for aarch64-darwin, as it breaks building
 # a foreign one: https://github.com/iains/gcc-12-branch/issues/18
 ++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && buildPlatform == hostPlatform && hostPlatform == targetPlatform) ({
-  "14" = [ (fetchpatch {
-    # There are no upstream release tags in https://github.com/iains/gcc-14-branch.
-    # 04696df09633baf97cdbbdd6e9929b9d472161d3 is the commit from https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-14.2.0
-    name = "gcc-14-darwin-aarch64-support.patch";
-    url = "https://github.com/iains/gcc-14-branch/compare/04696df09633baf97cdbbdd6e9929b9d472161d3..gcc-14.2-darwin-r0.diff";
-    hash = "sha256-GEUz7KdGzd2WJ0gjX3Uddq2y9bWKdZpT3E9uZ09qLs4=";
-  }) ];
+  "14" = [
+    (fetchpatch {
+      name = "gcc-14-darwin-aarch64-support.patch";
+      url = "https://raw.githubusercontent.com/Homebrew/formula-patches/41fdb9d5ec21fc8165cd4bee89bd23d0c90572ee/gcc/gcc-14.2.0-r2.diff";
+      # The patch is based on 14.2.0, but we use a GCC snapshot. We
+      # exclude the files with conflicts and apply our own merged patch
+      # to avoid vendoring the entire huge patch in‐tree.
+      excludes = [
+        "gcc/config/aarch64/aarch64-tune.md"
+        "gcc/config/darwin.h"
+        "libgcc/config.host"
+        "libgcc/config/t-darwin-min-11"
+      ];
+      hash = "sha256-E4zEKm4tMhovOJKc1/FXZCLQvA+Jt5SC0O2C6SEvZjI=";
+    })
+    ./14/fixup-gcc-14-darwin-aarch64-support.patch
+  ];
   "13" = [ (fetchpatch {
     name = "gcc-13-darwin-aarch64-support.patch";
     url = "https://raw.githubusercontent.com/Homebrew/formula-patches/bda0faddfbfb392e7b9c9101056b2c5ab2500508/gcc/gcc-13.3.0.diff";

--- a/pkgs/development/compilers/gcc/versions.nix
+++ b/pkgs/development/compilers/gcc/versions.nix
@@ -1,6 +1,6 @@
 let
   majorMinorToVersionMap = {
-    "14" = "14.2.0";
+    "14" = "14-20241116";
     "13" = "13.3.0";
     "12" = "12.4.0";
     "11" = "11.5.0";
@@ -16,7 +16,7 @@ let
 
   # TODO(amjoseph): convert older hashes to SRI form
   srcHashForVersion = version: {
-    "14.2.0" = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
+    "14-20241116" = "sha256-aXSkle8Mzj/Q15cHOu0D9Os2PWQwMIboUZULhnsRSUo=";
     "13.3.0" = "sha256-CEXpYhyVQ6E/SE6UWEpJ/8ASmXDpkUYkI1/B0GGgwIM=";
     "12.4.0" = "sha256-cE9lJgTMvMsUvavzR4yVEciXiLEss7v/3tNzQZFqkXU=";
     "11.5.0" = "sha256-puIYaOrVRc+H8MAfhCduS1KB1nIJhZHByJYkHwk2NHg=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6155,7 +6155,7 @@ with pkgs;
   gerbilPackages-unstable = pkgs.gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
   glow-lang = pkgs.gerbilPackages-unstable.glow-lang;
 
-  default-gcc-version = 13;
+  default-gcc-version = 14;
   gcc = pkgs.${"gcc${toString default-gcc-version}"};
   gccFun = callPackage ../development/compilers/gcc;
   gcc-unwrapped = gcc.cc;


### PR DESCRIPTION
Here we go again…

The stable release has too many AArch64 issues, but they seem to have been fixed upstream; Arch is shipping a Git snapshot. The next stable release should be out by the time 25.05 is finishing up, so this should be okay as a temporary solution.

This is the GCC 14-20241116 snapshot. We use that identifier as our package version, diverging from our usual unstable version convention, because it identifies itself as “gcc (GCC) 14.2.1 20241116” and comes in `gcc-14-20241116.tar.xz`; 20241116 is therefore a useful version identifier to use verbatim, and 14.2.0-unstable-2024-11-16 would potentially be confusing for a version that calls itself 14.2.1. The next stable release from the GCC 14 branch will be 14.3.0, so there should be no ambiguity here.

Getting this version is a little complicated; we need the precompiled `flex(1)` output that these Git snapshots don’t include. Thankfully, the source file hasn’t changed since 14.2.0, so we can simply download 14.2.0 too and extract the precompiled file. A little merging finesse is required for the `aarch64-darwin` patch, which we also upgrade.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
