### PR TITLE
icmptx: init at 0.2-unstable-2023-11-07

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -112,6 +112,8 @@
 
 - [zwave-js-ui](https://zwave-js.github.io/zwave-js-ui/), a full featured Z-Wave Control Panel and MQTT Gateway. Available as [services.zwave-js-ui](#opt-services.zwave-js-ui.enable).
 
+- [ICMPTX](https://codeberg.org/jakkarth/icmptx), an IP-over-ICMP tunnel. Available as [services.icmptx.server](#opt-services.icmptx.server.enable) and [services.icmptx.client](#opt-services.icmptx.client.enable).
+
 - [Amazon CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent), the official telemetry collector for AWS CloudWatch and AWS X-Ray. Available as [services.amazon-cloudwatch-agent](options.html#opt-services.amazon-cloudwatch-agent.enable).
 
 - [Bat](https://github.com/sharkdp/bat), a {manpage}`cat(1)` clone with wings. Available as [programs.bat](options.html#opt-programs.bat).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1133,6 +1133,7 @@
   ./services/networking/i2pd.nix
   ./services/networking/icecream/daemon.nix
   ./services/networking/icecream/scheduler.nix
+  ./services/networking/icmptx.nix
   ./services/networking/imaginary.nix
   ./services/networking/inadyn.nix
   ./services/networking/inspircd.nix

--- a/nixos/modules/services/networking/icmptx.nix
+++ b/nixos/modules/services/networking/icmptx.nix
@@ -1,0 +1,199 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.icmptx;
+in
+{
+  options = {
+    services.icmptx =
+      let
+        commonOptions = {
+          tun = lib.mkOption {
+            type = lib.types.str;
+            default = "tun0";
+            description = ''
+              Name of the tunnel interface.
+              ICMPTX will just use the first free tun device and since there is no way to tell ICMPTX to use any specific interface name, we have to assume that there are no other tun interfaces and hardcode tun0.
+              If ICMPTX ever gains the ability to specify the interface name, this option will become writable.
+            '';
+            readOnly = true;
+          };
+        };
+      in
+      {
+        package = lib.mkPackageOption pkgs "icmptx" { };
+
+        server = {
+          enable = lib.mkEnableOption ''
+            ICMPTX server.
+            Make sure that no other network interfaces with the name tun0 exist on the machine. See the description of the option `services.icmptx.server.tun` for an explanation.
+          '';
+
+          serverIPv4 = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            example = "1.2.3.4";
+            description = "Public IPv4 address of the server";
+          };
+        } // commonOptions;
+
+        client = {
+          enable = lib.mkEnableOption ''
+            ICMPTX client.
+            Make sure that no other network interfaces with the name tun0 exist on the machine. See the description of the option `services.icmptx.client.tun` for an explanation.
+          '';
+
+          serverIPv4 = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            example = "1.2.3.4";
+            description = "Public IPv4 address of the server";
+          };
+        } // commonOptions;
+      };
+  };
+
+  config =
+    let
+      commonServiceOptions = {
+        AmbientCapabilities = [
+          "CAP_NET_ADMIN"
+          "CAP_NET_RAW"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_ADMIN"
+          "CAP_NET_RAW"
+        ];
+        DeviceAllow = [ "/dev/net/tun" ];
+        DevicePolicy = "closed";
+        DynamicUser = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = false;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = false;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        ReadWritePaths = [ ];
+        RemoveIPC = true;
+        Restart = "on-failure";
+        RestrictAddressFamilies = [ "AF_INET" ]; # Tunnel does not work over IPv6, so no AF_INET6
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@resources"
+          "~@privileged"
+        ];
+        Type = "simple";
+        UMask = "0777";
+      };
+    in
+    lib.mkMerge [
+      (lib.mkIf (cfg.server.enable || cfg.client.enable) {
+        assertions = [
+          {
+            assertion = config.networking.useNetworkd;
+            message = ''
+              The ICMPTX NixOS module requires using systemd-networkd rather than the scripted network backend because the scripted network backend does not support assigning an IP address once the interface was created by ICMPTX instead of trying to assign it immediately. Please enable systemd-networkd by setting `networking.useNetworkd` to `true`.
+            '';
+          }
+          {
+            assertion = cfg.server.enable != cfg.client.enable;
+            message = ''
+              Only one of `services.icmptx.server.enable` and `services.icmptx.client.enable` may be enabled at once on any given NixOS system. The reason for this is that ICMPTX will create its tun interface with the first available name without a way to change it and without a way to find out which name the newly created interface has. We therefore hardcode tun0, which would break if more than one instance of this program ran on the given system.
+            '';
+          }
+        ];
+
+        boot.kernelModules = [ "tun" ];
+
+        boot.kernel.sysctl."net.ipv4.icmp_echo_ignore_all" = 1;
+
+        # Prevent sending ping packets through the ping tunnel since that would result in an infinite loop
+        networking.firewall.extraCommands = lib.optionalString (!config.networking.nftables.enable) ''
+          iptables -A OUTPUT -o tun0 -p icmp --icmp-type echo-request -j DROP
+        '';
+        networking.nftables.tables.icmptx = lib.optionalAttrs config.networking.nftables.enable {
+          family = "ip";
+          content = ''
+            chain output {
+              type filter hook output priority 0; policy accept;
+              oifname tun0 icmp type echo-request drop
+            }
+          '';
+        };
+      })
+
+      (lib.mkIf (cfg.server.enable) {
+        assertions = [
+          {
+            assertion = builtins.hasAttr "40-${cfg.server.tun}" config.systemd.network.networks;
+            message = ''
+              You need to manually configure the tunnel interface of ICMPTX, for example by setting `networking.interfaces.''${config.services.icmptx.server.tun} = { mtu = 1500 - 20 - 8; /* Path MTU minus IPv4 header size minus ICMP header size. If your path MTU is smaller than this, for example because your internet connection is using PPPoE, then you need to adjust this. */ ipv4.addresses = [{ address = "10.0.3.1"; prefixLength = 24; }]; }` or by using the appropriate networkd-specific options.
+            '';
+          }
+          {
+            assertion = cfg.server.serverIPv4 != "";
+            message = ''
+              You need to configure the public IPv4 address of the ICMPTX server by setting `services.icmptx.server.serverIPv4`.
+            '';
+          }
+        ];
+
+        systemd.services.icmptx-server = {
+          description = "IP-over-ICMP tunnel server";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = "${lib.getExe cfg.package} -s ${utils.escapeSystemdExecArgs [ cfg.server.serverIPv4 ]}";
+          } // commonServiceOptions;
+        };
+      })
+
+      (lib.mkIf (cfg.client.enable) {
+        assertions = [
+          {
+            assertion = builtins.hasAttr "40-${cfg.client.tun}" config.systemd.network.networks;
+            message = ''
+              You need to manually configure the tunnel interface of ICMPTX, for example by setting `networking.interfaces.''${config.services.icmptx.client.tun} = { mtu = 1500 - 20 - 8; /* Path MTU minus IPv4 header size minus ICMP header size. If your path MTU is smaller than this, for example because your internet connection is using PPPoE, then you need to adjust this. */ ipv4.addresses = [{ address = "10.0.3.2"; prefixLength = 24; }]; }` or by using the appropriate networkd-specific options.
+            '';
+          }
+          {
+            assertion = cfg.client.serverIPv4 != "";
+            message = ''
+              You need to configure the public IPv4 address of the ICMPTX server by setting `services.icmptx.client.serverIPv4`.
+            '';
+          }
+        ];
+
+        systemd.services.icmptx-client = {
+          description = "IP-over-ICMP tunnel client";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = "${lib.getExe cfg.package} -c ${utils.escapeSystemdExecArgs [ cfg.client.serverIPv4 ]}";
+            IPAddressDeny = "any";
+            IPAddressAllow = cfg.client.serverIPv4;
+          } // commonServiceOptions;
+        };
+      })
+    ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -547,6 +547,7 @@ in {
   hydra = handleTest ./hydra {};
   i3wm = handleTest ./i3wm.nix {};
   icingaweb2 = handleTest ./icingaweb2.nix {};
+  icmptx = import ./icmptx.nix { inherit recurseIntoAttrs runTest; };
   ifm = handleTest ./ifm.nix {};
   iftop = handleTest ./iftop.nix {};
   immich = handleTest ./web-apps/immich.nix {};

--- a/nixos/tests/icmptx.nix
+++ b/nixos/tests/icmptx.nix
@@ -1,0 +1,213 @@
+# Test ICMPTX.
+# In a real deployment, you should use an encryption layer like WireGuard to encrypt and authenticate the data.
+# Putting the program in a NixOS container with the Ethernet interface and then moving the tun0 interface outside of the container seems like a good idea for better isolation.
+{
+  recurseIntoAttrs,
+  runTest,
+}:
+let
+  mkTest =
+    { useNftables }:
+    { lib, ... }:
+    {
+      name = "ICMPTX-${if useNftables then "nftables" else "iptables"}";
+
+      meta = with lib.maintainers; {
+        maintainers = [ Luflosi ];
+      };
+
+      defaults =
+        { ... }:
+        {
+          networking.nftables.enable = useNftables;
+
+          networking.firewall.allowPing = true;
+
+          # Using networkd is required for this NixOS module.
+          networking.useNetworkd = true;
+
+          virtualisation.interfaces.eth1 = {
+            vlan = 1;
+            assignIP = false;
+          };
+
+          # The tunnel does not support ICMPv6 anyways, so remove some noise from the packet capture
+          systemd.network.networks."40-eth1".networkConfig.LinkLocalAddressing = "no";
+        };
+
+      nodes = {
+        server =
+          { config, pkgs, ... }:
+          {
+            networking.firewall.trustedInterfaces = [ config.services.icmptx.server.tun ];
+
+            networking.interfaces.eth1.ipv4.addresses = lib.singleton {
+              address = "1.2.3.4";
+              prefixLength = 24;
+            };
+
+            # Test using the NixOS-style IP address configuration here
+            networking.interfaces.${config.services.icmptx.server.tun} = {
+              # Path MTU minus IPv4 header size minus ICMP header size.
+              # If your path MTU is smaller than this, for example because your internet connection is using PPPoE, then you need to adjust this.
+              mtu = 1500 - 20 - 8;
+
+              ipv4.addresses = lib.singleton {
+                address = "10.0.3.1";
+                prefixLength = 24;
+              };
+              ipv6.addresses = lib.singleton {
+                address = "2001:db8::1";
+                prefixLength = 64;
+              };
+            };
+
+            services.icmptx.server = {
+              enable = true;
+              serverIPv4 = "1.2.3.4";
+            };
+
+            # test resource: accessible only via tunnel
+            services.openssh = {
+              enable = true;
+              openFirewall = false;
+            };
+          };
+
+        client =
+          { config, pkgs, ... }:
+          {
+            networking.interfaces.eth1.ipv4.addresses = lib.singleton {
+              address = "1.2.3.5";
+              prefixLength = 24;
+            };
+
+            # Test using the networkd-style IP address configuration here
+            systemd.network.networks."40-${config.services.icmptx.server.tun}" = {
+              name = config.services.icmptx.server.tun;
+              networkConfig = {
+                DHCP = "no";
+                Address = [
+                  "10.0.3.2/24"
+                  "2001:db8::2/64"
+                ];
+              };
+
+              # Path MTU minus IPv4 header size minus ICMP header size.
+              # If your path MTU is smaller than this, for example because your internet connection is using PPPoE, then you need to adjust this.
+              linkConfig.MTUBytes = 1500 - 20 - 8;
+            };
+
+            services.icmptx.client = {
+              enable = true;
+              serverIPv4 = "1.2.3.4";
+            };
+
+            environment.systemPackages = with pkgs; [
+              lsof
+              nagiosPluginsOfficial
+              tcpdump
+            ];
+          };
+      };
+
+      testScript = ''
+        import os
+
+        def start_packet_capture(machine):
+          machine.succeed("tcpdump -n -i eth1 -w /tmp/eth1.pcap 2>/tmp/stderr-eth1 >/dev/null & echo $! >/tmp/pid-eth1")
+          machine.succeed("tcpdump -n -i tun0 -w /tmp/tun0.pcap 2>/tmp/stderr-tun0 >/dev/null & echo $! >/tmp/pid-tun0")
+
+          # Wait for tcpdump to start recording
+          machine.succeed("sleep 1")
+
+
+        def stop_packet_capture(machine):
+          # TODO: find a better way to wait for wireshark to be done capturing
+          machine.succeed("sleep 1")
+
+          # Send a signal to tcpdump
+          machine.succeed('kill -s SIGTERM "$(</tmp/pid-eth1)"')
+          machine.succeed('kill -s SIGTERM "$(</tmp/pid-tun0)"')
+
+          # Wait for tcpdump to stop
+          machine.succeed('tail --pid="$(</tmp/pid-eth1)" -f /dev/null')
+          machine.succeed('tail --pid="$(</tmp/pid-tun0)" -f /dev/null')
+
+          # Print stderr of tcpdump
+          machine.succeed("cat /tmp/stderr-eth1 >&2")
+          machine.succeed("cat /tmp/stderr-tun0 >&2")
+
+          # Make sure no packets were dropped by the kernel
+          assert "0 packets dropped by kernel" in machine.succeed("cat /tmp/stderr-eth1").splitlines(), "The kernel dropped some packets"
+          assert "0 packets dropped by kernel" in machine.succeed("cat /tmp/stderr-tun0").splitlines(), "The kernel dropped some packets"
+
+          # Copy packet captures to the output for easy debugging
+          # This output is unfortunately not reproducible
+          machine.copy_from_vm("/tmp/eth1.pcap")
+          machine.copy_from_vm("/tmp/tun0.pcap")
+
+          eth1_size = os.stat(machine.out_dir / "eth1.pcap").st_size
+          tun0_size = os.stat(machine.out_dir / "tun0.pcap").st_size
+          assert eth1_size >= tun0_size, "The packet capture of the tun0 interface was larger than that of the eth1 interface. This indicates that ping packets were sent into the ping tunnel, resulting in an infinite loop"
+
+
+        def check_ping(machine, ip_addr):
+          # Send two pings so the ping program runs long enough to see any potential duplicates
+          result = machine.succeed(f"ping -c 2 {ip_addr}")
+          assert "2 packets transmitted, 2 received, 0% packet loss" in result, "Did not receive exactly one ping response per request:\n" + result
+
+
+        start_all()
+
+        client.wait_for_unit("icmptx-client.service")
+        server.wait_for_unit("icmptx-server.service")
+        server.wait_for_unit("sshd.service")
+
+        client.log(client.succeed(
+          "systemd-analyze security icmptx-client.service | grep -v '✓'"
+        ))
+
+        # Wait for interface to exist and have an IP address
+        client.wait_until_succeeds("ip addr show dev tun0 | grep inet")
+        server.wait_until_succeeds("ip addr show dev tun0 | grep inet")
+
+        start_packet_capture(client)
+
+        client.succeed("ip a >&2")
+        client.succeed("ip route >&2")
+        server.succeed("ip a >&2")
+        server.succeed("ip route >&2")
+
+        with subtest("Normal ping outside of the tunnel still works"):
+          check_ping(client, "1.2.3.4")
+          check_ping(server, "1.2.3.5")
+
+        with subtest("Establish an SSH connection via the tunnel"):
+          client.succeed("check_ssh -H 10.0.3.1")
+          client.succeed("check_ssh -H 2001:db8::1")
+
+        with subtest("IPv6 Ping inside the tunnel works"):
+          check_ping(client, "2001:db8::1")
+          check_ping(server, "2001:db8::2")
+
+        with subtest("IPv4 Ping inside the tunnel fails"):
+          client.fail("ping -c 1 10.0.3.1 >&2")
+          server.fail("ping -c 1 10.0.3.2 >&2")
+
+        stop_packet_capture(client)
+
+        # Check that ICMPTX is still running
+        client.require_unit_state("icmptx-client.service")
+        server.require_unit_state("icmptx-server.service")
+      '';
+    };
+in
+recurseIntoAttrs {
+  icmptx-nftables = runTest (mkTest {
+    useNftables = true;
+  });
+  icmptx-iptables = runTest (mkTest {
+    useNftables = false;
+  });
+}

--- a/pkgs/by-name/ic/icmptx/package.nix
+++ b/pkgs/by-name/ic/icmptx/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  nixosTests,
   fetchFromGitea,
 }:
 
@@ -23,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   strictDeps = true;
+
+  passthru.tests = {
+    inherit (nixosTests) icmptx;
+  };
 
   meta = {
     description = "IP-over-ICMP tunnel";

--- a/pkgs/by-name/ic/icmptx/package.nix
+++ b/pkgs/by-name/ic/icmptx/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "icmptx";
+  version = "0.2-unstable-2023-11-07";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "jakkarth";
+    repo = "icmptx";
+    rev = "bffe9841f423da24f2d318773ec2f97db2805c0f";
+    hash = "sha256-4p84bn9YgrbMqfl65P3KASvWWYIO0rX5q3mlBJbOiUE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 icmptx "$out/bin/icmptx"
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+
+  meta = {
+    description = "IP-over-ICMP tunnel";
+    homepage = "https://codeberg.org/jakkarth/icmptx";
+    license = with lib.licenses; [
+      # The README.md and the header in some program files claim GPL2 or later but the LICENSE file contains the GPL3
+      gpl2Plus
+      gpl3Plus
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Luflosi ];
+    mainProgram = "icmptx";
+  };
+})


### PR DESCRIPTION
Add ICMPTX, a program to tunnel IP packets over Ping messages.
https://codeberg.org/jakkarth/icmptx

Also add a NixOS module and a NixOS test.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
