### PR TITLE
lib: add defaultTo

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,7 +71,7 @@ let
     # these are the only ones that are currently not
     inherit (builtins) addErrorContext isPath trace typeOf unsafeGetAttrPos;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
-      bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
+      bitNot boolToString mergeAttrs flip defaultTo mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease oldestSupportedReleaseIsAtLeast
       mod compare splitByAndCompare seq deepSeq lessThan add sub

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -317,6 +317,40 @@ in {
   flip = f: a: b: f b a;
 
   /**
+    Return `maybeValue` if not null, otherwise return `default`.
+
+
+    # Inputs
+
+    `default`
+
+    : 1\. Function argument
+
+    `maybeValue`
+
+    : 2\. Function argument
+
+
+    # Examples
+    :::{.example}
+    ## `lib.trivial.defaultTo` usage example
+
+    ```nix
+    defaultTo "default" null
+    => "default"
+    defaultTo "default" "foo"
+    => "foo"
+    defaultTo "default" false
+    => false
+    ```
+
+    :::
+  */
+  defaultTo = default: maybeValue:
+    if maybeValue != null then maybeValue
+    else default;
+
+  /**
     Apply function if the supplied argument is non-null.
 
 


### PR DESCRIPTION
I'm surprised this is not a thing yet. I swear I have a need for this function every single day.

If you have some long nullable expression like `foo.bar.baz`, or a function call `foo 123`, then using `if a != null then a else b` can get unnecessarily long, and even unnecessarily re-evaluated. So you usually need to wrap it into a `let` binding like `let a = foo.bar.baz; if a != null then a else b`. Of course this is annoying.

I propose adding a `lib.trivial.defaultTo` function to nixpkgs to handle this very common use case.

Example usage:

```nix
lib.defaultTo "default" null
=> "default"
```
```nix
lib.defaultTo "default" "foo"
=> "foo"
```
```nix
lib.defaultTo "default" false
=> false
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
