### PR TITLE
home-assistant-custom-components.xiaomi_miot: 0.7.21 -> 0.7.23

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -2,9 +2,8 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  hap-python,
+  construct,
   micloud,
-  pyqrcode,
   python-miio,
   nix-update-script,
 }:
@@ -12,19 +11,18 @@
 buildHomeAssistantComponent rec {
   owner = "al-one";
   domain = "xiaomi_miot";
-  version = "0.7.21";
+  version = "0.7.23";
 
   src = fetchFromGitHub {
     owner = "al-one";
     repo = "hass-xiaomi-miot";
     rev = "v${version}";
-    hash = "sha256-5MYA5MejQAANyjVqhqZtaIEQEs1K/aOx+1n+L9TmNmY=";
+    hash = "sha256-PTjkKuK+DAOmKREr0AHjFXzy4ktguD4ZOHcWuLedLH0=";
   };
 
-  propagatedBuildInputs = [
-    hap-python
+  dependencies = [
+    construct
     micloud
-    pyqrcode
     python-miio
   ];
 

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -30,11 +30,24 @@ buildHomeAssistantComponent rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/al-one/hass-xiaomi-miot/releases/tag/v${version}";
     description = "Automatic integrate all Xiaomi devices to HomeAssistant via miot-spec, support Wi-Fi, BLE, ZigBee devices";
+    longDescription = ''
+      Xiaomi Miot For HomeAssistant depends on `ffmpeg` and `homekit`, example how to setup in NixOS `configuration.nix`:
+
+      ```
+      { config, lib, pkgs, ... }:
+      {
+        services.home-assistant = {
+          customComponents = [ pkgs.home-assistant-custom-components.xiaomi_miot ];
+          extraComponents = [ "ffmpeg" "homekit" ];
+        };
+      }
+      ```
+    '';
     homepage = "https://github.com/al-one/hass-xiaomi-miot";
-    maintainers = with maintainers; [ azuwis ];
-    license = licenses.asl20;
+    maintainers = with lib.maintainers; [ azuwis ];
+    license = lib.licenses.asl20;
   };
 }


### PR DESCRIPTION
Diff: https://github.com/al-one/hass-xiaomi-miot/compare/v0.7.21...v0.7.23

Changelog: https://github.com/al-one/hass-xiaomi-miot/releases/tag/v0.7.23

Fix with home-assistant v2024.11:

```
  File "/var/lib/hass/custom_components/xiaomi_miot/__init__.py", line 30, in <module>
    from homeassistant.config import DATA_CUSTOMIZE
ImportError: cannot import name 'DATA_CUSTOMIZE' from 'homeassistant.config' (/nix/store/m1bqz8krvqssm8zq8i456ds5287dfvd9-homeassistant-2024.11.1/lib/python3.12/site-packages/homeassistant/config.py)
```

We also need to backport to release-24.11, because it's already home-assistant v2024.11 there, https://github.com/NixOS/nixpkgs/blob/release-24.11/pkgs/servers/home-assistant/default.nix#L442.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
