### PR TITLE
q2pro: 3510 -> 0-unstable-2025-01-02

### DIFF
--- a/pkgs/by-name/q2/q2pro/update.sh
+++ b/pkgs/by-name/q2/q2pro/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p git common-updater-scripts
+set -euo pipefail
+
+attr="q2pro"
+
+tmpdir=$(mktemp -d "/tmp/$attr.XXX")
+repo="$tmpdir/repo"
+trap 'rm -rf $tmpdir' EXIT
+
+git clone https://github.com/skullernet/q2pro.git "$repo"
+
+rev="$(git -C "$repo" rev-parse HEAD)"
+revCount="$(git -C "$repo" rev-list --count HEAD)"
+sourceDate="$(git -C "$repo" show -s --format=%cd --date=format:'%Y-%m-%d' HEAD)"
+sourceDateEpoch="$(git -C "$repo" show -s --format=%ct HEAD)"
+version="0-unstable-$sourceDate"
+
+echo "Updating q2pro to version $version (rev: $rev, date: $sourceDateEpoch)"
+
+update-source-version "$attr" "$version" --rev="${rev}"
+update-source-version "$attr" "$revCount" --ignore-same-hash --version-key=revCount
+update-source-version "$attr" "$sourceDateEpoch" --ignore-same-hash --version-key=SOURCE_DATE_EPOCH


### PR DESCRIPTION
https://github.com/skullernet/q2pro/compare/r3510...5b2d9f29aa9fb07cfe2b4ba9ee628a0153e759c2

The r{xxxx} tags in upstream are not more significant than any other commits in master and shouldn't be considered as a form of releases - https://github.com/skullernet/q2pro/issues/363#issuecomment-2442448224. That's why the version is changed to `0-unstable-...`.

Additionally, I added an update script to ease and automate updates for this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
