### PR TITLE
workflows/check-nix-format: reminder to rebase

### DIFF
--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -85,6 +85,7 @@ jobs:
             echo "Some new/changed Nix files are not properly formatted"
             echo "Please go to the Nixpkgs root directory, run \`nix-shell\`, then:"
             echo "nixfmt ${unformattedFiles[*]@Q}"
+            echo "Make sure your branch is up to date with master, rebase if not."
             echo "If you're having trouble, please ping @NixOS/nix-formatting"
             exit 1
           fi


### PR DESCRIPTION
The most typical mistake here is that the user doesn't have the correct nixfmt in their (old) branch.

I'm not sure about the exact wording, but some reminder is certainly needed.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc