### PR TITLE
hyprgui: 0.1.8 -> 0.1.9

### DIFF
--- a/pkgs/by-name/hy/hyprgui/package.nix
+++ b/pkgs/by-name/hy/hyprgui/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hyprgui";
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "hyprutils";
     repo = "hyprgui";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Bg1S/FhduRSSXc3Yd7SkyrmMKff7oh0jw781jTB0J60=";
+    hash = "sha256-VP+6qWu4nv8h9LLjTnl8Mh1aAlIA+zuufRYoouxl2Tc=";
   };
 
-  cargoHash = "sha256-bhtmU0vGptUYrPN/BbbSvSa27Ykma8UI6TS17eiQkyU=";
+  cargoHash = "sha256-t0HqraCA4q7K4EEtPS8J0ZmnhBB+Zf0aX+yXSUdKJzo=";
 
   strictDeps = true;
 
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     wrapGAppsHook4
   ];
+
   buildInputs = [
     glib
     cairo
@@ -36,9 +37,15 @@ rustPlatform.buildRustPackage rec {
     gtk4
   ];
 
+  prePatch = ''
+    substituteInPlace hyprgui.desktop \
+    --replace-fail "/usr/bin/" ""
+  '';
+
   postInstall = ''
     install -Dm644 -t $out/usr/share/icons hyprgui.png
     install -Dm644 -t $out/usr/share/applications hyprgui.desktop
+    install -Dm644 -t $out/usr/share/licenses/${pname} LICENSE
   '';
 
   meta = {


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
