### PR TITLE
Systemd 257

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -1,115 +1,117 @@
-/* Technical details
+/*
+  Technical details
 
-`make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine.
+  `make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine.
 
-It relies on the [LKL (Linux Kernel Library) project](https://github.com/lkl/linux) which provides Linux kernel as userspace library.
+  It relies on the [LKL (Linux Kernel Library) project](https://github.com/lkl/linux) which provides Linux kernel as userspace library.
 
-The Nix-store only image only need to run LKL tools to produce an image and will never spawn a virtual machine, whereas full images will always require a virtual machine, but also use LKL.
+  The Nix-store only image only need to run LKL tools to produce an image and will never spawn a virtual machine, whereas full images will always require a virtual machine, but also use LKL.
 
-### Image preparation phase
+  ### Image preparation phase
 
-Image preparation phase will produce the initial image layout in a folder:
+  Image preparation phase will produce the initial image layout in a folder:
 
-- devise a root folder based on `$PWD`
-- prepare the contents by copying and restoring ACLs in this root folder
-- load in the Nix store database all additional paths computed by `pkgs.closureInfo` in a temporary Nix store
-- run `nixos-install` in a temporary folder
-- transfer from the temporary store the additional paths registered to the installed NixOS
-- compute the size of the disk image based on the apparent size of the root folder
-- partition the disk image using the corresponding script according to the partition table type
-- format the partitions if needed
-- use `cptofs` (LKL tool) to copy the root folder inside the disk image
+  - devise a root folder based on `$PWD`
+  - prepare the contents by copying and restoring ACLs in this root folder
+  - load in the Nix store database all additional paths computed by `pkgs.closureInfo` in a temporary Nix store
+  - run `nixos-install` in a temporary folder
+  - transfer from the temporary store the additional paths registered to the installed NixOS
+  - compute the size of the disk image based on the apparent size of the root folder
+  - partition the disk image using the corresponding script according to the partition table type
+  - format the partitions if needed
+  - use `cptofs` (LKL tool) to copy the root folder inside the disk image
 
-At this step, the disk image already contains the Nix store, it now only needs to be converted to the desired format to be used.
+  At this step, the disk image already contains the Nix store, it now only needs to be converted to the desired format to be used.
 
-### Image conversion phase
+  ### Image conversion phase
 
-Using `qemu-img`, the disk image is converted from a raw format to the desired format: qcow2(-compressed), vdi, vpc.
+  Using `qemu-img`, the disk image is converted from a raw format to the desired format: qcow2(-compressed), vdi, vpc.
 
-### Image Partitioning
+  ### Image Partitioning
 
-#### `none`
+  #### `none`
 
-No partition table layout is written. The image is a bare filesystem image.
+  No partition table layout is written. The image is a bare filesystem image.
 
-#### `legacy`
+  #### `legacy`
 
-The image is partitioned using MBR. There is one primary ext4 partition starting at 1 MiB that fills the rest of the disk image.
+  The image is partitioned using MBR. There is one primary ext4 partition starting at 1 MiB that fills the rest of the disk image.
 
-This partition layout is unsuitable for UEFI.
+  This partition layout is unsuitable for UEFI.
 
-#### `legacy+gpt`
+  #### `legacy+gpt`
 
-This partition table type uses GPT and:
+  This partition table type uses GPT and:
 
-- create a "no filesystem" partition from 1MiB to 2MiB ;
-- set `bios_grub` flag on this "no filesystem" partition, which marks it as a [GRUB BIOS partition](https://www.gnu.org/software/parted/manual/html_node/set.html) ;
-- create a primary ext4 partition starting at 2MiB and extending to the full disk image ;
-- perform optimal alignments checks on each partition
+  - create a "no filesystem" partition from 1MiB to 2MiB ;
+  - set `bios_grub` flag on this "no filesystem" partition, which marks it as a [GRUB BIOS partition](https://www.gnu.org/software/parted/manual/html_node/set.html) ;
+  - create a primary ext4 partition starting at 2MiB and extending to the full disk image ;
+  - perform optimal alignments checks on each partition
 
-This partition layout is unsuitable for UEFI boot, because it has no ESP (EFI System Partition) partition. It can work with CSM (Compatibility Support Module) which emulates legacy (BIOS) boot for UEFI.
+  This partition layout is unsuitable for UEFI boot, because it has no ESP (EFI System Partition) partition. It can work with CSM (Compatibility Support Module) which emulates legacy (BIOS) boot for UEFI.
 
-#### `efi`
+  #### `efi`
 
-This partition table type uses GPT and:
+  This partition table type uses GPT and:
 
-- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
-- creates an primary ext4 partition starting after the boot partition and extending to the full disk image
+  - creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+  - creates an primary ext4 partition starting after the boot partition and extending to the full disk image
 
-#### `efixbootldr`
+  #### `efixbootldr`
 
-This partition table type uses GPT and:
+  This partition table type uses GPT and:
 
-- creates an FAT32 ESP partition from 8MiB to 100MiB, set it bootable ;
-- creates an FAT32 BOOT partition from 100MiB to specified `bootSize` parameter (256MiB by default), set `bls_boot` flag ;
-- creates an primary ext4 partition starting after the boot partition and extending to the full disk image
+  - creates an FAT32 ESP partition from 8MiB to 100MiB, set it bootable ;
+  - creates an FAT32 BOOT partition from 100MiB to specified `bootSize` parameter (256MiB by default), set `bls_boot` flag ;
+  - creates an primary ext4 partition starting after the boot partition and extending to the full disk image
 
-#### `hybrid`
+  #### `hybrid`
 
-This partition table type uses GPT and:
+  This partition table type uses GPT and:
 
-- creates a "no filesystem" partition from 0 to 1MiB, set `bios_grub` flag on it ;
-- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
-- creates a primary ext4 partition starting after the boot one and extending to the full disk image
+  - creates a "no filesystem" partition from 0 to 1MiB, set `bios_grub` flag on it ;
+  - creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+  - creates a primary ext4 partition starting after the boot one and extending to the full disk image
 
-This partition could be booted by a BIOS able to understand GPT layouts and recognizing the MBR at the start.
+  This partition could be booted by a BIOS able to understand GPT layouts and recognizing the MBR at the start.
 
-### How to run determinism analysis on results?
+  ### How to run determinism analysis on results?
 
-Build your derivation with `--check` to rebuild it and verify it is the same.
+  Build your derivation with `--check` to rebuild it and verify it is the same.
 
-If it fails, you will be left with two folders with one having `.check`.
+  If it fails, you will be left with two folders with one having `.check`.
 
-You can use `diffoscope` to see the differences between the folders.
+  You can use `diffoscope` to see the differences between the folders.
 
-However, `diffoscope` is currently not able to diff two QCOW2 filesystems, thus, it is advised to use raw format.
+  However, `diffoscope` is currently not able to diff two QCOW2 filesystems, thus, it is advised to use raw format.
 
-Even if you use raw disks, `diffoscope` cannot diff the partition table and partitions recursively.
+  Even if you use raw disks, `diffoscope` cannot diff the partition table and partitions recursively.
 
-To solve this, you can run `fdisk -l $image` and generate `dd if=$image of=$image-p$i.raw skip=$start count=$sectors` for each `(start, sectors)` listed in the `fdisk` output. Now, you will have each partition as a separate file and you can compare them in pairs.
+  To solve this, you can run `fdisk -l $image` and generate `dd if=$image of=$image-p$i.raw skip=$start count=$sectors` for each `(start, sectors)` listed in the `fdisk` output. Now, you will have each partition as a separate file and you can compare them in pairs.
 */
-{ pkgs
-, lib
+{
+  pkgs,
+  lib,
 
-, # The NixOS configuration to be installed onto the disk image.
-  config
+  # The NixOS configuration to be installed onto the disk image.
+  config,
 
-, # The size of the disk, in megabytes.
+  # The size of the disk, in megabytes.
   # if "auto" size is calculated based on the contents copied to it and
   #   additionalSpace is taken into account.
-  diskSize ? "auto"
+  diskSize ? "auto",
 
-, # additional disk space to be added to the image if diskSize "auto"
+  # additional disk space to be added to the image if diskSize "auto"
   # is used
-  additionalSpace ? "512M"
+  additionalSpace ? "512M",
 
-, # size of the boot partition, is only used if partitionTableType is
+  # size of the boot partition, is only used if partitionTableType is
   # either "efi" or "hybrid"
   # This will be undersized slightly, as this is actually the offset of
   # the end of the partition. Generally it will be 1MiB smaller.
-  bootSize ? "256M"
+  bootSize ? "256M",
 
-, # The files and directories to be placed in the target file system.
+  # The files and directories to be placed in the target file system.
   # This is a list of attribute sets {source, target, mode, user, group} where
   # `source' is the file system object (regular file or directory) to be
   # grafted in the file system at path `target', `mode' is a string containing
@@ -117,54 +119,54 @@ To solve this, you can run `fdisk -l $image` and generate `dd if=$image of=$imag
   # user and group name that will be set as owner of the files.
   # `mode', `user', and `group' are optional.
   # When setting one of `user' or `group', the other needs to be set too.
-  contents ? []
+  contents ? [ ],
 
-, # Type of partition table to use; described in the `Image Partitioning` section above.
-  partitionTableType ? "legacy"
+  # Type of partition table to use; described in the `Image Partitioning` section above.
+  partitionTableType ? "legacy",
 
-, # Whether to invoke `switch-to-configuration boot` during image creation
-  installBootLoader ? true
+  # Whether to invoke `switch-to-configuration boot` during image creation
+  installBootLoader ? true,
 
-, # Whether to output have EFIVARS available in $out/efi-vars.fd and use it during disk creation
-  touchEFIVars ? false
+  # Whether to output have EFIVARS available in $out/efi-vars.fd and use it during disk creation
+  touchEFIVars ? false,
 
-, # OVMF firmware derivation
-  OVMF ? pkgs.OVMF.fd
+  # OVMF firmware derivation
+  OVMF ? pkgs.OVMF.fd,
 
-, # EFI firmware
-  efiFirmware ? OVMF.firmware
+  # EFI firmware
+  efiFirmware ? OVMF.firmware,
 
-, # EFI variables
-  efiVariables ? OVMF.variables
+  # EFI variables
+  efiVariables ? OVMF.variables,
 
-, # The root file system type.
-  fsType ? "ext4"
+  # The root file system type.
+  fsType ? "ext4",
 
-, # Filesystem label
-  label ? if onlyNixStore then "nix-store" else "nixos"
+  # Filesystem label
+  label ? if onlyNixStore then "nix-store" else "nixos",
 
-, # The initial NixOS configuration file to be copied to
+  # The initial NixOS configuration file to be copied to
   # /etc/nixos/configuration.nix.
-  configFile ? null
+  configFile ? null,
 
-, # Shell code executed after the VM has finished.
-  postVM ? ""
+  # Shell code executed after the VM has finished.
+  postVM ? "",
 
-, # Guest memory size
-  memSize ? 1024
+  # Guest memory size
+  memSize ? 1024,
 
-, # Copy the contents of the Nix store to the root of the image and
+  # Copy the contents of the Nix store to the root of the image and
   # skip further setup. Incompatible with `contents`,
   # `installBootLoader` and `configFile`.
-  onlyNixStore ? false
+  onlyNixStore ? false,
 
-, name ? "nixos-disk-image"
+  name ? "nixos-disk-image",
 
-, # Disk image format, one of qcow2, qcow2-compressed, vdi, vpc, raw.
-  format ? "raw"
+  # Disk image format, one of qcow2, qcow2-compressed, vdi, vpc, raw.
+  format ? "raw",
 
-, # Disk image filename, without any extensions (e.g. `image_1`).
-  baseName ? "nixos"
+  # Disk image filename, without any extensions (e.g. `image_1`).
+  baseName ? "nixos",
 
   # Whether to fix:
   #   - GPT Disk Unique Identifier (diskGUID)
@@ -174,139 +176,181 @@ To solve this, you can run `fdisk -l $image` and generate `dd if=$image of=$imag
   # BIOS/MBR support is "best effort" at the moment.
   # Boot partitions may not be deterministic.
   # Also, to fix last time checked of the ext4 partition if fsType = ext4.
-, deterministic ? true
+  deterministic ? true,
 
   # GPT Partition Unique Identifier for root partition.
-, rootGPUID ? "F222513B-DED1-49FA-B591-20CE86A2FE7F"
+  rootGPUID ? "F222513B-DED1-49FA-B591-20CE86A2FE7F",
   # When fsType = ext4, this is the root Filesystem Unique Identifier.
   # TODO: support other filesystems someday.
-, rootFSUID ? (if fsType == "ext4" then rootGPUID else null)
+  rootFSUID ? (if fsType == "ext4" then rootGPUID else null),
 
-, # Whether a nix channel based on the current source tree should be
+  # Whether a nix channel based on the current source tree should be
   # made available inside the image. Useful for interactive use of nix
   # utils, but changes the hash of the image when the sources are
   # updated.
-  copyChannel ? true
+  copyChannel ? true,
 
-, # Additional store paths to copy to the image's store.
-  additionalPaths ? []
+  # Additional store paths to copy to the image's store.
+  additionalPaths ? [ ],
 }:
 
-assert (lib.assertOneOf "partitionTableType" partitionTableType [ "legacy" "legacy+gpt" "efi" "efixbootldr" "hybrid" "none" ]);
-assert (lib.assertMsg (fsType == "ext4" && deterministic -> rootFSUID != null) "In deterministic mode with a ext4 partition, rootFSUID must be non-null, by default, it is equal to rootGPUID.");
-  # We use -E offset=X below, which is only supported by e2fsprogs
-assert (lib.assertMsg (partitionTableType != "none" -> fsType == "ext4") "to produce a partition table, we need to use -E offset flag which is support only for fsType = ext4");
-assert (lib.assertMsg (touchEFIVars -> partitionTableType == "hybrid" || partitionTableType == "efi" || partitionTableType == "efixbootldr" || partitionTableType == "legacy+gpt") "EFI variables can be used only with a partition table of type: hybrid, efi, efixbootldr, or legacy+gpt.");
-  # If only Nix store image, then: contents must be empty, configFile must be unset, and we should no install bootloader.
-assert (lib.assertMsg (onlyNixStore -> contents == [] && configFile == null && !installBootLoader) "In a only Nix store image, the contents must be empty, no configuration must be provided and no bootloader should be installed.");
+assert (
+  lib.assertOneOf "partitionTableType" partitionTableType [
+    "legacy"
+    "legacy+gpt"
+    "efi"
+    "efixbootldr"
+    "hybrid"
+    "none"
+  ]
+);
+assert (
+  lib.assertMsg (fsType == "ext4" && deterministic -> rootFSUID != null)
+    "In deterministic mode with a ext4 partition, rootFSUID must be non-null, by default, it is equal to rootGPUID."
+);
+# We use -E offset=X below, which is only supported by e2fsprogs
+assert (
+  lib.assertMsg (partitionTableType != "none" -> fsType == "ext4")
+    "to produce a partition table, we need to use -E offset flag which is support only for fsType = ext4"
+);
+assert (
+  lib.assertMsg
+    (
+      touchEFIVars
+      ->
+        partitionTableType == "hybrid"
+        || partitionTableType == "efi"
+        || partitionTableType == "efixbootldr"
+        || partitionTableType == "legacy+gpt"
+    )
+    "EFI variables can be used only with a partition table of type: hybrid, efi, efixbootldr, or legacy+gpt."
+);
+# If only Nix store image, then: contents must be empty, configFile must be unset, and we should no install bootloader.
+assert (
+  lib.assertMsg (onlyNixStore -> contents == [ ] && configFile == null && !installBootLoader)
+    "In a only Nix store image, the contents must be empty, no configuration must be provided and no bootloader should be installed."
+);
 # Either both or none of {user,group} need to be set
-assert (lib.assertMsg (lib.all
-         (attrs: ((attrs.user  or null) == null)
-              == ((attrs.group or null) == null))
-        contents) "Contents of the disk image should set none of {user, group} or both at the same time.");
+assert (
+  lib.assertMsg (lib.all (
+    attrs: ((attrs.user or null) == null) == ((attrs.group or null) == null)
+  ) contents) "Contents of the disk image should set none of {user, group} or both at the same time."
+);
 
-let format' = format; in let
+let
+  format' = format;
+in
+let
 
   format = if format' == "qcow2-compressed" then "qcow2" else format';
 
   compress = lib.optionalString (format' == "qcow2-compressed") "-c";
 
-  filename = "${baseName}." + {
-    qcow2 = "qcow2";
-    vdi   = "vdi";
-    vpc   = "vhd";
-    raw   = "img";
-  }.${format} or format;
+  filename =
+    "${baseName}."
+    + {
+      qcow2 = "qcow2";
+      vdi = "vdi";
+      vpc = "vhd";
+      raw = "img";
+    }
+    .${format} or format;
 
-  rootPartition = { # switch-case
-    legacy = "1";
-    "legacy+gpt" = "2";
-    efi = "2";
-    efixbootldr = "3";
-    hybrid = "3";
-  }.${partitionTableType};
+  rootPartition =
+    {
+      # switch-case
+      legacy = "1";
+      "legacy+gpt" = "2";
+      efi = "2";
+      efixbootldr = "3";
+      hybrid = "3";
+    }
+    .${partitionTableType};
 
-  partitionDiskScript = { # switch-case
-    legacy = ''
-      parted --script $diskImage -- \
-        mklabel msdos \
-        mkpart primary ext4 1MiB -1
-    '';
-    "legacy+gpt" = ''
-      parted --script $diskImage -- \
-        mklabel gpt \
-        mkpart no-fs 1MB 2MB \
-        set 1 bios_grub on \
-        align-check optimal 1 \
-        mkpart primary ext4 2MB -1 \
-        align-check optimal 2 \
-        print
-      ${lib.optionalString deterministic ''
+  partitionDiskScript =
+    {
+      # switch-case
+      legacy = ''
+        parted --script $diskImage -- \
+          mklabel msdos \
+          mkpart primary ext4 1MiB -1
+      '';
+      "legacy+gpt" = ''
+        parted --script $diskImage -- \
+          mklabel gpt \
+          mkpart no-fs 1MB 2MB \
+          set 1 bios_grub on \
+          align-check optimal 1 \
+          mkpart primary ext4 2MB -1 \
+          align-check optimal 2 \
+          print
+        ${lib.optionalString deterministic ''
           sgdisk \
           --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C \
           --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC \
           --partition-guid=2:970C694F-AFD0-4B99-B750-CDB7A329AB6F \
           --partition-guid=3:${rootGPUID} \
           $diskImage
-      ''}
-    '';
-    efi = ''
-      parted --script $diskImage -- \
-        mklabel gpt \
-        mkpart ESP fat32 8MiB ${bootSize} \
-        set 1 boot on \
-        mkpart primary ext4 ${bootSize} -1
-      ${lib.optionalString deterministic ''
+        ''}
+      '';
+      efi = ''
+        parted --script $diskImage -- \
+          mklabel gpt \
+          mkpart ESP fat32 8MiB ${bootSize} \
+          set 1 boot on \
+          mkpart primary ext4 ${bootSize} -1
+        ${lib.optionalString deterministic ''
           sgdisk \
           --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C \
           --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC \
           --partition-guid=2:${rootGPUID} \
           $diskImage
-      ''}
-    '';
-    efixbootldr = ''
-      parted --script $diskImage -- \
-        mklabel gpt \
-        mkpart ESP fat32 8MiB 100MiB \
-        set 1 boot on \
-        mkpart BOOT fat32 100MiB ${bootSize} \
-        set 2 bls_boot on \
-        mkpart ROOT ext4 ${bootSize} -1
-      ${lib.optionalString deterministic ''
+        ''}
+      '';
+      efixbootldr = ''
+        parted --script $diskImage -- \
+          mklabel gpt \
+          mkpart ESP fat32 8MiB 100MiB \
+          set 1 boot on \
+          mkpart BOOT fat32 100MiB ${bootSize} \
+          set 2 bls_boot on \
+          mkpart ROOT ext4 ${bootSize} -1
+        ${lib.optionalString deterministic ''
           sgdisk \
           --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C \
           --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC  \
           --partition-guid=2:970C694F-AFD0-4B99-B750-CDB7A329AB6F  \
           --partition-guid=3:${rootGPUID} \
           $diskImage
-      ''}
-    '';
-    hybrid = ''
-      parted --script $diskImage -- \
-        mklabel gpt \
-        mkpart ESP fat32 8MiB ${bootSize} \
-        set 1 boot on \
-        mkpart no-fs 0 1024KiB \
-        set 2 bios_grub on \
-        mkpart primary ext4 ${bootSize} -1
-      ${lib.optionalString deterministic ''
+        ''}
+      '';
+      hybrid = ''
+        parted --script $diskImage -- \
+          mklabel gpt \
+          mkpart ESP fat32 8MiB ${bootSize} \
+          set 1 boot on \
+          mkpart no-fs 0 1024KiB \
+          set 2 bios_grub on \
+          mkpart primary ext4 ${bootSize} -1
+        ${lib.optionalString deterministic ''
           sgdisk \
           --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C \
           --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC \
           --partition-guid=2:970C694F-AFD0-4B99-B750-CDB7A329AB6F \
           --partition-guid=3:${rootGPUID} \
           $diskImage
-      ''}
-    '';
-    none = "";
-  }.${partitionTableType};
+        ''}
+      '';
+      none = "";
+    }
+    .${partitionTableType};
 
   useEFIBoot = touchEFIVars;
 
   nixpkgs = lib.cleanSource pkgs.path;
 
   # FIXME: merge with channel.nix / make-channel.nix.
-  channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}" {} ''
+  channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}" { } ''
     mkdir -p $out
     cp -prd ${nixpkgs.outPath} $out/nixos
     chmod -R u+w $out/nixos
@@ -317,7 +361,9 @@ let format' = format; in let
     echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
   '';
 
-  binPath = lib.makeBinPath (with pkgs; [
+  binPath = lib.makeBinPath (
+    with pkgs;
+    [
       rsync
       util-linux
       parted
@@ -329,19 +375,19 @@ let format' = format; in let
       systemdMinimal
     ]
     ++ lib.optional deterministic gptfdisk
-    ++ stdenv.initialPath);
+    ++ stdenv.initialPath
+  );
 
   # I'm preserving the line below because I'm going to search for it across nixpkgs to consolidate
   # image building logic. The comment right below this now appears in 4 different places in nixpkgs :)
   # !!! should use XML.
   sources = map (x: x.source) contents;
   targets = map (x: x.target) contents;
-  modes   = map (x: x.mode  or "''") contents;
-  users   = map (x: x.user  or "''") contents;
-  groups  = map (x: x.group or "''") contents;
+  modes = map (x: x.mode or "''") contents;
+  users = map (x: x.user or "''") contents;
+  groups = map (x: x.group or "''") contents;
 
-  basePaths = [ config.system.build.toplevel ]
-    ++ lib.optional copyChannel channelSources;
+  basePaths = [ config.system.build.toplevel ] ++ lib.optional copyChannel channelSources;
 
   additionalPaths' = lib.subtractLists basePaths additionalPaths;
 
@@ -444,75 +490,96 @@ let format' = format; in let
       ${if copyChannel then "--channel ${channelSources}" else "--no-channel-copy"} \
       --substituters ""
 
-    ${lib.optionalString (additionalPaths' != []) ''
+    ${lib.optionalString (additionalPaths' != [ ]) ''
       nix --extra-experimental-features nix-command copy --to $root --no-check-sigs ${lib.concatStringsSep " " additionalPaths'}
     ''}
 
     diskImage=nixos.raw
 
-    ${if diskSize == "auto" then ''
-      ${if partitionTableType == "efi" || partitionTableType == "efixbootldr" || partitionTableType == "hybrid" then ''
-        # Add the GPT at the end
-        gptSpace=$(( 512 * 34 * 1 ))
-        # Normally we'd need to account for alignment and things, if bootSize
-        # represented the actual size of the boot partition. But it instead
-        # represents the offset at which it ends.
-        # So we know bootSize is the reserved space in front of the partition.
-        reservedSpace=$(( gptSpace + $(numfmt --from=iec '${bootSize}') ))
-      '' else if partitionTableType == "legacy+gpt" then ''
-        # Add the GPT at the end
-        gptSpace=$(( 512 * 34 * 1 ))
-        # And include the bios_grub partition; the ext4 partition starts at 2MB exactly.
-        reservedSpace=$(( gptSpace + 2 * mebibyte ))
-      '' else if partitionTableType == "legacy" then ''
-        # Add the 1MiB aligned reserved space (includes MBR)
-        reservedSpace=$(( mebibyte ))
-      '' else ''
-        reservedSpace=0
-      ''}
-      additionalSpace=$(( $(numfmt --from=iec '${additionalSpace}') + reservedSpace ))
+    ${
+      if diskSize == "auto" then
+        ''
+          ${
+            if
+              partitionTableType == "efi" || partitionTableType == "efixbootldr" || partitionTableType == "hybrid"
+            then
+              ''
+                # Add the GPT at the end
+                gptSpace=$(( 512 * 34 * 1 ))
+                # Normally we'd need to account for alignment and things, if bootSize
+                # represented the actual size of the boot partition. But it instead
+                # represents the offset at which it ends.
+                # So we know bootSize is the reserved space in front of the partition.
+                reservedSpace=$(( gptSpace + $(numfmt --from=iec '${bootSize}') ))
+              ''
+            else if partitionTableType == "legacy+gpt" then
+              ''
+                # Add the GPT at the end
+                gptSpace=$(( 512 * 34 * 1 ))
+                # And include the bios_grub partition; the ext4 partition starts at 2MB exactly.
+                reservedSpace=$(( gptSpace + 2 * mebibyte ))
+              ''
+            else if partitionTableType == "legacy" then
+              ''
+                # Add the 1MiB aligned reserved space (includes MBR)
+                reservedSpace=$(( mebibyte ))
+              ''
+            else
+              ''
+                reservedSpace=0
+              ''
+          }
+          additionalSpace=$(( $(numfmt --from=iec '${additionalSpace}') + reservedSpace ))
 
-      # Compute required space in filesystem blocks
-      diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --count-links --block-size "${blockSize}" | cut -f1 | sum_lines)
-      # Each inode takes space!
-      numInodes=$(find . | wc -l)
-      # Convert to bytes, inodes take two blocks each!
-      diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
-      # Then increase the required space to account for the reserved blocks.
-      fudge=$(compute_fudge $diskUsage)
-      requiredFilesystemSpace=$(( diskUsage + fudge ))
+          # Compute required space in filesystem blocks
+          diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --count-links --block-size "${blockSize}" | cut -f1 | sum_lines)
+          # Each inode takes space!
+          numInodes=$(find . | wc -l)
+          # Convert to bytes, inodes take two blocks each!
+          diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
+          # Then increase the required space to account for the reserved blocks.
+          fudge=$(compute_fudge $diskUsage)
+          requiredFilesystemSpace=$(( diskUsage + fudge ))
 
-      diskSize=$(( requiredFilesystemSpace  + additionalSpace ))
+          diskSize=$(( requiredFilesystemSpace  + additionalSpace ))
 
-      # Round up to the nearest mebibyte.
-      # This ensures whole 512 bytes sector sizes in the disk image
-      # and helps towards aligning partitions optimally.
-      if (( diskSize % mebibyte )); then
-        diskSize=$(( ( diskSize / mebibyte + 1) * mebibyte ))
-      fi
+          # Round up to the nearest mebibyte.
+          # This ensures whole 512 bytes sector sizes in the disk image
+          # and helps towards aligning partitions optimally.
+          if (( diskSize % mebibyte )); then
+            diskSize=$(( ( diskSize / mebibyte + 1) * mebibyte ))
+          fi
 
-      truncate -s "$diskSize" $diskImage
+          truncate -s "$diskSize" $diskImage
 
-      printf "Automatic disk size...\n"
-      printf "  Closure space use: %d bytes\n" $diskUsage
-      printf "  fudge: %d bytes\n" $fudge
-      printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
-      printf "  Additional space: %d bytes\n" $additionalSpace
-      printf "  Disk image size: %d bytes\n" $diskSize
-    '' else ''
-      truncate -s ${toString diskSize}M $diskImage
-    ''}
+          printf "Automatic disk size...\n"
+          printf "  Closure space use: %d bytes\n" $diskUsage
+          printf "  fudge: %d bytes\n" $fudge
+          printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
+          printf "  Additional space: %d bytes\n" $additionalSpace
+          printf "  Disk image size: %d bytes\n" $diskSize
+        ''
+      else
+        ''
+          truncate -s ${toString diskSize}M $diskImage
+        ''
+    }
 
     ${partitionDiskScript}
 
-    ${if partitionTableType != "none" then ''
-      # Get start & length of the root partition in sectors to $START and $SECTORS.
-      eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
+    ${
+      if partitionTableType != "none" then
+        ''
+          # Get start & length of the root partition in sectors to $START and $SECTORS.
+          eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
 
-      mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
-    '' else ''
-      mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
-    ''}
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
+        ''
+      else
+        ''
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
+        ''
+    }
 
     echo "copying staging root to image..."
     cptofs -p ${lib.optionalString (partitionTableType != "none") "-P ${rootPartition}"} \
@@ -523,11 +590,16 @@ let format' = format; in let
   '';
 
   moveOrConvertImage = ''
-    ${if format == "raw" then ''
-      mv $diskImage $out/${filename}
-    '' else ''
-      ${pkgs.qemu-utils}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
-    ''}
+    ${
+      if format == "raw" then
+        ''
+          mv $diskImage $out/${filename}
+        ''
+      else
+        ''
+          ${pkgs.qemu-utils}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
+        ''
+    }
     diskImage=$out/${filename}
   '';
 
@@ -543,118 +615,131 @@ let format' = format; in let
   '';
 
   buildImage = pkgs.vmTools.runInLinuxVM (
-    pkgs.runCommand name {
-      preVM = prepareImage + lib.optionalString touchEFIVars createEFIVars;
-      buildInputs = with pkgs; [ util-linux e2fsprogs dosfstools ];
-      postVM = moveOrConvertImage + createHydraBuildProducts + postVM;
-      QEMU_OPTS =
-        lib.concatStringsSep " " (lib.optional useEFIBoot "-drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
-        ++ lib.optionals touchEFIVars [
-          "-drive if=pflash,format=raw,unit=1,file=$efiVars"
-        ] ++ lib.optionals (OVMF.systemManagementModeRequired or false) [
-          "-machine" "q35,smm=on"
-          "-global" "driver=cfi.pflash01,property=secure,value=on"
-        ]
-      );
-      inherit memSize;
-    } ''
-      export PATH=${binPath}:$PATH
+    pkgs.runCommand name
+      {
+        preVM = prepareImage + lib.optionalString touchEFIVars createEFIVars;
+        buildInputs = with pkgs; [
+          util-linux
+          e2fsprogs
+          dosfstools
+        ];
+        postVM = moveOrConvertImage + createHydraBuildProducts + postVM;
+        QEMU_OPTS = lib.concatStringsSep " " (
+          lib.optional useEFIBoot "-drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
+          ++ lib.optionals touchEFIVars [
+            "-drive if=pflash,format=raw,unit=1,file=$efiVars"
+          ]
+          ++ lib.optionals (OVMF.systemManagementModeRequired or false) [
+            "-machine"
+            "q35,smm=on"
+            "-global"
+            "driver=cfi.pflash01,property=secure,value=on"
+          ]
+        );
+        inherit memSize;
+      }
+      ''
+        export PATH=${binPath}:$PATH
 
-      rootDisk=${if partitionTableType != "none" then "/dev/vda${rootPartition}" else "/dev/vda"}
+        rootDisk=${if partitionTableType != "none" then "/dev/vda${rootPartition}" else "/dev/vda"}
 
-      # It is necessary to set root filesystem unique identifier in advance, otherwise
-      # bootloader might get the wrong one and fail to boot.
-      # At the end, we reset again because we want deterministic timestamps.
-      ${lib.optionalString (fsType == "ext4" && deterministic) ''
-        tune2fs -T now ${lib.optionalString deterministic "-U ${rootFSUID}"} -c 0 -i 0 $rootDisk
-      ''}
-      # make systemd-boot find ESP without udev
-      mkdir /dev/block
-      ln -s /dev/vda1 /dev/block/254:1
+        # It is necessary to set root filesystem unique identifier in advance, otherwise
+        # bootloader might get the wrong one and fail to boot.
+        # At the end, we reset again because we want deterministic timestamps.
+        ${lib.optionalString (fsType == "ext4" && deterministic) ''
+          tune2fs -T now ${lib.optionalString deterministic "-U ${rootFSUID}"} -c 0 -i 0 $rootDisk
+        ''}
+        # make systemd-boot find ESP without udev
+        mkdir /dev/block
+        ln -s /dev/vda1 /dev/block/254:1
 
-      mountPoint=/mnt
-      mkdir $mountPoint
-      mount $rootDisk $mountPoint
+        mountPoint=/mnt
+        mkdir $mountPoint
+        mount $rootDisk $mountPoint
 
-      # Create the ESP and mount it. Unlike e2fsprogs, mkfs.vfat doesn't support an
-      # '-E offset=X' option, so we can't do this outside the VM.
-      ${lib.optionalString (partitionTableType == "efi" || partitionTableType == "hybrid") ''
-        mkdir -p /mnt/boot
-        mkfs.vfat -n ESP /dev/vda1
-        mount /dev/vda1 /mnt/boot
+        # Create the ESP and mount it. Unlike e2fsprogs, mkfs.vfat doesn't support an
+        # '-E offset=X' option, so we can't do this outside the VM.
+        ${lib.optionalString (partitionTableType == "efi" || partitionTableType == "hybrid") ''
+          mkdir -p /mnt/boot
+          mkfs.vfat -n ESP /dev/vda1
+          mount /dev/vda1 /mnt/boot
 
-        ${lib.optionalString touchEFIVars "mount -t efivarfs efivarfs /sys/firmware/efi/efivars"}
-      ''}
-      ${lib.optionalString (partitionTableType == "efixbootldr") ''
-        mkdir -p /mnt/{boot,efi}
-        mkfs.vfat -n ESP /dev/vda1
-        mkfs.vfat -n BOOT /dev/vda2
-        mount /dev/vda1 /mnt/efi
-        mount /dev/vda2 /mnt/boot
+          ${lib.optionalString touchEFIVars "mount -t efivarfs efivarfs /sys/firmware/efi/efivars"}
+        ''}
+        ${lib.optionalString (partitionTableType == "efixbootldr") ''
+          mkdir -p /mnt/{boot,efi}
+          mkfs.vfat -n ESP /dev/vda1
+          mkfs.vfat -n BOOT /dev/vda2
+          mount /dev/vda1 /mnt/efi
+          mount /dev/vda2 /mnt/boot
 
-        ${lib.optionalString touchEFIVars "mount -t efivarfs efivarfs /sys/firmware/efi/efivars"}
-      ''}
+          ${lib.optionalString touchEFIVars "mount -t efivarfs efivarfs /sys/firmware/efi/efivars"}
+        ''}
 
-      # Install a configuration.nix
-      mkdir -p /mnt/etc/nixos
-      ${lib.optionalString (configFile != null) ''
-        cp ${configFile} /mnt/etc/nixos/configuration.nix
-      ''}
+        # Install a configuration.nix
+        mkdir -p /mnt/etc/nixos
+        ${lib.optionalString (configFile != null) ''
+          cp ${configFile} /mnt/etc/nixos/configuration.nix
+        ''}
 
-      ${lib.optionalString installBootLoader ''
-        # In this throwaway resource, we only have /dev/vda, but the actual VM may refer to another disk for bootloader, e.g. /dev/vdb
-        # Use this option to create a symlink from vda to any arbitrary device you want.
-        ${lib.optionalString (config.boot.loader.grub.enable) (lib.concatMapStringsSep " " (device:
-          lib.optionalString (device != "/dev/vda") ''
-            mkdir -p "$(dirname ${device})"
-            ln -s /dev/vda ${device}
-          '') config.boot.loader.grub.devices)}
+        ${lib.optionalString installBootLoader ''
+          # In this throwaway resource, we only have /dev/vda, but the actual VM may refer to another disk for bootloader, e.g. /dev/vdb
+          # Use this option to create a symlink from vda to any arbitrary device you want.
+          ${lib.optionalString (config.boot.loader.grub.enable) (
+            lib.concatMapStringsSep " " (
+              device:
+              lib.optionalString (device != "/dev/vda") ''
+                mkdir -p "$(dirname ${device})"
+                ln -s /dev/vda ${device}
+              ''
+            ) config.boot.loader.grub.devices
+          )}
 
-        # Set up core system link, bootloader (sd-boot, GRUB, uboot, etc.), etc.
+          # Set up core system link, bootloader (sd-boot, GRUB, uboot, etc.), etc.
 
-        # NOTE: systemd-boot-builder.py calls nix-env --list-generations which
-        # clobbers $HOME/.nix-defexpr/channels/nixos This would cause a  folder
-        # /homeless-shelter to show up in the final image which  in turn breaks
-        # nix builds in the target image if sandboxing is turned off (through
-        # __noChroot for example).
-        export HOME=$TMPDIR
-        NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+          # NOTE: systemd-boot-builder.py calls nix-env --list-generations which
+          # clobbers $HOME/.nix-defexpr/channels/nixos This would cause a  folder
+          # /homeless-shelter to show up in the final image which  in turn breaks
+          # nix builds in the target image if sandboxing is turned off (through
+          # __noChroot for example).
+          export HOME=$TMPDIR
+          NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 
-        # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
-        rm -f $mountPoint/etc/machine-id
-      ''}
+          # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
+          rm -f $mountPoint/etc/machine-id
+        ''}
 
-      # Set the ownerships of the contents. The modes are set in preVM.
-      # No globbing on targets, so no need to set -f
-      targets_=(${lib.concatStringsSep " " targets})
-      users_=(${lib.concatStringsSep " " users})
-      groups_=(${lib.concatStringsSep " " groups})
-      for ((i = 0; i < ''${#targets_[@]}; i++)); do
-        target="''${targets_[$i]}"
-        user="''${users_[$i]}"
-        group="''${groups_[$i]}"
-        if [ -n "$user$group" ]; then
-          # We have to nixos-enter since we need to use the user and group of the VM
-          nixos-enter --root $mountPoint -- chown -R "$user:$group" "$target"
-        fi
-      done
+        # Set the ownerships of the contents. The modes are set in preVM.
+        # No globbing on targets, so no need to set -f
+        targets_=(${lib.concatStringsSep " " targets})
+        users_=(${lib.concatStringsSep " " users})
+        groups_=(${lib.concatStringsSep " " groups})
+        for ((i = 0; i < ''${#targets_[@]}; i++)); do
+          target="''${targets_[$i]}"
+          user="''${users_[$i]}"
+          group="''${groups_[$i]}"
+          if [ -n "$user$group" ]; then
+            # We have to nixos-enter since we need to use the user and group of the VM
+            nixos-enter --root $mountPoint -- chown -R "$user:$group" "$target"
+          fi
+        done
 
-      umount -R /mnt
+        umount -R /mnt
 
-      # Make sure resize2fs works. Note that resize2fs has stricter criteria for resizing than a normal
-      # mount, so the `-c 0` and `-i 0` don't affect it. Setting it to `now` doesn't produce deterministic
-      # output, of course, but we can fix that when/if we start making images deterministic.
-      # In deterministic mode, this is fixed to 1970-01-01 (UNIX timestamp 0).
-      # This two-step approach is necessary otherwise `tune2fs` will want a fresher filesystem to perform
-      # some changes.
-      ${lib.optionalString (fsType == "ext4") ''
-        tune2fs -T now ${lib.optionalString deterministic "-U ${rootFSUID}"} -c 0 -i 0 $rootDisk
-        ${lib.optionalString deterministic "tune2fs -f -T 19700101 $rootDisk"}
-      ''}
-    ''
+        # Make sure resize2fs works. Note that resize2fs has stricter criteria for resizing than a normal
+        # mount, so the `-c 0` and `-i 0` don't affect it. Setting it to `now` doesn't produce deterministic
+        # output, of course, but we can fix that when/if we start making images deterministic.
+        # In deterministic mode, this is fixed to 1970-01-01 (UNIX timestamp 0).
+        # This two-step approach is necessary otherwise `tune2fs` will want a fresher filesystem to perform
+        # some changes.
+        ${lib.optionalString (fsType == "ext4") ''
+          tune2fs -T now ${lib.optionalString deterministic "-U ${rootFSUID}"} -c 0 -i 0 $rootDisk
+          ${lib.optionalString deterministic "tune2fs -f -T 19700101 $rootDisk"}
+        ''}
+      ''
   );
 in
-  if onlyNixStore then
-    pkgs.runCommand name {}
-      (prepareImage + moveOrConvertImage + createHydraBuildProducts + postVM)
-  else buildImage
+if onlyNixStore then
+  pkgs.runCommand name { } (prepareImage + moveOrConvertImage + createHydraBuildProducts + postVM)
+else
+  buildImage

--- a/nixos/tests/systemd-journal-gateway.nix
+++ b/nixos/tests/systemd-journal-gateway.nix
@@ -47,7 +47,7 @@ import ./make-test-python.nix (
 
       def copy_pem(file: str):
         machine.copy_from_host(source=f"{tmpdir}/{file}", target=f"/run/secrets/{file}")
-        machine.succeed(f"chmod 644 /run/secrets/{file}")
+        machine.succeed(f"chmod 600 /run/secrets/{file} && chown systemd-journal-gateway /run/secrets/{file}")
 
       with subtest("Copying keys and certificates"):
         machine.succeed("mkdir -p /run/secrets/{client,server}")

--- a/nixos/tests/systemd-repart.nix
+++ b/nixos/tests/systemd-repart.nix
@@ -22,7 +22,7 @@ let
     shutil.copyfile("${machine.system.build.diskImage}/nixos.img", tmp_disk_image.name)
 
     subprocess.run([
-      "${machine.config.virtualisation.qemu.package}/bin/qemu-img",
+      "${machine.virtualisation.qemu.package}/bin/qemu-img",
       "resize",
       "-f",
       "raw",

--- a/nixos/tests/systemd-repart.nix
+++ b/nixos/tests/systemd-repart.nix
@@ -151,6 +151,7 @@ in
       }:
       {
         virtualisation.useDefaultFilesystems = false;
+        virtualisation.mountHostNixStore = false;
         virtualisation.fileSystems = {
           "/" = {
             device = "/dev/disk/by-partlabel/created-root";

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -128,7 +128,7 @@ import ./make-test-python.nix (
             # it's not possible because we're not in a tty when grepping
             # (i.e. hacky way to ensure that the error from above doesn't appear here).
             _, out = machine.execute("systemctl --user edit testservice2.service 2>&1")
-            assert out.rstrip("\n") == "Cannot edit units if not on a tty."
+            assert out.rstrip("\n") == "Cannot edit units interactively if not on a tty."
 
         # Regression test for https://github.com/NixOS/nixpkgs/issues/105049
         with subtest("systemd reads timezone database in /etc/zoneinfo"):

--- a/pkgs/by-name/ni/nixos-enter/nixos-enter.sh
+++ b/pkgs/by-name/ni/nixos-enter/nixos-enter.sh
@@ -12,7 +12,7 @@ if [ -z "$NIXOS_ENTER_REEXEC" ]; then
     if [ "$(id -u)" != 0 ]; then
         extraFlags="-r"
     fi
-    exec unshare --fork --mount --uts --mount-proc --pid $extraFlags -- "$0" "$@"
+    exec unshare --fork --mount --uts --mount-proc $extraFlags -- "$0" "$@"
 else
     mount --make-rprivate /
 fi

--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -13,10 +13,10 @@ unit.  (However, this ignores the fsck unit, so it's not perfect...)
  1 file changed, 4 deletions(-)
 
 diff --git a/rules.d/99-systemd.rules.in b/rules.d/99-systemd.rules.in
-index ad0c7e2fb5..79f3086e78 100644
+index 882cda0dcd..8e8d1f04ce 100644
 --- a/rules.d/99-systemd.rules.in
 +++ b/rules.d/99-systemd.rules.in
-@@ -26,10 +26,6 @@ SUBSYSTEM=="block", ACTION=="add", KERNEL=="dm-*", ENV{DM_NAME}!="?*", ENV{SYSTE
+@@ -30,10 +30,6 @@ SUBSYSTEM=="block", ACTION=="add", KERNEL=="dm-*", ENV{DM_NAME}!="?*", ENV{SYSTE
  # Import previous SYSTEMD_READY state.
  SUBSYSTEM=="block", ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}=="", IMPORT{db}="SYSTEMD_READY"
  

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -14,7 +14,7 @@ Original-Author: Eelco Dolstra <eelco.dolstra@logicblox.com>
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src/shared/fstab-util.c b/src/shared/fstab-util.c
-index eac5bb8d3b..d8187bfa99 100644
+index d6a256c4a7..f74d5198f1 100644
 --- a/src/shared/fstab-util.c
 +++ b/src/shared/fstab-util.c
 @@ -66,6 +66,8 @@ bool fstab_is_extrinsic(const char *mount, const char *opts) {
@@ -27,7 +27,7 @@ index eac5bb8d3b..d8187bfa99 100644
                          "/etc"))
                  return true;
 diff --git a/src/shutdown/umount.c b/src/shutdown/umount.c
-index ca6d36e054..0a9227c9a8 100644
+index 4bc01c75e0..ede9ac7b87 100644
 --- a/src/shutdown/umount.c
 +++ b/src/shutdown/umount.c
 @@ -170,8 +170,10 @@ int mount_points_list_get(const char *mountinfo, MountPoint **head) {

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 4fee8a693c..756ce11b1f 100644
+index 500725d35f..2b735e4df4 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -6028,6 +6028,7 @@ static int run(int argc, char *argv[]) {
+@@ -6189,6 +6189,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,8 +21,8 @@ index 4fee8a693c..756ce11b1f 100644
                          _cleanup_free_ char *p = NULL;
  
                          if (arg_pivot_root_new)
-@@ -6044,6 +6045,7 @@ static int run(int argc, char *argv[]) {
-                                                     "Directory %s doesn't look like it has an OS tree (/usr/ directory is missing). Refusing.", arg_directory);
+@@ -6208,6 +6209,7 @@ static int run(int argc, char *argv[]) {
+                                 log_error_errno(r, "Unable to determine if %s looks like it has an OS tree (i.e. whether /usr/ exists): %m", arg_directory);
                                  goto finish;
                          }
 +#endif

--- a/pkgs/os-specific/linux/systemd/0004-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Add-some-NixOS-specific-unit-directories.patch
@@ -11,93 +11,12 @@ Also, remove /usr and /lib as these don't exist on NixOS.
 
 Original-Author: Eelco Dolstra <eelco.dolstra@logicblox.com>
 ---
- src/basic/path-lookup.c | 18 ++----------------
- src/core/systemd.pc.in  |  8 ++++----
- 2 files changed, 6 insertions(+), 20 deletions(-)
+ src/core/systemd.pc.in               |  8 ++++----
+ src/libsystemd/sd-path/path-lookup.c | 20 +++-----------------
+ 2 files changed, 7 insertions(+), 21 deletions(-)
 
-diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
-index 540256b73b..a115ec09a3 100644
---- a/src/basic/path-lookup.c
-+++ b/src/basic/path-lookup.c
-@@ -123,11 +123,7 @@ int runtime_directory(char **ret, RuntimeScope scope, const char *suffix) {
- }
- 
- static const char* const user_data_unit_paths[] = {
--        "/usr/local/lib/systemd/user",
--        "/usr/local/share/systemd/user",
-         USER_DATA_UNIT_DIR,
--        "/usr/lib/systemd/user",
--        "/usr/share/systemd/user",
-         NULL
- };
- 
-@@ -634,16 +630,13 @@ int lookup_paths_init(
-                                         persistent_config,
-                                         SYSTEM_CONFIG_UNIT_DIR,
-                                         "/etc/systemd/system",
-+                                        "/nix/var/nix/profiles/default/lib/systemd/system",
-                                         STRV_IFNOTNULL(persistent_attached),
-                                         runtime_config,
-                                         "/run/systemd/system",
-                                         STRV_IFNOTNULL(runtime_attached),
-                                         STRV_IFNOTNULL(generator),
--                                        "/usr/local/lib/systemd/system",
-                                         SYSTEM_DATA_UNIT_DIR,
--                                        "/usr/lib/systemd/system",
--                                        /* To be used ONLY for images which might be legacy split-usr */
--                                        STRV_IFNOTNULL(flags & LOOKUP_PATHS_SPLIT_USR ? "/lib/systemd/system" : NULL),
-                                         STRV_IFNOTNULL(generator_late));
-                         break;
- 
-@@ -659,14 +652,11 @@ int lookup_paths_init(
-                                         persistent_config,
-                                         USER_CONFIG_UNIT_DIR,
-                                         "/etc/systemd/user",
-+                                        "/nix/var/nix/profiles/default/lib/systemd/user",
-                                         runtime_config,
-                                         "/run/systemd/user",
-                                         STRV_IFNOTNULL(generator),
--                                        "/usr/local/share/systemd/user",
--                                        "/usr/share/systemd/user",
--                                        "/usr/local/lib/systemd/user",
-                                         USER_DATA_UNIT_DIR,
--                                        "/usr/lib/systemd/user",
-                                         STRV_IFNOTNULL(generator_late));
-                         break;
- 
-@@ -825,7 +815,6 @@ char **generator_binary_paths(RuntimeScope scope) {
-                 case RUNTIME_SCOPE_SYSTEM:
-                         add = strv_new("/run/systemd/system-generators",
-                                        "/etc/systemd/system-generators",
--                                       "/usr/local/lib/systemd/system-generators",
-                                        SYSTEM_GENERATOR_DIR);
-                         break;
- 
-@@ -833,7 +822,6 @@ char **generator_binary_paths(RuntimeScope scope) {
-                 case RUNTIME_SCOPE_USER:
-                         add = strv_new("/run/systemd/user-generators",
-                                        "/etc/systemd/user-generators",
--                                       "/usr/local/lib/systemd/user-generators",
-                                        USER_GENERATOR_DIR);
-                         break;
- 
-@@ -872,14 +860,12 @@ char **env_generator_binary_paths(RuntimeScope runtime_scope) {
-                 case RUNTIME_SCOPE_SYSTEM:
-                         add = strv_new("/run/systemd/system-environment-generators",
-                                         "/etc/systemd/system-environment-generators",
--                                        "/usr/local/lib/systemd/system-environment-generators",
-                                         SYSTEM_ENV_GENERATOR_DIR);
-                         break;
- 
-                 case RUNTIME_SCOPE_USER:
-                         add = strv_new("/run/systemd/user-environment-generators",
-                                        "/etc/systemd/user-environment-generators",
--                                       "/usr/local/lib/systemd/user-environment-generators",
-                                        USER_ENV_GENERATOR_DIR);
-                         break;
- 
 diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
-index f3b85b0190..8ae544b495 100644
+index f3b85b0190..f7aa5fca50 100644
 --- a/src/core/systemd.pc.in
 +++ b/src/core/systemd.pc.in
 @@ -43,10 +43,10 @@ systemdsystemconfdir=${systemd_system_conf_dir}
@@ -105,11 +24,11 @@ index f3b85b0190..8ae544b495 100644
  systemduserconfdir=${systemd_user_conf_dir}
  
 -systemd_system_unit_path=${systemd_system_conf_dir}:/etc/systemd/system:/run/systemd/system:/usr/local/lib/systemd/system:${systemd_system_unit_dir}:/usr/lib/systemd/system:/lib/systemd/system
-+systemd_system_unit_path=${systemd_system_conf_dir}:/etc/systemd/system:/nix/var/nix/profiles/default/lib/systemd/system:/run/systemd/system:${systemdsystemunitdir}
++systemd_system_unit_path=${systemd_system_conf_dir}:/etc/systemd/system:/nix/var/nix/profiles/default/lib/systemd/system:/run/systemd/system:${systemd_system_unit_dir}
  systemdsystemunitpath=${systemd_system_unit_path}
  
 -systemd_user_unit_path=${systemd_user_conf_dir}:/etc/systemd/user:/run/systemd/user:/usr/local/lib/systemd/user:/usr/local/share/systemd/user:${systemd_user_unit_dir}:/usr/lib/systemd/user:/usr/share/systemd/user
-+systemd_user_unit_path=${systemd_user_conf_dir}:/etc/systemd/user:/nix/var/nix/profiles/default/lib/systemd/user:/run/systemd/user:${systemduserunitdir}
++systemd_user_unit_path=${systemd_user_conf_dir}:/etc/systemd/user:/nix/var/nix/profiles/default/lib/systemd/user:/run/systemd/user:${systemd_user_unit_dir}
  systemduserunitpath=${systemd_user_unit_path}
  
  systemd_system_generator_dir=${prefix}/lib/systemd/system-generators
@@ -126,3 +45,85 @@ index f3b85b0190..8ae544b495 100644
  systemdusergeneratorpath=${systemd_user_generator_path}
  
  systemd_sleep_dir=${prefix}/lib/systemd/system-sleep
+diff --git a/src/libsystemd/sd-path/path-lookup.c b/src/libsystemd/sd-path/path-lookup.c
+index a3b09208cb..91a085c6bc 100644
+--- a/src/libsystemd/sd-path/path-lookup.c
++++ b/src/libsystemd/sd-path/path-lookup.c
+@@ -69,11 +69,7 @@ int runtime_directory(RuntimeScope scope, const char *suffix, char **ret) {
+ }
+ 
+ static const char* const user_data_unit_paths[] = {
+-        "/usr/local/lib/systemd/user",
+-        "/usr/local/share/systemd/user",
+         USER_DATA_UNIT_DIR,
+-        "/usr/lib/systemd/user",
+-        "/usr/share/systemd/user",
+         NULL
+ };
+ 
+@@ -481,16 +477,13 @@ int lookup_paths_init(
+                                        persistent_config,
+                                        SYSTEM_CONFIG_UNIT_DIR,
+                                        "/etc/systemd/system",
++                                       "/nix/var/nix/profiles/default/lib/systemd/system",
+                                        ASSERT_PTR(persistent_attached),
+                                        ASSERT_PTR(runtime_config),
+                                        "/run/systemd/system",
+                                        ASSERT_PTR(runtime_attached),
+                                        STRV_IFNOTNULL(generator),
+-                                       "/usr/local/lib/systemd/system",
+                                        SYSTEM_DATA_UNIT_DIR,
+-                                       "/usr/lib/systemd/system",
+-                                       /* To be used ONLY for images which might be legacy split-usr */
+-                                       FLAGS_SET(flags, LOOKUP_PATHS_SPLIT_USR) ? "/lib/systemd/system" : STRV_IGNORE,
+                                        STRV_IFNOTNULL(generator_late));
+                         break;
+ 
+@@ -508,13 +501,10 @@ int lookup_paths_init(
+                         add = strv_new(persistent_config,
+                                        USER_CONFIG_UNIT_DIR,
+                                        "/etc/systemd/user",
++                                       "/nix/var/nix/profiles/default/lib/systemd/user",
+                                        ASSERT_PTR(runtime_config),
+                                        "/run/systemd/user",
+-                                       "/usr/local/share/systemd/user",
+-                                       "/usr/share/systemd/user",
+-                                       "/usr/local/lib/systemd/user",
+-                                       USER_DATA_UNIT_DIR,
+-                                       "/usr/lib/systemd/user");
++                                       USER_DATA_UNIT_DIR);
+                         break;
+ 
+                 case RUNTIME_SCOPE_USER:
+@@ -653,7 +643,6 @@ void lookup_paths_log(LookupPaths *lp) {
+ static const char* const system_generator_paths[] = {
+         "/run/systemd/system-generators",
+         "/etc/systemd/system-generators",
+-        "/usr/local/lib/systemd/system-generators",
+         SYSTEM_GENERATOR_DIR,
+         NULL,
+ };
+@@ -661,7 +650,6 @@ static const char* const system_generator_paths[] = {
+ static const char* const user_generator_paths[] = {
+         "/run/systemd/user-generators",
+         "/etc/systemd/user-generators",
+-        "/usr/local/lib/systemd/user-generators",
+         USER_GENERATOR_DIR,
+         NULL,
+ };
+@@ -669,7 +657,6 @@ static const char* const user_generator_paths[] = {
+ static const char* const system_env_generator_paths[] = {
+         "/run/systemd/system-environment-generators",
+         "/etc/systemd/system-environment-generators",
+-        "/usr/local/lib/systemd/system-environment-generators",
+         SYSTEM_ENV_GENERATOR_DIR,
+         NULL,
+ };
+@@ -677,7 +664,6 @@ static const char* const system_env_generator_paths[] = {
+ static const char* const user_env_generator_paths[] = {
+         "/run/systemd/user-environment-generators",
+         "/etc/systemd/user-environment-generators",
+-        "/usr/local/lib/systemd/user-environment-generators",
+         USER_ENV_GENERATOR_DIR,
+         NULL,
+ };

--- a/pkgs/os-specific/linux/systemd/0005-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -13,10 +13,10 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 04103e0fe9..e26c6c5cfd 100644
+index f21a4f7ceb..4c24ce5c98 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -1611,7 +1611,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
+@@ -1672,7 +1672,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
                  if (!unit_is_bound_by_inactive(u, &culprit))
                          continue;
  

--- a/pkgs/os-specific/linux/systemd/0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] hostnamed, localed, timedated: disable methods that change
  3 files changed, 25 insertions(+)
 
 diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
-index 82d08803fa..8e40b77eba 100644
+index ba50b59f92..9827487453 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -1116,6 +1116,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
+@@ -1115,6 +1115,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;
  
@@ -24,7 +24,7 @@ index 82d08803fa..8e40b77eba 100644
          name = empty_to_null(name);
  
          context_read_etc_hostname(c);
-@@ -1178,6 +1181,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
+@@ -1177,6 +1180,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
          if (r < 0)
                  return r;
  
@@ -35,7 +35,7 @@ index 82d08803fa..8e40b77eba 100644
  
          context_read_machine_info(c);
 diff --git a/src/locale/localed.c b/src/locale/localed.c
-index c0d104578d..51a714ee23 100644
+index 062744519d..95bde4b1c3 100644
 --- a/src/locale/localed.c
 +++ b/src/locale/localed.c
 @@ -226,6 +226,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
@@ -69,10 +69,10 @@ index c0d104578d..51a714ee23 100644
  
          r = x11_context_verify_and_warn(&in, LOG_ERR, error);
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index e3b4367ec0..448aa7e94d 100644
+index c79bb864df..cbd30214b7 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
-@@ -673,6 +673,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
+@@ -676,6 +676,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
          if (r < 0)
                  return r;
  
@@ -83,7 +83,7 @@ index e3b4367ec0..448aa7e94d 100644
          if (!timezone_is_valid(z, LOG_DEBUG))
                  return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid or not installed time zone '%s'", z);
  
-@@ -750,6 +754,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
+@@ -754,6 +758,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
          if (r < 0)
                  return r;
  
@@ -93,7 +93,7 @@ index e3b4367ec0..448aa7e94d 100644
          if (lrtc == c->local_rtc && !fix_system)
                  return sd_bus_reply_method_return(m, NULL);
  
-@@ -928,6 +935,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
+@@ -948,6 +955,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
          if (r < 0)
                  return r;
  

--- a/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -35,10 +35,10 @@ index 3a13e04a27..4fd58068a1 100644
      <literal>Etc/UTC</literal>. The resulting link should lead to the
      corresponding binary
 diff --git a/src/basic/time-util.c b/src/basic/time-util.c
-index b94f37c31c..48f5a2526b 100644
+index 29afb08ebc..398ff340cd 100644
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1412,7 +1412,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
+@@ -1418,7 +1418,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
  
          assert(ret);
  
@@ -47,7 +47,7 @@ index b94f37c31c..48f5a2526b 100644
          if (!f)
                  return -errno;
  
-@@ -1453,7 +1453,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
+@@ -1459,7 +1459,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
  
          assert(ret);
  
@@ -56,7 +56,7 @@ index b94f37c31c..48f5a2526b 100644
          if (!f)
                  return -errno;
  
-@@ -1565,7 +1565,7 @@ int verify_timezone(const char *name, int log_level) {
+@@ -1570,7 +1570,7 @@ int verify_timezone(const char *name, int log_level) {
          if (p - name >= PATH_MAX)
                  return -ENAMETOOLONG;
  
@@ -65,7 +65,7 @@ index b94f37c31c..48f5a2526b 100644
  
          fd = open(t, O_RDONLY|O_CLOEXEC);
          if (fd < 0)
-@@ -1617,7 +1617,7 @@ int get_timezone(char **ret) {
+@@ -1622,7 +1622,7 @@ int get_timezone(char **ret) {
          if (r < 0)
                  return r; /* Return EINVAL if not a symlink */
  
@@ -75,10 +75,10 @@ index b94f37c31c..48f5a2526b 100644
                  return -EINVAL;
          if (!timezone_is_valid(e, LOG_DEBUG))
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index 6afabef430..c1e3af77e1 100644
+index 9be62b8df3..2044e9f8d0 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -648,7 +648,7 @@ static int process_timezone(int rfd) {
+@@ -598,7 +598,7 @@ static int process_timezone(int rfd) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -88,10 +88,10 @@ index 6afabef430..c1e3af77e1 100644
          r = symlinkat_atomic_full(e, pfd, f, /* make_relative= */ false);
          if (r < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 756ce11b1f..436804b3bd 100644
+index 2b735e4df4..7a21f34edd 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1862,8 +1862,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
+@@ -1851,8 +1851,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -103,7 +103,7 @@ index 756ce11b1f..436804b3bd 100644
  
  static bool etc_writable(void) {
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 448aa7e94d..2161e09579 100644
+index cbd30214b7..b9b2f533a4 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
 @@ -280,7 +280,7 @@ static int context_read_data(Context *c) {

--- a/pkgs/os-specific/linux/systemd/0008-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0008-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -10,10 +10,10 @@ NixOS has an option to link the xkb data files to /etc/X11, but not to
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/locale/localectl.c b/src/locale/localectl.c
-index 32354027f1..1d231f1afc 100644
+index 36dbeb9daa..265eda2751 100644
 --- a/src/locale/localectl.c
 +++ b/src/locale/localectl.c
-@@ -297,7 +297,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
+@@ -301,7 +301,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
          } state = NONE, look_for;
          int r;
  

--- a/pkgs/os-specific/linux/systemd/0009-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0009-add-rootprefix-to-lookup-dir-paths.patch
@@ -12,7 +12,7 @@ files that I might have missed.
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/constants.h b/src/basic/constants.h
-index e70817c51f..859e673a67 100644
+index 5aaf8f535c..934175fb51 100644
 --- a/src/basic/constants.h
 +++ b/src/basic/constants.h
 @@ -62,13 +62,15 @@

--- a/pkgs/os-specific/linux/systemd/0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -10,7 +10,7 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index 67f44e16e9..dda6614561 100644
+index e26a8579c5..af814cd551 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
 @@ -358,6 +358,7 @@ static void notify_supervisor(void) {

--- a/pkgs/os-specific/linux/systemd/0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -9,10 +9,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index c96207428d..1e95eec7f1 100644
+index 181bb4ccef..2b1410d8a1 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
-@@ -217,6 +217,7 @@ static int execute(
+@@ -218,6 +218,7 @@ static int execute(
          };
          static const char* const dirs[] = {
                  SYSTEM_SLEEP_PATH,

--- a/pkgs/os-specific/linux/systemd/0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -10,7 +10,7 @@ systemd itself uses extensively.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/basic/path-util.h b/src/basic/path-util.h
-index fcb3aa9399..b9e69cbf91 100644
+index dff5a3a549..01344e5cf6 100644
 --- a/src/basic/path-util.h
 +++ b/src/basic/path-util.h
 @@ -17,10 +17,10 @@

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index e26c6c5cfd..6cc1642684 100644
+index 4c24ce5c98..3c944559fc 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -4035,9 +4035,17 @@ static int build_generator_environment(Manager *m, char ***ret) {
+@@ -4135,9 +4135,17 @@ static int build_generator_environment(Manager *m, char ***ret) {
           * adjust generated units to that. Let's pass down some bits of information that are easy for us to
           * determine (but a bit harder for generator scripts to determine), as environment variables. */
  

--- a/pkgs/os-specific/linux/systemd/0014-core-don-t-taint-on-unmerged-usr.patch
+++ b/pkgs/os-specific/linux/systemd/0014-core-don-t-taint-on-unmerged-usr.patch
@@ -17,10 +17,10 @@ See also: https://github.com/systemd/systemd/issues/24191
  1 file changed, 8 deletions(-)
 
 diff --git a/src/core/taint.c b/src/core/taint.c
-index 969b37f209..de64e8f1f9 100644
+index b7a1c647a2..c04864c478 100644
 --- a/src/core/taint.c
 +++ b/src/core/taint.c
-@@ -41,14 +41,6 @@ char* taint_string(void) {
+@@ -41,14 +41,6 @@ char** taint_strv(void) {
  
          _cleanup_free_ char *bin = NULL, *usr_sbin = NULL, *var_run = NULL;
  

--- a/pkgs/os-specific/linux/systemd/0015-tpm2_context_init-fix-driver-name-checking.patch
+++ b/pkgs/os-specific/linux/systemd/0015-tpm2_context_init-fix-driver-name-checking.patch
@@ -27,10 +27,10 @@ filename_is_valid with path_is_valid.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shared/tpm2-util.c b/src/shared/tpm2-util.c
-index 10a78adfaf..6493d5d270 100644
+index 36a0f906da..e0f42abca2 100644
 --- a/src/shared/tpm2-util.c
 +++ b/src/shared/tpm2-util.c
-@@ -670,7 +670,7 @@ int tpm2_context_new(const char *device, Tpm2Context **ret_context) {
+@@ -721,7 +721,7 @@ int tpm2_context_new(const char *device, Tpm2Context **ret_context) {
                  fn = strjoina("libtss2-tcti-", driver, ".so.0");
  
                  /* Better safe than sorry, let's refuse strings that cannot possibly be valid driver early, before going to disk. */
@@ -38,4 +38,4 @@ index 10a78adfaf..6493d5d270 100644
 +                if (!path_is_valid(fn))
                          return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "TPM2 driver name '%s' not valid, refusing.", driver);
  
-                 context->tcti_dl = dlopen(fn, RTLD_NOW);
+                 context->tcti_dl = dlopen(fn, RTLD_NOW|RTLD_NODELETE);

--- a/pkgs/os-specific/linux/systemd/0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
@@ -30,10 +30,10 @@ are written into `$XDG_CONFIG_HOME/systemd/user`.
  1 file changed, 3 insertions(+)
 
 diff --git a/src/systemctl/systemctl-edit.c b/src/systemctl/systemctl-edit.c
-index 15398f8364..8d440cee59 100644
+index c42a31153d..154dbf0402 100644
 --- a/src/systemctl/systemctl-edit.c
 +++ b/src/systemctl/systemctl-edit.c
-@@ -322,6 +322,9 @@ int verb_edit(int argc, char *argv[], void *userdata) {
+@@ -323,6 +323,9 @@ int verb_edit(int argc, char *argv[], void *userdata) {
          sd_bus *bus;
          int r;
  
@@ -41,5 +41,5 @@ index 15398f8364..8d440cee59 100644
 +                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "The unit-directory '/etc/systemd/system' is read-only on NixOS, so it's not possible to edit system-units directly. Use 'systemctl edit --runtime' instead.");
 +
          if (!on_tty() && !arg_stdin)
-                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Cannot edit units if not on a tty.");
+                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Cannot edit units interactively if not on a tty.");
  

--- a/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
+++ b/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] meson.build: do not create systemdstatedir
  1 file changed, 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index cecdbc3aa7..bd7f8ec580 100644
+index bffda86845..cb5dcec0f9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2652,7 +2652,6 @@ install_data('LICENSE.GPL2',
+@@ -2781,7 +2781,6 @@ install_data('LICENSE.GPL2',
  install_subdir('LICENSES',
                 install_dir : docdir)
  

--- a/pkgs/os-specific/linux/systemd/0018-Revert-bootctl-update-list-remove-all-instances-of-s.patch
+++ b/pkgs/os-specific/linux/systemd/0018-Revert-bootctl-update-list-remove-all-instances-of-s.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jared Baur <jaredbaur@fastmail.com>
+Date: Sun, 17 Nov 2024 12:46:36 -0800
+Subject: [PATCH] Revert "bootctl: update/list/remove all instances of
+ systemd-boot in /EFI/BOOT"
+
+This reverts commit 929f41c6528fb630753d4e2f588a8eb6c2f6a609.
+---
+ src/bootctl/bootctl-install.c | 52 ++++-------------------------------
+ src/bootctl/bootctl-status.c  |  8 ++++--
+ 2 files changed, 12 insertions(+), 48 deletions(-)
+
+diff --git a/src/bootctl/bootctl-install.c b/src/bootctl/bootctl-install.c
+index 7ad264d882..298e749ed6 100644
+--- a/src/bootctl/bootctl-install.c
++++ b/src/bootctl/bootctl-install.c
+@@ -323,46 +323,6 @@ static int create_subdirs(const char *root, const char * const *subdirs) {
+         return 0;
+ }
+ 
+-static int update_efi_boot_binaries(const char *esp_path, const char *source_path) {
+-        _cleanup_closedir_ DIR *d = NULL;
+-        _cleanup_free_ char *p = NULL;
+-        int r, ret = 0;
+-
+-        r = chase_and_opendir("/EFI/BOOT", esp_path, CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS, &p, &d);
+-        if (r == -ENOENT)
+-                return 0;
+-        if (r < 0)
+-                return log_error_errno(r, "Failed to open directory \"%s/EFI/BOOT\": %m", esp_path);
+-
+-        FOREACH_DIRENT(de, d, break) {
+-                _cleanup_close_ int fd = -EBADF;
+-                _cleanup_free_ char *v = NULL;
+-
+-                if (!endswith_no_case(de->d_name, ".efi"))
+-                        continue;
+-
+-                fd = openat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC);
+-                if (fd < 0)
+-                        return log_error_errno(errno, "Failed to open \"%s/%s\" for reading: %m", p, de->d_name);
+-
+-                r = get_file_version(fd, &v);
+-                if (r == -ESRCH)
+-                        continue;  /* No version information */
+-                if (r < 0)
+-                        return r;
+-                if (startswith(v, "systemd-boot ")) {
+-                        _cleanup_free_ char *dest_path = NULL;
+-
+-                        dest_path = path_join(p, de->d_name);
+-                        if (!dest_path)
+-                                return log_oom();
+-
+-                        RET_GATHER(ret, copy_file_with_version_check(source_path, dest_path, /* force = */ false));
+-                }
+-        }
+-
+-        return ret;
+-}
+ 
+ static int copy_one_file(const char *esp_path, const char *name, bool force) {
+         char *root = IN_SET(arg_install_source, ARG_INSTALL_SOURCE_AUTO, ARG_INSTALL_SOURCE_IMAGE) ? arg_root : NULL;
+@@ -416,12 +376,9 @@ static int copy_one_file(const char *esp_path, const char *name, bool force) {
+                 if (r < 0)
+                         return log_error_errno(r, "Failed to resolve path %s under directory %s: %m", v, esp_path);
+ 
+-                RET_GATHER(ret, copy_file_with_version_check(source_path, default_dest_path, force));
+-
+-                /* If we were installed under any other name in /EFI/BOOT, make sure we update those binaries
+-                 * as well. */
+-                if (!force)
+-                        RET_GATHER(ret, update_efi_boot_binaries(esp_path, source_path));
++                r = copy_file_with_version_check(source_path, default_dest_path, force);
++                if (r < 0 && ret == 0)
++                        ret = r;
+         }
+ 
+         return ret;
+@@ -1102,6 +1059,9 @@ static int remove_boot_efi(const char *esp_path) {
+                 if (!endswith_no_case(de->d_name, ".efi"))
+                         continue;
+ 
++                if (!startswith_no_case(de->d_name, "boot"))
++                        continue;
++
+                 fd = openat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC);
+                 if (fd < 0)
+                         return log_error_errno(errno, "Failed to open \"%s/%s\" for reading: %m", p, de->d_name);
+diff --git a/src/bootctl/bootctl-status.c b/src/bootctl/bootctl-status.c
+index 6bcb348935..fe753510ce 100644
+--- a/src/bootctl/bootctl-status.c
++++ b/src/bootctl/bootctl-status.c
+@@ -187,6 +187,7 @@ static int status_variables(void) {
+ static int enumerate_binaries(
+                 const char *esp_path,
+                 const char *path,
++                const char *prefix,
+                 char **previous,
+                 bool *is_first) {
+ 
+@@ -212,6 +213,9 @@ static int enumerate_binaries(
+                 if (!endswith_no_case(de->d_name, ".efi"))
+                         continue;
+ 
++                if (prefix && !startswith_no_case(de->d_name, prefix))
++                        continue;
++
+                 filename = path_join(p, de->d_name);
+                 if (!filename)
+                         return log_oom();
+@@ -268,11 +272,11 @@ static int status_binaries(const char *esp_path, sd_id128_t partition) {
+                 printf(" (/dev/disk/by-partuuid/" SD_ID128_UUID_FORMAT_STR ")", SD_ID128_FORMAT_VAL(partition));
+         printf("\n");
+ 
+-        r = enumerate_binaries(esp_path, "EFI/systemd", &last, &is_first);
++        r = enumerate_binaries(esp_path, "EFI/systemd", NULL, &last, &is_first);
+         if (r < 0)
+                 goto fail;
+ 
+-        k = enumerate_binaries(esp_path, "EFI/BOOT", &last, &is_first);
++        k = enumerate_binaries(esp_path, "EFI/BOOT", "boot", &last, &is_first);
+         if (k < 0) {
+                 r = k;
+                 goto fail;

--- a/pkgs/os-specific/linux/systemd/0019-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
+++ b/pkgs/os-specific/linux/systemd/0019-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
@@ -13,10 +13,10 @@ directly.
  1 file changed, 11 insertions(+)
 
 diff --git a/src/timesync/timesyncd.c b/src/timesync/timesyncd.c
-index 5c308a04bc..81aa3d3334 100644
+index d002501d29..9b835dc031 100644
 --- a/src/timesync/timesyncd.c
 +++ b/src/timesync/timesyncd.c
-@@ -21,6 +21,11 @@
+@@ -23,6 +23,11 @@
  #include "timesyncd-conf.h"
  #include "timesyncd-manager.h"
  #include "user-util.h"
@@ -26,9 +26,9 @@ index 5c308a04bc..81aa3d3334 100644
 +extern void __nss_disable_nscd(void (*)(size_t, struct traced_file *));
 +static void register_traced_file(size_t dbidx, struct traced_file *finfo) {}
  
- static int advance_tstamp(int fd, const struct stat *st) {
-         assert_se(fd >= 0);
-@@ -198,6 +203,12 @@ static int run(int argc, char *argv[]) {
+ static int advance_tstamp(int fd, usec_t epoch) {
+         assert(fd >= 0);
+@@ -201,6 +206,12 @@ static int run(int argc, char *argv[]) {
          if (r < 0)
                  return log_error_errno(r, "Failed to parse fallback server strings: %m");
  

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,77 +1,78 @@
 # NOTE: Make sure to (re-)format this file on changes with `nixpkgs-fmt`!
 
-{ stdenv
-, lib
-, nixosTests
-, pkgsCross
-, testers
-, fetchFromGitHub
-, fetchzip
-, fetchpatch2
-, buildPackages
-, makeBinaryWrapper
-, ninja
-, meson
-, m4
-, pkg-config
-, coreutils
-, gperf
-, getent
-, glibcLocales
-, autoPatchelfHook
+{
+  stdenv,
+  lib,
+  nixosTests,
+  pkgsCross,
+  testers,
+  fetchFromGitHub,
+  fetchzip,
+  fetchpatch2,
+  buildPackages,
+  makeBinaryWrapper,
+  ninja,
+  meson,
+  m4,
+  pkg-config,
+  coreutils,
+  gperf,
+  getent,
+  glibcLocales,
+  autoPatchelfHook,
 
   # glib is only used during tests (test-bus-gvariant, test-bus-marshal)
-, glib
-, gettext
-, python3Packages
+  glib,
+  gettext,
+  python3Packages,
 
   # Mandatory dependencies
-, libcap
-, util-linux
-, kbd
-, kmod
-, libxcrypt
+  libcap,
+  util-linux,
+  kbd,
+  kmod,
+  libxcrypt,
 
   # Optional dependencies
-, pam
-, cryptsetup
-, audit
-, acl
-, lz4
-, libgcrypt
-, libgpg-error
-, libidn2
-, curl
-, gnutar
-, gnupg
-, zlib
-, xz
-, zstd
-, tpm2-tss
-, libuuid
-, libapparmor
-, intltool
-, bzip2
-, pcre2
-, elfutils
-, linuxHeaders ? stdenv.cc.libc.linuxHeaders
-, gnutls
-, iptables
-, withSelinux ? false
-, libselinux
-, withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp
-, libseccomp
-, withKexectools ? lib.meta.availableOn stdenv.hostPlatform kexec-tools
-, kexec-tools
-, bashInteractive
-, bash
-, libmicrohttpd
-, libfido2
-, p11-kit
-, libpwquality
-, qrencode
-, libarchive
-, llvmPackages
+  pam,
+  cryptsetup,
+  audit,
+  acl,
+  lz4,
+  libgcrypt,
+  libgpg-error,
+  libidn2,
+  curl,
+  gnutar,
+  gnupg,
+  zlib,
+  xz,
+  zstd,
+  tpm2-tss,
+  libuuid,
+  libapparmor,
+  intltool,
+  bzip2,
+  pcre2,
+  elfutils,
+  linuxHeaders ? stdenv.cc.libc.linuxHeaders,
+  gnutls,
+  iptables,
+  withSelinux ? false,
+  libselinux,
+  withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp,
+  libseccomp,
+  withKexectools ? lib.meta.availableOn stdenv.hostPlatform kexec-tools,
+  kexec-tools,
+  bashInteractive,
+  bash,
+  libmicrohttpd,
+  libfido2,
+  p11-kit,
+  libpwquality,
+  qrencode,
+  libarchive,
+  llvmPackages,
 
   # the (optional) BPF feature requires bpftool, libbpf, clang and llvm-strip to
   # be available during build time.
@@ -84,38 +85,40 @@
   # `buildPackages.targetPackages.stdenv.cc == stdenv.cc` relative to
   # us. Working around this is important, because systemd is in the dependency
   # closure of GHC via emscripten and jdk.
-, bpftools
-, libbpf
+  bpftools,
+  libbpf,
 
   # Needed to produce a ukify that works for cross compiling UKIs.
-, targetPackages
+  targetPackages,
 
-, withAcl ? true
-, withAnalyze ? true
-, withApparmor ? true
-, withAudit ? true
+  withAcl ? true,
+  withAnalyze ? true,
+  withApparmor ? true,
+  withAudit ? true,
   # compiles systemd-boot, assumes EFI is available.
-, withBootloader ? withEfi
+  withBootloader ?
+    withEfi
     && !stdenv.hostPlatform.isMusl
     # "Unknown 64-bit data model"
-    && !stdenv.hostPlatform.isRiscV32
+    && !stdenv.hostPlatform.isRiscV32,
   # adds bzip2, lz4, xz and zstd
-, withCompression ? true
-, withCoredump ? true
-, withCryptsetup ? true
-, withRepart ? true
-, withDocumentation ? true
-, withEfi ? stdenv.hostPlatform.isEfi
-, withFido2 ? true
+  withCompression ? true,
+  withCoredump ? true,
+  withCryptsetup ? true,
+  withRepart ? true,
+  withDocumentation ? true,
+  withEfi ? stdenv.hostPlatform.isEfi,
+  withFido2 ? true,
   # conflicts with the NixOS /etc management
-, withFirstboot ? false
-, withHomed ? !stdenv.hostPlatform.isMusl
-, withHostnamed ? true
-, withHwdb ? true
-, withImportd ? !stdenv.hostPlatform.isMusl
-, withIptables ? true
-, withKmod ? true
-, withLibBPF ? lib.versionAtLeast buildPackages.llvmPackages.clang.version "10.0"
+  withFirstboot ? false,
+  withHomed ? !stdenv.hostPlatform.isMusl,
+  withHostnamed ? true,
+  withHwdb ? true,
+  withImportd ? !stdenv.hostPlatform.isMusl,
+  withIptables ? true,
+  withKmod ? true,
+  withLibBPF ?
+    lib.versionAtLeast buildPackages.llvmPackages.clang.version "10.0"
     # assumes hard floats
     && (stdenv.hostPlatform.isAarch -> lib.versionAtLeast stdenv.hostPlatform.parsed.cpu.version "6")
     # see https://github.com/NixOS/nixpkgs/pull/194149#issuecomment-1266642211
@@ -127,51 +130,51 @@
     # buildPackages.targetPackages.llvmPackages is the same as llvmPackages,
     # but we do it this way to avoid taking llvmPackages as an input, and
     # risking making it too easy to ignore the above comment about llvmPackages.
-    && lib.meta.availableOn stdenv.hostPlatform buildPackages.targetPackages.llvmPackages.compiler-rt
-, withLibidn2 ? true
-, withLocaled ? true
-, withLogind ? true
-, withMachined ? true
-, withNetworkd ? true
-, withNss ? !stdenv.hostPlatform.isMusl
-, withOomd ? true
-, withPam ? true
-, withPasswordQuality ? true
-, withPCRE2 ? true
-, withPolkit ? true
-, withPortabled ? !stdenv.hostPlatform.isMusl
-, withQrencode ? true
-, withRemote ? !stdenv.hostPlatform.isMusl
-, withResolved ? true
-, withShellCompletions ? true
-, withSysusers ? true
-, withSysupdate ? true
-, withTimedated ? true
-, withTimesyncd ? true
-, withTpm2Tss ? true
+    && lib.meta.availableOn stdenv.hostPlatform buildPackages.targetPackages.llvmPackages.compiler-rt,
+  withLibidn2 ? true,
+  withLocaled ? true,
+  withLogind ? true,
+  withMachined ? true,
+  withNetworkd ? true,
+  withNss ? !stdenv.hostPlatform.isMusl,
+  withOomd ? true,
+  withPam ? true,
+  withPasswordQuality ? true,
+  withPCRE2 ? true,
+  withPolkit ? true,
+  withPortabled ? !stdenv.hostPlatform.isMusl,
+  withQrencode ? true,
+  withRemote ? !stdenv.hostPlatform.isMusl,
+  withResolved ? true,
+  withShellCompletions ? true,
+  withSysusers ? true,
+  withSysupdate ? true,
+  withTimedated ? true,
+  withTimesyncd ? true,
+  withTpm2Tss ? true,
   # adds python to closure which is too much by default
-, withUkify ? false
-, withUserDb ? true
-, withUtmp ? !stdenv.hostPlatform.isMusl
-, withVmspawn ? true
+  withUkify ? false,
+  withUserDb ? true,
+  withUtmp ? !stdenv.hostPlatform.isMusl,
+  withVmspawn ? true,
   # kernel-install shouldn't usually be used on NixOS, but can be useful, e.g. for
   # building disk images for non-NixOS systems. To save users from trying to use it
   # on their live NixOS system, we disable it by default.
-, withKernelInstall ? false
-, withLibarchive ? true
+  withKernelInstall ? false,
+  withLibarchive ? true,
   # tests assume too much system access for them to be feasible for us right now
-, withTests ? false
+  withTests ? false,
   # build only libudev and libsystemd
-, buildLibsOnly ? false
+  buildLibsOnly ? false,
 
   # yes, pname is an argument here
-, pname ? "systemd"
+  pname ? "systemd",
 
-, libxslt
-, docbook_xsl
-, docbook_xml_dtd_42
-, docbook_xml_dtd_45
-, withLogTrace ? false
+  libxslt,
+  docbook_xsl,
+  docbook_xml_dtd_42,
+  docbook_xml_dtd_45,
+  withLogTrace ? false,
 }:
 
 assert withImportd -> withCompression;
@@ -214,100 +217,114 @@ stdenv.mkDerivation (finalAttrs: {
   #   `git -c format.signoff=false format-patch v${version} --no-numbered --zero-commit --no-signature`.
   # Use `find . -name "*.patch" | sort` to get an up-to-date listing of all
   # patches
-  patches = [
-    ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
-    ./0002-Don-t-try-to-unmount-nix-or-nix-store.patch
-    ./0003-Fix-NixOS-containers.patch
-    ./0004-Add-some-NixOS-specific-unit-directories.patch
-    ./0005-Get-rid-of-a-useless-message-in-user-sessions.patch
-    ./0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
-    ./0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
-    ./0008-localectl-use-etc-X11-xkb-for-list-x11.patch
-    ./0009-add-rootprefix-to-lookup-dir-paths.patch
-    ./0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
-    ./0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
-    ./0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
-    ./0013-inherit-systemd-environment-when-calling-generators.patch
-    ./0014-core-don-t-taint-on-unmerged-usr.patch
-    ./0015-tpm2_context_init-fix-driver-name-checking.patch
-    ./0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
-    ./0017-meson.build-do-not-create-systemdstatedir.patch
-
-    # https://github.com/systemd/systemd/issues/33392
-    (fetchpatch2 {
-      url = "https://github.com/systemd/systemd/commit/f8b02a56febf14adf2474875a1b6625f1f346a6f.patch?full_index=1";
-      hash = "sha256-qRW92gPtACjk+ifptkw5mujhHlkCF56M3azGIjLiMKE=";
-      revert = true;
-    })
-  ] ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
-    ./0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
-  ] ++ lib.optional stdenv.hostPlatform.isMusl (
-    let
-      oe-core = fetchzip {
-        url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-89b75b46371d5e9172cb496b461824d8551a2af5.tar.gz";
-        hash = "sha256-etdIIdo3FezVafEYP5uAS9pO36Rdea2A+Da1P44cPXg=";
-      };
-      musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
-    in
+  patches =
     [
-      (musl-patches + "/0004-missing_type.h-add-comparison_fn_t.patch")
-      (musl-patches + "/0005-add-fallback-parse_printf_format-implementation.patch")
-      (musl-patches + "/0006-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
-      (musl-patches + "/0007-add-missing-FTW_-macros-for-musl.patch")
-      (musl-patches + "/0008-Use-uintmax_t-for-handling-rlim_t.patch")
-      (musl-patches + "/0009-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
-      (musl-patches + "/0010-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
-      (musl-patches + "/0011-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
-      (musl-patches + "/0012-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
-      (musl-patches + "/0013-avoid-redefinition-of-prctl_mm_map-structure.patch")
-      (musl-patches + "/0014-do-not-disable-buffer-in-writing-files.patch")
-      (musl-patches + "/0015-Handle-__cpu_mask-usage.patch")
-      (musl-patches + "/0016-Handle-missing-gshadow.patch")
-      (musl-patches + "/0017-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
-      (musl-patches + "/0018-pass-correct-parameters-to-getdents64.patch")
-      (musl-patches + "/0019-Adjust-for-musl-headers.patch")
-      (musl-patches + "/0020-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch")
-      (musl-patches + "/0021-errno-util-Make-STRERROR-portable-for-musl.patch")
-      (musl-patches + "/0022-sd-event-Make-malloc_trim-conditional-on-glibc.patch")
-      (musl-patches + "/0023-shared-Do-not-use-malloc_info-on-musl.patch")
-      (musl-patches + "/0024-avoid-missing-LOCK_EX-declaration.patch")
-      (musl-patches + "/0025-include-signal.h-to-avoid-the-undeclared-error.patch")
-      (musl-patches + "/0026-undef-stdin-for-references-using-stdin-as-a-struct-m.patch")
-      (musl-patches + "/0027-adjust-header-inclusion-order-to-avoid-redeclaration.patch")
-      (musl-patches + "/0028-build-path.c-avoid-boot-time-segfault-for-musl.patch")
+      ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+      ./0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+      ./0003-Fix-NixOS-containers.patch
+      ./0004-Add-some-NixOS-specific-unit-directories.patch
+      ./0005-Get-rid-of-a-useless-message-in-user-sessions.patch
+      ./0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
+      ./0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+      ./0008-localectl-use-etc-X11-xkb-for-list-x11.patch
+      ./0009-add-rootprefix-to-lookup-dir-paths.patch
+      ./0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+      ./0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+      ./0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+      ./0013-inherit-systemd-environment-when-calling-generators.patch
+      ./0014-core-don-t-taint-on-unmerged-usr.patch
+      ./0015-tpm2_context_init-fix-driver-name-checking.patch
+      ./0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+      ./0017-meson.build-do-not-create-systemdstatedir.patch
+
+      # https://github.com/systemd/systemd/issues/33392
+      (fetchpatch2 {
+        url = "https://github.com/systemd/systemd/commit/f8b02a56febf14adf2474875a1b6625f1f346a6f.patch?full_index=1";
+        hash = "sha256-qRW92gPtACjk+ifptkw5mujhHlkCF56M3azGIjLiMKE=";
+        revert = true;
+      })
     ]
-  );
+    ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
+      ./0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
+    ]
+    ++ lib.optional stdenv.hostPlatform.isMusl (
+      let
+        oe-core = fetchzip {
+          url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-89b75b46371d5e9172cb496b461824d8551a2af5.tar.gz";
+          hash = "sha256-etdIIdo3FezVafEYP5uAS9pO36Rdea2A+Da1P44cPXg=";
+        };
+        musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
+      in
+      [
+        (musl-patches + "/0004-missing_type.h-add-comparison_fn_t.patch")
+        (musl-patches + "/0005-add-fallback-parse_printf_format-implementation.patch")
+        (musl-patches + "/0006-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
+        (musl-patches + "/0007-add-missing-FTW_-macros-for-musl.patch")
+        (musl-patches + "/0008-Use-uintmax_t-for-handling-rlim_t.patch")
+        (musl-patches + "/0009-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
+        (musl-patches + "/0010-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
+        (musl-patches + "/0011-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
+        (musl-patches + "/0012-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
+        (musl-patches + "/0013-avoid-redefinition-of-prctl_mm_map-structure.patch")
+        (musl-patches + "/0014-do-not-disable-buffer-in-writing-files.patch")
+        (musl-patches + "/0015-Handle-__cpu_mask-usage.patch")
+        (musl-patches + "/0016-Handle-missing-gshadow.patch")
+        (musl-patches + "/0017-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
+        (musl-patches + "/0018-pass-correct-parameters-to-getdents64.patch")
+        (musl-patches + "/0019-Adjust-for-musl-headers.patch")
+        (musl-patches + "/0020-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch")
+        (musl-patches + "/0021-errno-util-Make-STRERROR-portable-for-musl.patch")
+        (musl-patches + "/0022-sd-event-Make-malloc_trim-conditional-on-glibc.patch")
+        (musl-patches + "/0023-shared-Do-not-use-malloc_info-on-musl.patch")
+        (musl-patches + "/0024-avoid-missing-LOCK_EX-declaration.patch")
+        (musl-patches + "/0025-include-signal.h-to-avoid-the-undeclared-error.patch")
+        (musl-patches + "/0026-undef-stdin-for-references-using-stdin-as-a-struct-m.patch")
+        (musl-patches + "/0027-adjust-header-inclusion-order-to-avoid-redeclaration.patch")
+        (musl-patches + "/0028-build-path.c-avoid-boot-time-segfault-for-musl.patch")
+      ]
+    );
 
-  postPatch = ''
-    substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"
-  '' + lib.optionalString withLibBPF ''
-    substituteInPlace meson.build \
-      --replace "find_program('clang'" "find_program('${stdenv.cc.targetPrefix}clang'"
-  '' + lib.optionalString withUkify ''
-    substituteInPlace src/ukify/ukify.py \
-      --replace \
-      "'readelf'" \
-      "'${targetPackages.stdenv.cc.bintools.targetPrefix}readelf'" \
-      --replace \
-      "/usr/lib/systemd/boot/efi" \
-      "$out/lib/systemd/boot/efi"
-  ''
-  # Finally, patch shebangs in scripts used at build time. This must not patch
-  # scripts that will end up in the output, to avoid build platform references
-  # when cross-compiling.
-  + ''
-    shopt -s extglob
-    patchShebangs tools test src/!(rpm|kernel-install|ukify) src/kernel-install/test-kernel-install.sh
-  '';
+  postPatch =
+    ''
+      substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"
+    ''
+    + lib.optionalString withLibBPF ''
+      substituteInPlace meson.build \
+        --replace "find_program('clang'" "find_program('${stdenv.cc.targetPrefix}clang'"
+    ''
+    + lib.optionalString withUkify ''
+      substituteInPlace src/ukify/ukify.py \
+        --replace \
+        "'readelf'" \
+        "'${targetPackages.stdenv.cc.bintools.targetPrefix}readelf'" \
+        --replace \
+        "/usr/lib/systemd/boot/efi" \
+        "$out/lib/systemd/boot/efi"
+    ''
+    # Finally, patch shebangs in scripts used at build time. This must not patch
+    # scripts that will end up in the output, to avoid build platform references
+    # when cross-compiling.
+    + ''
+      shopt -s extglob
+      patchShebangs tools test src/!(rpm|kernel-install|ukify) src/kernel-install/test-kernel-install.sh
+    '';
 
-  outputs = [ "out" "dev" ] ++ (lib.optional (!buildLibsOnly) "man");
+  outputs = [
+    "out"
+    "dev"
+  ] ++ (lib.optional (!buildLibsOnly) "man");
   separateDebugInfo = true;
 
-  hardeningDisable = [
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111523
-    "trivialautovarinit"
-    # breaks clang -target bpf; should be fixed to filter target?
-  ] ++ (lib.optionals withLibBPF ["zerocallusedregs" "shadowstack"]);
+  hardeningDisable =
+    [
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111523
+      "trivialautovarinit"
+      # breaks clang -target bpf; should be fixed to filter target?
+    ]
+    ++ (lib.optionals withLibBPF [
+      "zerocallusedregs"
+      "shadowstack"
+    ]);
 
   nativeBuildInputs =
     [
@@ -329,14 +346,21 @@ stdenv.mkDerivation (finalAttrs: {
       docbook_xml_dtd_42
       docbook_xml_dtd_45
       bash
-      (buildPackages.python3Packages.python.withPackages (ps: with ps; [ lxml jinja2 ] ++ lib.optional withEfi ps.pyelftools))
+      (buildPackages.python3Packages.python.withPackages (
+        ps:
+        with ps;
+        [
+          lxml
+          jinja2
+        ]
+        ++ lib.optional withEfi ps.pyelftools
+      ))
     ]
     ++ lib.optionals withLibBPF [
       bpftools
       buildPackages.llvmPackages.clang
       buildPackages.llvmPackages.libllvm
-    ]
-  ;
+    ];
 
   autoPatchelfFlags = [ "--keep-libc" ];
 
@@ -349,13 +373,22 @@ stdenv.mkDerivation (finalAttrs: {
       bashInteractive # for patch shebangs
     ]
 
-    ++ lib.optionals wantGcrypt [ libgcrypt libgpg-error ]
+    ++ lib.optionals wantGcrypt [
+      libgcrypt
+      libgpg-error
+    ]
     ++ lib.optional withTests glib
     ++ lib.optional withAcl acl
     ++ lib.optional withApparmor libapparmor
     ++ lib.optional withAudit audit
     ++ lib.optional wantCurl (lib.getDev curl)
-    ++ lib.optionals withCompression [ zlib bzip2 lz4 xz zstd ]
+    ++ lib.optionals withCompression [
+      zlib
+      bzip2
+      lz4
+      xz
+      zstd
+    ]
     ++ lib.optional withCoredump elfutils
     ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
     ++ lib.optional withKexectools kexec-tools
@@ -366,7 +399,10 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withPam pam
     ++ lib.optional withPCRE2 pcre2
     ++ lib.optional withSelinux libselinux
-    ++ lib.optionals withRemote [ libmicrohttpd gnutls ]
+    ++ lib.optionals withRemote [
+      libmicrohttpd
+      gnutls
+    ]
     ++ lib.optionals (withHomed || withCryptsetup) [ p11-kit ]
     ++ lib.optionals (withHomed || withCryptsetup) [ libfido2 ]
     ++ lib.optionals withLibBPF [ libbpf ]
@@ -375,182 +411,185 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withPasswordQuality [ libpwquality ]
     ++ lib.optionals withQrencode [ qrencode ]
     ++ lib.optionals withLibarchive [ libarchive ]
-    ++ lib.optional (withBootloader && stdenv.targetPlatform.useLLVM or false) (llvmPackages.compiler-rt.override {
-      doFakeLibgcc = true;
-    })
-  ;
+    ++ lib.optional (withBootloader && stdenv.targetPlatform.useLLVM or false) (
+      llvmPackages.compiler-rt.override {
+        doFakeLibgcc = true;
+      }
+    );
 
   mesonBuildType = "release";
 
-  mesonFlags = [
-    # Options
+  mesonFlags =
+    [
+      # Options
 
-    # We bump this attribute on every (major) version change to ensure that we
-    # have known-good value for a timestamp that is in the (not so distant)
-    # past. This serves as a lower bound for valid system timestamps during
-    # startup. Systemd will reset the system timestamp if this date is +- 15
-    # years from the system time.
-    # See the systemd v250 release notes for further details:
-    #   https://github.com/systemd/systemd/blob/60e930fc3e6eb8a36fbc184773119eb8d2f30364/NEWS#L258-L266
-    (lib.mesonOption "time-epoch" releaseTimestamp)
+      # We bump this attribute on every (major) version change to ensure that we
+      # have known-good value for a timestamp that is in the (not so distant)
+      # past. This serves as a lower bound for valid system timestamps during
+      # startup. Systemd will reset the system timestamp if this date is +- 15
+      # years from the system time.
+      # See the systemd v250 release notes for further details:
+      #   https://github.com/systemd/systemd/blob/60e930fc3e6eb8a36fbc184773119eb8d2f30364/NEWS#L258-L266
+      (lib.mesonOption "time-epoch" releaseTimestamp)
 
-    (lib.mesonOption "version-tag" version)
-    (lib.mesonOption "mode" "release")
-    (lib.mesonOption "tty-gid" "3") # tty in NixOS has gid 3
-    (lib.mesonOption "debug-shell" "${bashInteractive}/bin/bash")
-    (lib.mesonOption "pamconfdir" "${placeholder "out"}/etc/pam.d")
-    (lib.mesonOption "kmod-path" "${kmod}/bin/kmod")
+      (lib.mesonOption "version-tag" version)
+      (lib.mesonOption "mode" "release")
+      (lib.mesonOption "tty-gid" "3") # tty in NixOS has gid 3
+      (lib.mesonOption "debug-shell" "${bashInteractive}/bin/bash")
+      (lib.mesonOption "pamconfdir" "${placeholder "out"}/etc/pam.d")
+      (lib.mesonOption "kmod-path" "${kmod}/bin/kmod")
 
-    # Attempts to check /usr/sbin and that fails in macOS sandbox because
-    # permission is denied. If /usr/sbin is not a symlink, it defaults to true.
-    # We set it to false since stdenv moves sbin/* to bin and creates a symlink,
-    # that is, we do not have split bin.
-    (lib.mesonOption "split-bin" "false")
+      # Attempts to check /usr/sbin and that fails in macOS sandbox because
+      # permission is denied. If /usr/sbin is not a symlink, it defaults to true.
+      # We set it to false since stdenv moves sbin/* to bin and creates a symlink,
+      # that is, we do not have split bin.
+      (lib.mesonOption "split-bin" "false")
 
-    # D-Bus
-    (lib.mesonOption "dbuspolicydir" "${placeholder "out"}/share/dbus-1/system.d")
-    (lib.mesonOption "dbussessionservicedir" "${placeholder "out"}/share/dbus-1/services")
-    (lib.mesonOption "dbussystemservicedir" "${placeholder "out"}/share/dbus-1/system-services")
+      # D-Bus
+      (lib.mesonOption "dbuspolicydir" "${placeholder "out"}/share/dbus-1/system.d")
+      (lib.mesonOption "dbussessionservicedir" "${placeholder "out"}/share/dbus-1/services")
+      (lib.mesonOption "dbussystemservicedir" "${placeholder "out"}/share/dbus-1/system-services")
 
-    # pkgconfig
-    (lib.mesonOption "pkgconfiglibdir" "${placeholder "dev"}/lib/pkgconfig")
-    (lib.mesonOption "pkgconfigdatadir" "${placeholder "dev"}/share/pkgconfig")
+      # pkgconfig
+      (lib.mesonOption "pkgconfiglibdir" "${placeholder "dev"}/lib/pkgconfig")
+      (lib.mesonOption "pkgconfigdatadir" "${placeholder "dev"}/share/pkgconfig")
 
-    # Keyboard
-    (lib.mesonOption "loadkeys-path" "${kbd}/bin/loadkeys")
-    (lib.mesonOption "setfont-path" "${kbd}/bin/setfont")
+      # Keyboard
+      (lib.mesonOption "loadkeys-path" "${kbd}/bin/loadkeys")
+      (lib.mesonOption "setfont-path" "${kbd}/bin/setfont")
 
-    # SBAT
-    (lib.mesonOption "sbat-distro" "nixos")
-    (lib.mesonOption "sbat-distro-summary" "NixOS")
-    (lib.mesonOption "sbat-distro-url" "https://nixos.org/")
-    (lib.mesonOption "sbat-distro-pkgname" pname)
-    (lib.mesonOption "sbat-distro-version" version)
+      # SBAT
+      (lib.mesonOption "sbat-distro" "nixos")
+      (lib.mesonOption "sbat-distro-summary" "NixOS")
+      (lib.mesonOption "sbat-distro-url" "https://nixos.org/")
+      (lib.mesonOption "sbat-distro-pkgname" pname)
+      (lib.mesonOption "sbat-distro-version" version)
 
-    # Users
-    (lib.mesonOption "system-uid-max" "999")
-    (lib.mesonOption "system-gid-max" "999")
+      # Users
+      (lib.mesonOption "system-uid-max" "999")
+      (lib.mesonOption "system-gid-max" "999")
 
-    # SysVinit
-    (lib.mesonOption "sysvinit-path" "")
-    (lib.mesonOption "sysvrcnd-path" "")
+      # SysVinit
+      (lib.mesonOption "sysvinit-path" "")
+      (lib.mesonOption "sysvrcnd-path" "")
 
-    # Login
-    (lib.mesonOption "sulogin-path" "${util-linux.login}/bin/sulogin")
-    (lib.mesonOption "nologin-path" "${util-linux.login}/bin/nologin")
+      # Login
+      (lib.mesonOption "sulogin-path" "${util-linux.login}/bin/sulogin")
+      (lib.mesonOption "nologin-path" "${util-linux.login}/bin/nologin")
 
-    # Mount
-    (lib.mesonOption "mount-path" "${lib.getOutput "mount" util-linux}/bin/mount")
-    (lib.mesonOption "umount-path" "${lib.getOutput "mount" util-linux}/bin/umount")
+      # Mount
+      (lib.mesonOption "mount-path" "${lib.getOutput "mount" util-linux}/bin/mount")
+      (lib.mesonOption "umount-path" "${lib.getOutput "mount" util-linux}/bin/umount")
 
-    # SSH
-    # Disabled for now until someone makes this work.
-    (lib.mesonOption "sshconfdir" "no")
-    (lib.mesonOption "sshdconfdir" "no")
+      # SSH
+      # Disabled for now until someone makes this work.
+      (lib.mesonOption "sshconfdir" "no")
+      (lib.mesonOption "sshdconfdir" "no")
 
+      # Features
 
-    # Features
+      # Tests
+      (lib.mesonBool "tests" withTests)
+      (lib.mesonEnable "glib" withTests)
+      (lib.mesonEnable "dbus" withTests)
 
-    # Tests
-    (lib.mesonBool "tests" withTests)
-    (lib.mesonEnable "glib" withTests)
-    (lib.mesonEnable "dbus" withTests)
+      # Compression
+      (lib.mesonEnable "bzip2" withCompression)
+      (lib.mesonEnable "lz4" withCompression)
+      (lib.mesonEnable "xz" withCompression)
+      (lib.mesonEnable "zstd" withCompression)
+      (lib.mesonEnable "zlib" withCompression)
 
-    # Compression
-    (lib.mesonEnable "bzip2" withCompression)
-    (lib.mesonEnable "lz4" withCompression)
-    (lib.mesonEnable "xz" withCompression)
-    (lib.mesonEnable "zstd" withCompression)
-    (lib.mesonEnable "zlib" withCompression)
+      # NSS
+      (lib.mesonEnable "nss-mymachines" (withNss && withMachined))
+      (lib.mesonEnable "nss-resolve" withNss)
+      (lib.mesonBool "nss-myhostname" withNss)
+      (lib.mesonBool "nss-systemd" withNss)
 
-    # NSS
-    (lib.mesonEnable "nss-mymachines" (withNss && withMachined))
-    (lib.mesonEnable "nss-resolve" withNss)
-    (lib.mesonBool "nss-myhostname" withNss)
-    (lib.mesonBool "nss-systemd" withNss)
+      # Cryptsetup
+      (lib.mesonEnable "libcryptsetup" withCryptsetup)
+      (lib.mesonEnable "libcryptsetup-plugins" withCryptsetup)
+      (lib.mesonEnable "p11kit" (withHomed || withCryptsetup))
 
-    # Cryptsetup
-    (lib.mesonEnable "libcryptsetup" withCryptsetup)
-    (lib.mesonEnable "libcryptsetup-plugins" withCryptsetup)
-    (lib.mesonEnable "p11kit" (withHomed || withCryptsetup))
+      # FIDO2
+      (lib.mesonEnable "libfido2" withFido2)
+      (lib.mesonEnable "openssl" (withHomed || withFido2 || withSysupdate))
 
-    # FIDO2
-    (lib.mesonEnable "libfido2" withFido2)
-    (lib.mesonEnable "openssl" (withHomed || withFido2 || withSysupdate))
+      # Password Quality
+      (lib.mesonEnable "pwquality" withPasswordQuality)
+      (lib.mesonEnable "passwdqc" false)
 
-    # Password Quality
-    (lib.mesonEnable "pwquality" withPasswordQuality)
-    (lib.mesonEnable "passwdqc" false)
+      # Remote
+      (lib.mesonEnable "remote" withRemote)
+      (lib.mesonEnable "microhttpd" withRemote)
 
-    # Remote
-    (lib.mesonEnable "remote" withRemote)
-    (lib.mesonEnable "microhttpd" withRemote)
+      (lib.mesonEnable "pam" withPam)
+      (lib.mesonEnable "acl" withAcl)
+      (lib.mesonEnable "audit" withAudit)
+      (lib.mesonEnable "apparmor" withApparmor)
+      (lib.mesonEnable "gcrypt" wantGcrypt)
+      (lib.mesonEnable "importd" withImportd)
+      (lib.mesonEnable "homed" withHomed)
+      (lib.mesonEnable "polkit" withPolkit)
+      (lib.mesonEnable "elfutils" withCoredump)
+      (lib.mesonEnable "libcurl" wantCurl)
+      (lib.mesonEnable "libidn" false)
+      (lib.mesonEnable "libidn2" withLibidn2)
+      (lib.mesonEnable "libiptc" withIptables)
+      (lib.mesonEnable "repart" withRepart)
+      (lib.mesonEnable "sysupdate" withSysupdate)
+      (lib.mesonEnable "seccomp" withLibseccomp)
+      (lib.mesonEnable "selinux" withSelinux)
+      (lib.mesonEnable "tpm2" withTpm2Tss)
+      (lib.mesonEnable "pcre2" withPCRE2)
+      (lib.mesonEnable "bpf-framework" withLibBPF)
+      (lib.mesonEnable "bootloader" withBootloader)
+      (lib.mesonEnable "ukify" withUkify)
+      (lib.mesonEnable "kmod" withKmod)
+      (lib.mesonEnable "qrencode" withQrencode)
+      (lib.mesonEnable "vmspawn" withVmspawn)
+      (lib.mesonEnable "libarchive" withLibarchive)
+      (lib.mesonEnable "xenctrl" false)
+      (lib.mesonEnable "gnutls" false)
+      (lib.mesonEnable "xkbcommon" false)
+      (lib.mesonEnable "man" true)
 
-    (lib.mesonEnable "pam" withPam)
-    (lib.mesonEnable "acl" withAcl)
-    (lib.mesonEnable "audit" withAudit)
-    (lib.mesonEnable "apparmor" withApparmor)
-    (lib.mesonEnable "gcrypt" wantGcrypt)
-    (lib.mesonEnable "importd" withImportd)
-    (lib.mesonEnable "homed" withHomed)
-    (lib.mesonEnable "polkit" withPolkit)
-    (lib.mesonEnable "elfutils" withCoredump)
-    (lib.mesonEnable "libcurl" wantCurl)
-    (lib.mesonEnable "libidn" false)
-    (lib.mesonEnable "libidn2" withLibidn2)
-    (lib.mesonEnable "libiptc" withIptables)
-    (lib.mesonEnable "repart" withRepart)
-    (lib.mesonEnable "sysupdate" withSysupdate)
-    (lib.mesonEnable "seccomp" withLibseccomp)
-    (lib.mesonEnable "selinux" withSelinux)
-    (lib.mesonEnable "tpm2" withTpm2Tss)
-    (lib.mesonEnable "pcre2" withPCRE2)
-    (lib.mesonEnable "bpf-framework" withLibBPF)
-    (lib.mesonEnable "bootloader" withBootloader)
-    (lib.mesonEnable "ukify" withUkify)
-    (lib.mesonEnable "kmod" withKmod)
-    (lib.mesonEnable "qrencode" withQrencode)
-    (lib.mesonEnable "vmspawn" withVmspawn)
-    (lib.mesonEnable "libarchive" withLibarchive)
-    (lib.mesonEnable "xenctrl" false)
-    (lib.mesonEnable "gnutls" false)
-    (lib.mesonEnable "xkbcommon" false)
-    (lib.mesonEnable "man" true)
+      (lib.mesonBool "analyze" withAnalyze)
+      (lib.mesonBool "logind" withLogind)
+      (lib.mesonBool "localed" withLocaled)
+      (lib.mesonBool "hostnamed" withHostnamed)
+      (lib.mesonBool "machined" withMachined)
+      (lib.mesonBool "networkd" withNetworkd)
+      (lib.mesonBool "oomd" withOomd)
+      (lib.mesonBool "portabled" withPortabled)
+      (lib.mesonBool "hwdb" withHwdb)
+      (lib.mesonBool "timedated" withTimedated)
+      (lib.mesonBool "timesyncd" withTimesyncd)
+      (lib.mesonBool "userdb" withUserDb)
+      (lib.mesonBool "coredump" withCoredump)
+      (lib.mesonBool "firstboot" withFirstboot)
+      (lib.mesonBool "resolve" withResolved)
+      (lib.mesonBool "sysusers" withSysusers)
+      (lib.mesonBool "efi" withEfi)
+      (lib.mesonBool "utmp" withUtmp)
+      (lib.mesonBool "log-trace" withLogTrace)
+      (lib.mesonBool "kernel-install" withKernelInstall)
+      (lib.mesonBool "quotacheck" false)
+      (lib.mesonBool "ldconfig" false)
+      (lib.mesonBool "install-sysconfdir" false)
+      (lib.mesonBool "create-log-dirs" false)
+      (lib.mesonBool "smack" true)
+      (lib.mesonBool "b_pie" true)
 
-    (lib.mesonBool "analyze" withAnalyze)
-    (lib.mesonBool "logind" withLogind)
-    (lib.mesonBool "localed" withLocaled)
-    (lib.mesonBool "hostnamed" withHostnamed)
-    (lib.mesonBool "machined" withMachined)
-    (lib.mesonBool "networkd" withNetworkd)
-    (lib.mesonBool "oomd" withOomd)
-    (lib.mesonBool "portabled" withPortabled)
-    (lib.mesonBool "hwdb" withHwdb)
-    (lib.mesonBool "timedated" withTimedated)
-    (lib.mesonBool "timesyncd" withTimesyncd)
-    (lib.mesonBool "userdb" withUserDb)
-    (lib.mesonBool "coredump" withCoredump)
-    (lib.mesonBool "firstboot" withFirstboot)
-    (lib.mesonBool "resolve" withResolved)
-    (lib.mesonBool "sysusers" withSysusers)
-    (lib.mesonBool "efi" withEfi)
-    (lib.mesonBool "utmp" withUtmp)
-    (lib.mesonBool "log-trace" withLogTrace)
-    (lib.mesonBool "kernel-install" withKernelInstall)
-    (lib.mesonBool "quotacheck" false)
-    (lib.mesonBool "ldconfig" false)
-    (lib.mesonBool "install-sysconfdir" false)
-    (lib.mesonBool "create-log-dirs" false)
-    (lib.mesonBool "smack" true)
-    (lib.mesonBool "b_pie" true)
-
-  ] ++ lib.optionals (withShellCompletions == false) [
-    (lib.mesonOption "bashcompletiondir" "no")
-    (lib.mesonOption "zshcompletiondir" "no")
-  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
-    (lib.mesonBool "gshadow" false)
-    (lib.mesonBool "idn" false)
-  ];
+    ]
+    ++ lib.optionals (withShellCompletions == false) [
+      (lib.mesonOption "bashcompletiondir" "no")
+      (lib.mesonOption "zshcompletiondir" "no")
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isMusl [
+      (lib.mesonBool "gshadow" false)
+      (lib.mesonBool "idn" false)
+    ];
   preConfigure =
     let
       # A list of all the runtime binaries referenced by the source code (plus
@@ -560,98 +599,119 @@ stdenv.mkDerivation (finalAttrs: {
       # The `where` attribute for each of the replacement patterns must be
       # exhaustive. If another (unhandled) case is found in the source code the
       # build fails with an error message.
-      binaryReplacements = [
-        {
-          search = "/usr/bin/getent";
-          replacement = "${getent}/bin/getent";
-          where = [ "src/nspawn/nspawn-setuid.c" ];
-        }
-        {
-          search = "/sbin/mkswap";
-          replacement = "${lib.getBin util-linux}/sbin/mkswap";
-          where = [
-            "man/systemd-makefs@.service.xml"
-          ];
-        }
-        {
-          search = "/sbin/swapon";
-          replacement = "${lib.getOutput "swap" util-linux}/sbin/swapon";
-          where = [
-            "src/core/swap.c"
-            "src/basic/unit-def.h"
-          ];
-        }
-        {
-          search = "/sbin/swapoff";
-          replacement = "${lib.getOutput "swap" util-linux}/sbin/swapoff";
-          where = [ "src/core/swap.c" ];
-        }
-        {
-          search = "/bin/echo";
-          replacement = "${coreutils}/bin/echo";
-          where = [
-            "man/systemd-analyze.xml"
-            "man/systemd.service.xml"
-            "man/systemd-run.xml"
-            "src/analyze/test-verify.c"
-            "src/test/test-env-file.c"
-            "src/test/test-fileio.c"
-            "src/test/test-load-fragment.c"
-          ];
-        }
-        {
-          search = "/bin/cat";
-          replacement = "${coreutils}/bin/cat";
-          where = [
-            "test/test-execute/exec-noexecpaths-simple.service"
-            "src/journal/cat.c"
-          ];
-        }
-        {
-          search = "/usr/lib/systemd/systemd-fsck";
-          replacement = "$out/lib/systemd/systemd-fsck";
-          where = [ "man/systemd-fsck@.service.xml" ];
-        }
-      ] ++ lib.optionals withImportd [
-        {
-          search = "\"gpg\"";
-          replacement = "\\\"${gnupg}/bin/gpg\\\"";
-          where = [ "src/import/pull-common.c" ];
-        }
-        {
-          search = "\"tar\"";
-          replacement = "\\\"${gnutar}/bin/tar\\\"";
-          where = [
-            "src/import/export-tar.c"
-            "src/import/import-common.c"
-            "src/import/import-tar.c"
-          ];
-          ignore = [
-            # occurrences here refer to the tar sub command
-            "src/sysupdate/sysupdate-resource.c"
-            "src/sysupdate/sysupdate-transfer.c"
-            "src/import/pull.c"
-            "src/import/export.c"
-            "src/import/import.c"
-            "src/import/importd.c"
-            # runs `tar` but also also creates a temporary directory with the string
-            "src/import/pull-tar.c"
-          ];
-        }
-      ] ++ lib.optionals withKmod [
-        {
-          search = "/sbin/modprobe";
-          replacement = "${lib.getBin kmod}/sbin/modprobe";
-          where = [ "units/modprobe@.service" ];
-        }
-      ];
+      binaryReplacements =
+        [
+          {
+            search = "/usr/bin/getent";
+            replacement = "${getent}/bin/getent";
+            where = [ "src/nspawn/nspawn-setuid.c" ];
+          }
+          {
+            search = "/sbin/mkswap";
+            replacement = "${lib.getBin util-linux}/sbin/mkswap";
+            where = [
+              "man/systemd-makefs@.service.xml"
+            ];
+          }
+          {
+            search = "/sbin/swapon";
+            replacement = "${lib.getOutput "swap" util-linux}/sbin/swapon";
+            where = [
+              "src/core/swap.c"
+              "src/basic/unit-def.h"
+            ];
+          }
+          {
+            search = "/sbin/swapoff";
+            replacement = "${lib.getOutput "swap" util-linux}/sbin/swapoff";
+            where = [ "src/core/swap.c" ];
+          }
+          {
+            search = "/bin/echo";
+            replacement = "${coreutils}/bin/echo";
+            where = [
+              "man/systemd-analyze.xml"
+              "man/systemd.service.xml"
+              "man/systemd-run.xml"
+              "src/analyze/test-verify.c"
+              "src/test/test-env-file.c"
+              "src/test/test-fileio.c"
+              "src/test/test-load-fragment.c"
+            ];
+          }
+          {
+            search = "/bin/cat";
+            replacement = "${coreutils}/bin/cat";
+            where = [
+              "test/test-execute/exec-noexecpaths-simple.service"
+              "src/journal/cat.c"
+            ];
+          }
+          {
+            search = "/usr/lib/systemd/systemd-fsck";
+            replacement = "$out/lib/systemd/systemd-fsck";
+            where = [ "man/systemd-fsck@.service.xml" ];
+          }
+        ]
+        ++ lib.optionals withImportd [
+          {
+            search = "\"gpg\"";
+            replacement = "\\\"${gnupg}/bin/gpg\\\"";
+            where = [ "src/import/pull-common.c" ];
+          }
+          {
+            search = "\"tar\"";
+            replacement = "\\\"${gnutar}/bin/tar\\\"";
+            where = [
+              "src/import/export-tar.c"
+              "src/import/import-common.c"
+              "src/import/import-tar.c"
+            ];
+            ignore = [
+              # occurrences here refer to the tar sub command
+              "src/sysupdate/sysupdate-resource.c"
+              "src/sysupdate/sysupdate-transfer.c"
+              "src/import/pull.c"
+              "src/import/export.c"
+              "src/import/import.c"
+              "src/import/importd.c"
+              # runs `tar` but also also creates a temporary directory with the string
+              "src/import/pull-tar.c"
+            ];
+          }
+        ]
+        ++ lib.optionals withKmod [
+          {
+            search = "/sbin/modprobe";
+            replacement = "${lib.getBin kmod}/sbin/modprobe";
+            where = [ "units/modprobe@.service" ];
+          }
+        ];
 
       # { replacement, search, where, ignore } -> List[str]
-      mkSubstitute = { replacement, search, where, ignore ? [ ] }:
+      mkSubstitute =
+        {
+          replacement,
+          search,
+          where,
+          ignore ? [ ],
+        }:
         map (path: "substituteInPlace ${path} --replace '${search}' \"${replacement}\"") where;
-      mkEnsureSubstituted = { replacement, search, where, ignore ? [ ] }:
+      mkEnsureSubstituted =
+        {
+          replacement,
+          search,
+          where,
+          ignore ? [ ],
+        }:
         let
-          ignore' = lib.concatStringsSep "|" (ignore ++ [ "^test" "NEWS" ]);
+          ignore' = lib.concatStringsSep "|" (
+            ignore
+            ++ [
+              "^test"
+              "NEWS"
+            ]
+          );
         in
         ''
           set +e
@@ -687,24 +747,27 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "SYSTEMD_CGROUP_AGENTS_PATH" "_SYSTEMD_CGROUP_AGENT_PATH"
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString ([
-    # Can't say ${polkit.bin}/bin/pkttyagent here because that would
-    # lead to a cyclic dependency.
-    "-UPOLKIT_AGENT_BINARY_PATH"
-    "-DPOLKIT_AGENT_BINARY_PATH=\"/run/current-system/sw/bin/pkttyagent\""
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      # Can't say ${polkit.bin}/bin/pkttyagent here because that would
+      # lead to a cyclic dependency.
+      "-UPOLKIT_AGENT_BINARY_PATH"
+      "-DPOLKIT_AGENT_BINARY_PATH=\"/run/current-system/sw/bin/pkttyagent\""
 
-    # Set the release_agent on /sys/fs/cgroup/systemd to the
-    # currently running systemd (/run/current-system/systemd) so
-    # that we don't use an obsolete/garbage-collected release agent.
-    "-USYSTEMD_CGROUP_AGENTS_PATH"
-    "-DSYSTEMD_CGROUP_AGENTS_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
+      # Set the release_agent on /sys/fs/cgroup/systemd to the
+      # currently running systemd (/run/current-system/systemd) so
+      # that we don't use an obsolete/garbage-collected release agent.
+      "-USYSTEMD_CGROUP_AGENTS_PATH"
+      "-DSYSTEMD_CGROUP_AGENTS_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
 
-    "-USYSTEMD_BINARY_PATH"
-    "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
+      "-USYSTEMD_BINARY_PATH"
+      "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
 
-  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
-    "-D__UAPI_DEF_ETHHDR=0"
-  ]);
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isMusl [
+      "-D__UAPI_DEF_ETHHDR=0"
+    ]
+  );
 
   doCheck = false; # fails a bunch of tests
 
@@ -713,34 +776,43 @@ stdenv.mkDerivation (finalAttrs: {
     export DESTDIR=/
   '';
 
-  mesonInstallTags = lib.optionals buildLibsOnly [ "devel" "libudev" "libsystemd" ];
+  mesonInstallTags = lib.optionals buildLibsOnly [
+    "devel"
+    "libudev"
+    "libsystemd"
+  ];
 
-  postInstall = lib.optionalString (!buildLibsOnly) ''
-    mkdir -p $out/example/systemd
-    mv $out/lib/{binfmt.d,sysctl.d,tmpfiles.d} $out/example
-    mv $out/lib/systemd/{system,user} $out/example/systemd
+  postInstall =
+    lib.optionalString (!buildLibsOnly) ''
+      mkdir -p $out/example/systemd
+      mv $out/lib/{binfmt.d,sysctl.d,tmpfiles.d} $out/example
+      mv $out/lib/systemd/{system,user} $out/example/systemd
 
-    rm -rf $out/etc/systemd/system
+      rm -rf $out/etc/systemd/system
 
-    # Fix reference to /bin/false in the D-Bus services.
-    for i in $out/share/dbus-1/system-services/*.service; do
-      substituteInPlace $i --replace /bin/false ${coreutils}/bin/false
-    done
+      # Fix reference to /bin/false in the D-Bus services.
+      for i in $out/share/dbus-1/system-services/*.service; do
+        substituteInPlace $i --replace /bin/false ${coreutils}/bin/false
+      done
 
-    # For compatibility with dependents that use sbin instead of bin.
-    ln -s bin "$out/sbin"
+      # For compatibility with dependents that use sbin instead of bin.
+      ln -s bin "$out/sbin"
 
-    rm -rf $out/etc/rpm
-  '' + lib.optionalString (!withKernelInstall) ''
-    # "kernel-install" shouldn't be used on NixOS.
-    find $out -name "*kernel-install*" -exec rm {} \;
-  '' + lib.optionalString (!withDocumentation) ''
-    rm -rf $out/share/doc
-  '' + lib.optionalString (withKmod && !buildLibsOnly) ''
-    mv $out/lib/modules-load.d $out/example
-  '' + lib.optionalString withSysusers ''
-    mv $out/lib/sysusers.d $out/example
-  '';
+      rm -rf $out/etc/rpm
+    ''
+    + lib.optionalString (!withKernelInstall) ''
+      # "kernel-install" shouldn't be used on NixOS.
+      find $out -name "*kernel-install*" -exec rm {} \;
+    ''
+    + lib.optionalString (!withDocumentation) ''
+      rm -rf $out/share/doc
+    ''
+    + lib.optionalString (withKmod && !buildLibsOnly) ''
+      mv $out/lib/modules-load.d $out/example
+    ''
+    + lib.optionalString withSysusers ''
+      mv $out/lib/sysusers.d $out/example
+    '';
 
   # Avoid *.EFI binary stripping.
   # At least on aarch64-linux strip removes too much from PE32+ files:
@@ -752,23 +824,29 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Wrap in the correct path for LUKS2 tokens.
-  postFixup = lib.optionalString withCryptsetup ''
-    for f in bin/systemd-cryptsetup bin/systemd-cryptenroll; do
-      # This needs to be in LD_LIBRARY_PATH because rpath on a binary is not propagated to libraries using dlopen, in this case `libcryptsetup.so`
-      wrapProgram $out/$f --prefix LD_LIBRARY_PATH : ${placeholder "out"}/lib/cryptsetup
-    done
-  '' + lib.optionalString withBootloader ''
-    mv $out/dont-strip-me $out/lib/systemd/boot/efi
-  '' + lib.optionalString withUkify ''
-    # To cross compile a derivation that builds a UKI with ukify, we need to wrap
-    # ukify with the correct binutils. When wrapping, no splicing happens so we
-    # have to explicitly pull binutils from targetPackages.
-    wrapProgram $out/bin/ukify --prefix PATH : ${lib.makeBinPath [ targetPackages.stdenv.cc.bintools ] }:${placeholder "out"}/lib/systemd
-  '';
+  postFixup =
+    lib.optionalString withCryptsetup ''
+      for f in bin/systemd-cryptsetup bin/systemd-cryptenroll; do
+        # This needs to be in LD_LIBRARY_PATH because rpath on a binary is not propagated to libraries using dlopen, in this case `libcryptsetup.so`
+        wrapProgram $out/$f --prefix LD_LIBRARY_PATH : ${placeholder "out"}/lib/cryptsetup
+      done
+    ''
+    + lib.optionalString withBootloader ''
+      mv $out/dont-strip-me $out/lib/systemd/boot/efi
+    ''
+    + lib.optionalString withUkify ''
+      # To cross compile a derivation that builds a UKI with ukify, we need to wrap
+      # ukify with the correct binutils. When wrapping, no splicing happens so we
+      # have to explicitly pull binutils from targetPackages.
+      wrapProgram $out/bin/ukify --prefix PATH : ${
+        lib.makeBinPath [ targetPackages.stdenv.cc.bintools ]
+      }:${placeholder "out"}/lib/systemd
+    '';
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
-    # 'or p' is for manually specified buildPackages as they dont have __spliced
-    (builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs);
+  disallowedReferences =
+    lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+      # 'or p' is for manually specified buildPackages as they dont have __spliced
+      (builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs);
 
   passthru = {
     # The `interfaceVersion` attribute below points out the incompatibilities
@@ -778,22 +856,34 @@ stdenv.mkDerivation (finalAttrs: {
     # needed - and therefore `interfaceVersion` should be incremented.
     interfaceVersion = 2;
 
-    inherit withBootloader withCryptsetup withEfi withHostnamed withImportd withKmod
-      withLocaled withMachined withPortabled withTimedated withTpm2Tss withUtmp
-      util-linux kmod kbd;
+    inherit
+      withBootloader
+      withCryptsetup
+      withEfi
+      withHostnamed
+      withImportd
+      withKmod
+      withLocaled
+      withMachined
+      withPortabled
+      withTimedated
+      withTpm2Tss
+      withUtmp
+      util-linux
+      kmod
+      kbd
+      ;
 
     tests = {
       inherit (nixosTests)
         switchTest
         systemd-journal
         systemd-journal-gateway
-        systemd-journal-upload;
+        systemd-journal-upload
+        ;
       cross =
         let
-          systemString =
-            if stdenv.buildPlatform.isAarch64
-            then "gnu64"
-            else "aarch64-multiplatform";
+          systemString = if stdenv.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform";
         in
         pkgsCross.${systemString}.systemd;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
@@ -831,11 +921,20 @@ stdenv.mkDerivation (finalAttrs: {
       ofl
       publicDomain
     ];
-    maintainers = with lib.maintainers; [ flokli kloenk ];
-    pkgConfigModules = [ "libsystemd" "libudev" "systemd" "udev" ];
+    maintainers = with lib.maintainers; [
+      flokli
+      kloenk
+    ];
+    pkgConfigModules = [
+      "libsystemd"
+      "libudev"
+      "systemd"
+      "udev"
+    ];
     # See src/basic/missing_syscall_def.h
-    platforms = with lib.platforms; lib.intersectLists linux
-      (aarch ++ x86 ++ loongarch64 ++ m68k ++ mips ++ power ++ riscv ++ s390);
+    platforms =
+      with lib.platforms;
+      lib.intersectLists linux (aarch ++ x86 ++ loongarch64 ++ m68k ++ mips ++ power ++ riscv ++ s390);
     priority = 10;
     badPlatforms = [
       # https://github.com/systemd/systemd/issues/20600#issuecomment-912338965


### PR DESCRIPTION
<details><summary>Release notes for 257</summary>

# CHANGES WITH 257:

## Incompatible changes:

* The --purge switch of systemd-tmpfiles (which was added in v256) has been reworked: it will now only apply to tmpfiles.d/ lines marked with the new "$" flag. This is an incompatible change, and means any tmpfiles.d/ files which shall be used together with --purge need to be updated accordingly. This change has been made to make it harder to accidentally delete too many files when using --purge incorrectly.

* The systemd-creds 'cat' verb now expects base64-encoded encrypted credentials as input, for consistency with the 'decrypt' verb and the LoadCredentialEncrypted= service setting. Previously it could only read raw, unencoded binary data.

* Support for automatic flushing of the nscd user/group database caches has been dropped.

* The FileDescriptorName= setting for socket units is now honored by Accept=yes sockets too, where it was previously silently ignored and "connection" was used unconditionally.

* systemd-logind now always obeys block inhibitor locks, where previously it ignored locks taken by the caller or when the caller was root. A privileged caller can always close the other sessions, remove the inhibitor locks, or use --force or --check-inhibitors=no to ignore the inhibitors. This change thus doesn't affect security, since everything that was possible before at a given privilege level is still possible, but it should make the inhibitor logic easier to use and understand, and also help avoiding accidental reboots and shutdowns. New 'block-weak' inhibitor modes were added, if taken they will make the inhibitor lock work as in the previous versions. Inhibitor locks can also be taken by remote users (subject to polkit policy).

* systemd-nspawn will now mount the unified cgroup hierarchy into a container if no systemd installation is found in a container's root filesystem. $SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=0 can be used to override this behavior.

* /dev/disk/by-id/nvme-* block device symlinks without an NVMe namespace identifier are now fixed to namespace 1 of the device. If no namespace 1 exists for a device no such symlink is created. Previously, these symlinks would point to an unspecified namespace, and thus not be strictly stable references to multi-namespace NVMe devices. These un-namespaced symlinks are mostly obsolete, users and applications should always use the ones with encoded namespace information instead. This change should not affect too many systems, because most NVMe devices only know a namespace 1 by default.

* Support for cgroup v1 ('legacy' and 'hybrid' hierarchies) is now considered obsolete and systemd by default will ignore configuration that enables them. To forcibly reenable cgroup v1 support, SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 must additionally be set on the kernel command line.

## Announcements of Future Feature Removals:

* The D-Bus method org.freedesktop.systemd1.StartAuxiliaryScope() is deprecated because accounting data and such cannot be reasonably migrated between cgroups. It is likely to be fully removed in a future release (reach out if you have use cases).

* The recommended kernel baseline version has been bumped to v5.4 (released in 2019). Expect limited testing on older kernel versions, where \"old-kernel\" taint flag would also be set. Support for them will be phased out in a future release in 2025, i.e. we expect to bump the minimum baseline to v5.4 then too.

* The complete removal of support for cgroup v1 ('legacy' and 'hybrid' hierarchies) is scheduled for v258.

* Support for System V service scripts is deprecated and will be removed in v258. Please make sure to update your software *now* to include a native systemd unit file instead of a legacy System V script to retain compatibility with future systemd releases.

* To work around limitations of X11's keyboard handling systemd's keyboard mapping hardware database (hwdb.d/60-keyboard.hwdb) so far mapped the microphone mute and touchpad on/off/toggle keys to the function keys F20, F21, F22, F23 instead of their correct key codes. This key code mangling will be removed in the next systemd release. To maintain compatibility with X11 applications that rely on the old function key code mappings, this mangling has now been moved to the relevant X11 keyboard driver modules. In order to ensure these keys continue to work, update to xf86-input-evdev >= 2.11.0 and xf86-input-libinput >= 1.5.0 before updating to systemd >= 258.

* Support for the SystemdOptions EFI variable is deprecated. 'bootctl systemd-efi-options' will emit a warning when used. It seems that this feature is little-used and it is better to use alternative approaches like credentials and confexts. The plan is to drop support altogether at a later point, but this might be revisited based on user feedback.

* systemd-run's switch --expand-environment= which currently is disabled by default when combined with --scope, will be changed in a future release to be enabled by default.

## libsystemd:

* systemd's JSON API is now available as public interface of libsystemd, under the name \"sd-json\". The purpose of the library is to allow structures to be conveniently created in C code and serialized to JSON, and for JSON to be conveniently deserialized into in-memory structures, using callbacks to handle specific keys. Various data types like integers, floats, booleans, strings, UUIDs, base64-encoded and hex-encoded binary data, and arrays are supported natively. The library has been part of systemd for a while as internal component, and is now made publicly available. One major user of sd-json is sd-varlink (see below). Note that the documentation of sd-json is very much incomplete for now, but the systemd codebase provides plenty real-life code examples.

* systemd's Varlink IPC API is now available as part of libsystemd, under the name \"sd-varlink\". This library is a C implementation of the Varlink IPC system (https://varlink.org/) that has been adopted by systemd for various interfaces. It relies on the sd-json JSON component, see above. Note that the documentation of sd-varlink is very much incomplete for now, but the systemd codebase provides plenty real-life code examples.

* sd-bus gained a new call sd_bus_pending_method_calls() which returns the number of currently open asynchronous method calls initiated on this connection towards peers.

* sd-device gained a new call sd_device_monitor_is_running() that returns whether the specified monitor object is already running. It also gained sd_device_monitor_get_fd(), sd_device_monitor_get_events(), sd_device_monitor_get_timeout() and sd_device_monitor_receive() to permit sd-device to run on top of a foreign event loop implementation. It also gained sd_device_get_driver_subsystem() which returns the subsystem of driver objects. The new sd_device_get_device_id() call returns a short string identifying the device record.

## System and Service Management:

* The environment variable $REMOTE_ADDR is now set when using per-connection socket activation for AF_UNIX stream sockets. It contains the AF_UNIX peer address of the connection. (Previously the environment variable was only set for IP sockets.)

* Multipath TCP (MPTCP) is now supported as a socket protocol for .socket units.

* A new /etc/fstab option x-systemd.wants= creates \"Wants=\" dependencies.  (This is similar to the previously available x-systemd.requires=.)

* The initialization of the system clock during boot and updates has been simplified: both PID 1 or systemd-timesyncd will pick the latest minimum time as indicated by the compiled-in epoch, /usr/lib/clock-epoch, and /var/lib/systemd/timesync/clock. See systemd(1) for an detailed updated description.

* The kernel's Ctrl-Alt-Delete handling is re-enabled during late shutdown, so that the user may use it to initiate a reboot if the system freezes otherwise.

* The new value \"identity\" for the unit setting PrivateUsers= may be used to request a user namespace with an identity mapping for the first 65536 UIDs/GIDs.  This is analogous to the systemd-nspawn's --private-users=identity.

* The new value \"disconnected\" for the unit setting PrivateTmp= may be used to specify that a separate tmpfs instance should be used for /tmp/ and /var/tmp/ for the unit.

* The server manager (and various other tools too) use pidfds in more places to refer to processes.

* A build option -D link-executor-shared=false can be used to build the systemd-executor binary (added in a previous release) in a way where it does not link to shared libsystemd-shared-….so library. PID1 holds a reference to the executor binary that was on disk when the manager was started or restarted, but the shared libraries it is linked to are not loaded until the executor binary needs to be used. This partial static linking is a workaround for the issue where, during upgrades, the old libsystemd-shared-….so may have already been removed and the pinned executor binary will just fail to execute.

* The systemd.machine_id= kernel command line parameter interpreted by PID 1 now supports an additional special value: if set to \"firmware\" the machine ID is initialized from the SMBIOS/DeviceTree system UUID. (Previously this was already done automatically in VM environments, this extends the concept to any system, but only on explicit request via this option.)

* The ImportCredential= setting in service unit files now permits renaming of credentials as they are imported.

* The RestartMode= setting gained a new \"debug\" value. If specified and the service fails so that it shall be restarted it is invoked in \"debugging mode\". Debugging mode means that the $DEBUG_INVOCATION environment variable will be set to \"1\" for the new invocation. Moreover, any setting LogLevelMax= will be temporarily changed to \"debug\" for the next invocation. This mode is useful to automatically repeat invocation of tools in case they fail – but with additional logging or testing routines enabled.

* A new service setting BindLogSockets= has been added that controls whether the AF_UNIX sockets required for logging shall be bind mounted to the mount sandbox allocated for the service.

* At early boot, PID 1 will now optionally load a policy for the new Linux IPE LSM.

* Transient services (as invoked by the StartTransientUnit() D-Bus method) may now receive additional, arbitrary file descriptors to pass to executed service processes during activation using the new ExtraFileDescriptor= unit property.

* Calendar .timer units gained a new boolean DeferReactivation= option. If enabled and the repetitive calendar timer elapses again while the service the timer activates is still running, immediate reactivation of the service once it finishes is skipped, and the timer has to elapse again before the service is reactivated.

* Generator processes invoked by the service manager will now receive a new environment variable $SYSTEMD_SOFT_REBOOTS_COUNT that indicates how many times the system has been soft-rebooted since the kernel initialized.

* A new service property ManagedOOMMemoryPressureDurationSec= has been added that complements the existing ManagedOOMMemoryPressureDurationLimit= and specifies the PSI measurement interval for the specific unit.

* The sd_notify() protocol has been extended to allow changing the main PID of a process by providing a pidfd of the new main process, or by specifying the pidfd inode number. Previously this was only supported by specifying the classic UNIX PID, which of course is racy.

* The SocketUser=/SocketGroup= settings of .socket units are now also applied to POSIX message queues.

* The ProtectControlGroups= unit file setting now supports two additional values: if set to \"private\" a new cgroup namespace is allocated for the service and cgroupfs mounted accordingly; if set to \"strict\" a new cgroup namespace is allocated for the service, and cgroupfs is mounted read-only for the service.

* The StateDirectory=, RuntimeDirectory=, CacheDirectory=, LogsDirectory=, and ConfigurationDirectory= settings gained support for configuring the respective directories as read-only, via a ':ro' flag that can be appended to each setting's value.

* When DynamicUser= is combined with StateDirectory=/RuntimeDirectory=/CacheDirectory=/LogsDirectory= and ID mapped mounts are available on the referenced path, the data in there is now preferably made available by establishing ID mapped from the \"nobody\" user to the dynamic user, rather than via recursive chown()ing.

* A new service property PrivatePIDs= has been added that runs executed processes as PID 1 - the init process - within their own PID namespace.  PrivatePIDs= also mounts /proc/ so only processes within the new PID namespace are visible.

## systemd-udevd:

* udev rules now set 'uaccess' for /dev/udmabuf, giving locally logged-in users access to the hardware. This is useful in order to support IPMI cameras with libcamera.

* Serial port devices will no longer show up as systemd units, unless they have an IO port or memory assigned to them. This means that only serial ports that actually exist should show up as .device units now.

* mtd devices (i.e. certain kinds of flash memory devices) will now show up as .device units in systemd.

* The firmware_node/sun sysfs attribute will now be used (if available) for naming slot-based network interfaces, i.e. ID_NET_NAME_SLOT. Moreover the interface aliases specified in DeviceTree are now searched for both on the interface's parent device (as before) and the device itself (new).

* Various USB hardware wallets are now recognized by udev via a .hwdb file, and get the ID_HARDWARE_WALLET= property set, which enables \"uaccess\" for them, i.e. direct unprivileged access.

* udevadm info will now output the device ID string in lines prefixed with \"J:\", and the driver subsystem in lines prefixed with \"B:\".

* udev rules files now support case-insensitive attribute matching (e.g. ATTR{foo}==i\"abcd\")

## systemd-logind:

* New DesignatedMaintenanceTime= configuration option allows shutdowns to be automatically scheduled at the specified time.

* logind now reacts to Ctrl-Alt-Shift-Esc being pressed. It will send out a org.freedesktop.login1.SecureAttentionKey signal, indicating a request by the user for the system to display a secure login dialog. The handling of SAK can be suppressed in logind configuration.

* logind now supports handing off session-managed access to hidraw devices via its D-Bus APIs, the same way it already supports that for DRM and evdev input devices. This permits unprivileged clients to get hidraw fds for a device, that are automatically suspended when the session switches away.

* systemd-logind now exposes two D-Bus properties CanLock and CanIdle for all sessions. These properties indicate whether the session's class supports screen locking and idleness detection.

* systemd-inhibit now allows interactive polkit authorization. It gained a --no-ask-password option to suppress it.

## systemd-machined:

* Unprivileged clients are now allowed to register VMs and containers. Machines started via the systemd-vmspawn@.service unit will now be registered with systemd-machined.

* systemd-machined gained a pretty complete set of Varlink APIs exposing its functionality. This is an alternative to the pre-existing D-Bus interface.

## systemd-resolved:

* The resolvconf command now supports '-p' switch. If specified, the interface will not be used as the default route for domain name lookups.

* resolvectl now enables interactive polkit authorization. It gained a --no-ask-password option to suppress it.

## systemd-networkd and networkctl:

* IPv6 address labels can be also configured in a new [IPv6AddressLabel] section with Prefix= and Label= settings in networkd.conf. Please see networkd.conf(5) for more details.

* 'networkctl edit' can now read the new file contents from standard input with the new --stdin option.

* 'networkctl edit' and 'cat' now support editing/showing .netdev files by link. 'networkctl cat' can also list all configuration files associated with an interface at once with ':all'.

* networkctl gained a --no-ask-password option to suppress interactive polkit authorization.

* \"mac\" has been added to the default AlternativeNamesPolicy= setting for network links (via 99-default.link). This means \"enx*\" interface names will now be added to the list of alternative interface names by default, for all interfaces that have a MAC address assigned by hardware.

* networkd .netdev bridge devices gained a new setting FDBMaxLearned= for setting a limit on the number of dynamically learned FDB entries.

* networkd .network files for bridge devices now support Layer 2 (in addition to the pre-existing Layer 3) MDB entries, via MulticastGroupAddress=.

* systemd-networkd will now log when per-network sysctls belonging to network interfaces managed by it are changed outside of networkd, thus highlighting conflict of ownership/management of these knobs.

* systemd-networkd will now make RFC9463 DNR fields available to systemd-resolved, for automatic DNS DoT configuration, and similar.

* The \"dhcp\" and \"dhcp-on-stop\" values for KeepConfiguration= setting in .network file are replaced with \"dynamic\" and \"dynamic-on-stop\", respectively. When specified, systemd-networkd will preserve all dynamic configurations via DHCPv4, DHCPv6, NDISC, and IPv4LL with ACD, while previously only DHCPv4 configurations were kept. Also, when systemd-networkd is restarted, regardless of the setting, these dynamic configurations are unconditionally kept. So, systemd-networkd can be restarted without disturbing ongoing connections.

* systemd-networkd now updates traffic control configuration without clearing existing settings. Thus, those settings can be updated by editing relevant .network files and triggering 'networkctl reload'.

* systemd-networkd now gracefully updates netdev settings specified in .netdev files when 'networkctl reload' is called. Previously, if the relevant interfaces existed, new settings would not be applied. Now, new settings will be applied if possible. Some settings cannot be updated after a netdev is configured, e.g. VLAN ID can be only specified on creation. To change such settings, user needs to remove existing interfaces, and invoke 'networkctl reload' or restart systemd-networkd.

## systemd-boot, systemd-stub, and related tools:

* The EFI stub now supports loading of .ucode sections with microcode from PE add-on files. It also now supports loading .initrd sections from PE add-on files.

* A new .profile PE section type is now documented and supported in systemd-measure, ukify, systemd-stub and systemd-boot. These new sections allow multiple \"profiles\" to be stored together in the UKI, where each .profile section creates groupings of sections in the UKI, allowing some sections to be shared and other sections like .cmdline or .initrd unique to the profile. This may be used to provide a single UKI that synthesizes multiple menu items in the boot menu (for example, a regular one to boot, plus a debugging one, or a factory reset one, and so on – which only differ in kernel command line, but nothing else).

* New .dtbauto and .hwids sections are now documented and supported in systemd-measure, ukify, systemd-stub, and systemd-boot. A single UKI can contain multiple .dtbauto sections, and the 'compatible' string therein will be compared with the equivalent field in the DTB provided by the firmware, if present. If absent, SMBIOS will be used to calculate hardware IDs (CHIDs) and look them up in the content of .hwids, hopefully revealing an fallback 'compatible' string. This allows including multiple DTBs in a single UKI, with systemd-stub automatically loading the correct one for the current hardware.

* ukify gained an --extend switch to import an existing UKI to be extended, and a --measure-base= switch to support measurement of multi-profile UKIs.

* ukify gained a --certificate-provider switch to use an OpenSSL provider to load the certificate used to sign artifacts, instead of having to provide the path to a file on disk.

* bootctl, systemd-keyutil, systemd-measure, systemd-repart, and systemd-sbsign gained a new --certificate-source switch that allows loading the X.509 certificate from an OpenSSL provider instead of a file system path.

* systemd-boot's menu will now react to volume up/down rocker presses the same way as to arrow up/down presses: they move the menu item up or down. This is useful on device form factors that have only a volume rocker but no arrow keys (e.g. phones).

* systemd-stub will report the partition UUID and image identifier its UKI executable is placed on separately from the data systemd-boot provides about where to find its own executable, via EFI variables. This is useful when systemd-boot and UKIs are placed on distinct partitions (i.e. ESP and XBOOTLDR).

* bootctl gained new switches --print-loader-path and --print-stub-path that output the path to the boot loader or UKI used for the current boot.

* bootctl kernel-identify now recognizes EFI add-ons.

* bootctl gained a --random-seed=yes|no option to control provisioning of the random seed file in the ESP. (This is useful when producing an image that will be used in multiple instances.)

* bootctl now optionally supports installing UEFI Secure Boot databases (i.e. db/dbx/…  databases in ESL format) for systemd-boot to pick up and automatically enroll if the system is booted in Setup Mode. This is controlled via bootctl's new --secure-boot-auto-enroll=yes switch (and some auxiliary ones). A certificate can be provided in DER format, and is automatically converted into an ESL, as needed.

* bootctl, systemd-measure, systemd-repart when referencing signing keys on OpenSSL engines may now query for PINs and similar via systemd's native systemd-ask-password logic (and take benefit of its caching and UI).

* A new systemd-sbsign tool has been added, that can be used to sign EFI binaries (PE) for Secure Boot. This tool supports OpenSSL engines and providers, with pin caching support for PKCS11. ukify supports it as an alternative to sbsigntool and pesign.

* A new systemd-keyutil tool has been added, that can be used to perform various operations on private keys and X.509 certificates.

## The journal:

* journalctl can now list invocations of a unit with the --list-invocation options and show logs for a specific invocation with the new --invocation/-I option. (This is analogous to the --list-boots/--boot/-b options.)

## systemd-sysupdate and related tools:

* systemd-sysupdated has been added as system service, allowing unprivileged clients to update the system via D-Bus calls. Note that for now the systemd-sysupdated API is considered experimental, and is not considered stable yet.
 A new updatectl command-line tool can be used to control the service.

* systemd-sysupdate gained a new --offline option to force it to operate locally. This is useful when listing locally installed versions.

* systemd-sysupdate gained a new --transfer-source= option to set the directory to which transfer sources configured with PathRelativeTo=explicit will be interpreted.

* systemd-sysupdate now reports download progress via sd_notify().

* systemd-sysupdate now supports output in JSON mode for all commands.

* systemd-sysupdate definitions may now carry references to ChangeLog and AppStream metadata.

* Transfer definitions for systemd-sysupdate are supposed to carry the \".transfer\" suffix now, changing from \".conf\". The latter remains supported for compatibility, but it's recommended to rename all files reflecting this suffix change.

* systemd-sysupdate now supports new \".feature\" files that may be used in conjunction with \".transfer\" files to group them together, and allow them to be turned off or on, individually per group.

## TPM & systemd-cryptsetup:

* The 'has-tpm2' verb which reports whether TPM2 functionality is available has been moved from systemd-creds to systemd-analyze.

* systemd-tpm2-setup will gracefully handle TPMs that have a PIN set on the TPM, and not attempt to automatically set up a Storage Root Key (SRK) in that case.

* New crypttab option password-cache=yes|no|read-only can be used to customize password caching.

* New crypttab options fido2-pin=, fido2-up=, fido2-uv= can be used to enable/disable the PIN query, User Presence check, and User Verification.

* systemd-cryptenroll gained new options --fido2-salt-file= and --fido2-parameters-in-header= to simplify manual enrollment of FIDO2 tokens.

* systemd-cryptenroll, systemd-repart, and systemd-storagetm gained a new --list-devices option to list appropriate candidate block devices.

* systemd-cryptenroll/systemd-cryptsetup now support combined signed PCR policies and local systemd-pcrlock policies for unlocking a disk. Or in other words, it's now possible to bind unlocking of a local disk to a specific OS vendor *and* a locally managed set of measurements describing the local system.

## varlinkctl:

* varlinkctl gained a new verb 'list-methods' to show a list of methods implemented by a service.

* varlinkctl gained a --quiet/-q option to suppress method call replies.

* varlinkctl gained a --graceful= option to suppress specific Varlink errors, and treat them as success.

* varlinkctl gained a --timeout= option to limit how long the invocation can take.

* varlinkctl allows remote invocations over ssh, via the new \"ssh-exec:\" address specification. It'll make an ssh connection, start the specified executable on the remote side, and communicate with the remote process using the Varlink protocol.
 The \"ssh:\" address specification has been renamed to \"ssh-unix:\" (reflecting the fact it is used to connect to a remote AF_UNIX socket via SSH). The old syntax is still supported for backwards compatibility.

* varlinkctl's 'introspect' verb no longer requires specification of an interface name. If none is specified all interfaces exposed by the service are shown. Moreover, more than one interface name may be specified now, in which case all specified ones are displayed.

## systemd-repart:

* systemd-repart's CopyBlocks= directive can now use a character device as source (in addition to previously supported regular files and block devices). This is useful for initializing a partition from /dev/urandom or similar.

* systemd-repart gained new Compression= and CompressionLevel= settings to enable internal compression in filesystems created offline.

* systemd-repart understands a new MakeSymlinks= option to create one or more symlinks (each specified as a symlink name and target) within a newly formatted file system.

* systemd-repart gained a new SupplementFor= setting that allows allocating a partition only if some other existing partition cannot be adjusted to match the constraints defined for it. This is useful to generate an XBOOTLDR partition if and only if an ESP already exists that is too small for the required constraints.

* The default size of verity hash partitions is now automatically derived from SizeMaxBytes= of the data partition it is protecting.

## systemd-ssh-proxy:

* systemd-ssh-proxy now also supports the AF_UNIX-based "VSOCK MUX" protocol used by CloudHypervisor/Firecracker to expose AF_VSOCK sockets of the VM on the host. Or in other words: it's now possible to directly connect to ssh via AF_VSOCK from hosts to VMs of these two hypervisors (previously this was only supported for hypervisors which expose AF_VSOCK on the host as AF_VSOCK, such as qemu).

* systemd-ssh-proxy can now reference local VMs by their name: connect to any local VM "foobar" registered with systemd-machined via "ssh machine/foobar" using the AF_VSOCK protocol.

## systemd-analyze:

* systemd-analyze will now show the SMBIOS #11 vendor strings set for the machine with a new 'smbios11' verb.

* systemd-analyze gained a new --instance= option that can be used to provide an instance name to analyze multiple templates instantiated with the same instance name.

* systemd-analyze's \"capability\" verb now gained a new --mask parameter. If specified a numeric capbality mask can be specified which is decoded for its contained capabilities.

* systemd-analyze's \"plot\" verb gained two new settings: --scale-svg= allows the X axis of the split to be stritched by a factor. If --detailed is specified activation timestamps are shown in the plot.

## busctl:

* 'busctl monitor' gained new options --limit-messages= and --timeout= to set the number of matches or limit the runtime of the command.

* busctl now supports doing method calls with embedded unix file descriptors.

* busctl acquired a new \"wait\" command to wait for a specific signal to arrive.

## systemd-nspawn:

* systemd-nspawn --bind-user= will now propagate the bound user's SSH public key (if included in the user record) into the container, ensuring that any such bound user is directly accessible via ssh.

* systemd-nspawn now supports unprivileged FUSE inside containers.

## systemd-importd:

* A new generator sytemd-import-generator has been added to synthesize image download jobs. This provides functionality similar to importctl, but is configured via the kernel command line and system credentials. It may be used to automatically download sysext, confext, portable service, nspawn container or vmspawn VM images at boot.

* systemd-importd now provides a Varlink IPC interface, in addition to its existing D-Bus IPC interface.

* The individual import/export tools will now display a nice progress bar when downloading files.

## systemd-userdb & systemd-homed:

* userdbctl gained a pair of switches --uid-min= and --uid-max= to filter the UID/GID range of the listed users or groups. It also gained a new switch --disposition= to filter them by disposition (i.e. show only system users or only regular users, and so on). It also gained a new switch --fuzzy that permits a \"fuzzy\" search for a user, i.e. doing a substring and string distance search, and looking into the real name field of the user and other similar fields. It gained a new switch --boundaries=no for disabling display of the UID/GID range boundaries in its output.

* User records learnt a new set of fields that may list field names that may be changed by the user themselves without requiring administrator authentication. This new field is honoured by systemd-homed to allow users to change selected properties of their own user records.

## systemd-run & run0:

* run0 gained a new pair of settings --pty and --pipe that control whether to invoke the specified binary on a freshly allocated pseudo TTY, or whether to pass the client's STDIN/STDOUT/STDERR through directly.

* run0 gained a new switch --shell-prompt-prefix= that permits passing in a string to display on each shell prompt as prefix. If not specified otherwise this will show a superhero emoji (🦸), in order to visually communicate the temporarily elevated privileges a run0 session provides. This makes use of the $SHELL_PROMPT_PREFIX environment variables mentioned below.

* systemd-run can output some of its runtime data in JSON format via the new --json= option.

## systemd-tmpfiles:

* systemd-tmpfiles --purge switch now requires specification of at least one tmpfiles.d/ drop-in file.

* tmpfiles.d/ files gained a new '?' specifier for the 'L' line type to create a symlink only if the source exists, and gracefully skip the line otherwise.

## Miscellaneous:

* systemctl now supports the --now option with the 'reenable' verb.

* systemd-mount can now output JSON with a new --json= switch, for use with --list-devices. It also shows the \"diskseq\" property in the block device list.

* systemd-id128 gained a new 'var-partition-uuid' verb to calculate the DPS UUID for /var/ keyed by the local machine-id.

* localectl gained a -l/--full option to show output without ellipsization.

* timedatectl now supports interactive polkit authorization.

* The new Linux mseal(), listmount(), statmount() syscalls have been added to relevant system call groups.

* The systemd-ask-password logic has been extended with a per-user scope, i.e. user programs may now ask for passwords via the same mechanism and the previously system-wide only mechanism.

* A new set of system/service credentials are added: shell.prompt.prefix, shell.prompt.suffix and shell.welcome. At login time these are propagated into the $SHELL_PROMPT_PREFIX, $SHELL_PROMPT_SUFFIX, $SHELL_PROMPT_WELCOME environment variables. These in turn are included in the shell prompt of interactive shells and shown at login time, via /etc/profile.d/70-systemd-shell-extra.sh. This functionality is useful to visually highlight the fact a specific shell prompt originates from a specific system, execution context or tool. These credentials and environment variables are supposed to be generically useful within and outside of the immediate systemd context. It is also used by 'run0', see above.

* New RELEASE_TYPE=, EXPERIMENT=, EXPERIMENT_URL= fields have been defined for the /etc/os-release file. For example, \"RELEASE_TYPE=development|stable|lts\" can be used to indicate various stages of the release life cycle, and \"RELEASE_TYPE=experimental\" can indicate experimental builds, with the EXPERIMENT= field providing a human-readable description of the nature of the experiment.

* A new sleep.conf HibernateOnACPower= option has been added, which when disabled will suppress hibernation in suspend-then-hibernate mode until the system is disconnected from a power source.

* A bunch of patches to ease building against musl have been merged.

* The various components that display progress bars (i.e. systemd-repart, systemd-sysupdate/updatectl, importctl), will now also issue the ANSI sequences for progress reports that Windows Terminal understands. Most Linux terminals currently do not support this sequence (and ignore it), but hopefully this will change one day. The progress information is used to display a nice progress animation in the terminal tab and icon. For details about the ANSI sequence and its effects, see:
 https://github.com/microsoft/terminal/pull/8055 https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC

* systemd-sysusers is now able to create fully locked user accounts. For compatibility it so far created accounts with a locked (i.e. invalid) password, but not marked locked as a whole. With the new \"!\" modifier for \"u\" lines, it is now possible to create fully locked accounts. The distinction between accounts with a locked password and fully locked accounts is relevant when considering non-password forms of authentication, i.e. SSH and such. It is strongly recommended to make use of this new feature for almost all system accounts, since they usually do not require (and should not permit) interactive logins. All of systemd's own system users have been changed to be marked as fully locked.

* systemd-coredump now supports a new EnterNamespace= option, which defaults to off. If enabled systemd-coredump will access the mount namespace of any crashed process to acquire debug symbol information, in order to be able to symbolize backtraces. This option is useful to improve backtraces of processes of containerized applications. (Note that the host systemd-coredump preferably dispatches coredump processing to the container itself, if it supports that. Only full-OS containers which run systemd inside will support this however, in other cases EnterNamespace= might be an suitable approach to acquire symbolized backtraces.)

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
