### PR TITLE
prusa-slicer: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -3,6 +3,7 @@
 , binutils
 , fetchFromGitHub
 , fetchpatch
+, fetchurl
 , cmake
 , pkg-config
 , wrapGAppsHook3

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -50,7 +50,7 @@ let
       sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
     };
   });
-  eigen = eigen.overrideAttrs (old: {
+  eigen-prusa = eigen.overrideAttrs (old: {
     name = "eigen-3.3.7";
     src = fetchurl {
       url = "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz";
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     cgal
     curl
     dbus
-    eigen
+    eigen-prusa
     expat
     glew
     glib

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -49,6 +49,15 @@ let
       sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
     };
   });
+  eigen = eigen.overrideAttrs (old: {
+    name = "eigen-3.3.7";
+    src = fetchurl {
+      url = "https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz";
+      name = "eigen-3.3.7.tar.gz";
+      sha256 = "1nnh0v82a5xibcjaph51mx06mxbllk77fvihnd5ba0kpl23yz13y";
+    };
+    patches = [ ./include-dir.patch ];
+  });
   wxGTK-prusa = wxGTK32.overrideAttrs (old: rec {
     pname = "wxwidgets-prusa3d-patched";
     version = "3.2.0";

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -37,6 +37,7 @@
 , catch2
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 , wxGTK-override ? null
+, webkitgtk_4_1
 }:
 let
   opencascade-occt = opencascade-occt_7_6;
@@ -126,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     libbgcode
     heatshrink
     catch2
+    webkitgtk_4_1
   ] ++ lib.optionals withSystemd [
     systemd
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -40,7 +40,15 @@
 , webkitgtk_4_1
 }:
 let
-  opencascade-occt = opencascade-occt_7_6;
+  opencascade-occt = opencascade-occt_7_6.overrideAttrs (old: {
+    version = "7.6.1";
+    src = fetchFromGitHub {
+      owner = "Open-Cascade-SAS";
+      repo = "OCCT";
+      rev = "V7_6_1";
+      sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
+    };
+  });
   wxGTK-prusa = wxGTK32.overrideAttrs (old: rec {
     pname = "wxwidgets-prusa3d-patched";
     version = "3.2.0";

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -53,9 +53,9 @@ let
   eigen = eigen.overrideAttrs (old: {
     name = "eigen-3.3.7";
     src = fetchurl {
-      url = "https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz";
+      url = "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz";
       name = "eigen-3.3.7.tar.gz";
-      sha256 = "1nnh0v82a5xibcjaph51mx06mxbllk77fvihnd5ba0kpl23yz13y";
+      sha256 = "sha256-1W+62Vq/mT+K9ghIRynj2H72Ed2FszgKi60dXLw3Olc=";
     };
     patches = [ ./include-dir.patch ];
   });

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -81,13 +81,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prusa-slicer";
-  version = "2.8.0";
+  version = "2.8.1";
   inherit patches;
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "PrusaSlicer";
-    hash = "sha256-A/uxNIEXCchLw3t5erWdhqFAeh6nudcMfASi+RoJkFg=";
+    hash = "sha256-nMLZvvZLIOChCLn8A9sOph1lqWsHb00eTG8z98/l0C8=";
     rev = "version_${finalAttrs.version}";
   };
 

--- a/pkgs/applications/misc/prusa-slicer/include-dir.patch
+++ b/pkgs/applications/misc/prusa-slicer/include-dir.patch
@@ -1,0 +1,49 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(Eigen3)
+ 
+-cmake_minimum_required(VERSION 2.8.5)
++cmake_minimum_required(VERSION 3.7)
+ 
+ # guard against in-source builds
+ 
+@@ -408,13 +408,6 @@ install(FILES
+   DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
+   )
+ 
+-if(EIGEN_BUILD_PKGCONFIG)
+-    configure_file(eigen3.pc.in eigen3.pc @ONLY)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
+-        DESTINATION ${PKGCONFIG_INSTALL_DIR}
+-        )
+-endif()
+-
+ add_subdirectory(Eigen)
+ 
+ add_subdirectory(doc EXCLUDE_FROM_ALL)
+@@ -510,8 +503,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
+ set ( EIGEN_VERSION_MINOR  ${EIGEN_MAJOR_VERSION} )
+ set ( EIGEN_VERSION_PATCH  ${EIGEN_MINOR_VERSION} )
+ set ( EIGEN_DEFINITIONS "")
+-set ( EIGEN_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}" )
+ set ( EIGEN_ROOT_DIR ${CMAKE_INSTALL_PREFIX} )
++GNUInstallDirs_get_absolute_install_dir(EIGEN_INCLUDE_DIR INCLUDE_INSTALL_DIR)
++
++if(EIGEN_BUILD_PKGCONFIG)
++    configure_file(eigen3.pc.in eigen3.pc @ONLY)
++    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
++        DESTINATION ${PKGCONFIG_INSTALL_DIR}
++        )
++endif()
+ 
+ # Interface libraries require at least CMake 3.0
+ if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+--- a/eigen3.pc.in
++++ b/eigen3.pc.in
+@@ -6,4 +6,4 @@ Description: A C++ template library for linear algebra: vectors, matrices, and r
+ Requires:
+ Version: @EIGEN_VERSION_NUMBER@
+ Libs:
+-Cflags: -I${prefix}/@INCLUDE_INSTALL_DIR@
++Cflags: -I@EIGEN_INCLUDE_DIR@


### PR DESCRIPTION
Updated PrusaSlicer to version 2.8.1 and included required dependencies.

https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.8.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
