### PR TITLE
rquickshare: build from source

### DIFF
--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -1,34 +1,98 @@
 {
-  appimageTools,
   lib,
-  fetchurl,
+  cargo-tauri,
+  nodejs,
+  pnpm,
+  rustPlatform,
+  moreutils,
+  protobuf,
+  jq,
+  yq,
+  stdenv,
+  fetchFromGitHub,
+  zsh,
 }:
 let
   pname = "rquickshare";
   version = "0.11.2";
-  src = fetchurl {
-    url = "https://github.com/Martichou/rquickshare/releases/download/v${version}/r-quick-share-main_v${version}_glibc-2.39_amd64.AppImage";
-    hash = "sha256-7w1zybCPRg4RK5bKHoHLDUDXVDQL23ox/6wh8H9vTPg=";
+  src = fetchFromGitHub {
+    owner = "martichou";
+    repo = "rquickshare";
+    rev = "v${version}";
+    sha256 = "sha256-MYhM6FB3zfvMFnLMecbn4Ismvk8AAykIvhPBnFcNjdI=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  tauri = cargo-tauri;
 in
-appimageTools.wrapType2 {
-  inherit pname version src;
-  extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/rquickshare.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/rquickshare.desktop \
-      --replace-fail 'Exec=rquickshare' 'Exec=rquickshare %u'
-    cp -r ${appimageContents}/usr/share/icons $out/share
+# we could use rustPlatform.buildRustPackage, but there cargoDeps doesn't work
+stdenv.mkDerivation rec {
+  inherit version src pname;
+  name = pname;
+  sourceRoot = "${src.name}/app/main";
+  corelibSourceRoot = "${src.name}/core_lib";
+  cargoRoot = "src-tauri";
+  corelibPath = "rqs_lib";
+  nativeBuildInputs = [
+    tauri.hook
+    pnpm.configHook
+    nodejs
+    moreutils
+    protobuf
+    jq
+    yq
+    rustPlatform.cargoSetupHook
+  ];
+  # seemingly the fetcher ignores cargoRoot (contrary to the docs)
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src pname;
+    hash = cargoHash;
+    sourceRoot = "${sourceRoot}/${cargoRoot}";
+  };
+  cargoHash = "sha256-5vGXMHar9E25jVseXR2uI82DtZXyPaHgDD8QkqoRhhY=";
+  pnpmDeps = pnpm.fetchDeps {
+    inherit src sourceRoot pname;
+    hash = "sha256-VPb2idEiBruVCwz5lDojFmD2C5CfXYSe5mPWBwCGeJs=";
+  };
+  postUnpack =
+    let
+      fullCorePath = "${sourceRoot}/${cargoRoot}/${corelibPath}";
+    in
+    ''
+      cp -r ${corelibSourceRoot} ${fullCorePath} && chmod -R +w ${fullCorePath}
+    '';
+  # remove macOS signing and relative links
+  postConfigure = ''
+    jq     'del(.bundle.macOS.signingIdentity, .bundle.macOS.hardenedRuntime)' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+    yq -iy '.importers.".".dependencies."@martichou/core_lib".specifier = "link:${corelibPath}" | .importers.".".dependencies."@martichou/core_lib".version = "link:${corelibPath}"' pnpm-lock.yaml
+    jq     '.dependencies."@martichou/core_lib" = "link:${corelibPath}"' package.json | sponge package.json
+    sed -i 's|path = "../../../core_lib"|path = "${corelibPath}"|' ${cargoRoot}/Cargo.toml
   '';
-
+  checkPhase = "true"; # idk why checks fail, todo
+  installPhase =
+    let
+      path = "${cargoRoot}/target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/bundle";
+    in
+    if stdenv.isDarwin then
+      ''
+        mkdir -p $out/bin
+        mv ${path}/macos $out/Applications
+        echo "#!${lib.getExe zsh}" >> $out/bin/${name}
+        echo "open -a $out/Applications/${name}.app" >> $out/bin/${name}
+        chmod +x $out/bin/${name}
+      ''
+    else
+      ''
+        mv ${path}/deb/*/data/usr $out
+      '';
   meta = {
-    description = "Rust implementation of NearbyShare/QuickShare from Android for Linux";
+    description = "Rust implementation of NearbyShare/QuickShare from Android for Linux and macOS";
     homepage = "https://github.com/Martichou/rquickshare";
     changelog = "https://github.com/Martichou/rquickshare/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.luftmensch-luftmensch ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      hannesgith
+      luftmensch-luftmensch
+    ];
+    platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "rquickshare";
   };
 }


### PR DESCRIPTION
fixes #357017

rquickshare is now build from source instead of wrapping the appimage, this -alongside other benifits- allows it to be compatible with multiple platforms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
