### PR TITLE
cantata: use nullobsi fork at v3.3.0

### DIFF
--- a/pkgs/by-name/ca/cantata/dont-check-for-perl-in-PATH.diff
+++ b/pkgs/by-name/ca/cantata/dont-check-for-perl-in-PATH.diff
@@ -1,17 +1,16 @@
 diff --git a/playlists/dynamicplaylists.cpp b/playlists/dynamicplaylists.cpp
-index 07b6dce3..6a3f97c9 100644
+index b85e93b5..3c29f775 100644
 --- a/playlists/dynamicplaylists.cpp
 +++ b/playlists/dynamicplaylists.cpp
-@@ -211,11 +211,6 @@ void DynamicPlaylists::start(const QString &name)
-         return;
-     }
+@@ -205,11 +205,6 @@ void DynamicPlaylists::start(const QString& name)
+ 		return;
+ 	}
  
--    if (Utils::findExe("perl").isEmpty()) {
--        emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
--        return;
--    }
+-	if (Utils::findExe("perl").isEmpty()) {
+-		emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
+-		return;
+-	}
 -
-     QString fName(Utils::dataDir(rulesDir, false)+name+constExtension);
+ 	QString fName(Utils::dataDir(rulesDir, false) + name + constExtension);
  
-     if (!QFile::exists(fName)) {
-
+ 	if (!QFile::exists(fName)) {

--- a/pkgs/by-name/ca/cantata/package.nix
+++ b/pkgs/by-name/ca/cantata/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  qt5,
+  qt6,
   perl,
 
   # Cantata doesn't build with cdparanoia enabled so we disable that
@@ -19,7 +19,7 @@
   libmusicbrainz5,
 
   withTaglib ? true,
-  taglib,
+  taglib2,
   taglib_extras,
   withHttpStream ? true,
   withReplaygain ? true,
@@ -100,7 +100,7 @@ let
     {
       names = [ "HTTP_STREAM_PLAYBACK" ];
       enable = withHttpStream;
-      pkgs = [ qt5.qtmultimedia ];
+      pkgs = [ qt6.qtmultimedia ];
     }
     {
       names = [ "LAME" ];
@@ -139,7 +139,7 @@ let
       ];
       enable = withTaglib;
       pkgs = [
-        taglib
+        taglib2
         taglib_extras
       ];
     }
@@ -153,13 +153,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cantata";
-  version = "2.5.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
-    owner = "CDrummond";
+    owner = "nullobsi";
     repo = "cantata";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-UaZEKZvCA50WsdQSSJQQ11KTK6rM4ouCHDX7pn3NlQw=";
+    hash = "sha256-dx0XkMUrxg3+c3fxhXjYK36x5M8xbX+IyVAalvib2iY=";
   };
 
   patches = [
@@ -174,16 +174,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qtsvg
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
     (perl.withPackages (ppkgs: with ppkgs; [ URI ]))
   ] ++ lib.flatten (builtins.catAttrs "pkgs" (builtins.filter (e: e.enable) options));
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    qt5.qttools
-    qt5.wrapQtAppsHook
+    qt6.qttools
+    qt6.wrapQtAppsHook
   ];
 
   cmakeFlags = lib.flatten (map (e: map (f: fstat e.enable f) e.names) options);

--- a/pkgs/by-name/ta/taglib/2.x.nix
+++ b/pkgs/by-name/ta/taglib/2.x.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, zlib
+, testers
+, utf8cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "taglib";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "taglib";
+    repo = "taglib";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-zoZir1TtYtEEZBudlGRLYPFIFJl5oad4+l64lytJ+bc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib utf8cpp ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    # Workaround unconditional ${prefix} until upstream is fixed:
+    #   https://github.com/taglib/taglib/issues/1098
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    homepage = "https://taglib.org/";
+    description = "A library for reading and editing audio file metadata";
+    mainProgram = "taglib-config";
+    longDescription = ''
+      TagLib is a library for reading and editing the meta-data of several
+      popular audio formats. Currently it supports both ID3v1 and ID3v2 for MP3
+      files, Ogg Vorbis comments and ID3 tags and Vorbis comments in FLAC, MPC,
+      Speex, WavPack, TrueAudio, WAV, AIFF, MP4 and ASF files.
+    '';
+    license = with licenses; [ lgpl3 mpl11 ];
+    maintainers = with maintainers; [ ttuegel ];
+    pkgConfigModules = [ "taglib" "taglib_c" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11116,6 +11116,8 @@ with pkgs;
 
   tageditor = libsForQt5.callPackage ../applications/audio/tageditor { };
 
+  taglib2 = callPackage ../by-name/ta/taglib/2.x.nix { };
+
   tclap = tclap_1_2;
 
   tclap_1_2 = callPackage ../development/libraries/tclap/1.2.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19217,10 +19217,6 @@ with pkgs;
     fltk = fltk13;
   };
 
-  cantata = callPackage ../by-name/ca/cantata/package.nix {
-    ffmpeg = ffmpeg_6;
-  };
-
   tree-from-tags = callPackage ../by-name/tr/tree-from-tags/package.nix {
     ruby = ruby_3_1;
   };


### PR DESCRIPTION
Original developer archived the repo a few years ago: https://github.com/CDrummond/cantata

Switch to nulllobsi fork, which among other fixes, updates to Qt6 and supports ffmpeg7.
See https://github.com/nullobsi/cantata/releases for changelog information.

Includes new package for taglib 2.x

Based on PR #317834
closes #315695

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
