### PR TITLE
php: support two- and zero-argument overrideAttrs forms

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -37,7 +37,7 @@ let
     , hash ? null
     , extraPatches ? [ ]
     , packageOverrides ? (final: prev: { })
-    , phpAttrsOverrides ? (attrs: { })
+    , phpAttrsOverrides ? (final: prev: { })
     , pearInstallPhar ? (callPackage ./install-pear-nozlib-phar.nix { })
 
       # Sapi flags
@@ -63,16 +63,6 @@ let
     }@args:
 
     let
-      # Compose two functions of the type expected by 'overrideAttrs'
-      # into one where changes made in the first are available to the second.
-      composeOverrides =
-        f: g: attrs:
-        let
-          fApplied = f attrs;
-          attrs' = attrs // fApplied;
-        in
-        fApplied // g attrs';
-
       # buildEnv wraps php to provide additional extensions and
       # configuration. Its usage is documented in
       # doc/languages-frameworks/php.section.md.
@@ -153,7 +143,8 @@ let
               overrideAttrs =
                 f:
                 let
-                  newPhpAttrsOverrides = composeOverrides (filteredArgs.phpAttrsOverrides or (attrs: { })) f;
+                  phpAttrsOverrides = filteredArgs.phpAttrsOverrides or (final: prev: { });
+                  newPhpAttrsOverrides = lib.composeExtensions (lib.toExtension phpAttrsOverrides) (lib.toExtension f);
                   php = generic (filteredArgs // { phpAttrsOverrides = newPhpAttrsOverrides; });
                 in
                 php.buildEnv { inherit extensions extraConfig; };
@@ -342,7 +333,7 @@ let
             overrideAttrs =
               f:
               let
-                newPhpAttrsOverrides = composeOverrides phpAttrsOverrides f;
+                newPhpAttrsOverrides = lib.composeExtensions (lib.toExtension phpAttrsOverrides) (lib.toExtension f);
                 php = generic (args // { phpAttrsOverrides = newPhpAttrsOverrides; });
               in
               php;
@@ -359,8 +350,9 @@ let
             outputsToInstall = [ "out" "dev" ];
           };
         };
+        final = attrs // (lib.toExtension phpAttrsOverrides) final attrs;
       in
-      attrs // phpAttrsOverrides attrs
+      final
     );
 in
 generic


### PR DESCRIPTION
The nixpkgs manual on [`overrideAttrs`](https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs) says that three forms are accepted: `overrideAttrs ({ })`, `overrideAttrs (prev: { })`, and `overrideAttrs (final: prev: { })`. `pkgs.php` shadows the `overrideAttrs` provided by `stdenv`, but the bespoke implementation only supports the `prev: { }` form.

This change uses `lib.toExtension` and `lib.composeExtensions` to support all three forms of `overrideAttrs` described in the manual.

I don't know much about the PHP ecosystem, so I am relying on the package tests for backwards compatibility here, since they are mainly geared towards covering `overrideAttrs` scenarios.

Fixes #356639

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
