### PR TITLE
pomerium: 0.27.2 -> 0.28.0

### DIFF
--- a/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
+++ b/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
@@ -1,4 +1,4 @@
-From e82f2949b86d127aec908d90d872dfd6feb509e5 Mon Sep 17 00:00:00 2001
+From 54e426127a35ea6c88bf0ba882f97f0712533ef5 Mon Sep 17 00:00:00 2001
 From: Morgan Helton <mhelton@gmail.com>
 Date: Sun, 26 May 2024 12:17:01 -0500
 Subject: [PATCH] envoy: allow specification of external binary
@@ -8,7 +8,7 @@ Subject: [PATCH] envoy: allow specification of external binary
  1 file changed, 10 insertions(+), 7 deletions(-)
 
 diff --git a/pkg/envoy/envoy.go b/pkg/envoy/envoy.go
-index 6639d4bd..c6ca198f 100644
+index 66cf71ae..8d81090e 100644
 --- a/pkg/envoy/envoy.go
 +++ b/pkg/envoy/envoy.go
 @@ -8,9 +8,9 @@ import (
@@ -40,7 +40,7 @@ index 6639d4bd..c6ca198f 100644
  // NewServer creates a new server with traffic routed by envoy.
  func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Builder) (*Server, error) {
 -	if err := preserveRlimitNofile(); err != nil {
--		log.Debug(ctx).Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
+-		log.Ctx(ctx).Debug().Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
 -	}
 +	envoyPath := OverrideEnvoyPath
 +	wd := filepath.Join(os.TempDir(), workingDirectoryName)
@@ -59,5 +59,5 @@ index 6639d4bd..c6ca198f 100644
  		grpcPort:  src.GetConfig().GRPCPort,
  		httpPort:  src.GetConfig().HTTPPort,
 -- 
-2.46.0
+2.47.0
 

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -13,15 +13,15 @@ let
 in
 buildGo123Module rec {
   pname = "pomerium";
-  version = "0.27.2";
+  version = "0.28.0";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256-t1j5usgr/SO3Ev3JpCJWb3Ys8wgZUTGQVb6mo0oIsEc=";
+    hash = "sha256-Uj/mVklFRaoDNQjCFS5NW/AhSU+7V1XxPiZBAUuly7s=";
   };
 
-  vendorHash = "sha256-nTEFSLP0/GUVgtujVG6lQIxnj6DOEifc0MVh9CNxt8s=";
+  vendorHash = "sha256-s6EZUZoGNBpy5RaLAPiCCCVFli+YzZ0PHJ/aH3s4APA=";
 
   ui = mkYarnPackage {
     inherit version;


### PR DESCRIPTION
https://github.com/pomerium/pomerium/compare/v0.27.2...v0.28.0
- Bump patch allowing use of `envoy` from nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
