### PR TITLE
Revert "opentelemetry-collector-contrib: 0.110.0 -> 0.112.0"

### DIFF
--- a/pkgs/tools/misc/opentelemetry-collector/contrib.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/contrib.nix
@@ -8,18 +8,18 @@
 
 buildGoModule rec {
   pname = "opentelemetry-collector-contrib";
-  version = "0.112.0";
+  version = "0.110.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-collector-contrib";
     rev = "v${version}";
-    hash = "sha256-EWmSN9PfbNxEyRCz07pVQa1b0eQ9eq7LsrF2euWmz7E=";
+    hash = "sha256-bDtP7EFKus0NJpLccbD+HlzEusc+KAbKWmS/KGthtwY=";
   };
 
   # proxy vendor to avoid hash mismatches between linux and macOS
   proxyVendor = true;
-  vendorHash = null;
+  vendorHash = "sha256-pDDEqtXu167b+J1+k7rC1BE5/ehxzG0ZAkhxqmJpHsg=";
 
   # there is a nested go.mod
   sourceRoot = "${src.name}/cmd/otelcontribcol";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#351600

The output was empty.