### PR TITLE
hfsutils: init at 3.2.6

### DIFF
--- a/pkgs/by-name/hf/hfsutils/package.nix
+++ b/pkgs/by-name/hf/hfsutils/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  autoconf,
+  automake,
+}:
+stdenv.mkDerivation {
+  pname = "hfsutils";
+  version = "3.2.6";
+
+  src = fetchTarball {
+    url = "https://ftp.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz";
+    sha256 = "1pv3sw8jhsd1k2bkyy2r3b3mhiijwaa7jyvmaiw50s7dja2wa9qv";
+  };
+
+  preInstall = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/man/man1"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # hformat fails if HOME is not set.
+    export HOME=.
+    dd if=/dev/zero of=disk.hfs bs=1k count=800
+    ls -lha .
+    $out/bin/hformat -l 'Test Disk' disk.hfs
+    mount_output="$($out/bin/hmount disk.hfs)"
+    echo "$mount_output" | grep 'Volume name is "Test Disk"'
+    echo "$mount_output" | grep 'Volume has 803840 bytes free'
+    $out/bin/humount
+    rm disk.hfs
+  '';
+
+  meta = {
+    description = "Utilities for working with HFS filesystems";
+    longDescription = ''
+      A set of utilities for interacting with Apple's MacOS-9-era filesystem, HFS.
+      Useful for extracting data from classic MacOS CD-ROMs and HFS-formatted disk images.
+    '';
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ nateeag ];
+    homepage = "https://www.mars.org/home/rob/proj/hfs/";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [hfsutils](https://www.mars.org/home/rob/proj/hfs/), a collection of tools for working with Mac OS 9's default filesystem. hfsutils is indispensable for anyone preserving Mac OS 9-era software; I made this draft package so I could get the data off my old Mac OS 9 Descent and Descent II CDs.

The package is in a working state, functionally, but as a Nix / nixpkgs newbie I expect there are mistakes. Constructive criticism welcome. :pray: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
