### PR TITLE
tuxguitar: fix start script

### DIFF
--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -10,6 +10,8 @@
   fluidsynth,
   libpulseaudio,
   lilv,
+  which,
+  wrapGAppsHook,
   nixosTests,
 }:
 
@@ -22,8 +24,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-FD1+7jV69E9AfTczjD6DOGD+pPlscg4o8A9ADBUM9B4=";
   };
 
+  buildInputs = [
+    which
+  ];
+
   nativeBuildInputs = [
     makeWrapper
+    wrapGAppsHook
   ];
 
   installPhase = ''
@@ -36,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/share $out/bin/share
 
     wrapProgram $out/bin/tuxguitar \
-      --set JAVA "${jre}/bin/java" \
+      --set PATH "$PATH:${jre}/bin" \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${
         lib.makeLibraryPath [
           swt

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -11,7 +11,7 @@
   libpulseaudio,
   lilv,
   which,
-  wrapGAppsHook,
+  wrapGAppsHook3,
   nixosTests,
 }:
 
@@ -24,14 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-FD1+7jV69E9AfTczjD6DOGD+pPlscg4o8A9ADBUM9B4=";
   };
 
-  buildInputs = [
-    which
-  ];
-
   nativeBuildInputs = [
     makeWrapper
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
+
+  dontWrapGApps = true;
 
   installPhase = ''
     mkdir -p $out/bin
@@ -41,9 +39,12 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/dist $out/bin/dist
     ln -s $out/lib $out/bin/lib
     ln -s $out/share $out/bin/share
+  '';
 
+  postFixup = ''
     wrapProgram $out/bin/tuxguitar \
-      --set PATH "$PATH:${jre}/bin" \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH : ${lib.makeBinPath[ jre which ]} \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${
         lib.makeLibraryPath [
           swt

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -44,7 +44,12 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapProgram $out/bin/tuxguitar \
       "''${gappsWrapperArgs[@]}" \
-      --prefix PATH : ${lib.makeBinPath [ jre which ]} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jre
+          which
+        ]
+      } \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${
         lib.makeLibraryPath [
           swt

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapProgram $out/bin/tuxguitar \
       "''${gappsWrapperArgs[@]}" \
-      --prefix PATH : ${lib.makeBinPath[ jre which ]} \
+      --prefix PATH : ${lib.makeBinPath [ jre which ]} \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${
         lib.makeLibraryPath [
           swt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Fix #227206: The package now uses `which java` in the startup script, so we need `which` as build input and `java` in `$PATH`.
2. Add `warpGAppsHook` to run in KDE.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
