### PR TITLE
skawarePackages: split man page packages back out; lib/systems: use execline from a bootstrap package set

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -283,7 +283,10 @@ let
           # to an emulator program. That is, if an emulator requires additional
           # arguments, a wrapper should be used.
           if pkgs.stdenv.hostPlatform.canExecute final
-          then "${pkgs.execline}/bin/exec"
+          # We use a bootstrap package set here to avoid bringing in
+          # an entire cURL/OpenSSL/etc. set to download the execline
+          # source code.
+          then "${pkgs.stdenv.__bootPackages.stdenv.__bootPackages.execline}/bin/exec"
           else if final.isWindows
           then "${wine}/bin/wine${optionalString (final.parsed.cpu.bits == 64) "64"}"
           else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux && final.qemuArch != null

--- a/pkgs/development/skaware-packages/build-skaware-package.nix
+++ b/pkgs/development/skaware-packages/build-skaware-package.nix
@@ -6,8 +6,6 @@
 , version
   # : string
 , sha256 ? lib.fakeSha256
-  # : drv | null
-, manpages ? null
   # : string
 , description
   # : list Platform
@@ -66,15 +64,7 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  outputs =
-    if manpages == null
-    then outputs
-    else
-    assert (lib.assertMsg (!lib.elem "man" outputs) "If you pass `manpages` to `skawarePackages.buildPackage`, you cannot have a `man` output already!");
-    # insert as early as posible, but keep the first element
-    if lib.length outputs > 0
-    then [(lib.head outputs) "man"] ++ lib.tail outputs
-    else ["man"];
+  inherit outputs;
 
   dontDisableStatic = true;
   enableParallelBuilding = true;
@@ -108,13 +98,6 @@ stdenv.mkDerivation {
        docFiles = commonMetaFiles;
      }} $doc/share/doc/${pname}
 
-    ${if manpages == null
-      then ''echo "no manpages for this package"''
-      else ''
-        echo "copying manpages"
-        cp -vr ${manpages} $man
-      ''}
-
     ${postInstall}
   '';
 
@@ -122,7 +105,7 @@ stdenv.mkDerivation {
     ${cleanPackaging.checkForRemainingFiles}
   '';
 
-  passthru = passthru // (if manpages == null then {} else { inherit manpages; });
+  inherit passthru;
 
   meta = {
     homepage = "https://skarnet.org/software/${pname}/";

--- a/pkgs/development/skaware-packages/clean-packaging.nix
+++ b/pkgs/development/skaware-packages/clean-packaging.nix
@@ -3,7 +3,7 @@
 # files were either discarded or moved to outputs.
 # This ensures nothing is forgotten and new files
 # are correctly handled on update.
-{ lib, stdenv, file, writeScript }:
+{ lib, stdenv, writeScript }:
 
 let
   globWith = lib.concatMapStringsSep "\n";
@@ -35,15 +35,15 @@ let
 
   # Shell script to check whether the build directory is empty.
   # If there are still files remaining, exit 1 with a helpful
-  # listing of all remaining files and their types.
+  # listing of all remaining files.
   checkForRemainingFiles = writeScript "check-for-remaining-files.sh" ''
     #!${stdenv.shell}
     echo "Checking for remaining source files"
-    rem=$(find -mindepth 1 -xtype f -print0 \
+    rem=$(find -mindepth 1 -xtype f -print \
            | tee $TMP/remaining-files)
     if [[ "$rem" != "" ]]; then
       echo "ERROR: These files should be either moved or deleted:"
-      cat $TMP/remaining-files | xargs -0 ${file}/bin/file
+      cat $TMP/remaining-files
       exit 1
     fi
   '';

--- a/pkgs/development/skaware-packages/default.nix
+++ b/pkgs/development/skaware-packages/default.nix
@@ -10,6 +10,7 @@ lib.makeScope pkgs.newScope (self:
 
   # execline
   execline = callPackage ./execline { };
+  execline-man-pages = callPackage ./execline-man-pages { };
 
   # servers & tools
   mdevd = callPackage ./mdevd { };
@@ -31,10 +32,8 @@ lib.makeScope pkgs.newScope (self:
   s6-portable-utils = callPackage ./s6-portable-utils { };
   s6-rc = callPackage ./s6-rc { };
 
-  # manpages (DEPRECATED, they are added directly to the packages now)
-  execline-man-pages = self.execline.passthru.manpages;
-  s6-man-pages = self.s6.passthru.manpages;
-  s6-networking-man-pages = self.s6-networking.passthru.manpages;
-  s6-portable-utils-man-pages = self.s6-portable-utils.passthru.manpages;
-  s6-rc-man-pages = self.s6-rc.passthru.manpages;
+  s6-man-pages = callPackage ./s6-man-pages { };
+  s6-networking-man-pages = callPackage ./s6-networking-man-pages { };
+  s6-portable-utils-man-pages = callPackage ./s6-portable-utils-man-pages { };
+  s6-rc-man-pages = callPackage ./s6-rc-man-pages { };
 })

--- a/pkgs/development/skaware-packages/execline-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/execline-man-pages/default.nix
@@ -1,0 +1,13 @@
+{ lib, buildManPages }:
+
+# Maintainer of manpages uses following versioning scheme: for every
+# upstream $version he tags manpages release as ${version}.1, and,
+# in case of extra fixes to manpages, new tags in form ${version}.2,
+# ${version}.3 and so on are created.
+buildManPages {
+  pname = "execline-man-pages";
+  version = "2.9.6.1.1";
+  sha256 = "sha256-bj+74zTkGKLdLEb1k4iHfNI1lAuxLBASc5++m17Y0O8=";
+  description = "Port of the documentation for the execline suite to mdoc";
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -10,18 +10,6 @@ in skawarePackages.buildPackage {
   # ATTN: also check whether there is a new manpages version
   sha256 = "sha256-dpGdYvLeTbGsSzpZ7rPg4JtivN2a3ROuPy2tJvjw5co=";
 
-  # Maintainer of manpages uses following versioning scheme: for every
-  # upstream $version he tags manpages release as ${version}.1, and,
-  # in case of extra fixes to manpages, new tags in form ${version}.2,
-  # ${version}.3 and so on are created.
-  manpages = skawarePackages.buildManPages {
-    pname = "execline-man-pages";
-    version = "2.9.6.1.1";
-    sha256 = "sha256-bj+74zTkGKLdLEb1k4iHfNI1lAuxLBASc5++m17Y0O8=";
-    description = "Port of the documentation for the execline suite to mdoc";
-    maintainers = [ lib.maintainers.sternenseemann ];
-  };
-
   description = "Small scripting language, to be used in place of a shell in non-interactive scripts";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/development/skaware-packages/s6-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-man-pages/default.nix
@@ -1,0 +1,9 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-man-pages";
+  version = "2.13.0.0.1";
+  sha256 = "oZgyJ2mPxpgsV2Le29XM+NsjMhqvDQ70SUZ2gjYg5U8=";
+  description = "Port of the documentation for the s6 supervision suite to mdoc";
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/development/skaware-packages/s6-networking-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking-man-pages/default.nix
@@ -1,0 +1,9 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-networking-man-pages";
+  version = "2.7.0.3.1";
+  sha256 = "9u2C1TF9vma+7Qo+00uZ6eOCn/9eMgKALgHDVgMcrfg=";
+  description = "Port of the documentation for the s6-networking suite to mdoc";
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -21,14 +21,6 @@ skawarePackages.buildPackage {
   version = "2.7.0.3";
   sha256 = "20EcVDcaF+19RUPdhs+VMM4l/PYkvvg64rV5Ug5ecL8=";
 
-  manpages = skawarePackages.buildManPages {
-    pname = "s6-networking-man-pages";
-    version = "2.7.0.3.1";
-    sha256 = "9u2C1TF9vma+7Qo+00uZ6eOCn/9eMgKALgHDVgMcrfg=";
-    description = "Port of the documentation for the s6-networking suite to mdoc";
-    maintainers = [ lib.maintainers.sternenseemann ];
-  };
-
   description = "Suite of small networking utilities for Unix systems";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/development/skaware-packages/s6-portable-utils-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils-man-pages/default.nix
@@ -1,0 +1,9 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-portable-utils-man-pages";
+  version = "2.3.0.2.2";
+  sha256 = "0zbxr6jqrx53z1gzfr31nm78wjfmyjvjx7216l527nxl9zn8nnv1";
+  description = "Port of the documentation for the s6-portable-utils suite to mdoc";
+  maintainers = [ lib.maintainers.somasis ];
+}

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -5,14 +5,6 @@ skawarePackages.buildPackage {
   version = "2.3.0.3";
   sha256 = "PkSSBV0WDCX7kBU/DvwnfX1Sv5gbvj6i6d/lHEk1Yf8=";
 
-  manpages = skawarePackages.buildManPages {
-    pname = "s6-portable-utils-man-pages";
-    version = "2.3.0.2.2";
-    sha256 = "0zbxr6jqrx53z1gzfr31nm78wjfmyjvjx7216l527nxl9zn8nnv1";
-    description = "Port of the documentation for the s6-portable-utils suite to mdoc";
-    maintainers = [ lib.maintainers.somasis ];
-  };
-
   description = "Set of tiny general Unix utilities optimized for simplicity and small size";
 
   outputs = [ "bin" "dev" "doc" "out" ];

--- a/pkgs/development/skaware-packages/s6-rc-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc-man-pages/default.nix
@@ -1,0 +1,9 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-rc-man-pages";
+  version = "0.5.4.3.1";
+  sha256 = "Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
+  description = "mdoc(7) versions of the documentation for the s6-rc service manager";
+  maintainers = [ lib.maintainers.qyliss ];
+}

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -5,14 +5,6 @@ skawarePackages.buildPackage {
   version = "0.5.4.3";
   sha256 = "4ycnlqlHkE3jerNOwQQw4mEHuO8FIQ2BBZyLNiA+ap8=";
 
-  manpages = skawarePackages.buildManPages {
-    pname = "s6-rc-man-pages";
-    version = "0.5.4.3.1";
-    sha256 = "Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
-    description = "mdoc(7) versions of the documentation for the s6-rc service manager";
-    maintainers = [ lib.maintainers.qyliss ];
-  };
-
   description = "Service manager for s6-based systems";
   platforms = lib.platforms.unix;
 

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -5,14 +5,6 @@ skawarePackages.buildPackage {
   version = "2.13.0.0";
   sha256 = "fkb49V2Auw4gJaZNXWSa9KSsIeNIAgyqrd4wul5bSDA=";
 
-  manpages = skawarePackages.buildManPages {
-    pname = "s6-man-pages";
-    version = "2.13.0.0.1";
-    sha256 = "oZgyJ2mPxpgsV2Le29XM+NsjMhqvDQ70SUZ2gjYg5U8=";
-    description = "Port of the documentation for the s6 supervision suite to mdoc";
-    maintainers = [ lib.maintainers.sternenseemann ];
-  };
-
   description = "skarnet.org's small & secure supervision software suite";
 
   # NOTE lib: cannot split lib from bin at the moment,

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -8,7 +8,7 @@ let
     || (stdenv.cc.isGNU && stdenv.hostPlatform.isLinux)
   );
   staticLibc = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
-  emulator = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) (stdenv.hostPlatform.emulator buildPackages);
+  emulator = stdenv.hostPlatform.emulator buildPackages;
   isCxx = stdenv.cc.libcxx != null;
   libcxxStdenvSuffix = lib.optionalString isCxx "-libcxx";
   CC = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}cc"}";


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/293124#issuecomment-2482520728, https://github.com/NixOS/nixpkgs/pull/351768, and https://github.com/NixOS/nixpkgs/pull/352682 for context. Detail in the commit messages, and feedback welcome, especially on the `lib/systems` change because I sure don’t fully understand `__bootPackages` or the implications myself.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
