### PR TITLE
rubyPackages.ncursesw: 1.4.10 -> 1.4.11

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -2373,10 +2373,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1nc14wls1yiigz593vw7580hb99lf4n485axapiz6sqpg1jnlhcr";
+      sha256 = "0qlfhp9b445g0qp9kkdiylfjlpfzrv6nqvry4ar6y0yacn0zr5y8";
       type = "gem";
     };
-    version = "1.4.10";
+    version = "1.4.11";
   };
   net-http = {
     dependencies = ["uri"];


### PR DESCRIPTION
To fix build on darwin. Extracted from https://github.com/NixOS/nixpkgs/pull/356446 and https://github.com/NixOS/nixpkgs/pull/356447

ZHF: #352882
https://hydra.nixos.org/build/278936805
https://hydra.nixos.org/build/278911245

<details>
<summary>failed log</summary>

```
Running phase: unpackPhase
Running phase: patchPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: installPhase
buildFlags: --with-cflags=-I/nix/store/dmd31mvnbmqqjmgrd6sf519cjmmf0jl8-ncurses-6.4.20221231-dev/include --with-ldflags=-L/nix/store/skvqzr89y8bk7i2pazb1lpf2zfbnsxkc-ncurses-6.4.20221231/lib
WARNING:  You build with buildroot.
  Build root: /
  Bin dir: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/bin
  Gem home: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0
  Plugins dir: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/plugins
Building native extensions with: '--with-cflags=-I/nix/store/dmd31mvnbmqqjmgrd6sf519cjmmf0jl8-ncurses-6.4.20221231-dev/include --with-ldflags=-L/nix/store/skvqzr89y8bk7i2pazb1lpf2zfbnsxkc-ncurses-6.4.20221231/lib'
This could take a while...
ERROR:  Error installing /nix/store/yccljarsd0djrx3ybhhy6d9mzlyvjm1x-ncursesw-1.4.10.gem:
        ERROR: Failed to build gem native extension.

    current directory: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/gems/ncursesw-1.4.10
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/bin/ruby extconf.rb --with-cflags\=-I/nix/store/dmd31mvnbmqqjmgrd6sf519cjmmf0jl8-ncurses-6.4.20221231-dev/include --with-ldflags\=-L/nix/store/skvqzr89y8bk7i2pazb1lpf2zfbnsxkc-ncurses-6.4.20221231/lib
checking for pkg-config... no
checking for unistd.h... yes
checking for locale.h... yes
checking for ncursesw/curses.h... yes
checking for wmove() in -lncursesw... yes
checking for newscr()... yes
checking for TABSIZE()... yes
checking for ESCDELAY()... yes
checking for keybound()... yes
checking for curses_version()... yes
checking for tigetstr()... yes
checking for getwin()... yes
checking for putwin()... yes
checking for ungetmouse()... yes
checking for mousemask()... yes
checking for wenclose()... yes
checking for mouseinterval()... yes
checking for wmouse_trafo()... yes
checking for mcprint()... yes
checking for has_key()... yes
checking for delscreen()... yes
checking for define_key()... yes
checking for keyok()... yes
checking for resizeterm()... yes
checking for use_default_colors()... yes
checking for use_extended_names()... yes
checking for wresize()... yes
checking for attr_on()... yes
checking for attr_off()... yes
checking for attr_set()... yes
checking for chgat()... yes
checking for color_set()... yes
checking for filter()... yes
checking for intrflush()... yes
checking for mvchgat()... yes
checking for mvhline()... yes
checking for mvvline()... yes
checking for mvwchgat()... yes
checking for mvwhline()... yes
checking for mvwvline()... yes
checking for noqiflush()... yes
checking for putp()... yes
checking for qiflush()... yes
checking for scr_dump()... yes
checking for scr_init()... yes
checking for scr_restore()... yes
checking for scr_set()... yes
checking for slk_attr_off()... yes
checking for slk_attr_on()... yes
checking for slk_attr()... yes
checking for slk_attr_set()... yes
checking for slk_color()... yes
checking for tigetflag()... yes
checking for tigetnum()... yes
checking for use_env()... yes
checking for vidattr()... yes
checking for vid_attr()... yes
checking for wattr_on()... yes
checking for wattr_off()... yes
checking for wattr_set()... yes
checking for wchgat()... yes
checking for wcolor_set()... yes
checking for getattrs()... yes
checking for ncursesw (wide char) functions...
checking for wget_wch()... yes
checking for add_wch()... yes
checking for get_wch()... yes
checking which debugging functions to wrap...
checking for _tracef()... no
checking for _tracedump()... no
checking for _nc_tracebits()... no
checking for _traceattr()... no
checking for _traceattr2()... no
checking for _tracechar()... no
checking for _tracechtype()... no
checking for _tracechtype2()... no
checking for _tracemouse()... no
checking for other functions that appeared after ncurses version 5.0...
checking for assume_default_colors()... yes
checking for attr_get()... yes
checking for the panel library...
checking for panel.h... yes
checking for panel_hidden() in -lpanelw... yes
checking for the form library...
checking for form.h... yes
checking for new_form() in -lformw... yes
checking for form_driver_w() in -lformw... yes
checking for the menu library...
checking for menu.h... yes
checking for new_menu() in -lmenu... yes
checking for various ruby and standard functions..
checking for rb_thread_fd_select()... yes
checking for clock_gettime()... yes
checking for sys/time.h... yes
creating Makefile

current directory: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/gems/ncursesw-1.4.10
make DESTDIR\= sitearchdir\=./.gem.20241117-83789-i8tf83 sitelibdir\=./.gem.20241117-83789-i8tf83 clean

current directory: /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/gems/ncursesw-1.4.10
make DESTDIR\= sitearchdir\=./.gem.20241117-83789-i8tf83 sitelibdir\=./.gem.20241117-83789-i8tf83
compiling form_wrap.c
form_wrap.c:1422:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "back", field_back,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:61:3: note: expanded from macro 'RB_CLASS_METH'
  rb_define_method(class, #name, (&rbncurs_c_ ## name), nargs);      \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1422:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "back", field_back,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1424:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "fore", field_fore,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:61:3: note: expanded from macro 'RB_CLASS_METH'
  rb_define_method(class, #name, (&rbncurs_c_ ## name), nargs);      \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1424:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "fore", field_fore,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1431:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "pad", field_pad,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:61:3: note: expanded from macro 'RB_CLASS_METH'
  rb_define_method(class, #name, (&rbncurs_c_ ## name), nargs);      \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1431:3: error: incompatible function pointer types passing 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  RB_CLASS_METH(cFIELD, "pad", field_pad,1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
form_wrap.c:1373:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, current_field,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1374:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, data_ahead,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1375:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, data_behind,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1376:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, dup_field,2);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1377:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, field_count,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1378:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, field_init,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1379:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFORM, NULL, field_term,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
form_wrap.c:1438:3: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  RB_CLASS_METH(cFIELD, NULL, new_page,0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./form_wrap.h:63:5: note: expanded from macro 'RB_CLASS_METH'
    rb_define_method(class, alt_name, (&rbncurs_c_ ## name), nargs); \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/gnhw9pk0kzw42bpgxca2w2mc0jdm2n32-ruby-3.3.5/include/ruby-3.3.0/ruby/internal/anyargs.h:288:150: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                               ~~~~~                 ^
8 warnings and 6 errors generated.
make: *** [Makefile:258: form_wrap.o] Error 1

make failed, exit code 2

Gem files will remain installed in /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/gems/ncursesw-1.4.10 for inspection.
Results logged to /nix/store/8riync76y9jrm2ka33af07z141liwgba-ruby3.3-ncursesw-1.4.10/lib/ruby/gems/3.3.0/extensions/x86_64-darwin-24/3.3.0/ncursesw-1.4.10/gem_make.out
```

</details>

Changes:
  - https://github.com/sup-heliotrope/ncursesw-ruby/compare/v1.4.10...v1.4.11
  - https://my.diffend.io/gems/ncursesw/1.4.10/1.4.11

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
