### PR TITLE
krop: pin pypdf2 version

### DIFF
--- a/pkgs/by-name/kr/krop/package.nix
+++ b/pkgs/by-name/kr/krop/package.nix
@@ -1,6 +1,32 @@
-{ lib, fetchFromGitHub, python3Packages, libsForQt5, ghostscript, qt5}:
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  libsForQt5,
+  ghostscript,
+  qt5,
+  fetchPypi,
+}:
 
-python3Packages.buildPythonApplication rec {
+let
+  py = python3.override {
+    self = py;
+    packageOverrides = self: super: {
+      # Can be removed once this is merged
+      # https://github.com/arminstraub/krop/pull/40
+      pypdf2 = super.pypdf2.overridePythonAttrs (oldAttrs: rec {
+        version = "2.12.1";
+        src = fetchPypi {
+          pname = "PyPDF2";
+          inherit version;
+          hash = "sha256-4D7xirzHXadBoKzBp3SSU0loh744zZiHvM4c7jk9pF4=";
+        };
+      });
+    };
+  };
+in
+
+py.pkgs.buildPythonApplication rec {
   pname = "krop";
   version = "0.6.0";
 
@@ -11,21 +37,21 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1ygzc7vlwszqmsd3v1dsqp1dpsn6inx7g8gck63alvf88dbn8m3s";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with py.pkgs; [
     pyqt5
     pypdf2
     poppler-qt5
     ghostscript
   ];
+
   buildInputs = [
     libsForQt5.poppler
     libsForQt5.qtwayland
   ];
 
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
-  makeWrapperArgs = [
-   "\${qtWrapperArgs[@]}"
-  ];
+
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
 
   postInstall = ''
     install -m666 -Dt $out/share/applications krop.desktop
@@ -37,17 +63,17 @@ python3Packages.buildPythonApplication rec {
   meta = {
     homepage = "http://arminstraub.com/software/krop";
     description = "Graphical tool to crop the pages of PDF files";
-    mainProgram = "krop";
     longDescription = ''
-    Krop is a tool that allows you to optimise your PDF files, and remove
-    sections of the page you do not want.  A unique feature of krop, at least to my
-    knowledge, is its ability to automatically split pages into subpages to fit the
-    limited screensize of devices such as eReaders. This is particularly useful, if
-    your eReader does not support convenient scrolling. Krop also has a command line
-    interface.
+      Krop is a tool that allows you to optimise your PDF files, and remove
+      sections of the page you do not want.  A unique feature of krop, at least to my
+      knowledge, is its ability to automatically split pages into subpages to fit the
+      limited screensize of devices such as eReaders. This is particularly useful, if
+      your eReader does not support convenient scrolling. Krop also has a command line
+      interface.
     '';
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ leenaars ];
     platforms = lib.platforms.linux;
+    mainProgram = "krop";
   };
 }


### PR DESCRIPTION
Krop fails to save/export PDF because it doesn't support latest pypdf2 version. Pinning old version fixes it.

Fixes https://github.com/NixOS/nixpkgs/issues/226012
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
