### PR TITLE
nh_plus: init at 3.6.0-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22396,6 +22396,12 @@
     githubId = 90456;
     name = "Rebecca (Bex) Kelly";
   };
+  ToyVo = {
+    name = "Collin Diekvoss";
+    email = "Collin@Diekvoss.com";
+    github = "ToyVo";
+    githubId = 5168912;
+  };
   tpw_rules = {
     name = "Thomas Watson";
     email = "twatson52@icloud.com";

--- a/pkgs/by-name/nh/nh_plus/package.nix
+++ b/pkgs/by-name/nh/nh_plus/package.nix
@@ -1,0 +1,65 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  installShellFiles,
+  makeBinaryWrapper,
+  darwin,
+  fetchFromGitHub,
+  nix-update-script,
+  nvd,
+  nix-output-monitor,
+}:
+let
+  version = "3.6.0-0";
+  runtimeDeps = [
+    nvd
+    nix-output-monitor
+  ];
+in
+rustPlatform.buildRustPackage {
+  inherit version;
+  pname = "nh_plus";
+
+  src = fetchFromGitHub {
+    owner = "ToyVo";
+    repo = "nh_plus";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-u6rTrvXRii4wm1qs1F0/IcRDLwfEcEDxC5YO5NkL8Gg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  preFixup = ''
+    installShellCompletion --cmd nh \
+      --bash <("$out/bin/nh" completions --shell bash) \
+      --zsh <("$out/bin/nh" completions --shell zsh) \
+      --fish <("$out/bin/nh" completions --shell fish)
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nh \
+      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+  '';
+
+  cargoHash = "sha256-U6ff8spNpAp50QcLVQzIB9zUOGkBbd5E5S4eFD5Cdgk=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fork of nh with added support for nix-darwin and other features.";
+    homepage = "https://github.com/ToyVo/nh_plus";
+    license = lib.licenses.eupl12;
+    mainProgram = "nh";
+    maintainers = with lib.maintainers; [ ToyVo ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
there currently exists `programs.nh.package` that can be set to this. For nix-darwin to get similar options, nh_plus exists to support nix-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
