### PR TITLE
poppler: format, add dependency for glib-mkenums to fix cross building

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,39 +1,46 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchFromGitLab
-, fetchpatch
-, cairo
-, cmake
-, boost
-, curl
-, fontconfig
-, freetype
-, lcms
-, libiconv
-, libintl
-, libjpeg
-, ninja
-, openjpeg
-, pkg-config
-, python3
-, zlib
-, withData ? true, poppler_data
-, qt5Support ? false, qt6Support ? false, qtbase ? null
-, introspectionSupport ? false, gobject-introspection ? null
-, gpgmeSupport ? false, gpgme ? null
-, utils ? false, nss ? null
-, minimal ? false
-, suffix ? "glib"
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitLab,
+  fetchpatch,
+  cairo,
+  cmake,
+  boost,
+  curl,
+  fontconfig,
+  freetype,
+  lcms,
+  libiconv,
+  libintl,
+  libjpeg,
+  ninja,
+  openjpeg,
+  pkg-config,
+  python3,
+  zlib,
+  withData ? true,
+  poppler_data,
+  qt5Support ? false,
+  qt6Support ? false,
+  qtbase ? null,
+  introspectionSupport ? false,
+  gobject-introspection ? null,
+  gpgmeSupport ? false,
+  gpgme ? null,
+  utils ? false,
+  nss ? null,
+  minimal ? false,
+  suffix ? "glib",
 
-# for passthru.tests
-, cups-filters
-, gdal
-, gegl
-, inkscape
-, pdfslicer
-, scribus
-, vips
+  # for passthru.tests
+  cups-filters,
+  gdal,
+  gegl,
+  inkscape,
+  pdfslicer,
+  scribus,
+  vips,
 }:
 
 let
@@ -55,7 +62,10 @@ stdenv.mkDerivation (finalAttrs: rec {
   pname = "poppler-${suffix}";
   version = "24.02.0"; # beware: updates often break cups-filters build, check scribus too!
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   src = fetchurl {
     url = "https://poppler.freedesktop.org/poppler-${version}.tar.xz";
@@ -86,49 +96,58 @@ stdenv.mkDerivation (finalAttrs: rec {
     python3
   ];
 
-  buildInputs = [
-    boost
-    libiconv
-    libintl
-  ] ++ lib.optionals withData [
-    poppler_data
-  ];
+  buildInputs =
+    [
+      boost
+      libiconv
+      libintl
+    ]
+    ++ lib.optionals withData [
+      poppler_data
+    ];
 
   # TODO: reduce propagation to necessary libs
-  propagatedBuildInputs = [
-    zlib
-    freetype
-    fontconfig
-    libjpeg
-    openjpeg
-  ] ++ lib.optionals (!minimal) [
-    cairo
-    lcms
-    curl
-    nss
-  ] ++ lib.optionals (qt5Support || qt6Support) [
-    qtbase
-  ] ++ lib.optionals introspectionSupport [
-    gobject-introspection
-  ] ++ lib.optionals gpgmeSupport [
-    gpgme
-  ];
+  propagatedBuildInputs =
+    [
+      zlib
+      freetype
+      fontconfig
+      libjpeg
+      openjpeg
+    ]
+    ++ lib.optionals (!minimal) [
+      cairo
+      lcms
+      curl
+      nss
+    ]
+    ++ lib.optionals (qt5Support || qt6Support) [
+      qtbase
+    ]
+    ++ lib.optionals introspectionSupport [
+      gobject-introspection
+    ]
+    ++ lib.optionals gpgmeSupport [
+      gpgme
+    ];
 
-  cmakeFlags = [
-    (mkFlag true "UNSTABLE_API_ABI_HEADERS") # previously "XPDF_HEADERS"
-    (mkFlag (!minimal) "GLIB")
-    (mkFlag (!minimal) "CPP")
-    (mkFlag (!minimal) "LIBCURL")
-    (mkFlag (!minimal) "LCMS")
-    (mkFlag (!minimal) "LIBTIFF")
-    (mkFlag (!minimal) "NSS3")
-    (mkFlag utils "UTILS")
-    (mkFlag qt5Support "QT5")
-    (mkFlag qt6Support "QT6")
-    (mkFlag gpgmeSupport "GPGME")
-  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
-    "-DTESTDATADIR=${testData}"
-  ];
+  cmakeFlags =
+    [
+      (mkFlag true "UNSTABLE_API_ABI_HEADERS") # previously "XPDF_HEADERS"
+      (mkFlag (!minimal) "GLIB")
+      (mkFlag (!minimal) "CPP")
+      (mkFlag (!minimal) "LIBCURL")
+      (mkFlag (!minimal) "LCMS")
+      (mkFlag (!minimal) "LIBTIFF")
+      (mkFlag (!minimal) "NSS3")
+      (mkFlag utils "UTILS")
+      (mkFlag qt5Support "QT5")
+      (mkFlag qt6Support "QT6")
+      (mkFlag gpgmeSupport "GPGME")
+    ]
+    ++ lib.optionals finalAttrs.finalPackage.doCheck [
+      "-DTESTDATADIR=${testData}"
+    ];
   disallowedReferences = lib.optional finalAttrs.finalPackage.doCheck testData;
 
   dontWrapQtApps = true;
@@ -159,13 +178,13 @@ stdenv.mkDerivation (finalAttrs: rec {
         cups-filters
         inkscape
         scribus
-      ;
+        ;
 
       inherit
         gegl
         pdfslicer
         vips
-      ;
+        ;
       gdal = gdal.override { usePoppler = true; };
       python-poppler-qt5 = python3.pkgs.poppler-qt5;
     };

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -10,6 +10,7 @@
   curl,
   fontconfig,
   freetype,
+  glib,
   lcms,
   libiconv,
   libintl,
@@ -94,6 +95,8 @@ stdenv.mkDerivation (finalAttrs: rec {
     ninja
     pkg-config
     python3
+  ] ++ lib.optionals (!minimal) [
+    glib # for glib-mkenums
   ];
 
   buildInputs =
@@ -190,7 +193,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://poppler.freedesktop.org/";
     changelog = "https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-${version}/NEWS";
     description = "PDF rendering library";
@@ -198,8 +201,8 @@ stdenv.mkDerivation (finalAttrs: rec {
       Poppler is a PDF rendering library based on the xpdf-3.0 code base. In
       addition it provides a number of tools that can be installed separately.
     '';
-    license = licenses.gpl2Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ ttuegel ] ++ teams.freedesktop.members;
+    license = with lib.licenses; [ gpl2Plus ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ttuegel ] ++ lib.teams.freedesktop.members;
   };
 })


### PR DESCRIPTION
Cross-building poppler is broken:

```
nix build .#pkgsCross.aarch64-multiplatform.poppler
error: builder for '/nix/store/xkgfqac2i1wz692ijvhqrb06gd2y2hba-poppler-glib-aarch64-unknown-linux-gnu-24.02.0.drv' failed with exit code 1;
       last 25 log lines:
       > [136/184] Building CXX object cpp/CMakeFiles/poppler-cpp.dir/poppler-document.cpp.o
       > [137/184] Building CXX object cpp/CMakeFiles/poppler-cpp.dir/poppler-toc.cpp.o
       > [138/184] Building CXX object test/CMakeFiles/cairo-thread-test.dir/__/poppler/CairoRescaleBox.cc.o
       > [139/184] Building CXX object test/CMakeFiles/pdf-fullrewrite.dir/__/utils/parseargs.cc.o
       > [140/184] Building CXX object cpp/CMakeFiles/poppler-cpp.dir/poppler-page.cpp.o
       > [141/184] Building CXX object CMakeFiles/poppler.dir/poppler/PSOutputDev.cc.o
       > [142/184] Building CXX object test/CMakeFiles/image-embedding.dir/__/utils/parseargs.cc.o
       > [143/184] Building CXX object cpp/tests/CMakeFiles/poppler-dump.dir/__/__/utils/parseargs.cc.o
       > [144/184] Linking CXX shared library libpoppler.so.134.0.0
       > [145/184] Creating library symlink libpoppler.so.134 libpoppler.so
       > [146/184] Generating poppler-enums.h
       > FAILED: glib/poppler-enums.h /build/poppler-24.02.0/build/glib/poppler-enums.h
       > cd /build/poppler-24.02.0/glib && /nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7/bin/python3 GLIB2_MKENUMS-NOTFOUND --template poppler-enums.h.template poppler-action.h poppler-date.h poppler-document.h poppler-page.h poppler-attachment.h poppler-form-field.h poppler-annot.h poppler-layer.h poppler-movie.h poppler-media.h poppler.h poppler-structure-element.h > /build/poppler-24.02.0/build/glib/poppler-enums.h
       > /nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7/bin/python3: can't open file '/build/poppler-24.02.0/glib/GLIB2_MKENUMS-NOTFOUND': [Errno 2] No such file or directory
       > [147/184] Building CXX object test/CMakeFiles/perf-test.dir/perf-test.cc.o
       > [148/184] Linking CXX shared library cpp/libpoppler-cpp.so.0.11.0
       > [149/184] Building CXX object cpp/tests/CMakeFiles/poppler-render.dir/__/__/utils/parseargs.cc.o
       > [150/184] Building CXX object test/CMakeFiles/image-embedding.dir/image-embedding.cc.o
       > [151/184] Building CXX object cpp/tests/CMakeFiles/poppler-render.dir/poppler-render.cpp.o
       > [152/184] Building CXX object test/CMakeFiles/pdf-fullrewrite.dir/pdf-fullrewrite.cc.o
       > [153/184] Building CXX object cpp/tests/CMakeFiles/poppler-dump.dir/poppler-dump.cpp.o
       > [154/184] Building CXX object test/CMakeFiles/cairo-thread-test.dir/__/poppler/CairoFontEngine.cc.o
       > [155/184] Building CXX object test/CMakeFiles/cairo-thread-test.dir/cairo-thread-test.cc.o
       > [156/184] Building CXX object test/CMakeFiles/cairo-thread-test.dir/__/poppler/CairoOutputDev.cc.o
       > ninja: build stopped: subcommand failed.
       For full logs, run 'nix log /nix/store/xkgfqac2i1wz692ijvhqrb06gd2y2hba-poppler-glib-aarch64-unknown-linux-gnu-24.02.0.drv'.
```

This PR adds the missing dependency on `glib-mkenums`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
