### PR TITLE
sublist3r: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11856,6 +11856,12 @@
     githubId = 1903418;
     name = "Kovacsics Robert";
   };
+  kpanuragh = {
+    email = "kpanuragh@gmail.com";
+    github = "kpanuragh";
+    githubId = 36616831;
+    name = "Anuragh K P";
+  };
   kquick = {
     email = "quick@sparq.org";
     github = "kquick";

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sublist3r";
-  version = "1.1"; # Version tag or commit hash of the repository
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "aboul3la";
     repo = "Sublist3r";
-    rev = "master"; # Or specify a commit hash for a specific version
+    rev = "master";
     sha256 = "nrnb3jAIHw6WXR7VLNmi1YdfMBzHEIiMlGSbrvEi6Uc=";
   };
 

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sublist3r";
+  version = "1.1"; # Version tag or commit hash of the repository
+
+  src = fetchFromGitHub {
+    owner = "aboul3la";
+    repo = "Sublist3r";
+    rev = "master"; # Or specify a commit hash for a specific version
+    sha256 = "nrnb3jAIHw6WXR7VLNmi1YdfMBzHEIiMlGSbrvEi6Uc=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    dnspython
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Fast subdomains enumeration tool for penetration testers";
+    homepage = "https://github.com/aboul3la/Sublist3r";
+    license = licenses.gpl2Oss;
+    maintainers = [ maintainers.kpanuragh ];
+  };
+}

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Fast subdomains enumeration tool for penetration testers";
     homepage = "https://github.com/aboul3la/Sublist3r";
-    license = licenses.gpl2Oss;
-    maintainers = [ maintainers.kpanuragh ];
+    license = lib.licenses.gpl2Oss;
+    maintainers = with lib.maintainers [ kpanuragh ];
   };
 }

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Fast subdomains enumeration tool for penetration testers";
     homepage = "https://github.com/aboul3la/Sublist3r";
     license = lib.licenses.gpl2Oss;

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -8,7 +8,7 @@ python3Packages.buildPythonApplication rec {
     owner = "aboul3la";
     repo = "Sublist3r";
     rev = "refs/tags/${version}";
-    sha256 = "nrnb3jAIHw6WXR7VLNmi1YdfMBzHEIiMlGSbrvEi6Uc=";
+    hash = "";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "aboul3la";
     repo = "Sublist3r";
-    rev = "master";
+    rev = "refs/tags/${version}";
     sha256 = "nrnb3jAIHw6WXR7VLNmi1YdfMBzHEIiMlGSbrvEi6Uc=";
   };
 

--- a/pkgs/tools/security/sublist3r/default.nix
+++ b/pkgs/tools/security/sublist3r/default.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication rec {
     hash = "";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     requests
     dnspython
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19241,4 +19241,5 @@ with pkgs;
   tree-from-tags = callPackage ../by-name/tr/tree-from-tags/package.nix {
     ruby = ruby_3_1;
   };
+  sublist3r = callPackage ../tools/security/sublist3r { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19241,5 +19241,4 @@ with pkgs;
   tree-from-tags = callPackage ../by-name/tr/tree-from-tags/package.nix {
     ruby = ruby_3_1;
   };
-  sublist3r = callPackage ../tools/security/sublist3r { };
 }


### PR DESCRIPTION
### **Summary**
This PR adds a new package: **Sublist3r**, a fast subdomain enumeration tool for penetration testers. Sublist3r supports popular search engines such as Google, Yahoo, Bing, Baidu, and Ask to discover subdomains for a given domain name.

Sublist3r's GitHub repository: [Sublist3r](https://github.com/aboul3la/Sublist3r).

Adding this package to Nixpkgs provides users with a convenient way to install and use this tool for security-related tasks.

---

### **Things Done**

#### **Built on platform(s):**
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin

#### **Sandboxing:**
- [ ] `sandbox = relaxed`
- [ ] `sandbox = true`

#### **Tests:**
- [x] Basic functionality of all binary files (e.g., `./result/bin/sublist3r --help`) tested.
- [ ] NixOS test(s).
- [ ] Package tests.
- [ ] Core functionality tests.
- [ ] `nixpkgs-review` tests.

#### **Release Notes:**
- [ ] Added a release notes entry if this change is significant or breaking.

#### **Other Checks:**
- [x] Verified the package fits the [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) guidelines.

---

By adding this package, we enable penetration testers and developers to quickly use Sublist3r in their workflows, leveraging Nix's reproducible environment.