### PR TITLE
bfg-repo-cleaner: format with nixfmt-rfc-style and add passthru.tests.version

### DIFF
--- a/pkgs/by-name/bf/bfg-repo-cleaner/package.nix
+++ b/pkgs/by-name/bf/bfg-repo-cleaner/package.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  jre,
+  makeWrapper,
+}:
 
 stdenv.mkDerivation rec {
   pname = "bfg-repo-cleaner";

--- a/pkgs/by-name/bf/bfg-repo-cleaner/package.nix
+++ b/pkgs/by-name/bf/bfg-repo-cleaner/package.nix
@@ -4,6 +4,8 @@
   fetchurl,
   jre,
   makeWrapper,
+  testers,
+  bfg-repo-cleaner,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +30,10 @@ stdenv.mkDerivation rec {
     cp $src $out/share/java/$jarName
     makeWrapper "${jre}/bin/java" $out/bin/bfg --add-flags "-cp $out/share/java/$jarName com.madgag.git.bfg.cli.Main"
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = bfg-repo-cleaner;
+  };
 
   meta = with lib; {
     homepage = "https://rtyley.github.io/bfg-repo-cleaner/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Before

```console
> nix-build --attr pkgs.bfg-repo-cleaner.passthru.tests
error: attribute 'tests' in selection path 'pkgs.bfg-repo-cleaner.passthru.tests' not found
```

After

```console
> nix-build --attr pkgs.bfg-repo-cleaner.passthru.tests          
this derivation will be built:
  /nix/store/yhxp8r4x2wq25v5av1hxzdjnfr6qip67-bfg-repo-cleaner-1.13.0-test-version.drv
this path will be fetched (11.67 MiB download, 12.84 MiB unpacked):
  /nix/store/830za1fyhzf0hvisaq3hl19kak942z6m-bfg-repo-cleaner-1.13.0
copying path '/nix/store/830za1fyhzf0hvisaq3hl19kak942z6m-bfg-repo-cleaner-1.13.0' from 'https://cache.nixos.org'...
building '/nix/store/yhxp8r4x2wq25v5av1hxzdjnfr6qip67-bfg-repo-cleaner-1.13.0-test-version.drv'...
bfg 1.13.0
/nix/store/pn26gvdhmsqfass8ish73bm4kr4zzbsz-bfg-repo-cleaner-1.13.0-test-version
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
