### PR TITLE
nixos/espeakup: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18445,6 +18445,12 @@
     githubId = 364510;
     name = "Tobias Geerinckx-Rice";
   };
+  ndarilek = {
+    email = "nolan@thewordnerd.info";
+    github = "ndarilek";
+    githubId = 1172;
+    name = "Nolan Darilek";
+  };
   ndl = {
     email = "ndl@endl.ch";
     github = "ndl";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -30,6 +30,8 @@
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
+- [espeakup](https://github.com/linux-speakup/espeakup), a connector for the Speakup kernel screen reader and espeak-ng text-to-speech synthesizer, enabling console-level speech synthesis for visually impaired users. Available as [services.espeakup](#opt-services.espeakup.enable).
+
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.
 
 - [Komodo Periphery](https://github.com/moghtech/komodo), a multi-server Docker and Git deployment agent by Komodo. Available as [services.komodo-periphery](#opt-services.komodo-periphery.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -409,6 +409,7 @@
   ./security/systemd-confinement.nix
   ./security/tpm2.nix
   ./security/wrappers/default.nix
+  ./services/accessibility/espeakup.nix
   ./services/accessibility/orca.nix
   ./services/accessibility/speechd.nix
   ./services/admin/docuum.nix

--- a/nixos/modules/services/accessibility/espeakup.nix
+++ b/nixos/modules/services/accessibility/espeakup.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.espeakup;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    mkOption
+    types
+    ;
+in
+{
+  options.services.espeakup = {
+    enable = mkEnableOption "Espeakup screen reader";
+    package = mkPackageOption pkgs "espeakup" { };
+    defaultVoice = mkOption {
+      type = types.str;
+      default = "en-gb";
+      description = "Default voice for espeakup";
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ ndarilek ];
+  config = mkIf cfg.enable {
+    boot.kernelModules = [ "speakup_soft" ];
+    systemd.packages = [ cfg.package ];
+    systemd.services.espeakup = {
+      wantedBy = [ "sound.target" ];
+      environment = {
+        default_voice = cfg.defaultVoice;
+      };
+      serviceConfig = {
+        ExecStartPre = "";
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added `services.espeakup` module which:
* Enables the `espeakup` systemd service
* Adds a `defaultVoice` configuration option for setting the espeakup default voice in the systemd unit. It defaults to "en-gb" as is typical with espeak.
* Adds "speakup_soft" to the boot kernel modules so speech synthesis is available when the kernel boots
* Clears the `ExecStartPre` of the unit as shipped--this just ran modprobe and is no longer necessary, and always errored out with an `exit(203)` when left in

I've tested that `services.espeakup.enable = true;` in my system configuration does in fact bring up espeakup on tty2. I'm running Pipewire and had to set `systemWide = true` so sound was available on the console, but it does speak and is responsive.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
