### PR TITLE
dcgm: 3.3.5 -> 3.3.9; cudaPackages_10{,_0,_1,_2}: drop

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -28,6 +28,8 @@
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
 
+- Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
+
 - `kanata` was updated to v1.7.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -14,23 +14,11 @@
 , Accelerate, CoreGraphics, CoreVideo
 , lmdbSupport ? true, lmdb
 , leveldbSupport ? true, leveldb, snappy
-, cudaSupport ? config.cudaSupport, cudaPackages ? { }
-, cudnnSupport ? cudaSupport
-, ncclSupport ? false
 , pythonSupport ? false, python ? null, numpy ? null
 , substituteAll
 }:
 
 let
-  inherit (cudaPackages) backendStdenv cudatoolkit nccl;
-  # The default for cudatoolkit 10.1 is CUDNN 8.0.5, the last version to support CUDA 10.1.
-  # However, this caffe does not build with CUDNN 8.x, so we use CUDNN 7.6.5 instead.
-  # Earlier versions of cudatoolkit use pre-8.x CUDNN, so we use the default.
-  hasCudnn =
-    if lib.versionOlder cudatoolkit.version "10.1"
-    then cudaPackages ? cudnn
-    else cudaPackages ? cudnn_7_6;
-
   toggle = bool: if bool then "ON" else "OFF";
 
   test_model_weights = fetchurl {
@@ -57,20 +45,12 @@ stdenv.mkDerivation rec {
     # boost_python expects
     [ (if pythonSupport then "-Dpython_version=${python.pythonVersion}" else "-DBUILD_python=OFF")
       "-DBLAS=open"
-    ] ++ (if cudaSupport then [
-           "-DCUDA_ARCH_NAME=All"
-           "-DCUDA_HOST_COMPILER=${backendStdenv.cc}/bin/cc"
-         ] else [ "-DCPU_ONLY=ON" ])
-      ++ ["-DUSE_NCCL=${toggle ncclSupport}"]
-      ++ ["-DUSE_LEVELDB=${toggle leveldbSupport}"]
+      "-DCPU_ONLY=ON"
+    ] ++ ["-DUSE_LEVELDB=${toggle leveldbSupport}"]
       ++ ["-DUSE_LMDB=${toggle lmdbSupport}"];
 
   buildInputs = [ boost gflags glog protobuf hdf5-cpp opencv4 blas ]
-                ++ lib.optional cudaSupport cudatoolkit
-                ++ lib.optional (lib.versionOlder cudatoolkit.version "10.1" && hasCudnn) cudaPackages.cudnn
-                ++ lib.optional (lib.versionAtLeast cudatoolkit.version "10.1" && hasCudnn) cudaPackages.cudnn_7_6
                 ++ lib.optional lmdbSupport lmdb
-                ++ lib.optional ncclSupport nccl
                 ++ lib.optionals leveldbSupport [ leveldb snappy ]
                 ++ lib.optionals pythonSupport [ python numpy ]
                 ++ lib.optionals stdenv.hostPlatform.isDarwin [ Accelerate CoreGraphics CoreVideo ]
@@ -105,9 +85,6 @@ stdenv.mkDerivation rec {
     substituteInPlace src/caffe/util/io.cpp --replace \
       'SetTotalBytesLimit(kProtoReadBytesLimit, 536870912)' \
       'SetTotalBytesLimit(kProtoReadBytesLimit)'
-  '' + lib.optionalString (cudaSupport && lib.versionAtLeast cudatoolkit.version "9.0") ''
-    # CUDA 9.0 doesn't support sm_20
-    sed -i 's,20 21(20) ,,' cmake/Cuda.cmake
   '';
 
   preConfigure = lib.optionalString pythonSupport ''
@@ -150,10 +127,7 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     broken =
       (pythonSupport && (python.isPy310))
-      || cudaSupport
       || !(leveldbSupport -> (leveldb != null && snappy != null))
-      || !(cudnnSupport -> (hasCudnn && cudaSupport))
-      || !(ncclSupport -> (cudaSupport && !nccl.meta.unsupported))
       || !(pythonSupport -> (python != null && numpy != null))
     ;
     license = licenses.bsd2;

--- a/pkgs/by-name/dc/dcgm/dynamic-libs.patch
+++ b/pkgs/by-name/dc/dcgm/dynamic-libs.patch
@@ -1,0 +1,40 @@
+diff --git a/cmake/FindJsoncpp.cmake b/cmake/FindJsoncpp.cmake
+index abedf7bb85..d7a52f5c7b 100644
+--- a/cmake/FindJsoncpp.cmake
++++ b/cmake/FindJsoncpp.cmake
+@@ -16,8 +16,8 @@
+ 
+ if (NOT TARGET JsonCpp::JsonCpp)
+     find_package(jsoncpp REQUIRED CONFIG)
+-    set(JSONCPP_STATIC_LIBS jsoncpp_static)
+-    set(JSONCPP_INCLUDE_PATH $<TARGET_PROPERTY:jsoncpp_static,INTERFACE_INCLUDE_DIRECTORIES>)
++    set(JSONCPP_STATIC_LIBS jsoncpp)
++    set(JSONCPP_INCLUDE_PATH $<TARGET_PROPERTY:jsoncpp,INTERFACE_INCLUDE_DIRECTORIES>)
+ endif()
+ # set(Jsoncpp_PATH_PREFIXES /usr/local "${Jsoncpp_ROOT}" "$ENV{HOME}")
+ # foreach(prefix ${Jsoncpp_PATH_PREFIXES})
+diff --git a/cmake/FindLibevent.cmake b/cmake/FindLibevent.cmake
+index 354d6f9b99..38aca9534e 100644
+--- a/cmake/FindLibevent.cmake
++++ b/cmake/FindLibevent.cmake
+@@ -26,16 +26,12 @@
+ endforeach()
+ 
+ find_path(LIBEVENT_INCLUDE_DIR evhttp.h event.h PATHS ${Libevent_INCLUDE_PATHS})
+-find_library(LIBEVENT_STATIC_LIB NAMES libevent.a libevent_core.a libevent_extra.a PATHS ${Libevent_LIB_PATHS})
+-find_library(LIBEVENT_PTHREAD_STATIC_LIB NAMES libevent_pthreads.a PATHS ${Libevent_LIB_PATHS})
++find_library(LIBEVENT_STATIC_LIB NAMES libevent.so libevent_core.so libevent_extra.so PATHS ${Libevent_LIB_PATHS})
++find_library(LIBEVENT_PTHREAD_STATIC_LIB NAMES libevent_pthreads.so PATHS ${Libevent_LIB_PATHS})
+ 
+-if (LIBEVENT_INCLUDE_DIR AND LIBEVENT_STATIC_LIB AND LIBEVENT_PTHREAD_STATIC_LIB)
++if (LIBEVENT_INCLUDE_DIR AND LIBEVENT_STATIC_LIB)
+     set(Libevent_FOUND TRUE)
+-    add_library(libevent_event_static STATIC IMPORTED)
+-    set_target_properties(libevent_event_static PROPERTIES IMPORTED_LOCATION ${LIBEVENT_STATIC_LIB})
+-    add_library(libevent_event_pthread STATIC IMPORTED)
+-    set_target_properties(libevent_event_pthread PROPERTIES IMPORTED_LOCATION ${LIBEVENT_PTHREAD_STATIC_LIB})
+-    set(LIBEVENT_STATIC_LIBS libevent_event_static libevent_event_pthread)
++    set(LIBEVENT_STATIC_LIBS ${LIBEVENT_STATIC_LIB} ${LIBEVENT_PTHREAD_STATIC_LIB})
+ else ()
+     set(Libevent_FOUND FALSE)
+ endif ()

--- a/pkgs/by-name/dc/dcgm/fix-includes.patch
+++ b/pkgs/by-name/dc/dcgm/fix-includes.patch
@@ -1,0 +1,110 @@
+diff --git a/common/CudaWorker/DcgmDgemm.cpp b/common/CudaWorker/DcgmDgemm.cpp
+index 8d33a3256e..6b3284258d 100644
+--- a/common/CudaWorker/DcgmDgemm.cpp
++++ b/common/CudaWorker/DcgmDgemm.cpp
+@@ -17,6 +17,7 @@
+ 
+ #include <exception>
+ #include <stdexcept>
++#include <cinttypes>
+ 
+ #define CU_CHK(op)                                               \
+     if (auto const status = op; status != CUBLAS_STATUS_SUCCESS) \
+@@ -122,4 +123,4 @@
+     return CUBLAS_STATUS_SUCCESS;
+ }
+ 
+-} // namespace DcgmNs
+\ No newline at end of file
++} // namespace DcgmNs
+diff --git a/common/DcgmError.h b/common/DcgmError.h
+index 8638cdceb1..e8d817c0d4 100644
+--- a/common/DcgmError.h
++++ b/common/DcgmError.h
+@@ -17,6 +17,7 @@
+ 
+ #include <sstream>
+ #include <string>
++#include <cinttypes>
+ 
+ #include <dcgm_agent.h>
+ #include <dcgm_errors.h>
+diff --git a/common/DcgmStringHelpers.cpp b/common/DcgmStringHelpers.cpp
+index b41917e3b7..1fe63980c7 100644
+--- a/common/DcgmStringHelpers.cpp
++++ b/common/DcgmStringHelpers.cpp
+@@ -17,6 +17,7 @@
+ 
+ #include <cstring>
+ #include <string>
++#include <algorithm>
+ 
+ /*****************************************************************************/
+ void dcgmTokenizeString(const std::string &src, const std::string &delimiter, std::vector<std::string> &tokens)
+diff --git a/dcgmi/CommandOutputController.cpp b/dcgmi/CommandOutputController.cpp
+index 5057205564..8520171efa 100644
+--- a/dcgmi/CommandOutputController.cpp
++++ b/dcgmi/CommandOutputController.cpp
+@@ -24,6 +24,7 @@
+ #include "dcgm_agent.h"
+ #include <DcgmStringHelpers.h>
+ #include <algorithm>
++#include <functional>
+ #include <cstdarg>
+ #include <iostream>
+ #include <string>
+diff --git a/dcgmi/Diag.h b/dcgmi/Diag.h
+index a326f7b949..563fb3c9c0 100755
+--- a/dcgmi/Diag.h
++++ b/dcgmi/Diag.h
+@@ -24,6 +24,7 @@
+ #define DIAG_H_
+ 
+ #include <optional>
++#include <functional>
+ 
+ #include "Command.h"
+ #include "CommandOutputController.h"
+diff --git a/hostengine/src/HostEngineOutput.cpp b/hostengine/src/HostEngineOutput.cpp
+index 23c6ca9f54..798b83b3e4 100644
+--- a/hostengine/src/HostEngineOutput.cpp
++++ b/hostengine/src/HostEngineOutput.cpp
+@@ -20,6 +20,7 @@
+ #include <iostream>
+ #include <limits>
+ #include <string_view>
++#include <unordered_map>
+ 
+ namespace
+ {
+@@ -365,4 +366,4 @@
+         }
+     }
+     os << std::endl;
+-}
+\ No newline at end of file
++}
+diff --git a/nvvs/src/NvvsCommon.cpp b/nvvs/src/NvvsCommon.cpp
+index 8f7888649b..1604d9dabe 100644
+--- a/nvvs/src/NvvsCommon.cpp
++++ b/nvvs/src/NvvsCommon.cpp
+@@ -15,6 +15,7 @@
+  */
+ #include <sstream>
+ #include <stdexcept>
++#include <algorithm>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
+diff --git a/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp b/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp
+index 9eebeaf1c4..6e21201229 100644
+--- a/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp
++++ b/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include <atomic>
+ #include <mutex>
++#include <cstdlib>
+ 
+ static void *g_nvmlLib                                     = 0;
+ static std::atomic_uint32_t g_nvmlStaticLibResetHooksCount = 1;

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -4,6 +4,7 @@
 , autoAddDriverRunpath
 , catch2
 , cmake
+, ninja
 , cudaPackages_10_2
 , cudaPackages_11_8
 , cudaPackages_12
@@ -104,6 +105,7 @@ in gcc11Stdenv.mkDerivation rec {
     autoAddDriverRunpath
 
     cmake
+    ninja
     git
     python3
   ];

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -109,6 +109,30 @@ in stdenv.mkDerivation rec {
   # Lots of dodgy C++.
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    ctest -j $NIX_BUILD_CORES --output-on-failure --exclude-regex ${
+      lib.escapeShellArg (
+        lib.concatMapStringsSep "|" (test: "^${lib.escapeRegex test}$") [
+          "DcgmModuleSysmon Watches"
+          "DcgmModuleSysmon maxSampleAge"
+          "DcgmModuleSysmon::CalculateCoreUtilization"
+          "DcgmModuleSysmon::ParseProcStatCpuLine"
+          "DcgmModuleSysmon::ParseThermalFileContentsAndStore"
+          "DcgmModuleSysmon::PopulateTemperatureFileMap"
+          "DcgmModuleSysmon::ReadCoreSpeed"
+          "DcgmModuleSysmon::ReadTemperature"
+          "Sysmon: initialize module"
+        ]
+      )
+    }
+
+    runHook postCheck
+  '';
+
   disallowedReferences = lib.concatMap getCudaPackages cudaPackageSets;
 
   meta = with lib; {

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -5,9 +5,9 @@
 , catch2
 , cmake
 , ninja
-, cudaPackages_10_2
 , cudaPackages_11_8
 , cudaPackages_12
+, boost
 , fmt_9
 , git
 , jsoncpp
@@ -21,26 +21,12 @@
 , static ? gcc11Stdenv.hostPlatform.isStatic
 }:
 let
-  # DCGM depends on 3 different versions of CUDA at the same time.
-  # The runtime closure, thankfully, is quite small because most things
-  # are statically linked.
-  cudaPackageSetByVersion = [
-    {
-      version = "10";
-      # Nixpkgs cudaPackages_10 doesn't have redist packages broken out.
-      pkgSet = [
-        cudaPackages_10_2.cudatoolkit
-        cudaPackages_10_2.cudatoolkit.lib
-      ];
-    }
-    {
-      version = "11";
-      pkgSet = getCudaPackages cudaPackages_11_8;
-    }
-    {
-      version = "12";
-      pkgSet = getCudaPackages cudaPackages_12;
-    }
+  # DCGM depends on 2 different versions of CUDA at the same time.
+  # The runtime closure, thankfully, is quite small as it does not
+  # include the CUDA libraries.
+  cudaPackageSets = [
+    cudaPackages_11_8
+    cudaPackages_12
   ];
 
   # Select needed redist packages from cudaPackages
@@ -55,44 +41,38 @@ let
     libcurand
   ];
 
-  # Builds CMake code to add CUDA paths for include and lib.
-  mkAppendCudaPaths = { version, pkgSet }:
+  # Builds CMake flags to add CUDA paths for include and lib.
+  mkCudaFlags = cudaPackages:
     let
+      version = cudaPackages.cudaMajorVersion;
       # The DCGM CMake assumes that the folder containing cuda.h contains all headers, so we must
       # combine everything together for headers to work.
-      # It would be more convenient to use symlinkJoin on *just* the include subdirectories
-      # of each package, but not all of them have an include directory and making that work
-      # is more effort than it's worth for this temporary, build-time package.
-      combined = symlinkJoin {
-        name = "cuda-combined-${version}";
-        paths = pkgSet;
+      headers = symlinkJoin {
+        name = "cuda-headers-combined-${version}";
+        paths = lib.map (pkg: "${lib.getInclude pkg}/include") (getCudaPackages cudaPackages);
       };
-      # The combined package above breaks the build for some reason so we just configure
-      # each package's library path.
-      libs = lib.concatMapStringsSep " " (x: ''"${x}/lib"'') pkgSet;
-    in ''
-      list(APPEND Cuda${version}_INCLUDE_PATHS "${combined}/include")
-      list(APPEND Cuda${version}_LIB_PATHS ${libs})
-    '';
+    in [
+      (lib.cmakeFeature "CUDA${version}_INCLUDE_DIR" "${headers}")
+      (lib.cmakeFeature "CUDA${version}_LIBS" "${cudaPackages.cuda_cudart.stubs}/lib/stubs/libcuda.so")
+      (lib.cmakeFeature "CUDA${version}_STATIC_LIBS" "${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so")
+      (lib.cmakeFeature "CUDA${version}_STATIC_CUBLAS_LIBS" (lib.concatStringsSep ";" [
+        "${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"
+        "${lib.getLib cudaPackages.libcublas}/lib/libcublasLt.so"
+      ]))
+    ];
 
 # gcc11 is required by DCGM's very particular build system
 # C.f. https://github.com/NVIDIA/DCGM/blob/7e1012302679e4bb7496483b32dcffb56e528c92/dcgmbuild/build.sh#L22
 in gcc11Stdenv.mkDerivation rec {
   pname = "dcgm";
-  version = "3.3.5"; # N.B: If you change this, be sure prometheus-dcgm-exporter supports this version.
+  version = "3.3.9"; # N.B: If you change this, be sure prometheus-dcgm-exporter supports this version.
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "DCGM";
     rev = "refs/tags/v${version}";
-    hash = "sha256-n/uWvgvxAGfr1X51XgtHfFGDOO5AMBSV5UWQQpsylpg=";
+    hash = "sha256-PysxuN5WT7GB0oOvT5ezYeOau6AMVDDWE5HOAcmqw/Y=";
   };
-
-  # Add our paths to the CUDA paths so FindCuda.cmake can find them.
-  EXTRA_CUDA_PATHS = lib.concatMapStringsSep "\n" mkAppendCudaPaths cudaPackageSetByVersion;
-  prePatch = ''
-    echo "$EXTRA_CUDA_PATHS"$'\n'"$(cat cmake/FindCuda.cmake)" > cmake/FindCuda.cmake
-  '';
 
   hardeningDisable = [ "all" ];
 
@@ -112,6 +92,7 @@ in gcc11Stdenv.mkDerivation rec {
 
   buildInputs = [
     # Header-only
+    boost
     catch2
     plog.dev
     tclap_1_4
@@ -125,7 +106,10 @@ in gcc11Stdenv.mkDerivation rec {
     (libevent.override { sslSupport = false; static = true; })
   ];
 
-  disallowedReferences = lib.concatMap (x: x.pkgSet) cudaPackageSetByVersion;
+  # Add our paths to the CMake flags so FindCuda.cmake can find them.
+  cmakeFlags = lib.concatMap mkCudaFlags cudaPackageSets;
+
+  disallowedReferences = lib.concatMap getCudaPackages cudaPackageSets;
 
   meta = with lib; {
     description = "Data Center GPU Manager (DCGM) is a daemon that allows users to monitor NVIDIA data-center GPUs";

--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
@@ -9,13 +9,13 @@ buildGoModule rec {
 
   # The first portion of this version string corresponds to a compatible DCGM
   # version.
-  version = "3.3.5-3.4.0"; # N.B: If you change this, update dcgm as well to the matching version.
+  version = "3.3.9-3.6.1"; # N.B: If you change this, update dcgm as well to the matching version.
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-IOVPEK+9ogBZJYns2pTyJwHUBMN8JqG1THTJPvpCwdo=";
+    hash = "sha256-BAMN2yuIW5FcHY3o9MUIMgPnTEFFRCbqhoAkcaZDxcM=";
   };
 
   CGO_LDFLAGS = "-ldcgm";
@@ -28,7 +28,7 @@ buildGoModule rec {
   # symbols are available on startup.
   hardeningDisable = [ "bindnow" ];
 
-  vendorHash = "sha256-urKa0O8QZnM8cWjPcGVhoAWhx6fCdMmhRX0JOriRaig=";
+  vendorHash = "sha256-b7GyPsmSGHx7hK0pDa88FKA+ZKJES2cdAGjT2aAfX/A=";
 
   nativeBuildInputs = [
     autoAddDriverRunpath

--- a/pkgs/development/cuda-modules/cudatoolkit/releases.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/releases.nix
@@ -10,24 +10,6 @@
 # }
 # Releases = AttrSet CudaVersion Release
 {
-  "10.0" = {
-    version = "10.0.130";
-    url = "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux";
-    sha256 = "16p3bv1lwmyqpxil8r951h385sy9asc578afrc7lssa68c71ydcj";
-  };
-
-  "10.1" = {
-    version = "10.1.243";
-    url = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run";
-    sha256 = "0caxhlv2bdq863dfp6wj7nad66ml81vasq2ayf11psvq2b12vhp7";
-  };
-
-  "10.2" = {
-    version = "10.2.89";
-    url = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run";
-    sha256 = "04fasl9sjkb1jvchvqgaqxprnprcz7a8r52249zp2ijarzyhf3an";
-  };
-
   "11.0" = {
     version = "11.0.3";
     url = "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run";

--- a/pkgs/development/cuda-modules/cudnn/releases.nix
+++ b/pkgs/development/cuda-modules/cudnn/releases.nix
@@ -97,48 +97,6 @@
     # x86_64
     linux-x86_64 = [
       {
-        version = "7.4.2.24";
-        minCudaVersion = "10.0";
-        maxCudaVersion = "10.0";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v7.4.2/cudnn-10.0-linux-x64-v7.4.2.24.tgz";
-        hash = "sha256-Lt/IagK1DRfojEeJVaMy5qHoF05+U6NFi06lH68C2qM=";
-      }
-      {
-        version = "7.6.5.32";
-        minCudaVersion = "10.0";
-        maxCudaVersion = "10.0";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.0-linux-x64-v7.6.5.32.tgz";
-        hash = "sha256-KDVeOV8LK5OsLIO2E2CzW6bNA3fkTni+GXtrYbS0kro=";
-      }
-      {
-        version = "7.6.5.32";
-        minCudaVersion = "10.1";
-        maxCudaVersion = "10.1";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-x64-v7.6.5.32.tgz";
-        hash = "sha256-fq7IA5osMKsLx1jTA1iHZ2k972v0myJIWiwAvy4TbLM=";
-      }
-      {
-        version = "7.6.5.32";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.2-linux-x64-v7.6.5.32.tgz";
-        hash = "sha256-YAJn8squ0v1Y6yFLpmnY6jXzlqfRm5SCLms2+fcIjCA='";
-      }
-      {
-        version = "8.0.5.39";
-        minCudaVersion = "10.1";
-        maxCudaVersion = "10.1";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-10.1-linux-x64-v8.0.5.39.tgz";
-        hash = "sha256-kJCElSmIlrM6qVBjo0cfk8NmJ9esAcF9w211xl7qSgA=";
-      }
-      {
-        version = "8.0.5.39";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-10.2-linux-x64-v8.0.5.39.tgz";
-        hash = "sha256-IfhMBcZ78eyFnnfDjM1b8VSWT6HDCPRJlZvkw1bjgvM=";
-      }
-      {
         version = "8.0.5.39";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.0";
@@ -154,24 +112,10 @@
       }
       {
         version = "8.1.1.33";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.1.1/cudnn-10.2-linux-x64-v8.1.1.33.tgz";
-        hash = "sha256-Kkp7mabpv6aQ6xm7QeSVU/KnpJGls6v8rpAOFmxbbr0=";
-      }
-      {
-        version = "8.1.1.33";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.2";
         url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.1.1/cudnn-11.2-linux-x64-v8.1.1.33.tgz";
         hash = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
-      }
-      {
-        version = "8.2.4.15";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.2.4/cudnn-10.2-linux-x64-v8.2.4.15.tgz";
-        hash = "sha256-0jyUoxFaHHcRamwSfZF1+/WfcjNkN08mo0aZB18yIvE=";
       }
       {
         version = "8.2.4.15";
@@ -182,24 +126,10 @@
       }
       {
         version = "8.3.3.40";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.3/local_installers/10.2/cudnn-linux-x86_64-8.3.3.40_cuda10.2-archive.tar.xz";
-        hash = "sha256-2FVPKzLmKV1fyPOsJeaPlAWLAYyAHaucFD42gS+JJqs=";
-      }
-      {
-        version = "8.3.3.40";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.6";
         url = "https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.3/local_installers/11.5/cudnn-linux-x86_64-8.3.3.40_cuda11.5-archive.tar.xz";
         hash = "sha256-6r6Wx1zwPqT1N5iU2RTx+K4UzqsSGYnoSwg22Sf7dzE=";
-      }
-      {
-        version = "8.4.1.50";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.4.1.50_cuda10.2-archive.tar.xz";
-        hash = "sha256-I88qMmU6lIiLVmaPuX7TTbisgTav839mssxUo3lQNjg=";
       }
       {
         version = "8.4.1.50";
@@ -210,13 +140,6 @@
       }
       {
         version = "8.5.0.96";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.5.0.96_cuda10-archive.tar.xz";
-        hash = "sha256-1mzhbbzR40WKkHnQLtJHhg0vYgf7G8a0OBcCwIOkJjM=";
-      }
-      {
-        version = "8.5.0.96";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.7";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz";
@@ -224,24 +147,10 @@
       }
       {
         version = "8.6.0.163";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.6.0.163_cuda10-archive.tar.xz";
-        hash = "sha256-t4sr/GrFqqdxu2VhaJQk5K1Xm/0lU4chXG8hVL09R9k=";
-      }
-      {
-        version = "8.6.0.163";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz";
         hash = "sha256-u8OW30cpTGV+3AnGAGdNYIyxv8gLgtz0VHBgwhcRFZ4=";
-      }
-      {
-        version = "8.7.0.84";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.7.0.84_cuda10-archive.tar.xz";
-        hash = "sha256-bZhaqc8+GbPV2FQvvbbufd8VnEJgvfkICc2N3/gitRg=";
       }
       {
         version = "8.7.0.84";

--- a/pkgs/development/cuda-modules/cutensor/extension.nix
+++ b/pkgs/development/cuda-modules/cutensor/extension.nix
@@ -101,10 +101,7 @@ let
     (attrsets.attrByPath [
       pname
       redistArch
-    ] null feature) != null
-
-    # NOTE: This is an ad hoc hack; manifest schemas do not support version constraints yet
-    && !(lib.versionOlder cudaVersion "11.0" && lib.versionAtLeast redistrib.${pname}.version "2.0.2");
+    ] null feature) != null;
 
   # TODO(@connorbaker): With an auxilliary file keeping track of the CUDA versions each release supports,
   # we could filter out releases that don't support our CUDA version.

--- a/pkgs/development/cuda-modules/gpus.nix
+++ b/pkgs/development/cuda-modules/gpus.nix
@@ -28,23 +28,6 @@
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 [
   {
-    # GeForce 700, GT-730
-    archName = "Kepler";
-    computeCapability = "3.0";
-    isJetson = false;
-    minCudaVersion = "10.0";
-    dontDefaultAfter = "10.2";
-    maxCudaVersion = "10.2";
-  }
-  {
-    archName = "Kepler";
-    computeCapability = "3.2";
-    isJetson = false;
-    minCudaVersion = "10.0";
-    dontDefaultAfter = "10.2";
-    maxCudaVersion = "10.2";
-  }
-  {
     # Tesla K40
     archName = "Kepler";
     computeCapability = "3.5";

--- a/pkgs/development/cuda-modules/nvcc-compatibilities.nix
+++ b/pkgs/development/cuda-modules/nvcc-compatibilities.nix
@@ -22,28 +22,6 @@ let
   # attrs :: AttrSet CudaVersion CompilerCompatibilities
   attrs = {
     # Our baseline
-    # https://docs.nvidia.com/cuda/archive/10.0/cuda-toolkit-release-notes/index.html#cuda-compiler-new-features
-    "10.0" = {
-      clangMaxMajorVersion = "6";
-      clangMinMajorVersion = "6";
-      gccMaxMajorVersion = "7";
-      gccMinMajorVersion = "5";
-    };
-
-    # Added support for Clang 7 and GCC 8
-    # https://docs.nvidia.com/cuda/archive/10.1/cuda-toolkit-release-notes/index.html#cuda-compiler-new-features
-    "10.1" = attrs."10.0" // {
-      clangMaxMajorVersion = "7";
-      gccMaxMajorVersion = "8";
-    };
-
-    # Added clang 8
-    # https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#cuda-compiler-new-features
-    "10.2" = attrs."10.1" // {
-      clangMaxMajorVersion = "8";
-    };
-
-    # Added support for Clang 9 and GCC 9
     # https://docs.nvidia.com/cuda/archive/11.0/cuda-toolkit-release-notes/index.html#cuda-compiler-new-features
     "11.0" = {
       clangMaxMajorVersion = "9";

--- a/pkgs/development/cuda-modules/tensorrt/releases.nix
+++ b/pkgs/development/cuda-modules/tensorrt/releases.nix
@@ -45,27 +45,11 @@
     linux-x86_64 = [
       {
         version = "8.0.3.4";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        cudnnVersion = "8.2";
-        filename = "TensorRT-8.0.3.4.Linux.x86_64-gnu.cuda-10.2.cudnn8.2.tar.gz";
-        hash = "sha256-LxcXgwe1OCRfwDsEsNLIkeNsOcx3KuF5Sj+g2dY6WD0=";
-      }
-      {
-        version = "8.0.3.4";
         minCudaVersion = "11.0";
         maxCudaVersion = "11.3";
         cudnnVersion = "8.2";
         filename = "TensorRT-8.0.3.4.Linux.x86_64-gnu.cuda-11.3.cudnn8.2.tar.gz";
         hash = "sha256-MXdDUCT/SqWm26jB7QarEcwOG/O7cS36Y6Q0IvQTE/M=";
-      }
-      {
-        version = "8.2.5.1";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        cudnnVersion = "8.2";
-        filename = "TensorRT-8.2.5.1.Linux.x86_64-gnu.cuda-10.2.cudnn8.2.tar.gz";
-        hash = "sha256-XV2Bf2LH8OM2GEMjV80MDweb1hSVF/wFUcaW3KP2m8Q=";
       }
       {
         # The docs claim this supports through 11.5 despite the file name indicating 11.4.
@@ -77,14 +61,6 @@
         hash = "sha256-LcNpYvDiT7AavqzK1MRlijo2qDN7jznigeS77US713E=";
       }
       {
-        version = "8.4.3.1";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        cudnnVersion = "8.4";
-        filename = "TensorRT-8.4.3.1.Linux.x86_64-gnu.cuda-10.2.cudnn8.4.tar.gz";
-        hash = "sha256-2c3Zzt93FBWWQtrSIvpbzzS6BT9s0NzALzdwXGLOZEU=";
-      }
-      {
         # The docs claim this supports through 11.7 despite the file name indicating 11.6.
         version = "8.4.3.1";
         minCudaVersion = "11.0";
@@ -92,14 +68,6 @@
         cudnnVersion = "8.4";
         filename = "TensorRT-8.4.3.1.Linux.x86_64-gnu.cuda-11.6.cudnn8.4.tar.gz";
         hash = "sha256-jXwghcFjncxzh1BIwjWYqFJs4wiRNoduMdkCWOSeT2E=";
-      }
-      {
-        version = "8.5.3.1";
-        minCudaVersion = "10.2";
-        maxCudaVersion = "10.2";
-        cudnnVersion = "8.6";
-        filename = "TensorRT-8.5.3.1.Linux.x86_64-gnu.cuda-10.2.cudnn8.6.tar.gz";
-        hash = "sha256-WCt6yfOmFbrjqdYCj6AE2+s2uFpISwk6urP+2I0BnGQ=";
       }
       {
         version = "8.5.3.1";

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -4,11 +4,6 @@
 
   cudaPackages,
 
-  cudaPackages_10_0,
-  cudaPackages_10_1,
-  cudaPackages_10_2,
-  cudaPackages_10,
-
   cudaPackages_11_0,
   cudaPackages_11_1,
   cudaPackages_11_2,

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -237,6 +237,10 @@ mapAliases {
   containerpilot = throw "'containerpilot' has been removed from nixpkgs, as it was broken and unmaintained"; # Added 2024-06-09
   crackmapexec = throw "'crackmapexec' has been removed as it was unmaintained. Use 'netexec' instead"; # 2024-08-11
   critcl = tclPackages.critcl; # Added 2024-10-02
+  cudaPackages_10_0 = throw "CUDA 10.0 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2024-11-20
+  cudaPackages_10_1 = throw "CUDA 10.1 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2024-11-20
+  cudaPackages_10_2 = throw "CUDA 10.2 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2024-11-20
+  cudaPackages_10 = throw "CUDA 10 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2024-11-20
   cups-kyodialog3 = cups-kyodialog; # Added 2022-11-12
   cvs_fast_export = throw "'cvs_fast_export' has been renamed to/replaced by 'cvs-fast-export'"; # Converted to throw 2024-10-17
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -182,6 +182,7 @@ mapAliases {
 
   ### C ###
 
+  caffeWithCuda = throw "caffeWithCuda has been removed, as it was broken and required CUDA 10"; # Added 2024-11-20
   calligra = kdePackages.calligra; # Added 2024-09-27
   callPackage_i686 = pkgsi686Linux.callPackage;
   cask = emacs.pkgs.cask; # Added 2022-11-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18102,14 +18102,10 @@ with pkgs;
   ### SCIENCE / MATH
 
   caffe = callPackage ../applications/science/math/caffe ({
-    inherit (config) cudaSupport;
-    cudaPackages = cudaPackages_10_1;
     opencv4 = opencv4WithoutCuda; # Used only for image loading.
     blas = openblas;
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   } // (config.caffe or {}));
-
-  caffeWithCuda = caffe.override { cudaSupport = true; };
 
   gap-minimal = lowPrio (gap.override { packageSet = "minimal"; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3101,11 +3101,6 @@ with pkgs;
 
   cron = isc-cron;
 
-  cudaPackages_10_0 = callPackage ./cuda-packages.nix { cudaVersion = "10.0"; };
-  cudaPackages_10_1 = callPackage ./cuda-packages.nix { cudaVersion = "10.1"; };
-  cudaPackages_10_2 = callPackage ./cuda-packages.nix { cudaVersion = "10.2"; };
-  cudaPackages_10 = recurseIntoAttrs cudaPackages_10_2;
-
   cudaPackages_11_0 = callPackage ./cuda-packages.nix { cudaVersion = "11.0"; };
   cudaPackages_11_1 = callPackage ./cuda-packages.nix { cudaVersion = "11.1"; };
   cudaPackages_11_2 = callPackage ./cuda-packages.nix { cudaVersion = "11.2"; };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -101,6 +101,7 @@ mapAliases ({
   BTrees = btrees; # added 2023-02-19
   cacheyou = throw "cacheyou has been removed, as it was no longer used for the only consumer pdm"; # added 2023-12-21
   cadquery = throw "cadquery was removed, because it was disabled on all python version since 3.8 and marked as broken"; # added 2024-05-13
+  caffeWithCuda = throw "caffeWithCuda has been removed, as it was broken and required CUDA 10"; # Added 2024-11-20
   can = python-can; # added 2024-08-12
   carrot = throw "carrot has been removed, as its development was discontinued in 2012"; # added 2022-01-18
   case = throw "case has been removed, since it is an unused leaf package with a dependency on the nose test framework"; # added 2024-07-08

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1989,11 +1989,6 @@ self: super: with self; {
     inherit (self) python numpy boost;
   });
 
-  caffeWithCuda = toPythonModule (pkgs.caffeWithCuda.override {
-    pythonSupport = true;
-    inherit (self) python numpy boost;
-  });
-
   caio = callPackage ../development/python-modules/caio { };
 
   cairocffi = callPackage ../development/python-modules/cairocffi { };

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -118,7 +118,6 @@ let
       python3Packages = {
         boxx = linux;
         bpycv = linux;
-        caffe = linux;
         catboost = linux;
         chainer = linux;
         cupy = linux;


### PR DESCRIPTION
An update of DCGM to a newer version that has dropped CUDA 10 support upstream, fixing the build and cleaning it up a bit in the process, and a [scheduled visit from the reaper](https://github.com/NixOS/nixpkgs/pull/342112) now that 24.11 has branched off and this is the last thing standing in the way of my unsupported‐compiler‐removing rampage. See the commit messages for details. CUDA 11 lives for now, mostly pending action on https://github.com/NixOS/nixpkgs/pull/345658, though it’s not urgent as there are other blockers to removing the slightly newer GCCs that I have to deal with first.

I don’t use DCGM, so cc @de11n for testing. It passes tests that we weren’t running before, at least.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 12 packages built:</summary>
  <ul>
    <li>caffe</li>
    <li>caffe.bin</li>
    <li>cudaPackages.cudatoolkit-legacy-runfile</li>
    <li>cudaPackages.cudatoolkit-legacy-runfile.doc</li>
    <li>cudaPackages.cudatoolkit-legacy-runfile.lib</li>
    <li>cudaPackages_11.cudatoolkit-legacy-runfile</li>
    <li>cudaPackages_11.cudatoolkit-legacy-runfile.doc</li>
    <li>cudaPackages_11.cudatoolkit-legacy-runfile.lib</li>
    <li>dcgm</li>
    <li>prometheus-dcgm-exporter</li>
    <li>python311Packages.caffe</li>
    <li>python311Packages.caffe.bin</li>
  </ul>
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
