### PR TITLE
python3Packages.doubles: init at 1.5.3

### DIFF
--- a/pkgs/development/python-modules/doubles/default.nix
+++ b/pkgs/development/python-modules/doubles/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest7CheckHook,
+  setuptools,
+  coverage,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "doubles";
+  version = "1.5.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "uber";
+    repo = "doubles";
+    tag = "v${version}";
+    hash = "sha256-7yygZ00H2eIGuI/E0dh0j30hicJKBhCqyagY6XAJTCA=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    coverage
+    six
+  ];
+
+  nativeCheckInputs = [
+    pytest7CheckHook
+  ];
+
+  # To avoid a ValueError: Plugin already registered under a different name:
+  # doubles.pytest_plugin
+  pytestFlags = [
+    "-p"
+    "no:doubles"
+  ];
+
+  disabledTestPaths = [
+    # nose is deprecated
+    "test/nose_test.py"
+
+    # These tests fail due to an incompatibility between the doubles pytest plugin
+    # and modern pytest versions (7+). The plugin's verification hook incorrectly
+    # raises a generic `AssertionError` during teardown, instead of the specific
+    # exceptions the negative test cases are designed to catch.
+    "test/allow_test.py"
+    "test/expect_test.py"
+    "test/class_double_test.py"
+    "test/object_double_test.py"
+  ];
+
+  pythonImportsCheck = [ "doubles" ];
+
+  meta = with lib; {
+    description = "Test doubles for Python";
+    homepage = "https://github.com/uber/doubles";
+    license = licenses.mit;
+    maintainers = with maintainers; [ b-rodrigues ];
+  };
+}

--- a/pkgs/development/python-modules/doubles/default.nix
+++ b/pkgs/development/python-modules/doubles/default.nix
@@ -56,10 +56,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "doubles" ];
 
-  meta = with lib; {
+  meta = {
     description = "Test doubles for Python";
     homepage = "https://github.com/uber/doubles";
-    license = licenses.mit;
-    maintainers = with maintainers; [ b-rodrigues ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4344,6 +4344,8 @@ self: super: with self; {
 
   doubleratchet = callPackage ../development/python-modules/doubleratchet { };
 
+  doubles = callPackage ../development/python-modules/doubles { };
+
   dowhen = callPackage ../development/python-modules/dowhen { };
 
   downloader-cli = callPackage ../development/python-modules/downloader-cli { };


### PR DESCRIPTION
This PR adds the `doubles` package, which is a dependency of `saiph`: https://github.com/NixOS/nixpkgs/pull/352710

`doubles` bundles a fairly large pytest suite that no longer runs successfully on modern Python:

- Several test files rely on nose, which is long unmaintained and not packaged in Nixpkgs.
- Other tests assume older unittest behavior (TestCase.runTest).

After deselecting those, the majority of the remaining suite fails at runtime with AssertionError, KeyError, or VerifyingDoubleArgumentError. These failures are likely caused by changes in pytest, pluggy (and perhaps even Python itself?)

Upstream is effectively unmaintained and has not been updated since 2018. 

For packaging purposes, the library itself still imports successfully and can be used as-is by downstream code. Therefore, this PR:

- Disables doCheck.
- Keeps pythonImportsCheck = [ "doubles" ]; to ensure the module is importable.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
