### PR TITLE
nixos/hot-resize: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1416,6 +1416,7 @@
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix
   ./services/system/earlyoom.nix
+  ./services/system/hot-resize.nix
   ./services/system/kerberos/default.nix
   ./services/system/localtimed.nix
   ./services/system/nix-daemon.nix

--- a/nixos/modules/services/system/hot-resize.nix
+++ b/nixos/modules/services/system/hot-resize.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.services.hotResize;
+  devicesJson = builtins.toJSON (
+    map (dev: {
+      device = dev.device;
+      fs_type = dev.fsType;
+      mount_point = dev.mountPoint;
+    }) cfg.devices
+  );
+
+in
+
+{
+  options.services.hotResize = {
+    enable = lib.mkEnableOption "the hot resize service for filesystems";
+
+    package = lib.mkPackageOption pkgs "hot-resize" { };
+
+    devices = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            device = lib.mkOption {
+              type = lib.types.str;
+              example = "/dev/sda1";
+              description = "Block device path to resize";
+            };
+            fsType = lib.mkOption {
+              type = lib.types.enum [
+                "ext4"
+                "xfs"
+                "btrfs"
+              ];
+              default = "ext4";
+              description = "Filesystem type (supported: ext4, xfs, btrfs)";
+            };
+            mountPoint = lib.mkOption {
+              type = lib.types.str;
+              example = "/";
+              description = "Mount point of the filesystem to resize";
+            };
+          };
+        }
+      );
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          {
+            device = "/dev/sda1";
+            fsType = "ext4";
+            mountPoint = "/";
+          }
+        ]
+      '';
+      description = "List of devices to monitor for resizing";
+    };
+
+    skipVerify = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Skip filesystem verification after resize";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.hotResize = {
+      description = "Hot resize service for filesystems";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "local-fs-pre.target" ];
+      after = [ "local-fs-pre.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = false;
+        ExecStart =
+          "${lib.getExe cfg.package}"
+          + " --devices '${devicesJson}'"
+          + lib.optionalString cfg.skipVerify " --skip-verify";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add ability to resize your fs ext4 or xfs or btrfs in vm or vma without reboot.
Have created dedicated module for this because is more agnostic to use it in various situations.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
