### PR TITLE
nixos/netbird: fix port conflict on metrics endpoint

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -36,6 +36,8 @@
 - `authelia` has been upgraded to version 4.38. This version brings several features and improvements which are detailed in the [release blog post](https://www.authelia.com/blog/4.38-release-notes/).
   This release also deprecates some configuration keys which are likely to be removed in version 5.0.0.
 
+- `netbird` has been updated to 0.31.1. This adds a built-in relay server which is not yet supported by the NixOS module, as well as a metrics endpoint for both the management and signal services. The default metrics port for the `signal` service has been changed from `9090` to `9091` to prevent a port conflict with the management server. This can be changed with their respective `metricsPort` as needed. Refer to the [release notes](https://github.com/netbirdio/netbird/releases/tag/v0.31.1) and [this pull request](https://github.com/NixOS/nixpkgs/pull/354032#issuecomment-2480925927) for more information.
+
 - `compressDrv` can compress selected files in a derivation. `compressDrvWeb` compresses files for common web server usage (`.gz` with `zopfli`, `.br` with `brotli`).
 
 - [`hardware.display`](#opt-hardware.display.edid.enable) is a new module implementing workarounds for misbehaving monitors

--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -196,6 +196,12 @@ in
       description = "Internal port of the management server.";
     };
 
+    metricsPort = mkOption {
+      type = port;
+      default = 9090;
+      description = "Internal port of the metrics server.";
+    };
+
     extraOptions = mkOption {
       type = listOf str;
       default = [ ];
@@ -360,6 +366,13 @@ in
           }
         ];
 
+    assertions = [
+      {
+        assertion = cfg.port != cfg.metricsPort;
+        message = "The primary listen port cannot be the same as the listen port for the metrics endpoint";
+      }
+    ];
+
     systemd.services.netbird-management = {
       description = "The management server for Netbird, a wireguard VPN";
       documentation = [ "https://netbird.io/docs/" ];
@@ -387,6 +400,9 @@ in
             # Port to listen on
             "--port"
             cfg.port
+            # Port the internal prometheus server listens on
+            "--metrics-port"
+            cfg.metricsPort
             # Log to stdout
             "--log-file"
             "console"

--- a/nixos/modules/services/networking/netbird/signal.nix
+++ b/nixos/modules/services/networking/netbird/signal.nix
@@ -15,7 +15,12 @@ let
     mkOption
     ;
 
-  inherit (lib.types) enum port str;
+  inherit (lib.types)
+    listOf
+    enum
+    port
+    str
+    ;
 
   inherit (utils) escapeSystemdExecArgs;
 
@@ -41,6 +46,20 @@ in
       description = "Internal port of the signal server.";
     };
 
+    metricsPort = mkOption {
+      type = port;
+      default = 9091;
+      description = "Internal port of the metrics server.";
+    };
+
+    extraOptions = mkOption {
+      type = listOf str;
+      default = [ ];
+      description = ''
+        Additional options given to netbird-signal as commandline arguments.
+      '';
+    };
+
     logLevel = mkOption {
       type = enum [
         "ERROR"
@@ -54,24 +73,38 @@ in
   };
 
   config = mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.port != cfg.metricsPort;
+        message = "The primary listen port cannot be the same as the listen port for the metrics endpoint";
+      }
+    ];
+
     systemd.services.netbird-signal = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = escapeSystemdExecArgs [
-          (getExe' cfg.package "netbird-signal")
-          "run"
-          # Port to listen on
-          "--port"
-          cfg.port
-          # Log to stdout
-          "--log-file"
-          "console"
-          # Log level
-          "--log-level"
-          cfg.logLevel
-        ];
+        ExecStart = escapeSystemdExecArgs (
+          [
+            (getExe' cfg.package "netbird-signal")
+            "run"
+            # Port to listen on
+            "--port"
+            cfg.port
+            # Port the internal prometheus server listens on
+            "--metrics-port"
+            cfg.metricsPort
+            # Log to stdout
+            "--log-file"
+            "console"
+            # Log level
+            "--log-level"
+            cfg.logLevel
+          ]
+          ++ cfg.extraOptions
+        );
 
         Restart = "always";
         RuntimeDirectory = "netbird-mgmt";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added changes discussed in https://github.com/NixOS/nixpkgs/pull/354032#issuecomment-2480925927 to fix a port clash between the netbird management and signal services, as well as an `extraOption` to facilitate ad-hoc changes in the future should more breaking changes be released by upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
