### PR TITLE
xcbuild: find system toolchain on macOS Sonoma and earlier

### DIFF
--- a/pkgs/by-name/xc/xcbuild/patches/Use-system-toolchain-for-usr-bin.patch
+++ b/pkgs/by-name/xc/xcbuild/patches/Use-system-toolchain-for-usr-bin.patch
@@ -1,8 +1,7 @@
-diff --git a/Libraries/xcsdk/Tools/xcrun.cpp b/Libraries/xcsdk/Tools/xcrun.cpp
-index 9d6d4576d7..73aabc3d42 100644
---- a/Libraries/xcsdk/Tools/xcrun.cpp
-+++ b/Libraries/xcsdk/Tools/xcrun.cpp
-@@ -23,10 +23,14 @@
+diff -Naur a/Libraries/xcsdk/Tools/xcrun.cpp b/Libraries/xcsdk/Tools/xcrun.cpp
+--- a/Libraries/xcsdk/Tools/xcrun.cpp	1970-01-01 09:00:01
++++ b/Libraries/xcsdk/Tools/xcrun.cpp	2024-11-19 01:44:38
+@@ -23,10 +23,19 @@
  #include <process/DefaultUser.h>
  #include <pbxsetting/Type.h>
  
@@ -12,12 +11,17 @@ index 9d6d4576d7..73aabc3d42 100644
  using libutil::Filesystem;
  using libutil::FSUtil;
  
-+#define SYSTEM_DEVELOPER_DIR "/private/var/select/developer_dir"
++namespace {
++  const std::vector<const std::string> kSystemDeveloperDirs = {
++    "/private/var/select/developer_dir",
++    "/private/var/db/xcode_select_link"
++  };
++}
 +
  class Options {
  private:
      ext::optional<bool>        _help;
-@@ -398,6 +402,8 @@
+@@ -398,6 +407,8 @@
              fprintf(stderr, "\n");
          }
  
@@ -26,7 +30,7 @@ index 9d6d4576d7..73aabc3d42 100644
          /*
           * Collect search paths for the tool.
           * Can be in toolchains, target (if one is provided), developer root,
-@@ -408,10 +414,42 @@
+@@ -408,10 +419,46 @@
          executablePaths.insert(executablePaths.end(), defaultExecutablePaths.begin(), defaultExecutablePaths.end());
  
          /*
@@ -49,16 +53,20 @@ index 9d6d4576d7..73aabc3d42 100644
 +             * Fixes https://github.com/NixOS/nixpkgs/issues/353875.
 +             */
 +            std::vector<std::string> toolchainPaths = { };
-+            if (executablePaths.size() < originalSize && filesystem->exists(SYSTEM_DEVELOPER_DIR)) {
-+                auto linkTarget = filesystem->readSymbolicLinkCanonical(SYSTEM_DEVELOPER_DIR);
-+                if (linkTarget) {
-+                    auto usrBinPath = FSUtil::NormalizePath(*linkTarget + "/usr/bin");
-+                    if (filesystem->exists(usrBinPath)) {
-+                        toolchainPaths.push_back(usrBinPath);
-+                    }
-+                    auto toolchainUsrBinPath = FSUtil::NormalizePath(*linkTarget + "/Toolchains/XcodeDefault.xctoolchain/usr/bin");
-+                    if (filesystem->exists(toolchainUsrBinPath)) {
-+                        toolchainPaths.push_back(toolchainUsrBinPath);
++            if (executablePaths.size() < originalSize) {
++                for (const auto& dir : kSystemDeveloperDirs) {
++                    if (filesystem->exists(dir)) {
++                        auto linkTarget = filesystem->readSymbolicLinkCanonical(dir);
++                        if (linkTarget) {
++                            auto usrBinPath = FSUtil::NormalizePath(*linkTarget + "/usr/bin");
++                            if (filesystem->exists(usrBinPath)) {
++                                toolchainPaths.push_back(usrBinPath);
++                            }
++                            auto toolchainUsrBinPath = FSUtil::NormalizePath(*linkTarget + "/Toolchains/XcodeDefault.xctoolchain/usr/bin");
++                            if (filesystem->exists(toolchainUsrBinPath)) {
++                                toolchainPaths.push_back(toolchainUsrBinPath);
++                            }
++                        }
 +                    }
 +                }
 +            }
@@ -69,12 +77,12 @@ index 9d6d4576d7..73aabc3d42 100644
              fprintf(stderr, "error: tool '%s' not found\n", options.tool()->c_str());
              return 1;
          }
-@@ -428,8 +466,6 @@
+@@ -427,8 +474,6 @@
+             return 0;
          } else {
              /* Run is the default. */
- 
--            std::unordered_map<std::string, std::string> environment = processContext->environmentVariables();
 -
+-            std::unordered_map<std::string, std::string> environment = processContext->environmentVariables();
+ 
              if (target != nullptr) {
                  /*
-                  * Update effective environment to include the target path.


### PR DESCRIPTION
This fixes #353893 to work on macOS Sonoma and earlier. #353893 looks for the native toolchain in `/private/var/select/developer_dir`. This works on Sequoia, but it doesn't on previous macOS releases. To make it work on Sonoma, `/private/var/db/xcode_select_link` would have to be searched too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
