### PR TITLE
copacetic: init at 0.9.0

### DIFF
--- a/pkgs/by-name/co/copacetic/package.nix
+++ b/pkgs/by-name/co/copacetic/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  installShellFiles,
+  versionCheckHook,
+}:
+buildGoModule rec {
+  pname = "copacetic";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "project-copacetic";
+    repo = "copacetic";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hvSbjkqrd//thUex2It31Z4Vrj1u07WEAQFAnWiPo6M=";
+  };
+
+  vendorHash = "sha256-eefYbB88wXQME8ehm/ieVBtOmmtxHkZSsjE05yeQ7Gw=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  CGO_ENABLED = "0";
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/project-copacetic/copacetic/pkg/version.GitVersion=${version}"
+    "-X main.version=${version}"
+  ];
+
+  checkFlags =
+    let
+      # Skip tests that require network access
+      skippedTests = [
+        "TestNewClient/custom_buildkit_addr"
+        "TestPatch"
+        "TestPlugins/docker.io"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+
+  postInstall =
+    ''
+      mv $out/bin/copacetic $out/bin/copa
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd copa \
+        --bash <($out/bin/copa completion bash) \
+        --fish <($out/bin/copa completion fish) \
+        --zsh <($out/bin/copa completion zsh)
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://project-copacetic.github.io/copacetic/";
+    description = "Tool for directly patching vulnerabilities in container images";
+    license = lib.licenses.asl20;
+    mainProgram = "copa";
+    maintainers = with lib.maintainers; [ bmanuel ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Copacetic is a CNCF sandbox project that can be used to patch vulnerabilities in container images. https://project-copacetic.github.io/copacetic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
