### PR TITLE
pkgs/build-support: cc-wrapper.sh not detecting c++ files by extension

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -56,6 +56,9 @@ while (( "$n" < "$nParams" )); do
                 c++*) isCxx=1 ;;
             esac
             ;;
+        # check common c++ file extensions
+        # taken from clang: https://github.com/llvm/llvm-project/blob/4d6a5fc702e568b0456c4d8f9e2307eb6d81e955/clang/lib/Driver/Types.cpp#L299-L369
+        *.C|*.H|*.cc|*.CC|*.cp|*.hh|*.ccm|*.cpp|*.CPP|*.c++|*.C++|*.cxx|*.CXX|*.hpp|*.hxx|*.c++m|*.cppm|*.cxxm) isCxx=1 ;;
         --) # Everything else is positional args!
             # See: https://github.com/llvm/llvm-project/commit/ed1d07282cc9d8e4c25d585e03e5c8a1b6f63a74
 
@@ -65,6 +68,12 @@ while (( "$n" < "$nParams" )); do
 
             positionalArgs=("${params[@]:$n}")
             params=("${params[@]:0:$((n - 1))}")
+
+            for pa in "${positionalArgs[@]}"; do
+                case $pa in
+                    *.C|*.H|*.cc|*.CC|*.cp|*.hh|*.ccm|*.cpp|*.CPP|*.c++|*.C++|*.cxx|*.CXX|*.hpp|*.hxx|*.c++m|*.cppm|*.cxxm) isCxx=1 ;;
+                esac
+            done
             break;
             ;;
         -?*) ;;


### PR DESCRIPTION
Closes #357281

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
