### PR TITLE
fltk: do not propagate fontconfig

### DIFF
--- a/pkgs/by-name/gi/giada/package.nix
+++ b/pkgs/by-name/gi/giada/package.nix
@@ -1,24 +1,25 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, pkg-config
-, fltk
-, fmt
-, rtmidi
-, libsamplerate
-, libmpg123
-, libsndfile
-, jack2
-, alsa-lib
-, libpulseaudio
-, libXpm
-, libXrandr
-, flac
-, libogg
-, libvorbis
-, libopus
-, nlohmann_json
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  fltk,
+  fmt,
+  rtmidi,
+  libsamplerate,
+  libmpg123,
+  libsndfile,
+  jack2,
+  alsa-lib,
+  libpulseaudio,
+  libXpm,
+  libXrandr,
+  flac,
+  libogg,
+  libvorbis,
+  libopus,
+  nlohmann_json,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/gi/giada/package.nix
+++ b/pkgs/by-name/gi/giada/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   fltk,
+  fontconfig,
   fmt,
   rtmidi,
   libsamplerate,
@@ -48,24 +49,28 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = [
-    rtmidi
-    fltk
-    fmt
-    libmpg123
-    libsndfile
-    libsamplerate
-    nlohmann_json
-    alsa-lib
-    libXpm
-    libpulseaudio
-    jack2
-    flac
-    libogg
-    libvorbis
-    libopus
-    libXrandr
-  ];
+  buildInputs =
+    [
+      rtmidi
+      fltk
+      fmt
+      libmpg123
+      libsndfile
+      libsamplerate
+      nlohmann_json
+      alsa-lib
+      libXpm
+      libpulseaudio
+      jack2
+      flac
+      libogg
+      libvorbis
+      libopus
+      libXrandr
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isFreeBSD) [
+      fontconfig
+    ];
 
   meta = {
     description = "Free, minimal, hardcore audio tool for DJs, live performers and electronic musicians";

--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -85,6 +85,8 @@ stdenv.mkDerivation rec {
     libGLU
   ] ++ lib.optionals (withExamples && withGL) [
     glew
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
   ];
 
   propagatedBuildInputs = [
@@ -93,7 +95,6 @@ stdenv.mkDerivation rec {
     libpng
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
     freetype
-    fontconfig
     libX11
     libXext
     libXinerama


### PR DESCRIPTION
On Linux and FreeBSD, giada depends directly on fontconfig. Currently, this is incorrectly propagated via the FLTK dependency.

This is being done as part of #357462, to incrementally move towards a better FLTK derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
