### PR TITLE
 nixos/qbittorrent: init module qbittorrent

### DIFF
--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.services.qbittorrent-nox;
+  settingsFormat = pkgs.formats.ini { };
+
+  confirmLegalNoticeString = if cfg.confirmLegalNotice then "--confirm-legal-notice" else "";
+
+in
+{
+  options = {
+    services.qbittorrent-nox = {
+      enable = lib.mkEnableOption "Enable qBittorrent-nox service";
+
+      settings = lib.mkOption {
+        type = lib.types.submodule { freeformType = settingsFormat.type; };
+        default = { };
+        description = lib.mdDoc ''
+          qBittorrent settings. These will be merged with the default settings.
+          Settings defined here will override the defaults.
+          Se https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8080;
+        description = "Port for the web UI.";
+      };
+
+      torrentPort = lib.mkOption {
+        type = lib.types.port;
+        default = 6881;
+        description = "Port for torrenting.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "qbittorrent";
+        description = "User to run the service.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "qbittorrent";
+        description = "Group to run the service.";
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.qbittorrent-nox;
+        description = "Package to use for the service.";
+      };
+
+      stateDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/qbittorrent";
+        description = "Directory for qBittorrent-nox data.";
+      };
+
+      confirmLegalNotice = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          qBittorrent is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility.
+
+          If you confirm the legal notice you can enable this option.
+        '';
+      };
+
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.qbittorrent-nox = {
+      description = "qBittorrent-nox Service";
+      wants = [ "network-online.target" ];
+      after = [
+        "network.target"
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      path = [
+        cfg.package
+        cfg.stateDir
+      ];
+
+      preStart = ''
+        # Ensure proper permissions on directories
+        mkdir -p ${cfg.stateDir}
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}
+
+        # Create config directory if it doesn't exist
+        mkdir -p ${cfg.stateDir}/qBittorrent/config
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/qBittorrent
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/qBittorrent/config
+
+        # Generate config file if settings are provided
+        ${lib.optionalString (cfg.settings != { }) ''
+          cp ${settingsFormat.generate "qBittorrent.conf" cfg.settings} ${cfg.stateDir}/qBittorrent/config/qBittorrent.conf
+          chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/qBittorrent/config/qBittorrent.conf
+          chmod 600 ${cfg.stateDir}/qBittorrent/config/qBittorrent.conf
+        ''}
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.stateDir;
+        Restart = "always";
+        RuntimeDirectory = "qbittorrent";
+        RuntimeDirectoryMode = "0755";
+        StateDirectory = "qbittorrent";
+        StateDirectoryMode = "0755";
+        ReadWritePaths = [ cfg.stateDir ];
+        ExecStart = "${cfg.package}/bin/qbittorrent-nox --profile=${cfg.stateDir} --webui-port=${builtins.toString cfg.port} --torrenting-port=${builtins.toString cfg.torrentPort} ${confirmLegalNoticeString}";
+      };
+
+    };
+
+    users.users = lib.mkIf (cfg.user == "qbittorrent") {
+      qbittorrent = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.stateDir;
+        useDefaultShell = true;
+        createHome = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "qbittorrent") { qbittorrent = { }; };
+
+  };
+}


### PR DESCRIPTION
Tried making a nixos module for qbittorrent-nox. 

It seems to work but have not really battle tested.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
