### PR TITLE
[Backport release-24.11] dxvk_2: 2.4 -> 2.5

### DIFF
--- a/pkgs/by-name/dx/dxvk_2/package.nix
+++ b/pkgs/by-name/dx/dxvk_2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   pkgsBuildHost,
   glslang,
   meson,
@@ -37,15 +38,28 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dxvk";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "doitsujin";
     repo = "dxvk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4U0Z1oR0BKIHZ6YNT/+8sFe2I/ZKmPecInMXUho4MHg=";
+    hash = "sha256-JwEKmzYnoDhad0VKadQYEqraMogXn7BFI9kmT9F+Ts0=";
     fetchSubmodules = true; # Needed for the DirectX headers and libdisplay-info
   };
+
+  patches = [
+    # Fixes `ERROR: Index 2 out of bounds of array of size 2` error on native builds.
+    (fetchpatch2 {
+      url = "https://github.com/doitsujin/dxvk/commit/e6209d28cd9c51ad371605db4c0de27547c0d28c.patch?full_index=1";
+      hash = "sha256-zKO6YXOUKBnwcijzCldDzmDqXSkf+wWe9KmUlhsaTyM=";
+    })
+    # Fixes missing symbol error when building with GLFW support enabled.
+    (fetchpatch2 {
+      url = "https://github.com/doitsujin/dxvk/commit/62ef4854a6accf2b042f25f44db667abadc0b3fd.patch?full_index=1";
+      hash = "sha256-oXybFqoD68gTLHO1kDHll4XCfpU+s9E+PmaXQFqEy/g=";
+    })
+  ];
 
   postPatch =
     ''
@@ -102,5 +116,12 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.zlib;
     badPlatforms = lib.platforms.darwin;
     platforms = lib.platforms.windows ++ lib.platforms.unix;
+    pkgConfigModules = [
+      "dxvk-d3d10core"
+      "dxvk-d3d11"
+      "dxvk-d3d8"
+      "dxvk-d3d9"
+      "dxvk-dxgi"
+    ];
   };
 })


### PR DESCRIPTION
https://github.com/doitsujin/dxvk/releases/tag/v2.5

(cherry picked from commit e0d0c3932b807d332666600264dc165979b49213)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
