### PR TITLE
ipbus-uhal: init at 2.8.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2582,6 +2582,12 @@
     name = "Wanderson Ferreira";
     keys = [ { fingerprint = "A3E1 C409 B705 50B3 BF41  492B 5684 0A61 4DBE 37AE"; } ];
   };
+  bashsu = {
+    name = "Joeal Subash";
+    email = "joeal.subash@cern.ch";
+    github = "joealsubash";
+    githubId = 98759349;
+  };
   bastaynav = {
     name = "Ivan Bastrakov";
     email = "bastaynav@proton.me";

--- a/pkgs/by-name/ip/ipbus-uhal/package.nix
+++ b/pkgs/by-name/ip/ipbus-uhal/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  bash,
+  cacert,
+  boost186,
+  pugixml,
+  python3,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ipbus-uhal";
+  version = "2.8.16";
+  src = fetchFromGitHub {
+    owner = "ipbus";
+    repo = "ipbus-software";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-R+a9VmONyWh3BEYoMjRcXKv+3HaNcKbJDnYH1hXHdPg=";
+  };
+
+  nativeBuildInputs = [
+    cacert
+    (python3.withPackages (ps: [
+      ps.distutils
+      ps.pybind11
+    ]))
+  ];
+  buildInputs = [
+    boost186
+    pugixml
+    python3.pkgs.distutils
+    python3.pkgs.pybind11
+  ];
+  postPatch = ''
+    substituteInPlace config/Makefile.macros --replace-fail \
+      'SHELL := /bin/bash' ""
+    patchShebangs --build uhal/config/install.sh
+    patchShebangs --build uhal/tests/setup.sh
+    patchShebangs --build scripts/doxygen/api_uhal.sh
+    patchShebangs --build config/progress.sh
+    patchShebangs --build config/Makefile.macros
+  '';
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "Set=uhal"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,include}
+    make Set=uhal install prefix=$out/bin includedir=$out/include
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Software which pairs with ipbus-firmware";
+    longDescription = ''
+      Software that provide a reliable high-performance
+      control link for particle-physics or other electronics,
+      by implementing a simple A32/D32 control protocol
+      for reading and modifying memory-mapped resources
+      within FPGA-based hardware devices.
+    '';
+    platforms = lib.platforms.linux;
+    homepage = "https://ipbus.web.cern.ch/";
+    maintainers = [ lib.maintainers.bashsu ];
+    mainProgram = "ipbus-uhal";
+  };
+})


### PR DESCRIPTION
<!--
^ IPBus uhal and firmware provide a reliable mechanism to read/write into FPGA firmware in a reliable fashion. It is used in many current particle-physics experiments at CERN like ATLAS and CMS.^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
IPBus uhal and firmware provide a mechanism to read/write into FPGA firmware in a reliable fashion. It is used in many current particle-physics experiments at CERN like ATLAS and CMS.
shell-env.sh allows development using the uhal API and provides python bindings for reading and writing into firmware.

https://ipbus.web.cern.ch/
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
