### PR TITLE
ant.hook: init, migrate a few packages

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -256,6 +256,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
 # Java
 /doc/languages-frameworks/java.section.md @NixOS/java
+/doc/languages-frameworks/ant.section.md @NixOS/java
 /doc/languages-frameworks/gradle.section.md @NixOS/java
 /doc/languages-frameworks/maven.section.md @NixOS/java
 /nixos/modules/programs/java.nix @NixOS/java

--- a/doc/languages-frameworks/ant.section.md
+++ b/doc/languages-frameworks/ant.section.md
@@ -1,0 +1,51 @@
+# Ant {#ant}
+
+[Ant](https://ant.apache.org) is a build system.
+It is primarily used to build Java projects.
+
+## `ant.hook` {#ant-hook}
+
+The `ant.hook` setup hook sets `buildPhase` and `checkPhase` by default.
+
+### `ant` thin wrapper {#ant-hook-thin-wrapper}
+
+The `ant` command is thinly wrapped by a Bash function of the same name.
+The function executes `ant` with the contents of the `antFlags` variable
+(and the associated `antFlagsArray`).
+
+This wrapper is always used in place of `ant` inside of the derivation.
+It can be circumvented by calling `command ant`.
+
+### `findExternalAntTasks` {#ant-hook-findExternalAntTasks}
+
+This hook traverses all dependencies of the derivation. If it finds a
+`/share/ant/lib` directory, that directory is appended to `antFlagsArray`
+with the `-lib` argument.
+
+### `buildPhase` {#ant-hook-buildPhase}
+
+The Ant `buildPhase` executes `ant` with no arguments by default.
+
+#### Parameters {#ant-hook-buildPhase-parameters}
+
+`dontUseAntBuild`
+: When set to `true`, disables setting this phase as `buildPhase`.
+`antBuildFlags`
+: Additional flags passed to Ant in this phase.
+`antBuildFlagsArray`
+: Additional flags passed to Ant in this phase, as a Bash array.
+
+### `checkPhase` {#ant-hook-checkPhase}
+
+The Ant `checkPhase` executes `ant check` by default.
+This default can be changed by setting `antCheckFlags` or `antCheckFlagsArray`.
+
+#### Parameters {#ant-hook-checkPhase-parameters}
+
+`dontUseAntCheck`
+: When set to `true`, disables setting this phase as `checkPhase`.
+`antCheckFlags`
+: Additional flags passed to Ant in this phase.
+`antCheckFlagsArray`
+: Additional flags passed to Ant in this phase, as a Bash array.
+

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -53,6 +53,7 @@ Each supported language or software ecosystem has its own package set named `<la
 ```{=include=} sections
 agda.section.md
 android.section.md
+ant.section.md
 astal.section.md
 beam.section.md
 chicken.section.md

--- a/doc/languages-frameworks/java.section.md
+++ b/doc/languages-frameworks/java.section.md
@@ -1,6 +1,6 @@
 # Java {#sec-language-java}
 
-Ant-based Java packages are typically built from source as follows:
+Java packages are typically built from source as follows:
 
 ```nix
 stdenv.mkDerivation {
@@ -12,14 +12,17 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    ant
     jdk
     stripJavaArchivesHook # removes timestamp metadata from jar files
   ];
 
+  # IMPORTANT: See the tip below if your project uses a build system
   buildPhase = ''
     runHook preBuild
-    ant # build the project using ant
+
+    javac com/example/MyProject/*.java
+    jar cf MyProject.jar com/example/MyProject/*.class
+
     runHook postBuild
   '';
 
@@ -27,12 +30,25 @@ stdenv.mkDerivation {
     runHook preInstall
 
     # copy generated jar file(s) to an appropriate location in $out
-    install -Dm644 build/foo.jar $out/share/java/foo.jar
+    install -Dm644 MyProject.jar $out/share/java/MyProject.jar
 
     runHook postInstall
   '';
 }
 ```
+
+::: {.tip}
+Many build systems, such as Ant, Gradle, and Maven, have
+[setup hooks](#ssec-setup-hooks) or builders to make building packages
+easier by automatically setting [the build phase](#build-phase)
+and other phases to common values as appropriate.
+
+For more information about setup hooks for Java build systems, see
+the following sections in the manual:
+* [Gradle](#gradle)
+* [Maven](#maven)
+* [Ant](#ant)
+:::
 
 Note that `jdk` is an alias for the OpenJDK (self-built where available,
 or pre-built via Zulu).

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2782,6 +2782,30 @@
   "agda-maintaining-packages": [
     "index.html#agda-maintaining-packages"
   ],
+  "ant": [
+    "index.html#ant"
+  ],
+  "ant-hook": [
+    "index.html#ant-hook"
+  ],
+  "ant-hook-findExternalAntTasks": [
+    "index.html#ant-hook-findExternalAntTasks"
+  ],
+  "ant-hook-thin-wrapper": [
+    "index.html#ant-hook-thin-wrapper"
+  ],
+  "ant-hook-buildPhase": [
+    "index.html#ant-hook-buildPhase"
+  ],
+  "ant-hook-buildPhase-parameters": [
+    "index.html#ant-hook-buildPhase-parameters"
+  ],
+  "ant-hook-checkPhase": [
+    "index.html#ant-hook-checkPhase"
+  ],
+  "ant-hook-checkPhase-parameters": [
+    "index.html#ant-hook-checkPhase-parameters"
+  ],
   "android": [
     "index.html#android"
   ],

--- a/pkgs/applications/misc/mkgmap/splitter/default.nix
+++ b/pkgs/applications/misc/mkgmap/splitter/default.nix
@@ -62,24 +62,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     jdk
     ant
+    ant.hook
     makeWrapper
     stripJavaArchivesHook
   ];
 
-  buildPhase = ''
-    runHook preBuild
-    ant
-    runHook postBuild
-  '';
-
   inherit doCheck;
 
-  checkPhase = ''
-    runHook preCheck
-    ant run.tests
-    ant run.func-tests
-    runHook postCheck
-  '';
+  antCheckFlags = [
+    "run.tests"
+    "run.func-tests"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -5,6 +5,7 @@
   coreutils,
   makeWrapper,
   gitUpdater,
+  callPackage,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -77,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     home = "${finalAttrs.finalPackage}/share/ant";
+    hook = callPackage ./setup-hook { };
     updateScript = gitUpdater {
       rev-prefix = "rel/";
       url = "https://gitbox.apache.org/repos/asf/ant";

--- a/pkgs/by-name/an/ant/setup-hook/default.nix
+++ b/pkgs/by-name/an/ant/setup-hook/default.nix
@@ -1,0 +1,7 @@
+{ makeSetupHook, callPackage }:
+makeSetupHook {
+  name = "ant-setup-hook";
+  passthru.tests = {
+    findExternalAntTasks = callPackage ./test-findExternalAntTasks.nix { };
+  };
+} ./setup-hook.sh

--- a/pkgs/by-name/an/ant/setup-hook/setup-hook.sh
+++ b/pkgs/by-name/an/ant/setup-hook/setup-hook.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+# Setup hook for the Ant build system.
+# Full documentation available at /doc/languages-frameworks/ant.section.md
+
+function findExternalAntTasks() {
+  if [ -d "$1/share/ant/lib" ]; then
+    antFlagsArray+=("-lib" "$1/share/ant/lib")
+  fi
+}
+
+addEnvHooks "$targetOffset" findExternalAntTasks
+
+function ant() {
+  local flagsArray=()
+  concatTo flagsArray antFlags antFlagsArray
+  command ant "${flagsArray[@]}" "$@"
+}
+
+function antBuildPhase() {
+  runHook preBuild
+
+  local flagsArray=()
+  concatTo flagsArray antBuildFlags antBuildFlagsArray
+  ant "${flagsArray[@]}"
+
+  runHook postBuild
+}
+
+function antCheckPhase() {
+  runHook preCheck
+
+  local flagsArray=()
+  concatTo flagsArray antCheckFlags antCheckFlagsArray
+
+  # Set a reasonable default
+  if [ ${#flagsArray[@]} -eq 0 ]; then
+    flagsArray=("check")
+  fi
+
+  ant "${flagsArray[@]}"
+
+  runHook postCheck
+}
+
+if [ -z "${dontUseAntBuild-}" ] && [ -z "${buildPhase-}" ]; then
+    buildPhase=antBuildPhase
+fi
+
+if [ -z "${dontUseAntCheck-}" ] && [ -z "${checkPhase-}" ]; then
+    checkPhase=antCheckPhase
+fi
+

--- a/pkgs/by-name/an/ant/setup-hook/test-findExternalAntTasks.nix
+++ b/pkgs/by-name/an/ant/setup-hook/test-findExternalAntTasks.nix
@@ -1,0 +1,31 @@
+{
+  stdenvNoCC,
+  writeTextFile,
+  ant,
+}:
+# Check that findExternalAntTasks finds an external Ant task.
+let
+  fake-ant-task = writeTextFile {
+    name = "fake-ant-task";
+    text = ''
+      Hello world! I am a text file with a misleading file extension.
+    '';
+    destination = "/share/ant/lib/fake-ant-task.jar";
+  };
+in
+stdenvNoCC.mkDerivation {
+  name = "ant-test-setup-hook-findExternalAntTasks";
+
+  src = null;
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    # Ant itself isn't needed for this test; we assume antFlags/antFlagsArray works
+    ant.hook
+    fake-ant-task
+  ];
+
+  buildPhase = ''
+    echo "$antFlags ''${antFlagsArray[@]}" | grep -F -- '-lib ${fake-ant-task}/share/ant/lib' > "$out"
+  '';
+}

--- a/pkgs/by-name/jf/jffi/package.nix
+++ b/pkgs/by-name/jf/jffi/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     ant
+    ant.hook
     jdk
     pkg-config
     texinfo
@@ -34,22 +35,17 @@ stdenv.mkDerivation (finalAttrs: {
   # The pkg-config script in the build.xml doesn't work propery
   # set the lib path manually to work around this.
   env.LIBFFI_LIBS = "${libffi}/lib/libffi${stdenv.hostPlatform.extensions.sharedLibrary}";
-  env.ANT_ARGS = "-Duse.system.libffi=1";
 
-  buildPhase = ''
-    runHook preBuild
-    ant jar
-    ant archive-platform-jar
-    runHook postBuild
-  '';
+  antFlags = [ "-Duse.system.libffi=1" ];
+
+  antBuildFlags = [
+    "jar"
+    "archive-platform-jar"
+  ];
 
   doCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-    ant test
-    runHook postCheck
-  '';
+  antCheckFlags = [ "test" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ji/jing-trang/package.nix
+++ b/pkgs/by-name/ji/jing-trang/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     jdk_headless
     ant
+    ant.hook
     saxon
   ];
 
@@ -33,8 +34,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./no-git-during-build.patch
   ];
-
-  preBuild = "ant";
 
   installPhase = ''
     mkdir -p "$out"/{share/java,bin}

--- a/pkgs/by-name/op/openrocket/package.nix
+++ b/pkgs/by-name/op/openrocket/package.nix
@@ -25,24 +25,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     ant
+    ant.hook
     jdk
     makeWrapper
     stripJavaArchivesHook
   ];
 
-  buildPhase = ''
-    runHook preBuild
-    ant
-    runHook postBuild
-  '';
-
   doCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-    ant unittest
-    runHook postCheck
-  '';
+  antCheckFlags = [ "unittest" ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Add a setup hook for Ant.
It does a few different things; I recommend reading the documentation for a full explanation.

I also migrated a few packages to demonstrate that this works in practice. Since there are many packages that use Ant in Nixpkgs, it would be impractical to do all of them at once in this PR.

### For maintainers of changed packages

I migrated your package to the new pattern. If something (e.g. an assumption about your package, or something with the hook) looks wrong, please let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
