### PR TITLE
trilium-next-{desktop,server}: init at 0.90.12

### DIFF
--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -26,6 +26,8 @@ in
   options.services.trilium-server = with lib; {
     enable = mkEnableOption "trilium-server";
 
+    package = mkPackageOption pkgs "trilium-server" {};
+
     dataDir = mkOption {
       type = types.str;
       default = "/var/lib/trilium";
@@ -117,7 +119,7 @@ in
       wantedBy = [ "multi-user.target" ];
       environment.TRILIUM_DATA_DIR = cfg.dataDir;
       serviceConfig = {
-        ExecStart = "${pkgs.trilium-server}/bin/trilium-server";
+        ExecStart = lib.getExe cfg.package;
         User = "trilium";
         Group = "trilium";
         PrivateTmp = "true";

--- a/pkgs/by-name/tr/trilium-next-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-next-desktop/package.nix
@@ -1,0 +1,129 @@
+{
+  stdenv,
+  lib,
+  unzip,
+  fetchurl,
+  fetchzip,
+  makeBinaryWrapper,
+  # use specific electron since it has to load a compiled module
+  electron_31,
+  autoPatchelfHook,
+  makeDesktopItem,
+  copyDesktopItems,
+  wrapGAppsHook3,
+  asar,
+}:
+
+let
+  pname = "trilium-next-desktop";
+  version = "0.90.12";
+
+  linuxSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-linux-x64.zip";
+  linuxSource.sha256 = "0ji28l60wyzhjbi6g5845dnm763bvg7535zfgzcmfgwjs6zr6nfq";
+
+  darwinSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-macos-x64.zip";
+  darwinSource.sha256 = "0jv80k7dk6gpyfj36iin6y7fk7qan4bya72f14jcgfla95wvk6ls";
+
+  meta = {
+    description = "Hierarchical note taking application with focus on building large personal knowledge bases";
+    homepage = "https://github.com/TriliumNext/Notes";
+    license = lib.licenses.agpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      eliandoran
+      fliegendewurst
+    ];
+    mainProgram = "trilium";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+  };
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version meta;
+
+    src = fetchurl linuxSource;
+
+    # Remove trilium-portable.sh, so trilium knows it is packaged making it stop auto generating a desktop item on launch
+    postPatch = ''
+      rm ./trilium-portable.sh
+    '';
+
+    nativeBuildInputs = [
+      unzip
+      makeBinaryWrapper
+      wrapGAppsHook3
+      copyDesktopItems
+      autoPatchelfHook
+      asar
+    ];
+
+    buildInputs = [
+      (lib.getLib stdenv.cc.cc)
+    ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "Trilium";
+        exec = "trilium";
+        icon = "trilium";
+        comment = meta.description;
+        desktopName = "TriliumNext Notes";
+        categories = [ "Office" ];
+        startupWMClass = "Trilium Notes Next";
+      })
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/bin"
+      mkdir -p "$out/share/trilium"
+      mkdir -p "$out/share/icons/hicolor/512x512/apps"
+
+      cp -r ./* "$out/share/trilium/"
+      rm $out/share/trilium/{*.so*,trilium,chrome_crashpad_handler,chrome-sandbox}
+
+      # Rebuild the ASAR archive, hardcoding the resourcesPath
+      tmp=$(mktemp -d)
+      asar extract $out/share/trilium/resources/app.asar $tmp
+      rm $out/share/trilium/resources/app.asar
+
+      for f in "src/services/utils.ts" "dist/src/services/utils.js"; do
+        substituteInPlace $tmp/$f \
+          --replace-fail "process.resourcesPath" "'$out/share/trilium/resources'"
+      done
+      autoPatchelf $tmp
+      cp $tmp/src/public/icon.png $out/share/icons/hicolor/512x512/apps/trilium.png
+
+      asar pack $tmp/ $out/share/trilium/resources/app.asar
+      rm -rf $tmp
+
+      makeWrapper ${lib.getExe electron_31} $out/bin/trilium \
+        "''${gappsWrapperArgs[@]}" \
+        --set-default ELECTRON_IS_DEV 0 \
+        --add-flags $out/share/trilium/resources/app.asar
+
+      runHook postInstall
+    '';
+
+    dontWrapGApps = true;
+
+    passthru.updateScript = ./update.sh;
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchzip darwinSource;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+      runHook postInstall
+    '';
+  };
+
+in
+if stdenv.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/tr/trilium-next-desktop/update.sh
+++ b/pkgs/by-name/tr/trilium-next-desktop/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl jq
+set -euo pipefail
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+setKV () {
+    sed -i "s|$2 = \".*\"|$2 = \"${3:-}\"|" $1
+}
+
+version=$(curl -s --show-error "https://api.github.com/repos/TriliumNext/Notes/releases/latest" | jq -r '.tag_name' | tail -c +2)
+setKV ./package.nix version $version
+
+# Update desktop application
+sha256_linux64=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-linux-x64.zip)
+sha256_darwin64=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-macos-x64.zip)
+setKV ./package.nix linuxSource.sha256 $sha256_linux64
+setKV ./package.nix darwinSource.sha256 $sha256_darwin64
+
+# Update server
+sha256_linux64_server=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-server-linux-x64.tar.xz)
+setKV ../trilium-next-server/package.nix version $version
+setKV ../trilium-next-server/package.nix serverSource.sha256 $sha256_linux64_server

--- a/pkgs/by-name/tr/trilium-next-server/0001-Use-console-logger-instead-of-rolling-files.patch
+++ b/pkgs/by-name/tr/trilium-next-server/0001-Use-console-logger-instead-of-rolling-files.patch
@@ -1,0 +1,79 @@
+diff --git a/src/services/log.js b/src/services/log.js
+index 2840c185a..7fb16dd08 100644
+--- a/src/services/log.js
++++ b/src/services/log.js
+@@ -1,45 +1,12 @@
+ "use strict";
+-import fs from "fs";
+-import dataDir from "./data_dir.js";
+ import cls from "./cls.js";
+-if (!fs.existsSync(dataDir.LOG_DIR)) {
+-    fs.mkdirSync(dataDir.LOG_DIR, 0o700);
+-}
+-let logFile;
+ const SECOND = 1000;
+ const MINUTE = 60 * SECOND;
+-const HOUR = 60 * MINUTE;
+-const DAY = 24 * HOUR;
+-const NEW_LINE = process.platform === "win32" ? '\r\n' : '\n';
+-let todaysMidnight;
+-initLogFile();
+-function getTodaysMidnight() {
+-    const now = new Date();
+-    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+-}
+-function initLogFile() {
+-    todaysMidnight = getTodaysMidnight();
+-    const path = `${dataDir.LOG_DIR}/trilium-${formatDate()}.log`;
+-    if (logFile) {
+-        logFile.end();
+-    }
+-    logFile = fs.createWriteStream(path, { flags: 'a' });
+-}
+-function checkDate(millisSinceMidnight) {
+-    if (millisSinceMidnight >= DAY) {
+-        initLogFile();
+-        millisSinceMidnight -= DAY;
+-    }
+-    return millisSinceMidnight;
+-}
+ function log(str) {
+     const bundleNoteId = cls.get("bundleNoteId");
+     if (bundleNoteId) {
+         str = `[Script ${bundleNoteId}] ${str}`;
+-    }
+-    let millisSinceMidnight = Date.now() - todaysMidnight.getTime();
+-    millisSinceMidnight = checkDate(millisSinceMidnight);
+-    logFile.write(`${formatTime(millisSinceMidnight)} ${str}${NEW_LINE}`);
++    }    
+     console.log(str);
+ }
+ function info(message) {
+@@ -61,27 +28,6 @@ function request(req, res, timeMs, responseLength = "?") {
+     info((timeMs >= 10 ? "Slow " : "") +
+         `${res.statusCode} ${req.method} ${req.url} with ${responseLength} bytes took ${timeMs}ms`);
+ }
+-function pad(num) {
+-    num = Math.floor(num);
+-    return num < 10 ? (`0${num}`) : num.toString();
+-}
+-function padMilli(num) {
+-    if (num < 10) {
+-        return `00${num}`;
+-    }
+-    else if (num < 100) {
+-        return `0${num}`;
+-    }
+-    else {
+-        return num.toString();
+-    }
+-}
+-function formatTime(millisSinceMidnight) {
+-    return `${pad(millisSinceMidnight / HOUR)}:${pad((millisSinceMidnight % HOUR) / MINUTE)}:${pad((millisSinceMidnight % MINUTE) / SECOND)}.${padMilli(millisSinceMidnight % SECOND)}`;
+-}
+-function formatDate() {
+-    return `${pad(todaysMidnight.getFullYear())}-${pad(todaysMidnight.getMonth() + 1)}-${pad(todaysMidnight.getDate())}`;
+-}
+ export default {
+     info,
+     error,

--- a/pkgs/by-name/tr/trilium-next-server/package.nix
+++ b/pkgs/by-name/tr/trilium-next-server/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  lib,
+  autoPatchelfHook,
+  fetchurl,
+  makeBinaryWrapper,
+}:
+
+let
+  version = "0.90.12";
+
+  serverSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-server-linux-x64.tar.xz";
+  serverSource.sha256 = "0gvb01cj334n805rs230xwwcv4rf2z2giikpagw8wqrs54gy3b35";
+in
+stdenv.mkDerivation {
+  pname = "trilium-next-server";
+  inherit version;
+
+  src = fetchurl serverSource;
+
+  patches = [
+    # patch logger to use console instead of rolling files
+    ./0001-Use-console-logger-instead-of-rolling-files.patch
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/trilium-server"
+
+    cp -r ./* "$out/share/trilium-server/"
+
+    makeWrapper "$out/share/trilium-server/node/bin/node" "$out/bin/trilium-server" \
+      --chdir "$out/share/trilium-server" \
+      --add-flags "src/main"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Hierarchical note taking application with focus on building large personal knowledge bases";
+    homepage = "https://github.com/TriliumNext/Notes";
+    license = lib.licenses.agpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      eliandoran
+      fliegendewurst
+    ];
+    mainProgram = "trilium-server";
+  };
+}


### PR DESCRIPTION
New package, based on the old Trilium.

cc @eliandoran

Closes #348144
Closes #339237

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc