### PR TITLE
falkor: init at 0.0.92

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9459,6 +9459,12 @@
     githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
+  icedborn = {
+    email = "github.envenomed@dralias.com";
+    github = "icedborn";
+    githubId = 51162078;
+    name = "IceDBorn";
+  };
   icewind1991 = {
     name = "Robin Appelman";
     email = "robin@icewind.nl";

--- a/pkgs/by-name/fa/falkor/package.nix
+++ b/pkgs/by-name/fa/falkor/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  electron,
+  dpkg,
+  makeWrapper,
+  commandLineArgs ? "",
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "falkor";
+  version = "0.0.92";
+
+  src = fetchurl {
+    url = "https://github.com/Team-Falkor/falkor/releases/download/v${finalAttrs.version}/falkor.deb";
+    hash = "sha256-yDpYu2ehrRQuD29jcyTQla2R2IT1zfBDeWDDRnmqc8Y=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    dpkg
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv usr/share $out/share
+    mkdir -p $out/share/falkor
+    sed -i "s|Exec=.*|Exec=falkor|" $out/share/applications/*.desktop
+    mv opt/falkor/{resources,resources.pak,locales} $out/share/falkor
+
+    makeWrapper ${lib.getExe electron} $out/bin/falkor \
+      --argv0 "falkor" \
+      --add-flags "$out/share/falkor/resources/app.asar" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Electron-based gaming hub";
+    homepage = "https://github.com/Team-Falkor/falkor";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ icedborn ];
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "falkor";
+  };
+})


### PR DESCRIPTION
Falkor is an Electron-based gaming hub.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
