### PR TITLE
kanboard: init at 1.2.42

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -18,6 +18,8 @@
 
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](#opt-services.agorakit.enable).
 
+- [KanBoard](https://github.com/kanboard/kanboard), a project management tool that focuses on the Kanban methodology. Available as [services.kanboard](#opt-services.kanboard.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1466,6 +1466,7 @@
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
   ./services/web-apps/kasmweb/default.nix
+  ./services/web-apps/kanboard.nix
   ./services/web-apps/kavita.nix
   ./services/web-apps/keycloak.nix
   ./services/web-apps/kimai.nix

--- a/nixos/modules/services/web-apps/kanboard.nix
+++ b/nixos/modules/services/web-apps/kanboard.nix
@@ -1,0 +1,175 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kanboard;
+
+  toStringAttrs = lib.mapAttrs (lib.const toString);
+in
+{
+  meta.maintainers = with lib.maintainers; [ yzx9 ];
+
+  options.services.kanboard = {
+    enable = lib.mkEnableOption "Kanboard";
+
+    package = lib.mkPackageOption pkgs "kanboard" { };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/kanboard";
+      description = "Default data folder for Kanboard.";
+      example = "/mnt/kanboard";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "kanboard";
+      description = "User under which Kanboard runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "kanboard";
+      description = "Group under which Kanboard runs.";
+    };
+
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          str
+          int
+          bool
+        ]);
+
+      default = { };
+
+      description = ''
+        Customize the default settings, refer to <https://github.com/kanboard/kanboard/blob/main/config.default.php>
+        for details on supported values.
+      '';
+    };
+
+    # Nginx
+    domain = lib.mkOption {
+      type = lib.types.str;
+      default = "kanboard";
+      description = "FQDN for the Kanboard instance.";
+      example = "kanboard.example.org";
+    };
+    nginx = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
+      );
+      default = { };
+      description = ''
+        With this option, you can customize an NGINX virtual host which already
+        has sensible defaults for Kanboard. Set to `{ }` if you do not need any
+        customization for the virtual host. If enabled, then by default, the
+        {option}`serverName` is `''${domain}`. If this is set to null (the
+        default), no NGINX virtual host will be configured.
+      '';
+      example = lib.literalExpression ''
+        {
+          enableACME = true;
+          forceHttps = true;
+        }
+      '';
+    };
+
+    phpfpm.settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          int
+          str
+          bool
+        ]);
+
+      default = { };
+
+      description = ''
+        Options for kanboard's PHPFPM pool.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users = {
+      users = lib.mkIf (cfg.user == "kanboard") {
+        kanboard = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.dataDir;
+          createHome = true;
+        };
+      };
+
+      groups = lib.mkIf (cfg.group == "kanboard") {
+        kanboard = { };
+      };
+    };
+
+    services.phpfpm.pools.kanboard = {
+      user = cfg.user;
+      group = cfg.group;
+
+      settings = lib.mkMerge [
+        {
+          "pm" = "dynamic";
+          "php_admin_value[error_log]" = "stderr";
+          "php_admin_flag[log_errors]" = true;
+          "listen.owner" = "nginx";
+          "catch_workers_output" = true;
+          "pm.max_children" = "32";
+          "pm.start_servers" = "2";
+          "pm.min_spare_servers" = "2";
+          "pm.max_spare_servers" = "4";
+          "pm.max_requests" = "500";
+        }
+        cfg.phpfpm.settings
+      ];
+
+      phpEnv = lib.mkMerge [
+        { DATA_DIR = cfg.dataDir; }
+        (toStringAttrs cfg.settings)
+      ];
+    };
+
+    services.nginx = lib.mkIf (cfg.nginx != null) {
+      enable = lib.mkDefault true;
+      virtualHosts."${cfg.domain}" = lib.mkMerge [
+        {
+          root = lib.mkForce "${cfg.package}/share/kanboard";
+          locations."/".extraConfig = ''
+            rewrite ^ /index.php;
+          '';
+          locations."~ \\.php$".extraConfig = ''
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass unix:${config.services.phpfpm.pools.kanboard.socket};
+            include ${config.services.nginx.package}/conf/fastcgi.conf;
+            include ${config.services.nginx.package}/conf/fastcgi_params;
+          '';
+          locations."~ \\.(js|css|ttf|woff2?|png|jpe?g|svg)$".extraConfig = ''
+            add_header Cache-Control "public, max-age=15778463";
+            add_header X-Content-Type-Options nosniff;
+            add_header X-XSS-Protection "1; mode=block";
+            add_header X-Robots-Tag none;
+            add_header X-Download-Options noopen;
+            add_header X-Permitted-Cross-Domain-Policies none;
+            add_header Referrer-Policy no-referrer;
+            access_log off;
+          '';
+          extraConfig = ''
+            try_files $uri /index.php;
+          '';
+        }
+        cfg.nginx
+      ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -498,6 +498,7 @@ in {
   jotta-cli = handleTest ./jotta-cli.nix {};
   k3s = handleTest ./k3s {};
   kafka = handleTest ./kafka.nix {};
+  kanboard = handleTest ./web-apps/kanboard.nix {};
   kanidm = handleTest ./kanidm.nix {};
   kanidm-provisioning = handleTest ./kanidm-provisioning.nix {};
   karma = handleTest ./karma.nix {};

--- a/nixos/tests/web-apps/kanboard.nix
+++ b/nixos/tests/web-apps/kanboard.nix
@@ -1,0 +1,25 @@
+import ../make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "kanboard";
+    meta.maintainers = with lib.maintainers; [ yzx9 ];
+
+    nodes = {
+      machine = {
+        services.kanboard = {
+          enable = true;
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("nginx.service")
+      machine.wait_for_unit("phpfpm-kanboard.service")
+      machine.wait_for_open_port(80)
+
+      machine.succeed("curl -k --fail http://localhost", timeout=10)
+    '';
+  }
+)

--- a/pkgs/by-name/ka/kanboard/package.nix
+++ b/pkgs/by-name/ka/kanboard/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nixosTests,
+  nix-update-script,
+  php,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kanboard";
+  version = "1.2.42";
+
+  src = fetchFromGitHub {
+    owner = "kanboard";
+    repo = "kanboard";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-/Unxl9Vh9pEWjO89sSviGGPFzUwxdb1mbOfpTFTyRL0=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/kanboard
+    cp -rv . $out/share/kanboard
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = lib.optionalAttrs stdenvNoCC.hostPlatform.isLinux {
+      inherit (nixosTests) kanboard;
+    };
+  };
+
+  meta = {
+    inherit (php.meta) platforms;
+    description = "Kanban project management software";
+    homepage = "https://kanboard.org";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[KanBoard](https://github.com/kanboard/kanboard) is project management software that focuses on the Kanban methodology.

Previously, Kanboard was added but later [removed due to its limited utility](#214791). This PR reinstates the package and introduces a NixOS module to facilitate hosting the web application.

close #288788


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
