### PR TITLE
android-translation-layer: init at 0-unstable-2025-07-14

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -208,6 +208,7 @@ in
   amazon-init-shell = runTest ./amazon-init-shell.nix;
   amazon-ssm-agent = runTest ./amazon-ssm-agent.nix;
   amd-sev = runTest ./amd-sev.nix;
+  android-translation-layer = runTest ./android-translation-layer.nix;
   angie-api = runTest ./angie-api.nix;
   anki-sync-server = runTest ./anki-sync-server.nix;
   anubis = runTest ./anubis.nix;

--- a/nixos/tests/android-translation-layer.nix
+++ b/nixos/tests/android-translation-layer.nix
@@ -1,0 +1,40 @@
+{ pkgs, lib, ... }:
+let
+  # Example Android app
+  demoApp = pkgs.fetchurl {
+    url = "https://gitlab.com/android_translation_layer/atl_test_apks/-/raw/061e32a3172c8167b1746768d098f0e62d8f564b/demo_app.apk";
+    hash = "sha256-aXxLZEAMNsL6nL4r2N9rVsbBPmf3+gFGmgo3kZjdo4s=";
+  };
+in
+{
+  name = "android-translation-layer";
+  meta.maintainers = with pkgs.lib.maintainers; [ onny ];
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages = [ pkgs.android-translation-layer ];
+      };
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("launch android translation layer demo app"):
+        machine.succeed("android-translation-layer ${demoApp} >&2 &")
+        machine.sleep(10)
+        machine.wait_for_text(r"hello PoC world!")
+        machine.screenshot("atl_demo_app")
+
+    machine.succeed("pkill -f android-translation-layer")
+  '';
+}

--- a/pkgs/by-name/an/android-translation-layer/add-gio-unix-dep.patch
+++ b/pkgs/by-name/an/android-translation-layer/add-gio-unix-dep.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 8f525118..658cd9e5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -178,7 +178,7 @@ libtranslationlayer_so = shared_library('translation_layer_main', [
+                                                                         extra_deps,
+                                                                   	dependency('gtk4', version: '>=4.14'), dependency('gl'), dependency('egl'), dependency('wayland-client'), dependency('jni'),
+                                                                   	dependency('libportal'), dependency('sqlite3'), dependency('libavcodec', version: '>=59'), dependency('libdrm'),
+-                                                                  	dependency('gudev-1.0'), dependency('libswscale'), dependency('webkitgtk-6.0'),
++                                                                  	dependency('gudev-1.0'), dependency('libswscale'), dependency('webkitgtk-6.0'), dependency('gio-unix-2.0'),
+                                                                   	libandroidfw_dep, wayland_protos_dep
+                                                                   ],
+                                                                   link_with: [ libandroid_so ],

--- a/pkgs/by-name/an/android-translation-layer/configure-art-path.patch
+++ b/pkgs/by-name/an/android-translation-layer/configure-art-path.patch
@@ -1,0 +1,29 @@
+diff --git a/meson.build b/meson.build
+index 8f525118..c1761a2d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -11,8 +11,8 @@ dir_base = meson.current_source_dir()
+ builddir_base = meson.current_build_dir()
+ # FIXME: make art install a pkgconfig file
+ libart_dep = [
+-	cc.find_library('art', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ]),
+-     	cc.find_library('nativebridge', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ])
++	cc.find_library('art', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / get_option('libdir') / 'art' ]),
++     	cc.find_library('nativebridge', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / get_option('libdir') / 'art' ])
+ ]
+ libdl_bio_dep = [
+ 	cc.find_library('dl_bio')
+@@ -21,10 +21,10 @@ libc_bio_dep = [
+ 	cc.find_library('c_bio')
+ ]
+ libandroidfw_dep = [
+-	cc.find_library('androidfw', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ]),
++	cc.find_library('androidfw', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / 'lib' / 'art' ]),
+ ]
+-if fs.is_file('/usr' / get_option('libdir') / 'java/core-all_classes.jar')
+-  bootclasspath_dir = '/usr' / get_option('libdir') / 'java'
++if fs.is_file('@artStandalonePackageDir@' / get_option('libdir') / 'java/core-all_classes.jar')
++  bootclasspath_dir = '@artStandalonePackageDir@' / get_option('libdir') / 'java'
+ elif fs.is_file('/usr/local' / get_option('libdir') / 'java/core-all_classes.jar')
+   bootclasspath_dir = '/usr/local' / get_option('libdir') / 'java'
+ elif fs.is_file(get_option('prefix') / get_option('libdir') / 'java/core-all_classes.jar')

--- a/pkgs/by-name/an/android-translation-layer/configure-dex-install-dir.patch
+++ b/pkgs/by-name/an/android-translation-layer/configure-dex-install-dir.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main-executable/main.c b/src/main-executable/main.c
+index d7cfbfe8..c542c71a 100644
+--- a/src/main-executable/main.c
++++ b/src/main-executable/main.c
+@@ -311,6 +311,7 @@ static void open(GtkApplication *app, GFile **files, gint nfiles, const gchar *h
+ 	} else {
+ 		dex_install_dir = "DIDN'T_GET_SO_PATH_WITH_dladdr_SUS"; // in case we print this as part of some other error, it should be clear what the real cause is
+ 	}
++	dex_install_dir = "@out@/lib/java/dex";
+ 
+ 	char *app_data_dir_base = getenv("ANDROID_APP_DATA_DIR");
+ 	if (!app_data_dir_base) {

--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -1,0 +1,97 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  ffmpeg,
+  meson,
+  openjdk17,
+  lib,
+  glib,
+  pkg-config,
+  wayland-protocols,
+  wayland,
+  wayland-scanner,
+  gtk4,
+  openxr-loader,
+  libglvnd,
+  libportal-gtk4,
+  sqlite,
+  libdrm,
+  libgudev,
+  webkitgtk_6_0,
+  ninja,
+  art-standalone,
+  bionic-translation,
+  alsa-lib,
+  makeWrapper,
+  replaceVars,
+}:
+
+stdenv.mkDerivation {
+  pname = "android-translation-layer";
+  version = "0-unstable-2025-07-14";
+
+  src = fetchFromGitLab {
+    owner = "android_translation_layer";
+    repo = "android_translation_layer";
+    rev = "828f779c4f7170f608047c500d6d3b64b480df7f";
+    hash = "sha256-1KYZWlzES3tbskqvA8qSQCegE0uLTLCq4q2CX6uix4o=";
+  };
+
+  patches = [
+    (replaceVars ./configure-art-path.patch {
+      artStandalonePackageDir = "${art-standalone}";
+    })
+
+    # Required gio-unix dependency is missing in meson.build
+    ./add-gio-unix-dep.patch
+
+    # Patch custon Dex install dir
+    ./configure-dex-install-dir.patch
+  ];
+
+  postPatch = ''
+    # As we need the $out reference, we can't use `replaceVars` here.
+    substituteInPlace src/main-executable/main.c \
+      --replace-fail '@out@' "$out"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    meson
+    ninja
+    openjdk17
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    art-standalone
+    bionic-translation
+    ffmpeg
+    gtk4
+    libdrm
+    libglvnd
+    libgudev
+    libportal-gtk4
+    openxr-loader
+    sqlite
+    wayland
+    wayland-protocols
+    wayland-scanner
+    webkitgtk_6_0
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/android-translation-layer \
+      --prefix LD_LIBRARY_PATH : ${art-standalone}/lib/art
+  '';
+
+  meta = {
+    description = "Translation layer that allows running Android apps on a Linux system";
+    homepage = "https://gitlab.com/android_translation_layer/android_translation_layer";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "android-translation-layer";
+  };
+}

--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -24,6 +24,7 @@
   alsa-lib,
   makeWrapper,
   replaceVars,
+  nixosTests,
 }:
 
 stdenv.mkDerivation {
@@ -85,6 +86,10 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/android-translation-layer \
       --prefix LD_LIBRARY_PATH : ${art-standalone}/lib/art
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) android-translation-layer;
+  };
 
   meta = {
     description = "Translation layer that allows running Android apps on a Linux system";

--- a/pkgs/by-name/ar/art-standalone/no-hardcode-path-addr2line.patch
+++ b/pkgs/by-name/ar/art-standalone/no-hardcode-path-addr2line.patch
@@ -1,0 +1,26 @@
+diff --git a/art/runtime/native_stack_dump.cc b/art/runtime/native_stack_dump.cc
+index 150fa782..2fca7caf 100644
+--- a/art/runtime/native_stack_dump.cc
++++ b/art/runtime/native_stack_dump.cc
+@@ -76,7 +76,7 @@ std::string FindAddr2line() {
+       return std::string(env_value) + kAddr2linePrebuiltPath;
+     }
+   }
+-  return std::string("/usr/bin/addr2line");
++  return std::string("addr2line");
+ }
+ 
+ ALWAYS_INLINE
+diff --git a/art/tools/timeout_dumper/timeout_dumper.cc b/art/tools/timeout_dumper/timeout_dumper.cc
+index 08d2f4c0..513324ad 100644
+--- a/art/tools/timeout_dumper/timeout_dumper.cc
++++ b/art/tools/timeout_dumper/timeout_dumper.cc
+@@ -122,7 +122,7 @@ std::unique_ptr<std::string> FindAddr2line() {
+     }
+   }
+ 
+-  constexpr const char* kHostAddr2line = "/usr/bin/addr2line";
++  constexpr const char* kHostAddr2line = "addr2line";
+   if (access(kHostAddr2line, F_OK) == 0) {
+     return std::make_unique<std::string>(kHostAddr2line);
+   }

--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  wolfssl,
+  bionic-translation,
+  python3,
+  which,
+  jdk17,
+  zip,
+  xz,
+  icu,
+  zlib,
+  libcap,
+  expat,
+  openssl,
+  libbsd,
+  lz4,
+  runtimeShell,
+  libpng,
+  makeWrapper,
+  binutils,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "art-standalone";
+  version = "0-unstable-2025-07-09";
+
+  src = fetchFromGitLab {
+    owner = "android_translation_layer";
+    repo = "art_standalone";
+    rev = "1eee3dce3ba6f324bb7a32a170b2da14889af39d";
+    hash = "sha256-OAO0k/LkQ+MKqR4HkFXD18LSXQZNPogjjRot4UVoE5A=";
+  };
+
+  patches = [
+    # Do not hardocde addr2line binary path
+    ./no-hardcode-path-addr2line.patch
+  ];
+
+  postPatch = ''
+    chmod +x dalvik/dx/etc/{dx,dexmerger}
+    patchShebangs .
+    sed -i "s|/bin/bash|${runtimeShell}|" build/core/config.mk build/core/main.mk
+  '';
+
+  enableParallelBuilding = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    jdk17
+    makeWrapper
+    python3
+    which
+    zip
+  ];
+
+  buildInputs = [
+    bionic-translation
+    expat
+    icu
+    libbsd
+    libcap
+    libpng
+    lz4
+    openssl
+    (wolfssl.overrideAttrs (oldAttrs: {
+      configureFlags = oldAttrs.configureFlags ++ [
+        "--enable-jni"
+      ];
+    }))
+    xz
+    zlib
+  ];
+
+  makeFlags = [
+    "____LIBDIR=lib"
+    "____PREFIX=${placeholder "out"}"
+    "____INSTALL_ETC=${placeholder "out"}/etc"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/dx \
+      --prefix LD_LIBRARY_PATH : $out/lib \
+      --prefix PATH : ${lib.makeBinPath [ binutils ]}
+  '';
+
+  meta = {
+    description = "Art and dependencies with modifications to make it work on Linux";
+    homepage = "https://gitlab.com/android_translation_layer/art_standalone";
+    # No license specified yet
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+})

--- a/pkgs/by-name/bi/bionic-translation/package.nix
+++ b/pkgs/by-name/bi/bionic-translation/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  mesa,
+  wayland,
+  libglvnd,
+  libbsd,
+  libunwind,
+  libelf,
+  meson,
+  pkg-config,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bionic-translation";
+  version = "0-unstable-2025-07-07";
+
+  src = fetchFromGitLab {
+    owner = "android_translation_layer";
+    repo = "bionic_translation";
+    rev = "18c65637bf02dba86415dd009036b72f62cbb37d";
+    hash = "sha256-cqmWT9mbYJRLaX1Ey0lDfRFYM7JXuwayDN4o2WJIAVc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libbsd
+    libelf
+    libglvnd
+    libunwind
+    mesa
+    wayland
+  ];
+
+  meta = {
+    description = "Set of libraries for loading bionic-linked .so files on musl/glibc";
+    homepage = "https://gitlab.com/android_translation_layer/bionic_translation";
+    # No license specified yet
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/312040

Original work by @balsoft https://github.com/NixOS/nixpkgs/issues/312040#issuecomment-2449263830
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
