### PR TITLE
linuxPackages.ipu6-drivers: fix build on Linux >= 6.12, bump

### DIFF
--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -1,36 +1,23 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , ivsc-driver
 , kernel
 }:
 
 stdenv.mkDerivation rec {
   pname = "ipu6-drivers";
-  version = "unstable-2024-10-10";
+  version = "unstable-2024-11-19";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-drivers";
-    rev = "118952d49ec598f56add50d93fa7bc3ac4a05643";
-    hash = "sha256-xdMwINoKrdRHCPMpdZQn86ATi1dAXncMU39LLXS16mc=";
+    rev = "0ad4988248d7e9382498a0b47fc78bb990b29a58";
+    hash = "sha256-UFvwuoAzwk1k4YiUK+4EeMKeTx9nVvBgBN5JKAfqZkQ=";
   };
 
   patches = [
     "${src}/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch"
-
-
-    # Fix compilation with kernels >= 6.12
-    # https://github.com/intel/ipu6-drivers/pull/283
-    (fetchpatch {
-      url = "https://github.com/intel/ipu6-drivers/pull/283/commits/391832777148e8e59ebf08e5d04f87dc8f3cef5b.patch";
-      hash = "sha256-oC7wn4jrHNtvsgouq7F+ufIE02pJcm42ZmgU2TrAvjA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/intel/ipu6-drivers/pull/283/commits/5379758bcb21be56b600817edf989dcc2c1775cf.patch";
-      hash = "sha256-9nOm0ffSNoyVV1y4J6RKBVRVYRxrEPOnggFXGIExLxs=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , ivsc-driver
 , kernel
 }:
@@ -16,7 +17,21 @@ stdenv.mkDerivation rec {
     hash = "sha256-xdMwINoKrdRHCPMpdZQn86ATi1dAXncMU39LLXS16mc=";
   };
 
-  patches = [ "${src}/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch" ];
+  patches = [
+    "${src}/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch"
+
+
+    # Fix compilation with kernels >= 6.12
+    # https://github.com/intel/ipu6-drivers/pull/283
+    (fetchpatch {
+      url = "https://github.com/intel/ipu6-drivers/pull/283/commits/391832777148e8e59ebf08e5d04f87dc8f3cef5b.patch";
+      hash = "sha256-oC7wn4jrHNtvsgouq7F+ufIE02pJcm42ZmgU2TrAvjA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/intel/ipu6-drivers/pull/283/commits/5379758bcb21be56b600817edf989dcc2c1775cf.patch";
+      hash = "sha256-9nOm0ffSNoyVV1y4J6RKBVRVYRxrEPOnggFXGIExLxs=";
+    })
+  ];
 
   postPatch = ''
     cp --no-preserve=mode --recursive --verbose \


### PR DESCRIPTION
There's been some header files being moved around, and these paches are necessary to build on Linux >= 6.12.

Tested compilation with 6.11 and 6.12.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
