### PR TITLE
cockpitPlugins.cockpit-machines: init at 323

### DIFF
--- a/pkgs/servers/monitoring/cockpit/cockpit-machines/default.nix
+++ b/pkgs/servers/monitoring/cockpit/cockpit-machines/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  cockpit,
+  nodejs,
+  gettext,
+  writeShellScriptBin,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cockpit-machines";
+  version = "323";
+
+  src = fetchFromGitHub {
+    owner = "cockpit-project";
+    repo = "cockpit-machines";
+    rev = "refs/tags/${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-7JWUwYGnxPq+/B1MXu8cOMptvj8P1htlgF2yOtVaNH4=";
+
+    postFetch = ''
+      cp $out/node_modules/.package-lock.json $out/package-lock.json
+    '';
+  };
+
+  buildInputs = [
+    nodejs
+    gettext
+    (writeShellScriptBin "git" "true")
+  ];
+
+  cockpitSrc = cockpit.src;
+
+  postPatch = ''
+    mkdir -p pkg; cp -r $cockpitSrc/pkg/lib pkg
+    mkdir -p test; cp -r $cockpitSrc/test/static-code test
+    mkdir -p test; cp -r $cockpitSrc/test/common test
+
+    substituteInPlace Makefile \
+      --replace-fail '$(MAKE) package-lock.json' 'true' \
+      --replace-fail '$(COCKPIT_REPO_FILES) | tar x' "" \
+      --replace-fail '/usr/local' "$out"
+    patchShebangs build.js
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Cockpit UI for virtual machines";
+    homepage = "https://github.com/cockpit-project/cockpit-machines";
+    changelog = "https://github.com/cockpit-project/cockpit-machines/releases/tag/${finalAttrs.version}";
+    license = [ lib.licenses.lgpl21 ];
+    maintainers = [ lib.maintainers.lucasew ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16964,6 +16964,9 @@ with pkgs;
     protobuf = protobuf_21;
   };
 
+  cockpitPlugins = recurseIntoAttrs
+    (callPackage ./cockpit-plugins.nix {} cockpit);
+
   construoBase = lowPrio (callPackage ../games/construo {
     libGL = null;
     libGLU = null;

--- a/pkgs/top-level/cockpit-plugins.nix
+++ b/pkgs/top-level/cockpit-plugins.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  newScope,
+  pkgs,
+  config,
+}:
+
+cockpit:
+(lib.makeScope newScope (self: {
+  inherit cockpit;
+
+  cockpit-machines = self.callPackage ../servers/monitoring/cockpit/cockpit-machines { };
+}))


### PR DESCRIPTION
- **cockpitPlugins.cockpit-machines: init at 323**

- Introduce the cockpitPlugins scope
- Introduce the first cockpit plugin: cockpit-machines

Closes #287644

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
