### PR TITLE
zellij: 0.41.1 -> 0.41.2

### DIFF
--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  fetchFromGitHub,
-  rustPlatform,
   stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  mandown,
   installShellFiles,
   pkg-config,
   curl,
   openssl,
-  mandown,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,6 +19,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "zellij-org";
     repo = "zellij";
+    rev = "refs/tags/v${version}";
     hash = "sha256-xdWfaXWmqFJuquE7n3moUjGuFqKB90OE6lqPuC3onOg=";
   };
 
@@ -45,7 +47,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   preCheck = ''
-    HOME=$TMPDIR
+    HOME=$(mktemp -d)
   '';
 
   nativeInstallCheckInputs = [
@@ -75,13 +77,14 @@ rustPlatform.buildRustPackage rec {
         --zsh <($out/bin/zellij setup --generate-completion zsh)
     '';
 
+  passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Terminal workspace with batteries included";
     homepage = "https://zellij.dev/";
     changelog = "https://github.com/zellij-org/zellij/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [
       therealansh
       _0x4A6F
       abbe

--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -8,8 +8,7 @@
   curl,
   openssl,
   mandown,
-  zellij,
-  testers,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -49,9 +48,14 @@ rustPlatform.buildRustPackage rec {
     HOME=$TMPDIR
   '';
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
   # Ensure that we don't vendor curl, but instead link against the libcurl from nixpkgs
-  doInstallCheck = stdenv.hostPlatform.libc == "glibc";
-  installCheckPhase = ''
+  installCheckPhase = lib.optionalString (stdenv.hostPlatform.libc == "glibc") ''
     runHook preInstallCheck
 
     ldd "$out/bin/zellij" | grep libcurl.so
@@ -71,7 +75,6 @@ rustPlatform.buildRustPackage rec {
         --zsh <($out/bin/zellij setup --generate-completion zsh)
     '';
 
-  passthru.tests.version = testers.testVersion { package = zellij; };
 
   meta = with lib; {
     description = "Terminal workspace with batteries included";

--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -14,24 +14,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zellij";
-  version = "0.41.1";
+  version = "0.41.2";
 
   src = fetchFromGitHub {
     owner = "zellij-org";
     repo = "zellij";
-    rev = "v${version}";
-    hash = "sha256-EUoJHM0Jm0uFKFeHhtzon/ZRC615SHfYa1gr4RnCNBw=";
+    hash = "sha256-xdWfaXWmqFJuquE7n3moUjGuFqKB90OE6lqPuC3onOg=";
   };
 
-  cargoHash = "sha256-rI3pa0dvC/OVJz8gzD1bM0Q+8OWwvGj+jGDEMSbSb2I=";
+  # Remove the `vendored_curl` feature in order to link against the libcurl from nixpkgs instead of
+  # the vendored one
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail ', "vendored_curl"' ""
+  '';
+
+  cargoHash = "sha256-38hTOsa1a5vpR1i8GK1aq1b8qaJoCE74ewbUOnun+Qs=";
 
   env.OPENSSL_NO_VENDOR = 1;
-
-  # Workaround for https://github.com/zellij-org/zellij/issues/3720
-  postPatch = ''
-    substituteInPlace zellij-utils/Cargo.toml \
-      --replace-fail 'isahc = "1.7.2"' 'isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }'
-  '';
 
   nativeBuildInputs = [
     mandown
@@ -63,7 +63,6 @@ rustPlatform.buildRustPackage rec {
     ''
       mandown docs/MANPAGE.md > zellij.1
       installManPage zellij.1
-
     ''
     + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd $pname \


### PR DESCRIPTION
## Things done

Changelog: https://github.com/zellij-org/zellij/blob/v0.41.2/CHANGELOG.md

cc @therealansh @0x4A6F @wahjava @pyrox0

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
