### PR TITLE
po4a: format, make msgmerge command available

### DIFF
--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -1,27 +1,28 @@
-{ stdenv
-, lib
-, fetchurl
-, docbook_xsl
-, docbook_xsl_ns
-, gettext
-, libxslt
-, glibcLocales
-, docbook_xml_dtd_45
-, docbook_sgml_dtd_41
-, opensp
-, bash
-, fetchpatch
-, perl
-, buildPerlPackage
-, ModuleBuild
-, TextWrapI18N
-, LocaleGettext
-, SGMLSpm
-, UnicodeLineBreak
-, PodParser
-, YAMLTiny
-, SyntaxKeywordTry
-, writeShellScriptBin
+{
+  stdenv,
+  lib,
+  fetchurl,
+  docbook_xsl,
+  docbook_xsl_ns,
+  gettext,
+  libxslt,
+  glibcLocales,
+  docbook_xml_dtd_45,
+  docbook_sgml_dtd_41,
+  opensp,
+  bash,
+  fetchpatch,
+  perl,
+  buildPerlPackage,
+  ModuleBuild,
+  TextWrapI18N,
+  LocaleGettext,
+  SGMLSpm,
+  UnicodeLineBreak,
+  PodParser,
+  YAMLTiny,
+  SyntaxKeywordTry,
+  writeShellScriptBin,
 }:
 
 buildPerlPackage rec {
@@ -41,8 +42,7 @@ buildPerlPackage rec {
     # shellscript that suffices for the tests in t/fmt/tex/, i.e. it looks up
     # article.cls to an existing file, but doesn't find article-wrong.cls.
     let
-      kpsewhich-stub = writeShellScriptBin "kpsewhich"
-        ''[[ $1 = "article.cls" ]] && echo /dev/null'';
+      kpsewhich-stub = writeShellScriptBin "kpsewhich" ''[[ $1 = "article.cls" ]] && echo /dev/null'';
     in
     [
       gettext
@@ -62,19 +62,21 @@ buildPerlPackage rec {
       url = "https://github.com/mquinson/po4a/commit/28fe52651eb8096d97d6bd3a97b3168522ba5306.patch";
       hash = "sha256-QUXxkSzcnwRvU+2y2KoBXmtfE8qTZ2BV0StkJHqZehQ=";
     })
-    ];
+  ];
 
   # TODO: TermReadKey was temporarily removed from propagatedBuildInputs to unfreeze the build
-  propagatedBuildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [
-    TextWrapI18N
-  ] ++ [
-    LocaleGettext
-    SGMLSpm
-    UnicodeLineBreak
-    PodParser
-    YAMLTiny
-    SyntaxKeywordTry
-  ];
+  propagatedBuildInputs =
+    lib.optionals (!stdenv.hostPlatform.isMusl) [
+      TextWrapI18N
+    ]
+    ++ [
+      LocaleGettext
+      SGMLSpm
+      UnicodeLineBreak
+      PodParser
+      YAMLTiny
+      SyntaxKeywordTry
+    ];
 
   buildInputs = [ bash ];
 


### PR DESCRIPTION
Also, run hooks.

Fixes #357684.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
