### PR TITLE
treewide: improve prepending and appending derivation arguments in bash code

### DIFF
--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -28,13 +28,15 @@ mkDerivation rec {
     substituteInPlace fmit.pro --replace '$$FMITVERSIONGITPRO' '${version}'
   '';
 
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags \
-      CONFIG+=${lib.optionalString alsaSupport "acs_alsa"} \
-      CONFIG+=${lib.optionalString jackSupport "acs_jack"} \
-      CONFIG+=${lib.optionalString portaudioSupport "acs_portaudio"} \
-      PREFIXSHORTCUT=$out"
-  '';
+  qmakeFlags = [
+    "PREFIXSHORTCUT=${placeholder "out"}"
+  ] ++ lib.optionals alsaSupport [
+    "CONFIG+=acs_alsa"
+  ] ++ lib.optionals jackSupport [
+    "CONFIG+=acs_jack"
+  ] ++ lib.optionals portaudioSupport [
+    "CONFIG+=acs_portaudio"
+  ];
 
   meta = with lib; {
     description = "Free Musical Instrument Tuner";

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -105,6 +105,7 @@ stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_LIBS=ON"
     "-DBUILD_IMGUI_INTERFACE=${if withImGui then "ON" else "OFF"}"
     "-DWITH_QT_GUI_WEBENGINE=${if withTauWidget then "ON" else "OFF"}"
+    "-DAPP_INSTALL_ROOT=${placeholder "out"}/app"
   ];
 
   doCheck = true;
@@ -136,9 +137,6 @@ stdenv.mkDerivation rec {
 
     # Prebuild Ruby vendored dependencies and Qt docs
     ./linux-prebuild.sh -o
-
-    # Append CMake flag depending on the value of $out
-    cmakeFlags+=" -DAPP_INSTALL_ROOT=$out/app"
   '';
 
   postBuild = ''

--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -18,7 +18,7 @@ mkDerivation {
     protobuf_21 qtscript qtsvg qtquickcontrols qtwebengine shared-mime-info krunner kparts
     knewstuff gpsd
   ];
-  preConfigure = ''
-    cmakeFlags+=" -DINCLUDE_INSTALL_DIR=''${!outputDev}/include"
-  '';
+  cmakeFlags = [
+    "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
+  ];
 }

--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -66,9 +66,9 @@ mkDerivation rec {
     wayland-scanner
   ];
 
-  preConfigure = ''
-    cmakeFlags+="-DQT5_PLUGINS_INSTALL_DIR=$out/$qtPluginPrefix"
-  '';
+  cmakeFlags = [
+    "-DQT5_PLUGINS_INSTALL_DIR=${placeholder "out"}/$qtPluginPrefix"
+  ];
 
   meta = with lib; {
     description = "Core libraries of Maliit and server";

--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -63,12 +63,14 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ./_autosetup
-    configureFlags="$configureFlags --sysconfdir=$out/etc"
   '';
 
   enableParallelBuilding = true;
 
-  configureFlags = [ "--disable-server" ] ++ lib.optionals headless [ "--disable-manager" ];
+  configureFlags = [
+    "--disable-server"
+    "--sysconfdir=${placeholder "out"}/etc"
+  ] ++ lib.optionals headless [ "--disable-manager" ];
 
   postInstall = ''
     install --mode=444 -D 'client/scripts/boinc-client.service' "$out/etc/systemd/system/boinc.service"

--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    configureFlags="$configureFlags --with-lablgtk-dir=$(echo ${lablgtk}/lib/ocaml/*/site-lib/lablgtk2)"
+    appendToVar configureFlags "--with-lablgtk-dir=$(echo ${lablgtk}/lib/ocaml/*/site-lib/lablgtk2)"
   '';
 
   postInstall = ''

--- a/pkgs/applications/version-management/vcprompt/default.nix
+++ b/pkgs/applications/version-management/vcprompt/default.nix
@@ -14,8 +14,11 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     autoconf
-    makeFlags="$makeFlags PREFIX=$out"
   '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   meta = with lib; {
     description = ''

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -214,10 +214,10 @@ in stdenv.mkDerivation (finalAttrs: {
       # Need these tools on the build system when cross compiling,
       # hacky, but have found no other way.
       CXX=$CXX_FOR_BUILD LD=ld make -C tools/depends/native/JsonSchemaBuilder
-      cmakeFlags+=" -DWITH_JSONSCHEMABUILDER=$PWD/tools/depends/native/JsonSchemaBuilder/bin"
+      appendToVar cmakeFlags "-DWITH_JSONSCHEMABUILDER=$PWD/tools/depends/native/JsonSchemaBuilder/bin"
 
       CXX=$CXX_FOR_BUILD LD=ld make EXTRA_CONFIGURE= -C tools/depends/native/TexturePacker
-      cmakeFlags+=" -DWITH_TEXTUREPACKER=$PWD/tools/depends/native/TexturePacker/bin"
+      appendToVar cmakeFlags "-DWITH_TEXTUREPACKER=$PWD/tools/depends/native/TexturePacker/bin"
     '';
 
     postPatch = ''

--- a/pkgs/build-support/release/binary-tarball.nix
+++ b/pkgs/build-support/release/binary-tarball.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (
 
       # Prefix hackery because of a bug in stdenv (it tries to `mkdir
       # $prefix', which doesn't work due to the DESTDIR).
-      configureFlags="--prefix=$prefix $configureFlags"
+      prependToVar configureFlags "--prefix=$prefix"
       dontAddPrefix=1
       prefix=$TMPDIR/inst$prefix
     '';

--- a/pkgs/by-name/cl/cl-launch/package.nix
+++ b/pkgs/by-name/cl/cl-launch/package.nix
@@ -9,9 +9,12 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export makeFlags="$makeFlags PREFIX='$out'"
     mkdir -p "$out/bin"
   '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   preBuild = ''
     sed -e 's/\t\t@/\t\t/g' -i Makefile

--- a/pkgs/by-name/fl/fluxus/package.nix
+++ b/pkgs/by-name/fl/fluxus/package.nix
@@ -58,10 +58,8 @@ stdenv.mkDerivation {
     "RacketInclude=${racket}/include/racket"
     "RacketLib=${racket}/lib/racket"
     "DESTDIR=build"
+    "Prefix=${placeholder "out"}"
   ];
-  configurePhase = ''
-    sconsFlags+=" Prefix=$out"
-  '';
   installPhase = ''
     mkdir -p $out
     cp -r build$out/* $out/

--- a/pkgs/by-name/gl/globulation2/package.nix
+++ b/pkgs/by-name/gl/globulation2/package.nix
@@ -51,11 +51,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ scons ];
   buildInputs = [ libGLU libGL SDL SDL_ttf SDL_image zlib SDL_net speex libvorbis libogg boost fribidi bsdiff ];
 
-  postConfigure = ''
-    sconsFlags+=" BINDIR=$out/bin"
-    sconsFlags+=" INSTALLDIR=$out/share/globulation2"
-    sconsFlags+=" DATADIR=$out/share/globulation2/glob2"
-  '';
+  sconsFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "INSTALLDIR=${placeholder "out"}/share/globulation2"
+    "DATADIR=${placeholder "out"}/share/globulation2/glob2"
+  ];
 
   NIX_LDFLAGS = "-lboost_system";
 

--- a/pkgs/by-name/gp/gpsd/package.nix
+++ b/pkgs/by-name/gp/gpsd/package.nix
@@ -89,9 +89,6 @@ stdenv.mkDerivation rec {
     sed -e "s|systemd_dir = .*|systemd_dir = '$out/lib/systemd/system'|" -i SConscript
     export TAR=noop
     substituteInPlace SConscript --replace "env['CCVERSION']" "env['CC']"
-
-    sconsFlags+=" udevdir=$out/lib/udev"
-    sconsFlags+=" python_libdir=$out/${python3Packages.python.sitePackages}"
   '';
 
   # - leapfetch=no disables going online at build time to fetch leap-seconds
@@ -102,6 +99,8 @@ stdenv.mkDerivation rec {
     "gpsd_group=${gpsdGroup}"
     "systemd=yes"
     "xgps=${if guiSupport then "True" else "False"}"
+    "udevdir=${placeholder "out"}/lib/udev"
+    "python_libdir=${placeholder "out"}/${python3Packages.python.sitePackages}"
   ];
 
   preCheck = ''

--- a/pkgs/by-name/gt/gt5/package.nix
+++ b/pkgs/by-name/gt/gt5/package.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
     sed 's/-o root -g root//' -i Makefile
   '';
 
-  preConfigure = ''
-    makeFlags="$makeFlags PREFIX=$out"
-  '';
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   meta = {
     description = "Diff-capable 'du' browser";

--- a/pkgs/by-name/lx/lxdvdrip/package.nix
+++ b/pkgs/by-name/lx/lxdvdrip/package.nix
@@ -12,8 +12,11 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i -e s,/usr/local,$out, -e s,/etc,$out/etc,g Makefile
     sed -i -e s,/usr/local,$out, mbuffer/Makefile
-    makeFlags="$makeFlags PREFIX=$out"
   '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   preInstall = ''
     mkdir -p $out/man/man1 $out/bin $out/share $out/etc

--- a/pkgs/by-name/ne/netcdfcxx4/package.nix
+++ b/pkgs/by-name/ne/netcdfcxx4/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    cmakeFlags+="-Dabs_top_srcdir=$(readlink -f ./)"
+    appendToVar cmakeFlags "-Dabs_top_srcdir=$(readlink -f ./)"
   '';
 
   nativeBuildInputs = [ cmake ninja ];

--- a/pkgs/by-name/nf/nfs-utils/package.nix
+++ b/pkgs/by-name/nf/nfs-utils/package.nix
@@ -42,7 +42,8 @@ stdenv.mkDerivation rec {
     '';
 
   configureFlags =
-    [ "--enable-gss"
+    [ "--with-start-statd=${placeholder "out"}/bin/start-statd"
+      "--enable-gss"
       "--enable-svcgss"
       "--with-statedir=/var/lib/nfs"
       "--with-krb5=${lib.getLib libkrb5}"
@@ -66,8 +67,6 @@ stdenv.mkDerivation rec {
       patchShebangs tests
       sed -i "s,/usr/sbin,$out/bin,g" utils/statd/statd.c
       sed -i "s,^PATH=.*,PATH=$out/bin:${statdPath}," utils/statd/start-statd
-
-      configureFlags="--with-start-statd=$out/bin/start-statd $configureFlags"
 
       substituteInPlace systemd/nfs-utils.service \
         --replace "/bin/true" "${coreutils}/bin/true"

--- a/pkgs/by-name/np/np2kai/package.nix
+++ b/pkgs/by-name/np/np2kai/package.nix
@@ -124,7 +124,8 @@ stdenv.mkDerivation rec {
 
   configurePhase = ''
     export GIT_VERSION=${builtins.substring 0 7 src.rev}
-    buildFlags="$buildFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '' + optionalString enableParallelBuilding ''
+    appendToVar buildFlags "-j$NIX_BUILD_CORES"
   '' + optionalString enableX11 ''
     cd x11
     substituteInPlace Makefile.am \

--- a/pkgs/by-name/pa/pacparser/package.nix
+++ b/pkgs/by-name/pa/pacparser/package.nix
@@ -11,10 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-X842+xPjM404aQJTc2JwqU4vq8kgyKhpnqVu70pNLks=";
   };
 
-  makeFlags = [ "NO_INTERNET=1" ];
+  makeFlags = [
+    "NO_INTERNET=1"
+    "PREFIX=${placeholder "out"}"
+  ];
 
   preConfigure = ''
-    export makeFlags="$makeFlags PREFIX=$out"
     patchShebangs tests/runtests.sh
     cd src
   '';

--- a/pkgs/by-name/pa/patchPpdFilesHook/patch-ppd-hook.sh
+++ b/pkgs/by-name/pa/patchPpdFilesHook/patch-ppd-hook.sh
@@ -174,7 +174,7 @@ patchPpdFileCommands () {
             # The end result might contain too many
             # propagated dependencies for multi-output packages,
             # but never a broken package.
-            propagatedBuildInputs+=("$path")
+            appendToVar propagatedBuildInputs "$path"
         done  < sorted-dependencies
     fi
 

--- a/pkgs/by-name/pu/pulseaudio-module-xrdp/package.nix
+++ b/pkgs/by-name/pu/pulseaudio-module-xrdp/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     mv pulseaudio-* pulseaudio-src
     chmod +w -Rv pulseaudio-src
     cp ${pulseaudio.dev}/include/pulse/config.h pulseaudio-src
-    configureFlags="$configureFlags PULSE_DIR=$(realpath ./pulseaudio-src)"
+    appendToVar configureFlags "PULSE_DIR=$(realpath ./pulseaudio-src)"
   '';
 
   installPhase = ''

--- a/pkgs/by-name/ro/rocksndiamonds/package.nix
+++ b/pkgs/by-name/ro/rocksndiamonds/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     dataDir="$out/share/rocksndiamonds"
-    makeFlags+="BASE_PATH=$dataDir"
+    appendToVar makeFlags "BASE_PATH=$dataDir"
   '';
 
   installPhase = ''

--- a/pkgs/by-name/rt/rt/package.nix
+++ b/pkgs/by-name/rt/rt/package.nix
@@ -123,12 +123,12 @@ stdenv.mkDerivation rec {
     echo rt-${version} > .tag
   '';
   preConfigure = ''
-    configureFlags="$configureFlags --with-web-user=$UID"
-    configureFlags="$configureFlags --with-web-group=$(id -g)"
-    configureFlags="$configureFlags --with-rt-group=$(id -g)"
-    configureFlags="$configureFlags --with-bin-owner=$UID"
-    configureFlags="$configureFlags --with-libs-owner=$UID"
-    configureFlags="$configureFlags --with-libs-group=$(id -g)"
+    appendToVar configureFlags "--with-web-user=$UID"
+    appendToVar configureFlags "--with-web-group=$(id -g)"
+    appendToVar configureFlags "--with-rt-group=$(id -g)"
+    appendToVar configureFlags "--with-bin-owner=$UID"
+    appendToVar configureFlags "--with-libs-owner=$UID"
+    appendToVar configureFlags "--with-libs-group=$(id -g)"
   '';
   configureFlags = [
     "--enable-graphviz"

--- a/pkgs/by-name/se/serf/package.nix
+++ b/pkgs/by-name/se/serf/package.nix
@@ -37,13 +37,13 @@ stdenv.mkDerivation rec {
   prefixKey = "PREFIX=";
 
   preConfigure = ''
-    sconsFlags+=" APR=$(echo ${apr.dev}/bin/*-config)"
-    sconsFlags+=" APU=$(echo ${aprutil.dev}/bin/*-config)"
-    sconsFlags+=" CC=$CC"
-    sconsFlags+=" OPENSSL=${openssl}"
-    sconsFlags+=" ZLIB=${zlib}"
+    appendToVar sconsFlags "APR=$(echo ${apr.dev}/bin/*-config)"
+    appendToVar sconsFlags "APU=$(echo ${aprutil.dev}/bin/*-config)"
+    appendToVar sconsFlags "CC=$CC"
+    appendToVar sconsFlags "OPENSSL=${openssl}"
+    appendToVar sconsFlags "ZLIB=${zlib}"
   '' + lib.optionalString (!stdenv.hostPlatform.isCygwin) ''
-    sconsFlags+=" GSSAPI=${libkrb5.dev}"
+    appendToVar sconsFlags "GSSAPI=${libkrb5.dev}"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/si/silc_client/package.nix
+++ b/pkgs/by-name/si/silc_client/package.nix
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = [ "--with-ncurses=${ncurses.dev}" ];
-
-  preConfigure = lib.optionalString enablePlugin ''
-    configureFlags="$configureFlags --with-silc-plugin=$out/lib/irssi"
-  '';
+  configureFlags = [
+    "--with-ncurses=${ncurses.dev}"
+  ] ++ lib.optionals enablePlugin [
+    "--with-silc-plugin=${placeholder "out"}/lib/irssi"
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ perl glib ncurses ];

--- a/pkgs/by-name/sp/spaceFM/package.nix
+++ b/pkgs/by-name/sp/spaceFM/package.nix
@@ -30,11 +30,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-bash-path=${pkgs.bash}/bin/bash"
+    "--sysconfdir=${placeholder "out"}/etc"
   ];
-
-  preConfigure = ''
-    configureFlags="$configureFlags --sysconfdir=$out/etc"
-  '';
 
   postInstall = ''
     rm -f $out/etc/spacefm/spacefm.conf

--- a/pkgs/by-name/tr/trigger/package.nix
+++ b/pkgs/by-name/tr/trigger/package.nix
@@ -32,8 +32,11 @@ stdenv.mkDerivation rec {
 
     sed s,lSDL2main,lSDL2, -i GNUmakefile
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL2.dev}/include/SDL2"
-    export makeFlags="$makeFlags prefix=$out"
   '';
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ts/tsocks/package.nix
+++ b/pkgs/by-name/ts/tsocks/package.nix
@@ -14,8 +14,11 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -i -e "s,\\\/usr,"$(echo $out|sed -e "s,\\/,\\\\\\\/,g")",g" tsocks
     substituteInPlace tsocks --replace /usr $out
-    export configureFlags="$configureFlags --libdir=$out/lib"
   '';
+
+  configureFlags = [
+    "--libdir=${placeholder "out"}/lib"
+  ];
 
   preBuild = ''
     # We don't need the saveme binary, it is in fact never stored and we're

--- a/pkgs/by-name/un/unbound/package.nix
+++ b/pkgs/by-name/un/unbound/package.nix
@@ -140,7 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Build libunbound again, but only against nettle instead of openssl.
     # This avoids gnutls.out -> unbound.lib -> lib.getLib openssl.
     ''
-      configureFlags="$configureFlags --with-nettle=${nettle.dev} --with-libunbound-only"
+      appendToVar configureFlags "--with-nettle=${nettle.dev}"
+      appendToVar configureFlags "--with-libunbound-only"
       configurePhase
       buildPhase
       if [ -n "$doCheck" ]; then

--- a/pkgs/by-name/xl/xlockmore/package.nix
+++ b/pkgs/by-name/xl/xlockmore/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   # fine via PAM without super user privileges.
   configureFlags =
     [ "--disable-setuid"
+      "--enable-appdefaultdir=${placeholder "out"}/share/X11/app-defaults"
     ] ++ (lib.optional (pam != null) "--enable-pam");
 
   postPatch =
@@ -27,7 +28,6 @@ stdenv.mkDerivation rec {
     in ''
       sed -i 's,\(for ac_dir in\),\1 ${inputs},' configure.ac
       sed -i 's,/usr/,/no-such-dir/,g' configure.ac
-      configureFlags+=" --enable-appdefaultdir=$out/share/X11/app-defaults"
     '';
 
   hardeningDisable = [ "format" ]; # no build output otherwise

--- a/pkgs/desktops/gnustep/make/default.nix
+++ b/pkgs/desktops/gnustep/make/default.nix
@@ -17,11 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-layout=fhs-system"
     "--disable-install-p"
+    "--with-config-file=${placeholder "out"}/etc/GNUstep/GNUstep.conf"
   ];
-
-  preConfigure = ''
-    configureFlags="$configureFlags --with-config-file=$out/etc/GNUstep/GNUstep.conf"
-  '';
 
   makeFlags = [
     "GNUSTEP_INSTALLATION_DOMAIN=SYSTEM"

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -61,7 +61,7 @@ let
                   postHooks+=("source @dev@/nix-support/setup-hook")
               else
                   # Propagate $${out} output
-                  propagatedUserEnvPkgs+=" @${out}@"
+                  appendToVar propagatedUserEnvPkgs "@${out}@"
 
                   if [ -z "$outputDev" ]; then
                       echo "error: \$outputDev is unset!" >&2
@@ -71,7 +71,7 @@ let
                   # Propagate $dev so that this setup hook is propagated
                   # But only if there is a separate $dev output
                   if [ "$outputDev" != out ]; then
-                      propagatedBuildInputs+=" @dev@"
+                      appendToVar propagatedBuildInputs "@dev@"
                   fi
               fi
             '';

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -185,7 +185,7 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
         mkdir -p ../mingw
         # --with-build-sysroot expects that:
         cp -R $libcCross/include ../mingw
-        configureFlags="$configureFlags --with-build-sysroot=`pwd`/.."
+        appendToVar configureFlags "--with-build-sysroot=`pwd`/.."
     fi
 
     # Perform the build in a different directory.

--- a/pkgs/development/cuda-modules/setup-hooks/setup-cuda-hook.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/setup-cuda-hook.sh
@@ -112,7 +112,7 @@ propagateCudaLibraries() {
     local propagatedBuildInputs=( "${!cudaHostPathsSeen[@]}" )
     for output in $(getAllOutputNames) ; do
         if [[ ! "$output" = "$cudaPropagateToOutput" ]] ; then
-            propagatedBuildInputs+=( "${!output}" )
+            appendToVar propagatedBuildInputs "${!output}"
         fi
         break
     done

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -255,7 +255,7 @@ self: super: builtins.intersectAttrs super {
   jni = overrideCabal (drv: {
     preConfigure = ''
       local libdir=( "${pkgs.jdk}/lib/openjdk/jre/lib/"*"/server" )
-      configureFlags+=" --extra-lib-dir=''${libdir[0]}"
+      appendToVar configureFlags "--extra-lib-dir=''${libdir[0]}"
     '';
   }) super.jni;
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -478,13 +478,13 @@ stdenv.mkDerivation ({
     for p in "''${pkgsHostHost[@]}" "''${pkgsHostTarget[@]}"; do
       ${buildPkgDb ghc "$packageConfDir"}
       if [ -d "$p/include" ]; then
-        configureFlags+=" --extra-include-dirs=$p/include"
+        appendToVar configureFlags "--extra-include-dirs=$p/include"
       fi
       if [ -d "$p/lib" ]; then
-        configureFlags+=" --extra-lib-dirs=$p/lib"
+        appendToVar configureFlags "--extra-lib-dirs=$p/lib"
       fi
       if [[ -d "$p/Library/Frameworks" ]]; then
-        configureFlags+=" --extra-framework-dirs=$p/Library/Frameworks"
+        appendToVar configureFlags "--extra-framework-dirs=$p/Library/Frameworks"
       fi
   '' + ''
     done

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
@@ -83,7 +83,7 @@ in {
     generatePythonPackage {
       pname = "cyclic-dependencies";
       preFixup = ''
-        propagatedBuildInputs+=("$out")
+        appendToVar propagatedBuildInputs "$out"
       '';
     };
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -224,6 +224,11 @@ stdenv.mkDerivation ({
     inherit sha256;
   };
 
+  makeFlags = lib.optionals (stdenv.cc.libc != null) [
+    "BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib"
+    "OBJDUMP=${stdenv.cc.bintools.bintools}/bin/objdump"
+  ];
+
   # Remove absolute paths from `configure' & co.; build out-of-tree.
   preConfigure = ''
     export PWD_P=$(type -tP pwd)
@@ -237,12 +242,6 @@ stdenv.mkDerivation ({
     cd ../build
 
     configureScript="`pwd`/../$sourceRoot/configure"
-
-    ${lib.optionalString (stdenv.cc.libc != null)
-      ''makeFlags="$makeFlags BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib OBJDUMP=${stdenv.cc.bintools.bintools}/bin/objdump"''
-    }
-
-
   '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i s/-lgcc_eh//g "../$sourceRoot/Makeconfig"
 

--- a/pkgs/development/libraries/grantlee/5/setup-hook.sh
+++ b/pkgs/development/libraries/grantlee/5/setup-hook.sh
@@ -6,8 +6,8 @@ providesGrantleeRuntime() {
 
 _grantleeEnvHook() {
     if providesGrantleeRuntime "$1"; then
-        propagatedBuildInputs+=" $1"
-        propagatedUserEnvPkgs+=" $1"
+        appendToVar propagatedBuildInputs "$1"
+        appendToVar propagatedUserEnvPkgs "$1"
     fi
 }
 addEnvHooks "$hostOffset" _grantleeEnvHook

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -52,7 +52,7 @@ let
                     # Propagate $dev so that this setup hook is propagated
                     # But only if there is a separate $dev output
                     if [ "''${outputDev:?}" != out ]; then
-                        propagatedBuildInputs="''${propagatedBuildInputs-} @dev@"
+                        appendToVar propagatedBuildInputs "@dev@"
                     fi
                 fi
               '';

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -111,7 +111,7 @@ ecmHostPathHook() {
 
     if [ -d "$1/dbus-1" ]
     then
-        propagatedUserEnvPkgs+=" $1"
+        appendToVar propagatedUserEnvPkgs "$1"
     fi
 }
 addEnvHooks "$targetOffset" ecmHostPathHook

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -62,9 +62,9 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   preConfigure = ''
-    cmakeFlags+=" -DPHONON_QT_MKSPECS_INSTALL_DIR=''${!outputDev}/mkspecs"
-    cmakeFlags+=" -DPHONON_QT_IMPORTS_INSTALL_DIR=''${!outputBin}/$qtQmlPrefix"
-    cmakeFlags+=" -DPHONON_QT_PLUGIN_INSTALL_DIR=''${!outputBin}/$qtPluginPrefix/designer"
+    appendToVar cmakeFlags "-DPHONON_QT_MKSPECS_INSTALL_DIR=''${!outputDev}/mkspecs"
+    appendToVar cmakeFlags "-DPHONON_QT_IMPORTS_INSTALL_DIR=''${!outputBin}/$qtQmlPrefix"
+    appendToVar cmakeFlags "-DPHONON_QT_PLUGIN_INSTALL_DIR=''${!outputBin}/$qtPluginPrefix/designer"
   '';
 
   postPatch = ''

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -72,7 +72,7 @@ qtEnvHostTargetHook() {
     qtEnvHostTargetSeen[$1]=1
     if providesQtRuntime "$1" && [ "z${!outputBin}" != "z${!outputDev}" ]
     then
-        propagatedBuildInputs+=" $1"
+        appendToVar propagatedBuildInputs "$1"
     fi
 }
 envHostTargetHooks+=(qtEnvHostTargetHook)

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -101,14 +101,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  preConfigure = lib.optionalString (clangStdenv.hostPlatform != clangStdenv.buildPlatform) ''
-    # Ignore gettext in cmake_prefix_path so that find_program doesn't
-    # pick up the wrong gettext. TODO: Find a better solution for
-    # this, maybe make cmake not look up executables in
-    # CMAKE_PREFIX_PATH.
-    cmakeFlags+=" -DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin"
-  '';
-
   nativeBuildInputs = [
     bison
     cmake

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -126,7 +126,7 @@ buildPythonPackage rec {
 
   # HACK: copy mesonEmulatorHook's flags to the variable used by meson-python
   postConfigure = ''
-    mesonFlags="$mesonFlags ''${mesonFlagsArray[@]}"
+    concatTo mesonFlags mesonFlagsArray
   '';
 
   preBuild = ''

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -103,7 +103,7 @@ buildPythonPackage rec {
 
   # HACK: copy mesonEmulatorHook's flags to the variable used by meson-python
   postConfigure = ''
-    mesonFlags="$mesonFlags ''${mesonFlagsArray[@]}"
+    concatTo mesonFlags mesonFlagsArray
   '';
 
   buildInputs = [

--- a/pkgs/development/tools/analysis/rr/zen_workaround.nix
+++ b/pkgs/development/tools/analysis/rr/zen_workaround.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     "-C${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
   postConfigure = ''
-    makeFlags="$makeFlags M=$(pwd)"
+    appendToVar makeFlags "M=$(pwd)"
   '';
   buildFlags = [ "modules" ];
 

--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -14,8 +14,11 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     sed -i 's|"/usr/include"|"${stdenv.cc.libc.dev}/include"|' pre-process.c
     sed -i 's|qx(\$ccom -print-file-name=)|"${GCC_BASE}"|' cgcc
-    makeFlags+=" PREFIX=$out"
   '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gtk3 libxml2 llvm perl sqlite ];

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -50,12 +50,12 @@ stdenv.mkDerivation (finalAttrs: {
     lua -e "" || {
         luajit -e "" && {
             export LUA_SUFFIX=jit
-            configureFlags="$configureFlags --lua-suffix=$LUA_SUFFIX"
+            appendToVar configureFlags "--lua-suffix=$LUA_SUFFIX"
         }
     }
     lua_inc="$(echo "${lua}/include"/*/)"
     if test -n "$lua_inc"; then
-        configureFlags="$configureFlags --with-lua-include=$lua_inc"
+        appendToVar configureFlags "--with-lua-include=$lua_inc"
     fi
   '';
 

--- a/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
+++ b/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
@@ -107,7 +107,7 @@ ecmHostPathHook() {
 
     if [ -d "$1/share/dbus-1" ]
     then
-        propagatedUserEnvPkgs+=" $1"
+        appendToVar propagatedUserEnvPkgs "$1"
     fi
 }
 addEnvHooks "$hostOffset" ecmHostPathHook

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bin.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bin.nix
@@ -81,7 +81,7 @@ mkDerivation {
   '';
 
   preInstall = ''
-    makeFlags="$makeFlags ROOTDIR=$out/root"
+    appendToVar makeFlags "ROOTDIR=$out/root"
   '';
 
   outputs = [

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -136,12 +136,12 @@ in stdenv.mkDerivation rec {
   hardeningDisable = [ "fortify3" ];
 
   preBuild = ''
-    sconsFlags+=" CC=$CC"
-    sconsFlags+=" CXX=$CXX"
+    appendToVar sconsFlags "CC=$CC"
+    appendToVar sconsFlags "CXX=$CXX"
   '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    sconsFlags+=" AR=$AR"
+    appendToVar sconsFlags "AR=$AR"
   '' + lib.optionalString stdenv.hostPlatform.isAarch64 ''
-    sconsFlags+=" CCFLAGS='-march=armv8-a+crc'"
+    appendToVar sconsFlags "CCFLAGS=-march=armv8-a+crc"
   '';
 
   preInstall = ''

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -21,14 +21,14 @@ postInstall() {
         for p in "${pkgsHostHost[@]}" "${pkgsHostTarget[@]}"; do
             if test -e $p/lib/pkgconfig/$r.pc; then
                 echo "  found requisite $r in $p"
-                propagatedBuildInputs+=" $p"
+                appendToVar propagatedBuildInputs "$p"
             fi
         done
     done
 }
 
 
-installFlags="appdefaultdir=$out/share/X11/app-defaults $installFlags"
+prependToVar installFlags "appdefaultdir=$out/share/X11/app-defaults"
 
 
 if test -n "$x11BuildHook"; then

--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -99,7 +99,7 @@ fi
 if test -f $rootNameBase.idx; then
     echo "MAKING INDEX..."
     if test -n "$compressBlanksInIndex"; then
-        makeindexFlags="$makeindexFlags -c"
+        appendToVar makeindexFlags "-c"
     fi
     makeindex $makeindexFlags $rootNameBase.idx
     runNeeded=1


### PR DESCRIPTION
Those would be problematic with __structuredAttrs turned on, because they'd turn those nice bash arrays back into strings - and potentially lose some of the values on the way.

Part of the overall effort to enable structuredAttrs by default eventually, tracking: #205690

I think those changes are straight-forward, but somebody better double check.

@ShamrockLee @emilazy 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
