### PR TITLE
nixos-containers: fix enableTun option

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -705,7 +705,7 @@ in
             allowedDevices = mkOption {
               type = with types; listOf (submodule allowedDeviceOpts);
               default = [];
-              example = [ { node = "/dev/net/tun"; modifier = "rw"; } ];
+              example = [ { node = "/dev/net/tun"; modifier = "rwm"; } ];
               description = ''
                 A list of device nodes to which the containers has access to.
               '';
@@ -835,7 +835,7 @@ in
             optionalAttrs cfg.enableTun
               {
                 allowedDevices = cfg.allowedDevices
-                  ++ [ { node = "/dev/net/tun"; modifier = "rw"; } ];
+                  ++ [ { node = "/dev/net/tun"; modifier = "rwm"; } ];
                 additionalCapabilities = cfg.additionalCapabilities
                   ++ [ "CAP_NET_ADMIN" ];
               }


### PR DESCRIPTION
After upgrading to `24.11`, my container failed to start:

```
Nov 19 14:29:18 nixos-oci systemd[1]: Starting Container 'web'...
Nov 19 14:29:18 nixos-oci systemd-nspawn[159842]: ░ Spawning container web on /var/lib/nixos-containers/web.
Nov 19 14:29:18 nixos-oci systemd-nspawn[159852]: Selected user namespace base 76480512 and range 65536.
Nov 19 14:29:18 nixos-oci systemd-nspawn[159852]: mknod(/var/lib/nixos-containers/web/dev/net/tun) failed: Operation not permitted
Nov 19 14:29:18 nixos-oci systemd[1]: run-systemd-nspawn-unix\x2dexport-web.mount: Deactivated successfully.
Nov 19 14:29:18 nixos-oci systemd[1]: container@web.service: Main process exited, code=exited, status=1/FAILURE
Nov 19 14:29:18 nixos-oci systemd[1]: container@web.service: Failed with result 'exit-code'.
Nov 19 14:29:18 nixos-oci systemd[1]: Failed to start Container 'web'.
Nov 19 14:29:18 nixos-oci systemd[1]: container@web.service: Scheduled restart job, restart counter is at 5.
Nov 19 14:29:18 nixos-oci systemd[1]: container@web.service: Start request repeated too quickly.
Nov 19 14:29:18 nixos-oci systemd[1]: container@web.service: Failed with result 'exit-code'.
Nov 19 14:29:18 nixos-oci systemd[1]: Failed to start Container 'web'.
```

I found this other helpful comment on discourse: https://discourse.nixos.org/t/error-cannot-open-tun-tap-dev-dev-net-tun-inside-systemd-nspawn-container/18079/4?u=paulgrandperrin and it works.

Looking a title bit into it, it makes sense to me: when using private users, `mknod /dev/net/tun` is run from the guest and therefor needs the `m` modifier.

Recent contributors: @r-vdp  @K900 @Sohalt @Gabriella439 @fpletz 



