### PR TITLE
git-prole: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/by-name/gi/git-prole/package.nix
+++ b/pkgs/by-name/gi/git-prole/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 let
-  version = "0.5.1";
+  version = "0.5.3";
 in
 rustPlatform.buildRustPackage {
   pname = "git-prole";
@@ -17,10 +17,10 @@ rustPlatform.buildRustPackage {
     owner = "9999years";
     repo = "git-prole";
     rev = "refs/tags/v${version}";
-    hash = "sha256-jJEskahZRCpM2WEH4myTLfowQxEJ4WCNXbTwGkwBHnY=";
+    hash = "sha256-QwLkByC8gdAnt6geZS285ErdH8nfV3vsWjMF4hTzq9Y=";
   };
 
-  cargoHash = "sha256-u4UJH+dIDI+I6fEQTRe3RRufYZwxBENxnwULSSCOZF8=";
+  cargoHash = "sha256-K4gIvK0qxMJh9SXF9JZFacDKv6TwvDQe8JVX2rtq/hU=";
 
   nativeCheckInputs = [
     git


### PR DESCRIPTION
Diff: https://github.com/9999years/git-prole/compare/refs/tags/v0.5.1...v0.5.3

Changelog: https://github.com/9999years/git-prole/releases/tag/v0.5.3

- In the `config.toml`, `add.copy_untracked` has been renamed `add.copy_ignored` and the functionality has been changed to match. (Thanks to @lf- for noticing this!)
- The tempdir is now created in the parent of the destination to prevent issues when moving worktrees across filesystems (i.e., into a `tmpfs`). (Thanks to @lordkekz for writing the fix for this!)
- The repo root displayed by `git prole convert` is now correct more of the time (functionality is unchanged). (Thanks to @ktang-hg for reporting this!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
