### PR TITLE
curl: backport other netrc regression fix

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/fix-netrc-regression-2.patch
+++ b/pkgs/by-name/cu/curlMinimal/fix-netrc-regression-2.patch
@@ -1,0 +1,31 @@
+From 0cdde0fdfbeb8c35420f6d03fa4b77ed73497694 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 7 Nov 2024 17:03:54 +0100
+Subject: [PATCH] netrc: support large file, longer lines, longer tokens
+
+Regression from 3b43a05e000aa8f6 (shipped in 8.11.0)
+
+Reported-by: Moritz
+Fixes #15513
+Closes #15514
+---
+ lib/netrc.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/netrc.c b/lib/netrc.c
+index c23f927cef32d35059360f04be3c7833589f5df5..034c0307a43e3b86c9c004387cedf273588370e1 100644
+--- a/lib/netrc.c
++++ b/lib/netrc.c
+@@ -58,9 +58,9 @@ enum found_state {
+ #define NETRC_FAILED -1
+ #define NETRC_SUCCESS 0
+ 
+-#define MAX_NETRC_LINE 4096
+-#define MAX_NETRC_FILE (64*1024)
+-#define MAX_NETRC_TOKEN 128
++#define MAX_NETRC_LINE 16384
++#define MAX_NETRC_FILE (128*1024)
++#define MAX_NETRC_TOKEN 4096
+ 
+ static CURLcode file2memory(const char *filename, struct dynbuf *filebuf)
+ {

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -65,6 +65,10 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88
     # TODO: Remove this patch when 8.11.1/8.12.0 releases
     ./fix-netrc-regression.patch
+
+    # https://github.com/curl/curl/issues/15513
+    # https://github.com/curl/curl/commit/0cdde0fdfbeb8c35420f6d03fa4b77ed73497694
+    ./fix-netrc-regression-2.patch
   ];
 
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/356114#issuecomment-2488646405

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
