### PR TITLE
television: init at 0.5.0

### DIFF
--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  testers,
+  television,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "television";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "alexpasmantier";
+    repo = "television";
+    rev = "refs/tags/" + version;
+    hash = "sha256-yi8lPm3zkmamN6gPlGfojNlIXM1cgSr1zL2zMNni5f0=";
+  };
+
+  cargoHash = "sha256-1SdyVtMjkfXH9iGew9i8xpx8WlUly4vIcKY3weeW3LQ=";
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = television;
+      command = "XDG_DATA_HOME=$TMPDIR tv --version";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Television is a blazingly fast general purpose fuzzy finder";
+
+    longDescription = ''
+      Television is a blazingly fast general purpose fuzzy finder TUI written
+      in Rust. It is inspired by the neovim telescope plugin and is designed
+      to be fast, efficient, simple to use and easily extensible. It is built
+      on top of tokio, ratatui and the nucleo matcher used by the helix editor.
+    '';
+
+    homepage = "https://github.com/alexpasmantier/television";
+    changelog = "https://github.com/alexpasmantier/television/releases/tag/${version}";
+    license = lib.licenses.mit;
+    mainProgram = "tv";
+    maintainers = with lib.maintainers; [
+      louis-thevenet
+      getchoo
+    ];
+  };
+}


### PR DESCRIPTION
[Television](https://github.com/alexpasmantier/television) is a blazingly fast general purpose fuzzy finder TUI written in Rust.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
