### PR TITLE
uv: Build as a standalone without Python

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -4,16 +4,14 @@
   fetchFromGitHub,
   installShellFiles,
   pkg-config,
-  python3Packages,
   rustPlatform,
   versionCheckHook,
   nix-update-script,
 }:
 
-python3Packages.buildPythonApplication rec {
+rustPlatform.buildRustPackage rec {
   pname = "uv";
   version = "0.5.4";
-  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "astral-sh";
@@ -22,17 +20,13 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-Kieh76RUrDEwdL04mvCXOqbXHasMMpXRqp0LwMOIHdM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    hash = "sha256-ZhHUKotXVDdwJs2kqIxME5I1FitWetx7FrQtluuIUWo=";
-  };
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ZhHUKotXVDdwJs2kqIxME5I1FitWetx7FrQtluuIUWo=";
 
   nativeBuildInputs = [
     cmake
     installShellFiles
     pkg-config
-    rustPlatform.cargoSetupHook
-    rustPlatform.maturinBuildHook
   ];
 
   dontUseCmakeConfigure = true;
@@ -42,6 +36,8 @@ python3Packages.buildPythonApplication rec {
     "uv"
   ];
 
+  doCheck = false;
+
   postInstall = ''
     export HOME=$TMPDIR
     installShellCompletion --cmd uv \
@@ -49,8 +45,6 @@ python3Packages.buildPythonApplication rec {
       --fish <($out/bin/uv --generate-shell-completion fish) \
       --zsh <($out/bin/uv --generate-shell-completion zsh)
   '';
-
-  pythonImportsCheck = [ "uv" ];
 
   nativeCheckInputs = [
     versionCheckHook

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  installShellFiles,
+  pkg-config,
+  rustPlatform,
+  pkgs,
+}:
+
+buildPythonPackage {
+  inherit (pkgs.uv)
+    pname
+    version
+    src
+    cargoDeps
+    dontUseCmakeConfigure
+    meta
+    cargoBuildFlags
+    postInstall
+    versionCheckProgramArg
+    ;
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    installShellFiles
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pyproject = true;
+  pythonImportsCheck = [ "uv" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17395,9 +17395,7 @@ self: super: with self; {
 
   uuid6 = callPackage ../development/python-modules/uuid6 { };
 
-  uv = toPythonModule (pkgs.uv.override {
-    python3Packages = self;
-  });
+  uv = callPackage ../development/python-modules/uv { };
 
   uvcclient = callPackage ../development/python-modules/uvcclient { };
 


### PR DESCRIPTION
## Things done

Using `buildPythonPackage` triggers dependency propagation, meaning that using `uv` with `nix-shell` results in a a shell with the `uv` Python input in it.
This is problematic for development usage where you only want the one specified version.
    
Often this design bug in the Python package builders is worked around by deleting `$out/nix-support/propagated-build-inputs`, but since `uv` is written in Rust and can be built without a Python interpreter so it's better to just build without a Python interpreter.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
