### PR TITLE
python3Packages.sphinx-markdown-builder: init at 0.6.8

### DIFF
--- a/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build system
+  setuptools,
+  wheel,
+
+  # deps
+  docutils,
+  sphinx,
+  tabulate,
+
+  # tests
+  pytestCheckHook,
+
+  # optional deps
+  black,
+  bumpver,
+  coveralls,
+  flake8,
+  isort,
+  pip-tools,
+  pylint,
+  pytest,
+  pytest-cov,
+  sphinxcontrib-httpdomain,
+  sphinxcontrib-plantuml,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-markdown-builder";
+  version = "0.6.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "liran-funaro";
+    repo = "sphinx-markdown-builder";
+    tag = version;
+    hash = "sha256-dPMOOG3myh9i2ez9uhasqLnlV0BEsE9CHEbZ57VWzAo=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    docutils
+    sphinx
+    tabulate
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      bumpver
+      coveralls
+      flake8
+      isort
+      pip-tools
+      pylint
+      pytest
+      pytest-cov
+      sphinx
+      sphinxcontrib-httpdomain
+      sphinxcontrib-plantuml
+    ];
+  };
+
+  pythonImportsCheck = [
+    "sphinx_markdown_builder"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # NOTE: not sure why, but a `Missing dependencies: wheel` error happens when
+  # `black` is included here, with python3.13
+  checkInputs = lib.remove black optional-dependencies.dev;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Sphinx extension to add markdown generation support";
+    homepage = "https://github.com/liran-funaro/sphinx-markdown-builder";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15634,6 +15634,8 @@ self: super: with self; {
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
+  sphinx-markdown-builder = callPackage ../development/python-modules/sphinx-markdown-builder { };
+
   sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };
 
   sphinx-markdown-tables = callPackage ../development/python-modules/sphinx-markdown-tables { };


### PR DESCRIPTION
[sphinx-markdown-builder](https://github.com/liran-funaro/sphinx-markdown-builder) is a sphinx extension to add markdown generation support.

This is a required dependency for the [taler-terms-generator](https://github.com/NixOS/nixpkgs/blob/2d8c1c8ece539fcbb30e317eefe6b49f2e5583a0/pkgs/by-name/ta/taler-exchange/package.nix) tool to create the Terms of Service files for the [taler-exchange](https://github.com/NixOS/nixpkgs/pull/332699) service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
