### PR TITLE
gf: unstable-2023-08-09 -> 0-unstable-2024-08-21; include extensions and add plugin support

### DIFF
--- a/pkgs/by-name/gf/gf/package.nix
+++ b/pkgs/by-name/gf/gf/package.nix
@@ -1,45 +1,58 @@
-{ lib
-, stdenv
-, makeWrapper
-, fetchFromGitHub
-, libX11
-, pkg-config
-, gdb
-, freetype
-, freetypeSupport ? true
-, extensions ? [ ]
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  fetchFromGitHub,
+  libX11,
+  pkg-config,
+  gdb,
+  freetype,
+  freetypeSupport ? true,
+  withExtensions ? true,
+  extraFlags ? "",
+  pluginsFile ? null,
 }:
 
 stdenv.mkDerivation {
   pname = "gf";
-  version = "unstable-2023-08-09";
+  version = "0-unstable-2024-08-21";
 
   src = fetchFromGitHub {
     repo = "gf";
     owner = "nakst";
-    rev = "4190211d63c1e5378a9e841d22fa2b96a1099e68";
-    hash = "sha256-28Xgw/KxwZ94r/TXsdISeUtXHSips4irB0D+tEefMYE=";
+    rev = "40f2ae604f3b94b7f818680ac53d4683c629bcf3";
+    hash = "sha256-Z8hW/GQjnnojoLeetrBlMnAJ9sP9ELv1lSQJjYPxtRc=";
   };
 
-  nativeBuildInputs = [ makeWrapper pkg-config ];
-  buildInputs = [ libX11 gdb ]
-    ++ lib.optional freetypeSupport freetype;
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+  buildInputs = [
+    libX11
+    gdb
+  ] ++ lib.optional freetypeSupport freetype;
 
   patches = [
     ./build-use-optional-freetype-with-pkg-config.patch
   ];
 
-  postPatch = lib.forEach extensions (ext: ''
-      cp ${ext} ./${ext.name or (builtins.baseNameOf ext)}
-  '');
+  postPatch = [
+    (lib.optionalString withExtensions ''
+      cp ./extensions_v5/extensions.cpp .
+    '')
+    (lib.optionalString (pluginsFile != null) ''
+      cp ${pluginsFile} ./plugins.cpp
+    '')
+  ];
 
-   preConfigure = ''
-     patchShebangs build.sh
-   '';
+  preConfigure = ''
+    patchShebangs build.sh
+  '';
 
   buildPhase = ''
     runHook preBuild
-    extra_flags=-DUI_FREETYPE_SUBPIXEL ./build.sh
+    extra_flags="${extraFlags} -DUI_FREETYPE_SUBPIXEL" ./build.sh
     runHook postBuild
   '';
 
@@ -51,7 +64,7 @@ stdenv.mkDerivation {
   '';
 
   postFixup = ''
-    wrapProgram $out/bin/gf2 --prefix PATH : ${lib.makeBinPath[ gdb ]}
+    wrapProgram $out/bin/gf2 --prefix PATH : ${lib.makeBinPath [ gdb ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
- bumped version to unstable-2024-08-21 ([changelog](https://github.com/nakst/gf/compare/4190211d63c1e5378a9e841d22fa2b96a1099e68..40f2ae604f3b94b7f818680ac53d4683c629bcf3));
- the developer has released freely their previously paywalled extensions: I've added a parameter (default on) to include such extensions;
- reading gf's README, there is a [section](https://github.com/nakst/gf?tab=readme-ov-file#plugins) about plugin support; I don't use them but I figured this make it easier for NixOS users who do.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
