### PR TITLE
fishnet: format with nixfmt-rfc-style and add passthru.tests.version

### DIFF
--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -1,7 +1,8 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, fetchurl
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchurl,
 }:
 
 let
@@ -16,7 +17,8 @@ let
     url = "https://tests.stockfishchess.org/api/nn/${nnueSmallFile}";
     sha256 = "sha256-N/GPYtdy8xB+HWqso4mMEww8hvKrY+ZVX7vKIGNaiZ0=";
   };
-in rustPlatform.buildRustPackage rec {
+in
+rustPlatform.buildRustPackage rec {
   pname = "fishnet";
   version = "2.9.3";
 
@@ -41,8 +43,14 @@ in rustPlatform.buildRustPackage rec {
     description = "Distributed Stockfish analysis for lichess.org";
     homepage = "https://github.com/lichess-org/fishnet";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ tu-maurice thibaultd ];
-    platforms = [ "aarch64-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [
+      tu-maurice
+      thibaultd
+    ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
     mainProgram = "fishnet";
   };
 }

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   fetchFromGitHub,
   fetchurl,
+  testers,
+  fishnet,
 }:
 
 let
@@ -38,6 +40,10 @@ rustPlatform.buildRustPackage rec {
   '';
 
   cargoHash = "sha256-Fb28XNhCt88PFnJ4s0I80L/rLJtBTEZ8Xd/68MYFoLs=";
+
+  passthru.tests.version = testers.testVersion {
+    package = fishnet;
+  };
 
   meta = with lib; {
     description = "Distributed Stockfish analysis for lichess.org";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Before

```console
> nix-build --attr pkgs.fishnet.passthru.tests
error: attribute 'tests' in selection path 'pkgs.fishnet.passthru.tests' not found
```

After

```console
> nix-build --attr pkgs.fishnet.passthru.tests
this derivation will be built:
  /nix/store/8v96cvrbqdpcanxwjc1xgrka3gk54arm-fishnet-2.9.3-test-version.drv
building '/nix/store/8v96cvrbqdpcanxwjc1xgrka3gk54arm-fishnet-2.9.3-test-version.drv'...
fishnet 2.9.3
/nix/store/m59f73dz5dzjxgwinv2m439s0sid5ang-fishnet-2.9.3-test-version
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
