### PR TITLE
flutter: revert remove usages of aliases {build,host,target}Platform

### DIFF
--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -6,7 +6,12 @@
   darwin,
   clang,
   llvm,
-  tools ? callPackage ./tools.nix { },
+  tools ? callPackage ./tools.nix {
+    inherit (stdenv)
+      hostPlatform
+      buildPlatform
+      ;
+  },
   stdenv,
   stdenvNoCC,
   dart,
@@ -62,6 +67,11 @@ let
       version
       hashes
       url
+      ;
+    inherit (stdenv)
+      hostPlatform
+      buildPlatform
+      targetPlatform
       ;
   };
 

--- a/pkgs/development/compilers/flutter/engine/source.nix
+++ b/pkgs/development/compilers/flutter/engine/source.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   callPackage,
   fetchgit,
@@ -15,16 +14,18 @@
   version,
   hashes,
   url,
+  hostPlatform,
+  targetPlatform,
+  buildPlatform,
 }@pkgs:
 let
-  target-constants = callPackage ./constants.nix { platform = stdenv.targetPlatform; };
-  build-constants = callPackage ./constants.nix { platform = stdenv.buildPlatform; };
-  tools = pkgs.tools or (callPackage ./tools.nix { });
+  target-constants = callPackage ./constants.nix { platform = targetPlatform; };
+  build-constants = callPackage ./constants.nix { platform = buildPlatform; };
+  tools = pkgs.tools or (callPackage ./tools.nix { inherit hostPlatform buildPlatform; });
 
   boolOption = value: if value then "True" else "False";
 in
-runCommand
-  "flutter-engine-source-${version}-${stdenv.buildPlatform.system}-${stdenv.targetPlatform.system}"
+runCommand "flutter-engine-source-${version}-${buildPlatform.system}-${targetPlatform.system}"
   {
     pname = "flutter-engine-source";
     inherit version;
@@ -52,7 +53,7 @@ runCommand
         "custom_vars": {
           "download_fuchsia_deps": False,
           "download_android_deps": False,
-          "download_linux_deps": ${boolOption stdenv.targetPlatform.isLinux},
+          "download_linux_deps": ${boolOption targetPlatform.isLinux},
           "setup_githooks": False,
           "download_esbuild": False,
           "download_dart_sdk": False,
@@ -82,8 +83,8 @@ runCommand
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
     outputHash =
-      (hashes."${stdenv.buildPlatform.system}" or { })."${stdenv.targetPlatform.system}"
-        or (throw "Hash not set for ${stdenv.targetPlatform.system} on ${stdenv.buildPlatform.system}");
+      (hashes."${buildPlatform.system}" or { })."${targetPlatform.system}"
+        or (throw "Hash not set for ${targetPlatform.system} on ${buildPlatform.system}");
   }
   ''
     source ${../../../../build-support/fetchgit/deterministic-git}

--- a/pkgs/development/compilers/flutter/engine/tools.nix
+++ b/pkgs/development/compilers/flutter/engine/tools.nix
@@ -1,5 +1,7 @@
 {
   stdenv,
+  buildPlatform,
+  hostPlatform,
   callPackage,
   fetchgit,
   fetchurl,
@@ -29,8 +31,8 @@
   },
 }:
 let
-  constants = callPackage ./constants.nix { platform = stdenv.buildPlatform; };
-  host-constants = callPackage ./constants.nix { platform = stdenv.hostPlatform; };
+  constants = callPackage ./constants.nix { platform = buildPlatform; };
+  host-constants = callPackage ./constants.nix { platform = hostPlatform; };
   stdenv-constants = callPackage ./constants.nix { platform = stdenv.hostPlatform; };
 in
 {

--- a/pkgs/development/compilers/flutter/update/get-engine-hashes.nix.in
+++ b/pkgs/development/compilers/flutter/update/get-engine-hashes.nix.in
@@ -17,12 +17,9 @@ let
           ++ (map
             (targetPlatform:
               callPackage "${nixpkgsRoot}/pkgs/development/compilers/flutter/engine/source.nix" {
-                stdenv = stdenv.override {
-                  targetPlatform = lib.systems.elaborate targetPlatform;
-                  hostPlatform = lib.systems.elaborate buildPlatform;
-                  buildPlatform = lib.systems.elaborate buildPlatform;
-                };
-
+                targetPlatform = lib.systems.elaborate targetPlatform;
+                hostPlatform = lib.systems.elaborate buildPlatform;
+                buildPlatform = lib.systems.elaborate buildPlatform;
                 flutterVersion = version;
                 version = engineVersion;
                 url = "https://github.com/flutter/engine.git@${engineVersion}";

--- a/pkgs/development/compilers/flutter/versions/3_24/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_24/data.json
@@ -10,8 +10,8 @@
       "x86_64-linux": "sha256-/jkMlcE0AZFWgTtUaUk8e/RxD31mObG91C6nfLzXdYU="
     },
     "x86_64-linux": {
-      "aarch64-linux": "sha256-/jkMlcE0AZFWgTtUaUk8e/RxD31mObG91C6nfLzXdYU=",
-      "x86_64-linux": "sha256-/jkMlcE0AZFWgTtUaUk8e/RxD31mObG91C6nfLzXdYU="
+      "aarch64-linux": "sha256-aQK3uD8n/V1ZH5+RbCNVZ1Fxx0Z33y5IEG4B0MVKh58=",
+      "x86_64-linux": "sha256-aQK3uD8n/V1ZH5+RbCNVZ1Fxx0Z33y5IEG4B0MVKh58="
     }
   },
   "dartVersion": "3.5.4",

--- a/pkgs/development/compilers/flutter/versions/3_26/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_26/data.json
@@ -10,8 +10,8 @@
       "x86_64-linux": "sha256-cDXCGikGuPWxMZZ0HWcnbS7Dt22no9wwbh4wei7w8Bw="
     },
     "x86_64-linux": {
-      "aarch64-linux": "sha256-cDXCGikGuPWxMZZ0HWcnbS7Dt22no9wwbh4wei7w8Bw=",
-      "x86_64-linux": "sha256-cDXCGikGuPWxMZZ0HWcnbS7Dt22no9wwbh4wei7w8Bw="
+      "aarch64-linux": "sha256-deuArmKBZvkjjt986wAAwGArKYMW01QvbgqzQ9FLBS8=",
+      "x86_64-linux": "sha256-deuArmKBZvkjjt986wAAwGArKYMW01QvbgqzQ9FLBS8="
     }
   },
   "dartVersion": "3.6.0-216.1.beta",

--- a/pkgs/development/compilers/flutter/versions/3_27/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_27/data.json
@@ -10,8 +10,8 @@
       "x86_64-linux": "sha256-xEUUengFzRbQhFB7jxTBd8eTMWUhyBTTKyT/ObuyD/o="
     },
     "x86_64-linux": {
-      "aarch64-linux": "sha256-xEUUengFzRbQhFB7jxTBd8eTMWUhyBTTKyT/ObuyD/o=",
-      "x86_64-linux": "sha256-xEUUengFzRbQhFB7jxTBd8eTMWUhyBTTKyT/ObuyD/o="
+      "aarch64-linux": "sha256-YFmK7eSt9lK/iEMPC5jxp5Vf2pnDjUDyPVoHzgxc8mA=",
+      "x86_64-linux": "sha256-YFmK7eSt9lK/iEMPC5jxp5Vf2pnDjUDyPVoHzgxc8mA="
     }
   },
   "dartVersion": "3.6.0-334.3.beta",


### PR DESCRIPTION
PR #350299 broke Flutter's update script with how it handled getting the platform. Furthermore, the problem was made worse in the last update to Flutter which had to work around that problem. We'll just revert it for now and do a proper fix once we can figure out how to satify setting the different platforms without causing any more problems.

Will backport this so 24.11 doesn't ship with a broken Flutter.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
