### PR TITLE
iproute2: fix build on recent musl

### DIFF
--- a/pkgs/by-name/ip/iproute2/package.nix
+++ b/pkgs/by-name/ip/iproute2/package.nix
@@ -34,6 +34,11 @@ stdenv.mkDerivation rec {
       url = "https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/patch/?id=6a77abab92516e65f07f8657fc4e384c4541ce0e";
       hash = "sha256-19FzTDvgnmqVFBykVgXl4VIsHs8Cy9NWGOLpxifxVlI=";
     })
+    (fetchpatch {
+      name = "musl-mst-2.patch";
+      url = "https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/patch/?id=043ef90e2fa94397eb5c85330889ca4146a6d58a";
+      hash = "sha256-6q4NcdT2YXhhbMgLaiAjO2WFUcM9Pv8+J34rGzJqU5Q=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
cf. <https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=043ef90e2fa94397eb5c85330889ca4146a6d58a>

```
In file included from mst.c:12:
../include/json_print.h:80:30: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
   80 | _PRINT_FUNC(tv, const struct timeval *)
      |                              ^~~~~~~
../include/json_print.h:50:37: note: in definition of macro ‘_PRINT_FUNC’
   50 |                                     type value);                        \
      |                                     ^~~~
../include/json_print.h:80:30: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
   80 | _PRINT_FUNC(tv, const struct timeval *)
      |                              ^~~~~~~
../include/json_print.h:55:45: note: in definition of macro ‘_PRINT_FUNC’
   55 |                                             type value)                 \
      |                                             ^~~~
../include/json_print.h: In function ‘print_tv’:
../include/json_print.h:58:48: error: passing argument 5 of ‘print_color_tv’ from incompatible pointer type [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
   58 |                                                value);                  \
      |                                                ^~~~~
      |                                                |
      |                                                const struct timeval *
../include/json_print.h:80:1: note: in expansion of macro ‘_PRINT_FUNC’
   80 | _PRINT_FUNC(tv, const struct timeval *)
      | ^~~~~~~~~~~
../include/json_print.h:50:42: note: expected ‘const struct timeval *’ but argument is of type ‘const struct timeval *’
   50 |                                     type value);                        \
      |                                          ^
../include/json_print.h:80:1: note: in expansion of macro ‘_PRINT_FUNC’
   80 | _PRINT_FUNC(tv, const struct timeval *)
      | ^~~~~~~~~~~
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
