### PR TITLE
python312Packages.forecast-solar: 3.1.0 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/forecast-solar/default.nix
+++ b/pkgs/development/python-modules/forecast-solar/default.nix
@@ -2,16 +2,22 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
   pythonOlder,
   aiodns,
   aiohttp,
+  aresponses,
+  poetry-core,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-freezer,
   pytestCheckHook,
+  syrupy,
+  yarl,
 }:
 
 buildPythonPackage rec {
   pname = "forecast-solar";
-  version = "3.1.0";
+  version = "4.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -20,21 +26,42 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "forecast_solar";
     rev = "refs/tags/v${version}";
-    hash = "sha256-iol0XtfPZI95o/uEyBcXgeQjcfl2kI+4mugtywa6BXI=";
+    hash = "sha256-lWP4ZG195IuP8E9n53EkvdIs3aVTYeEc171Yh3EngOI=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ poetry-core ];
 
   env.PACKAGE_VERSION = version;
 
   dependencies = [
     aiodns
     aiohttp
+    yarl
   ];
 
   pythonImportsCheck = [ "forecast_solar" ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    aresponses
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-freezer
+    pytestCheckHook
+    syrupy
+  ];
+
+  disabledTests = [
+    # "Error while resolving Forecast.Solar API address"
+    "test_api_key_validation"
+    "test_estimated_forecast"
+    "test_internal_session"
+    "test_json_request"
+    "test_plane_validation"
+    "test_status_400"
+    "test_status_401"
+    "test_status_422"
+    "test_status_429"
+  ];
 
   meta = with lib; {
     changelog = "https://github.com/home-assistant-libs/forecast_solar/releases/tag/v${version}";


### PR DESCRIPTION
Diff: https://github.com/home-assistant-libs/forecast_solar/compare/refs/tags/v3.1.0...v4.0.0

Changelog: https://github.com/home-assistant-libs/forecast_solar/releases/tag/v4.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
