### PR TITLE
matio: avoid ac_cv_av_copy check to fix cross building

### DIFF
--- a/pkgs/by-name/ma/matio/package.nix
+++ b/pkgs/by-name/ma/matio/package.nix
@@ -1,7 +1,14 @@
 {
   fetchurl,
+  hdf5,
   lib,
+  matio,
+  nix-update-script,
+  pkgconf,
   stdenv,
+  testers,
+  validatePkgConfig,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -13,13 +20,39 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-naaYk0ohVprwWOY0hWRmb0UCnmwrCHjKDY+WCb93uNg=";
   };
 
+  configureFlags = [ "ac_cv_va_copy=1" ];
+
+  nativeBuildInputs = [
+    pkgconf
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    hdf5
+    zlib
+  ];
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = matio;
+        versionCheck = true;
+      };
+      version = testers.testVersion {
+        package = matio;
+      };
+    };
+    updateScript = nix-update-script { };
+  };
+
   meta = {
     changelog = "https://sourceforge.net/p/matio/news/";
     description = "C library for reading and writing Matlab MAT files";
     homepage = "http://matio.sourceforge.net/";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ jwillikers ];
     mainProgram = "matdump";
     platforms = lib.platforms.all;
+    pkgConfigModules = [ "matio" ];
   };
 })


### PR DESCRIPTION
Set ac_cv_av_copy to indicate the av_copy function exists.
The function should exist in C99 implementations.

Add passthru tests and update script.
Remove use of pname.
Reduce scope of lib.
Add myself as maintainer.

Fixes #357232

This should be backported to 24.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
