### PR TITLE
qtscrcpy: switch to latest ffmpeg

### DIFF
--- a/pkgs/by-name/qt/qtscrcpy/package.nix
+++ b/pkgs/by-name/qt/qtscrcpy/package.nix
@@ -7,7 +7,7 @@
   libsForQt5,
   scrcpy,
   android-tools,
-  ffmpeg_4,
+  ffmpeg,
   makeDesktopItem,
   copyDesktopItems,
 }:
@@ -37,6 +37,11 @@ stdenv.mkDerivation rec {
     # remove predefined adb and scrcpy-server path
     # we later set them in wrapper
     ./remove_predefined_paths.patch
+
+    # remove avcodec_close which is deprecated in ffmpeg_7
+    # This doesn't affect functionality because
+    # it's followed by avcodec_free_context
+    ./remove_deprecated_avcodec_free_context.patch
   ];
 
   postPatch = ''
@@ -61,7 +66,8 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       scrcpy
-      ffmpeg_4
+      # Upstream vendors ffmpeg_4
+      ffmpeg
     ]
     ++ (with libsForQt5; [
       qtbase

--- a/pkgs/by-name/qt/qtscrcpy/remove_deprecated_avcodec_free_context.patch
+++ b/pkgs/by-name/qt/qtscrcpy/remove_deprecated_avcodec_free_context.patch
@@ -1,0 +1,14 @@
+diff --git a/src/device/decoder/decoder.cpp b/src/device/decoder/decoder.cpp
+index 79dec15..5f6979b 100644
+--- a/src/device/decoder/decoder.cpp
++++ b/QtScrcpy/QtScrcpyCore/src/device/decoder/decoder.cpp
+@@ -51,9 +51,6 @@ void Decoder::close()
+     if (!m_codecCtx) {
+         return;
+     }
+-    if (m_isCodecCtxOpen) {
+-        avcodec_close(m_codecCtx);
+-    }
+     avcodec_free_context(&m_codecCtx);
+ }
+ 


### PR DESCRIPTION
Per the request of https://github.com/NixOS/nixpkgs/pull/340257#issuecomment-2484225666. Tested and seems nothing broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
