### PR TITLE
factorio_achievement_enabler_linux: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8729,6 +8729,13 @@
     githubId = 982322;
     name = "Henrik Olsson";
   };
+  henriquelay = {
+    email = "nixpkgs@layber.bulc.club";
+    github = "henriquelay";
+    githubId = 37563861;
+    name = "Henrique Layber";
+    keys = [ { fingerprint = "B390 3EAC 57AD 1331 995C  D962 0284 3DDA 217C 9D81"; } ];
+  };
   henrirosten = {
     email = "henri.rosten@unikie.com";
     github = "henrirosten";

--- a/pkgs/by-name/fa/factorio_achievement_enabler_linux/package.nix
+++ b/pkgs/by-name/fa/factorio_achievement_enabler_linux/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "factorio_achievement_enabler_linux";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "UnlegitSenpaii";
+    repo = "FAE_Linux";
+    rev = "v${version}";
+    hash = "sha256-lm/s9rc4/2TIT2mzIPwdFoPB9GZm4qluK2yVoL7KwnE";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 out/bin/FAE_Linux $out/bin/fae_linux
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Factorio Achievement Enabler for Linux";
+    homepage = "https://github.com/UnlegitSenpaii/FAE_Linux";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ henriquelay ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "fae_linux";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds Factorio Achievement Enabler (FAE_Linux) at version v1.3.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Tested manually on Factorio 2.0.20 (build 80511 with the expansion), from steam-fhs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
