### PR TITLE
kubernetes-kcp: init at 0.26.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19408,6 +19408,13 @@
     name = "Maxwell Beck";
     keys = [ { fingerprint = "D260 79E3 C2BC 2E43 905B  D057 BB3E FA30 3760 A0DB"; } ];
   };
+  rytswd = {
+    email = "rytswd@gmail.com";
+    github = "rytswd";
+    githubId = 23435099;
+    name = "Ryota";
+    keys = [ { fingerprint = "537E 712F 0EC3 91C2 B47F  56E2 EB5D 1A84 5333 43BB"; } ];
+  };
   ryze = {
     name = "Ryze";
     github = "ryze312";

--- a/pkgs/by-name/ku/kubernetes-kcp/package.nix
+++ b/pkgs/by-name/ku/kubernetes-kcp/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+}:
+
+buildGoModule rec {
+  pname = "kubernetes-kcp";
+  version = "0.26.0";
+
+  src = fetchFromGitHub {
+    owner = "kcp-dev";
+    repo = "kcp";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ZEgDeILo2weSAZgBsfR2EQyzym/I/+3P99b47E5Tfrw=";
+  };
+  vendorHash = "sha256-IONbTih48LKAiEPFNFdBkJDMI2sjHWxiqVbEJCskyio=";
+
+  subPackages = [ "cmd/kcp" ];
+
+  # TODO: The upstream has the additional version information pulled from go.mod
+  # dependencies.
+  ldflags = [
+    "-X k8s.io/client-go/pkg/version.gitCommit=unknown"
+    "-X k8s.io/client-go/pkg/version.gitTreeState=clean"
+    "-X k8s.io/client-go/pkg/version.gitVersion=v${version}"
+    # "-X k8s.io/client-go/pkg/version.gitMajor=${KUBE_MAJOR_VERSION}"
+    # "-X k8s.io/client-go/pkg/version.gitMinor=${KUBE_MINOR_VERSION}"
+    "-X k8s.io/client-go/pkg/version.buildDate=unknown"
+    "-X k8s.io/component-base/version.gitCommit=unknown"
+    "-X k8s.io/component-base/version.gitTreeState=clean"
+    "-X k8s.io/component-base/version.gitVersion=v${version}"
+    # "-X k8s.io/component-base/version.gitMajor=${KUBE_MAJOR_VERSION}"
+    # "-X k8s.io/component-base/version.gitMinor=${KUBE_MINOR_VERSION}"
+    "-X k8s.io/component-base/version.buildDate=unknown"
+  ];
+
+  # TODO: Check if this is necessary.
+  # __darwinAllowLocalNetworking = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/kcp completion bash > kcp.bash
+    $out/bin/kcp completion zsh > kcp.zsh
+    $out/bin/kcp completion fish > kcp.fish
+    installShellCompletion kcp.{bash,zsh,fish}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    command = "kcp --version";
+    # NOTE: Once the go.mod version is pulled in, the version info here needs
+    # to be also updated.
+    version = "v${version}";
+  };
+
+  meta = {
+    homepage = "https://kcp.io";
+    description = "Kubernetes-like control planes for form-factors and use-cases beyond Kubernetes and container workloads";
+    mainProgram = "kcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      rytswd
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduces [kcp](https://kcp.io), Kubernetes-like control planes for form-factors and use-cases beyond Kubernetes and container workloads.

Closes #357434 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
