### PR TITLE
xmpp-bridge, tinyemu, mindustry, glow-lang: mark broken

### DIFF
--- a/pkgs/by-name/mi/mindustry/package.nix
+++ b/pkgs/by-name/mi/mindustry/package.nix
@@ -281,6 +281,8 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.all;
     # TODO alsa-lib is linux-only, figure out what dependencies are required on Darwin
-    broken = enableClient && stdenv.hostPlatform.isDarwin;
+    broken =
+      enableClient
+      && (stdenv.hostPlatform.isDarwin || (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64));
   };
 }

--- a/pkgs/by-name/ti/tinyemu/package.nix
+++ b/pkgs/by-name/ti/tinyemu/package.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [ AndersonTorres ];
     platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/xm/xmpp-bridge/package.nix
+++ b/pkgs/by-name/xm/xmpp-bridge/package.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     mainProgram = "xmpp-bridge";
     maintainers = with lib.maintainers; [ gigahawk ];
     platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/compilers/gerbil/glow-lang.nix
+++ b/pkgs/development/compilers/gerbil/glow-lang.nix
@@ -52,5 +52,6 @@ rec {
     license     = licenses.asl20;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ fare ];
+    broken      = true; # Broken for all platforms since 2023-10-13
   };
 }


### PR DESCRIPTION
I ran my [nixpkgs-broken script](https://github.com/Mindavi/nixpkgs-mark-broken/) to find broken packages and got a list out of it.
Cherry-picked a few and marked them broken for the relevant platforms.

Here's most of the list, for anyone interested in helping: https://gist.github.com/Mindavi/ae7b0de386de9a912062d97f847bb8bd. Do note there may be false positives and/or packages that are not being built for the platform (or at all) anymore.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
