### PR TITLE
rustup: add missing rust-darwin-setup script for ld-wrapper

### DIFF
--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -105,6 +105,7 @@ rustPlatform.buildRustPackage rec {
     # add a wrapper script for ld.lld
     mkdir -p $out/nix-support
     substituteAll ${../../../../../pkgs/build-support/wrapper-common/utils.bash} $out/nix-support/utils.bash
+    substituteAll ${../../../../../pkgs/build-support/wrapper-common/darwin-sdk-setup.bash} $out/nix-support/darwin-sdk-setup.bash
     substituteAll ${../../../../../pkgs/build-support/bintools-wrapper/add-flags.sh} $out/nix-support/add-flags.sh
     substituteAll ${../../../../../pkgs/build-support/bintools-wrapper/add-hardening.sh} $out/nix-support/add-hardening.sh
     export prog='$PROG'


### PR DESCRIPTION
This adds a missing `rust-darwin-setup.bash` script to the `nix-support` files of the `rustup` package.

This file is referenced by the included `ld-wrapper.sh`...
https://github.com/NixOS/nixpkgs/blob/262b6bfde05bc8bec0eda392ee930053522d6a80/pkgs/build-support/bintools-wrapper/ld-wrapper.sh#L19

...which is included in the `rustup` derivation's `postInstall` here:
https://github.com/NixOS/nixpkgs/blob/262b6bfde05bc8bec0eda392ee930053522d6a80/pkgs/development/tools/rust/rustup/default.nix#L112

This PR brings the included files in line with the `bintools-wrapper` derivation:
https://github.com/NixOS/nixpkgs/blob/262b6bfde05bc8bec0eda392ee930053522d6a80/pkgs/build-support/bintools-wrapper/default.nix#L372-L375

Without this fix, compiling certain crates results in errors like the following:

```
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/users/leons/.rustup/toolchains/nightly [...] "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: /nix/store/d1hc6cf5xdsak1r71af8l0aqvli0d0nc-rustup-1.27.1/nix-support/ld-wrapper.sh: line 19: /nix/store/d1hc6cf5xdsak1r71af8l0aqvli0d0nc-rustup-1.27.1/nix-support/darwin-sdk-setup.bash: No such file or directory
          collect2: error: ld returned 1 exit status
          

error: could not compile `clang-sys` (build script) due to 1 previous error
```

Unfortunately, I only manage to reproduce this compiling crates in a certain workspace (https://github.com/encapfn/encapfn-mpk), on a non-NixOS system with a Nix multi-user install (Ubuntu 22.04 with latest nixpkgs-unstable). That being said, this fix seems uncontroversial: we're referencing a file that doesn't exist, so we should make sure it exists. :smile: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
