### PR TITLE
ibmcloud-cli: 2.27.0 -> 2.30.0

### DIFF
--- a/pkgs/tools/admin/ibmcloud-cli/default.nix
+++ b/pkgs/tools/admin/ibmcloud-cli/default.nix
@@ -16,18 +16,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ibmcloud-cli";
-  version = "2.27.0";
+  version = "2.30.0";
 
   src = fetchurl {
     url = "https://download.clis.cloud.ibm.com/ibm-cloud-cli/${finalAttrs.version}/binaries/IBM_Cloud_CLI_${finalAttrs.version}_${platform}.tgz";
     sha256 = {
-      "x86_64-darwin"     = "0af5f110e094e7bf710c86d1e35af23ebbbc9ad8a4baf2a67895354b415618f6";
-      "aarch64-darwin"    = "1175977597102282cf7c1fd017ec4bdbc041ce367360204852d0798846cd21e4";
-      "x86_64-linux"      = "3c024bcb27519c8ed916ebc0266248249c127bbe93c343807e07d707cf159bb1";
-      "aarch64-linux"     = "bd2a6a3c4428061f17ac8b801b27d9700bf333284294e2834c34b4237f530256";
-      "i686-linux"        = "40dc32b2a76541847fd55b5b587105c90956468baf14016e4628bb8a2a3d73fa";
-      "powerpc64le-linux" = "e758a60d7de32f4dfc8c944edb8e45bbed41de2fcb1e12bcf6b4e2b35d09f9d5";
-      "s390x-linux"       = "dbee26a3c4be2dcaad28b110e309283c141d55ac923b9d0420ac62b25c8eb9c0";
+      "x86_64-darwin"     = "5d4d16f35c034aa336e28b5685684146ec5773a6d7f456ed0d0e5d686adf4b25";
+      "aarch64-darwin"    = "d563b8a4214da4360756bd18283b68c118139b5d3dd1b1d31c7ab7e61349e126";
+      "x86_64-linux"      = "e6c874702851f16a3c21570020da85122a0ec0ca7e9dd75091684df1030d7295";
+      "aarch64-linux"     = "6904c9de54845adcd08eb9906567493b68ad3f4cbba9d1121f63d9df2dd47185";
+      "i686-linux"        = "bc6be9a65a6942e158ab202a2d1c89c4294b5cebf60841f4ac1d21064052e7e7";
+      "powerpc64le-linux" = "271a0aa9c0a1dc2c84772fba33c9c6b97588d35eccf6757de6974c433b6e7874";
+      "s390x-linux"       = "e8ec8adaaae2eab091500c257c7b18acf5e9556b4910df8290600bd7f723fdc1";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 

--- a/pkgs/tools/admin/ibmcloud-cli/default.nix
+++ b/pkgs/tools/admin/ibmcloud-cli/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -D ibmcloud $out/bin/ibmcloud
     mkdir -p $out/share/ibmcloud
-    cp CF_CLI_Notices.txt CF_CLI_SLC_Notices.txt LICENSE NOTICE $out/share/ibmcloud
+    cp LICENSE NOTICE $out/share/ibmcloud
     export HOME=$(mktemp -d)
     installShellCompletion --cmd ibmcloud --bash <($out/bin/ibmcloud --generate-bash-completion)
 


### PR DESCRIPTION
## Description of changes

Updating ibmcloud-cli to the latest available [v2.30](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.30.0) release, which encompasses the following releases (link to changelogs):

| RELEASE URL | DATE |
| ----------------------------------------------------------------------- | -------------------- |
| https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.30.0 | 2024-11-06T21:43:28Z |
| https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.29.0 | 2024-10-18T14:29:01Z |
| https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.28.2 | 2024-10-08T02:03:17Z |
| https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.28.1 | 2024-10-01T18:34:59Z |
| https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.28.0 | 2024-09-17T20:01:19Z |

## v2.30.0 changelog

### New Commands

- `assist` ask IBM Cloud AI assistant a question. More details [here](https://cloud.ibm.com/docs/overview?topic=overview-ask-ai-assistant#ai-assistant-cli)

### Commands Changed

- `iam access-group-template-version-delete` supports deleting by template name in addition to ID
- All `iam` `template` and `assignment` commands return the entire JSON response

## Other Changes

- Tracing header is added to outbound requests of the CLI to facilitate end-to-end call tracing for IBM services

## v2.29.0 changelog

Command list help is organized by function.

## v2.28.2 changelog

No functional changes from the prior release. This release adds Windows versions missing from 2.28.1.

## v2.28.1 changelog

Windows versions are not updated in this release.

### Bug Fixes

- `iam service-api-key-update` was not properly handling the `-n` parameter as of release 2.28.0. Restoring the correct functionality

## v2.28.0 changelog

### Commands Changed

- `catalog pricing` improves help text, adds support for global deployment pricing, and adds tier pricing information to output
- `iam access-group-policy-create` now accepts `--service-group-id IAM` to allow creating a policy for this service group (this is the only possible service group at this time)
- `iam account-settings-update` adds `--unset-allowed-ip-addresses` to clear the allowed IP addresses for an account
- `iam authorization-policy-assignment` and `authorization-policy-template` enterprise commands are added
- `resource service-instance` details the onetime credential setting for the instance
- `resource instances` command is added to list all instances irrespective of type
- `resource service-instance-create` may enforce `--service-endpoints` as a required parameter depending on the service definition
- `resource service-instance-create` warns a user when selecting a public endpoint
- `resource service-instance-create` adds `--onetime-credentials` to direct that the service credentials be returned but not stored in IBM Cloud
- `resource service-instances` adds `--all-pages` to allow attempting to query all service instances
- `resource service-key` details the onetime credential setting for the key
- `resource tag-attach` adds `--update` to update specified tags
- `target` adds `--choose-account | -ca` to improve switching accounts at the command line
- `--version | -v` improves the version format with the Copyright on a 2nd line

### Bug Fixes

- `resource service-key-create` handles valid CRN or None as input for role and correctly enforces default role when Service ID is specified
- various commands correct an error in the help output when arguments are also specified (ex: `iam access-group-policy-create`)

## Other Changes

- Upgrades Golang to 1.22.7
- Upgrades Dev plug-in to 3.2.1
- Cloud Foundry Notices are removed from all installers


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
