### PR TITLE
plex-desktop: add libdrm to buildFHSEnv, update sqlite write permissions

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -140,6 +140,17 @@ buildFHSEnv {
   runScript = writeShellScript "plex-desktop.sh" ''
     # Widevine won't download unless this directory exists.
     mkdir -p $HOME/.cache/plex/
+
+    # Copy the sqlite plugin database on first run.
+    PLEX_DB="$HOME/.local/share/plex/Plex Media Server/Plug-in Support/Databases"
+    if [[ ! -d "$PLEX_DB" ]]; then
+      mkdir -p "$PLEX_DB"
+      cp "${plex-desktop}/resources/com.plexapp.plugins.library.db" "$PLEX_DB"
+    fi
+
+    # db files should have write access.
+    chmod --recursive 750 "$PLEX_DB"
+
     PLEX_USR_PATH=${lib.makeSearchPath "usr/lib/x86_64-linux-gnu" [ plex-desktop ]}
 
     set -o allexport

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -14,6 +14,7 @@
   libGL,
   libapparmor,
   libbsd,
+  libdrm,
   libedit,
   libffi_3_3,
   libgcrypt,
@@ -122,7 +123,10 @@ let
 in
 buildFHSEnv {
   inherit pname version meta;
-  targetPkgs = pkgs: [ xkeyboard_config ];
+  targetPkgs = pkgs: [
+    libdrm
+    xkeyboard_config
+  ];
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps


### PR DESCRIPTION
plex-desktop: plex-desktop: add libdrm to buildFHSEnv and update plugin sqlite write permissions.

Fixes #353227

## Things done

Fixes two issues:
1. A few users of plex-desktop reported that the app fails to launch under certain circumstances when it can't find /usr/share/libdrm/amdgpu.ids.
2. Things like downloads historically haven't worked because the sqlite database is copied from the nix store and inherits the read-only permissions. The current fix here copies the db from the nix store if `$HOME/.local/share/plex/.../Databases` folder doesn't exist and then updates the permissions for that file. Downloads won't work on first run, but the UI no longer shows that it's broken entirely. On the second run, permissions are updated for the other databases added to the folder and everything works.

Looking to see if there's a way to have write permissions added to the DB files automatically during the first run, but this works well enough.

Many thanks to @nayrsirhc for helping me fix both of these.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
