### PR TITLE
shntool: 3.0.10 -> 3.0.10+git20130108.4ca41f4-1

### DIFF
--- a/pkgs/by-name/sh/shntool/package.nix
+++ b/pkgs/by-name/sh/shntool/package.nix
@@ -1,19 +1,26 @@
-{ lib, stdenv, fetchurl, flac }:
+{ lib, stdenv, fetchFromGitLab, flac }:
 
-stdenv.mkDerivation {
-  version = "3.0.10";
+stdenv.mkDerivation rec {
+  version = "3.0.10+git20130108.4ca41f4-1";
   pname = "shntool";
 
-  src = fetchurl {
-    url = "http://www.etree.org/shnutils/shntool/dist/src/shntool-3.0.10.tar.gz";
-    sha256 = "00i1rbjaaws3drkhiczaign3lnbhr161b7rbnjr8z83w8yn2wc3l";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "shntool";
+    rev = "debian/${version}";
+    sha256 = "sha256-Qn4LwVx34EhypiZDIxuveNhePigkuiICn1nBukoQf5Y=";
   };
 
   buildInputs = [ flac ];
 
+  prePatch = ''
+    patches=$(grep -v '#' ./debian/patches/series | while read patch; do echo "./debian/patches/$patch"; done | tr '\n' ' ')
+  '';
+
   meta = {
     description = "Multi-purpose WAVE data processing and reporting utility";
-    homepage = "http://www.etree.org/shnutils/shntool/";
+    homepage = "https://packages.qa.debian.org/s/shntool.html";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ jcumming ];


### PR DESCRIPTION
## Things done

I'm updating `shntool` to source its code from the Debian folks and to use their patches; I encountered issues using shntool that were fixed by these.

While here I updated its homepage to the debian tracker; the original homepage now returns a 404.

Full details about the Debian package for this [can be found on their tracker](https://tracker.debian.org/pkg/shntool).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`: `nix-shell --option sandbox true -E "with import <nixpkgs> {}; callPackage ./package.nix {}"`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
