### PR TITLE
stdenv.mkDerivation: support output checks with and without structuredAttrs

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -193,18 +193,7 @@ stdenv.mkDerivation (
       find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
     '';
     # check that the above patching actually works
-    outputChecks =
-      let
-        disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
-      in
-      {
-        out = {
-          inherit disallowedRequisites;
-        };
-        debug = {
-          inherit disallowedRequisites;
-        };
-      };
+    disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
 
     cmakeFlags =
       [

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -132,21 +132,19 @@ let
       disallowedReferences = [ "dev" "doc" "man" ];
       disallowedRequisites = [
         stdenv'.cc
+        llvmPackages.llvm.out
       ] ++ (
         map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs)
-      ) ++ lib.optionals jitSupport [
-        llvmPackages.llvm.out
-      ];
+      );
     };
     outputChecks.lib = {
       disallowedReferences = [ "out" "dev" "doc" "man" ];
       disallowedRequisites = [
         stdenv'.cc
+        llvmPackages.llvm.out
       ] ++ (
         map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs)
-      ) ++ lib.optionals jitSupport [
-        llvmPackages.llvm.out
-      ];
+      );
     };
 
     buildInputs = [

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -134,6 +134,8 @@ let
     "__darwinAllowLocalNetworking"
     "__impureHostDeps" "__propagatedImpureHostDeps"
     "sandboxProfile" "propagatedSandboxProfile"
+    "disallowedReferences" "disallowedRequisites"
+    "allowedReferences" "allowedRequisites"
   ];
 
   # Turn a derivation into its outPath without a string context attached.
@@ -142,6 +144,42 @@ let
     if isDerivation drv
     then builtins.unsafeDiscardStringContext drv.outPath
     else drv;
+
+  makeOutputChecks = attrs:
+    # If we use derivations directly here, they end up as build-time dependencies.
+    # This is especially problematic in the case of disallowed*, since the disallowed
+    # derivations will be built by nix as build-time dependencies, while those
+    # derivations might take a very long time to build, or might not even build
+    # successfully on the platform used.
+    # We can improve on this situation by instead passing only the outPath,
+    # without an attached string context, to nix. The out path will be a placeholder
+    # which will be replaced by the actual out path if the derivation in question
+    # is part of the final closure (and thus needs to be built). If it is not
+    # part of the final closure, then the placeholder will be passed along,
+    # but in that case we know for a fact that the derivation is not part of the closure.
+    # This means that passing the out path to nix does the right thing in either
+    # case, both for disallowed and allowed references/requisites, and we won't
+    # build the derivation if it wouldn't be part of the closure, saving time and resources.
+    # While the problem is less severe for allowed*, since we want the derivation
+    # to be built eventually, we would still like to get the error early and without
+    # having to wait while nix builds a derivation that might not be used.
+    # See also https://github.com/NixOS/nix/issues/4629
+    optionalAttrs (attrs ? disallowedReferences) {
+      disallowedReferences =
+        map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
+    } //
+    optionalAttrs (attrs ? disallowedRequisites) {
+      disallowedRequisites =
+        map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
+    } //
+    optionalAttrs (attrs ? allowedReferences) {
+      allowedReferences =
+        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+    } //
+    optionalAttrs (attrs ? allowedRequisites) {
+      allowedRequisites =
+        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+    };
 
   makeDerivationArgument =
 
@@ -455,41 +493,9 @@ else let
         "/bin/sh"
       ];
       __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-    }) //
-    # If we use derivations directly here, they end up as build-time dependencies.
-    # This is especially problematic in the case of disallowed*, since the disallowed
-    # derivations will be built by nix as build-time dependencies, while those
-    # derivations might take a very long time to build, or might not even build
-    # successfully on the platform used.
-    # We can improve on this situation by instead passing only the outPath,
-    # without an attached string context, to nix. The out path will be a placeholder
-    # which will be replaced by the actual out path if the derivation in question
-    # is part of the final closure (and thus needs to be built). If it is not
-    # part of the final closure, then the placeholder will be passed along,
-    # but in that case we know for a fact that the derivation is not part of the closure.
-    # This means that passing the out path to nix does the right thing in either
-    # case, both for disallowed and allowed references/requisites, and we won't
-    # build the derivation if it wouldn't be part of the closure, saving time and resources.
-    # While the problem is less severe for allowed*, since we want the derivation
-    # to be built eventually, we would still like to get the error early and without
-    # having to wait while nix builds a derivation that might not be used.
-    # See also https://github.com/NixOS/nix/issues/4629
-    optionalAttrs (attrs ? disallowedReferences) {
-      disallowedReferences =
-        map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
-    } //
-    optionalAttrs (attrs ? disallowedRequisites) {
-      disallowedRequisites =
-        map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
-    } //
-    optionalAttrs (attrs ? allowedReferences) {
-      allowedReferences =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
-    } //
-    optionalAttrs (attrs ? allowedRequisites) {
-      allowedRequisites =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
-    };
+    }) // (
+      makeOutputChecks attrs
+    );
 
 in
   derivationArg;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -495,7 +495,9 @@ else let
       __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
     }) // (
       makeOutputChecks attrs
-    );
+    ) // lib.optionalAttrs (__structuredAttrs) {
+      outputChecks = builtins.mapAttrs (_: makeOutputChecks) attrs.outputChecks or {};
+    };
 
 in
   derivationArg;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -493,10 +493,16 @@ else let
         "/bin/sh"
       ];
       __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-    }) // (
+    }) // lib.optionalAttrs (!__structuredAttrs) (
       makeOutputChecks attrs
     ) // lib.optionalAttrs (__structuredAttrs) {
-      outputChecks = builtins.mapAttrs (_: makeOutputChecks) attrs.outputChecks or {};
+      outputChecks = builtins.listToAttrs (map (name: {
+        inherit name;
+        value = lib.zipAttrsWith (_: builtins.concatLists) [
+          (makeOutputChecks attrs)
+          (makeOutputChecks attrs.outputChecks.${name} or {})
+        ];
+      }) outputs);
     };
 
 in


### PR DESCRIPTION
With a [recent enough nix](https://github.com/NixOS/nix/issues/10856), there will be an eval warning when building a derivation with `__structuredAttrs = true` and e.g. `disallowedReferences = ..`. With structuredAttrs, nix expects those split up in `outputChecks.<output>.disallowedReferences` etc. instead.

To allow derivations to support both structuredAttrs enabled and disabled during a transition period, this PR maps top-level `disallowedReferences` and friends to each output's `outputChecks`. This has the nice side-effect that it is possible to define checks which should apply to *all* outputs at the top-level, and extend them with output-specific checks as well.

While on it, we also apply the same fix that #211783 did to those structured `outputChecks`, which had not been the case before.

Part of the overall effort to enable structuredAttrs by default eventually, tracking: https://github.com/NixOS/nixpkgs/issues/205690

~~Marking as draft for now, because I intend to add some tests as well.~~ It's really annoying to write tests for this, because we effectively need to test a `nix-build` failure :/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
