### PR TITLE
luminance: init at 1.1.0

### DIFF
--- a/pkgs/by-name/lu/luminance/package.nix
+++ b/pkgs/by-name/lu/luminance/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  ddcutil,
+  fetchFromGitHub,
+  gtk4,
+  installShellFiles,
+  libadwaita,
+  nix-update-script,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "luminance";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "sidevesh";
+    repo = "Luminance";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-1xDRs+OBzcrB75pILA3ZxIrZEleWVBROBNZz0MsCWnA=";
+  };
+
+  # Use our own ddcbc-api source
+  #
+  # Patch build.sh with the stdenv agnostic `$CC` variable
+  postPatch = ''
+    rmdir ddcbc-api
+    ln -sf ${finalAttrs.passthru.ddcbc-api} ddcbc-api
+
+    patchShebangs build.sh
+    substituteInPlace build.sh \
+      --replace-fail 'gcc' '"$CC"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    ddcutil
+    gtk4
+    libadwaita
+  ];
+
+  postBuild = "./build.sh";
+
+  postInstall = ''
+    mv build/app com.sidevesh.Luminance
+    installBin com.sidevesh.Luminance
+
+    install -Dm644 install_files/44-backlight-permissions.rules -t $out/lib/udev/rules.d
+    install -Dm644 install_files/com.sidevesh.Luminance.desktop -t $out/share/applications
+    install -Dm644 install_files/com.sidevesh.Luminance.gschema.xml -t $out/share/glib-2.0/schemas
+
+    mv icons $out/share/icons
+    rm $out/share/icons/com.sidevesh.luminance.Source.svg
+  '';
+
+  passthru = {
+    ddcbc-api = fetchFromGitHub {
+      owner = "ahshabbir";
+      repo = "ddcbc-api";
+      rev = "f54500284fcfc2f140d5ae01df779f3f47c9b563";
+      hash = "sha256-ViKik3468AHjE7NxdfrKicDNA0ENG6DmIplYtKVqduw=";
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Simple GTK application to control brightness of displays including external displays supporting DDC/CI";
+    homepage = "https://github.com/sidevesh/Luminance";
+    changelog = "https://github.com/sidevesh/Luminance/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ getchoo ];
+    inherit (ddcutil.meta) platforms;
+    mainProgram = "com.sidevesh.Luminance";
+  };
+})


### PR DESCRIPTION
[Luminance](https://github.com/sidevesh/Luminance) is a simple GTK application to control brightness of displays including external displays supporting DDC/CI

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
