### PR TITLE
quarto: use pandoc 3.5

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1943,6 +1943,24 @@ self: super: {
       )
     ];
 
+  # Pandoc 3.5 improves the quality of PDF rendering in Quarto >=1.6.30.
+  # https://github.com/NixOS/nixpkgs/pull/349683
+  pandoc-cli_3_5 = super.pandoc-cli_3_5.overrideScope (
+    self: super: {
+      doclayout = self.doclayout_0_5;
+      hslua-module-doclayout = self.hslua-module-doclayout_1_2_0;
+      lpeg = self.lpeg_1_1_0;
+      pandoc = self.pandoc_3_5;
+      pandoc-lua-engine = self.pandoc-lua-engine_0_3_3;
+      pandoc-server = self.pandoc-server_0_1_0_9;
+      texmath = self.texmath_0_12_8_11;
+      tls = self.tls_2_0_6;
+      toml-parser = self.toml-parser_2_0_1_0;
+      typst = self.typst_0_6;
+      typst-symbols = self.typst-symbols_0_1_6;
+    }
+  );
+
   # 2020-12-06: Restrictive upper bounds w.r.t. pandoc-types (https://github.com/owickstrom/pandoc-include-code/issues/27)
   pandoc-include-code = doJailbreak super.pandoc-include-code;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -109,6 +109,7 @@ extra-packages:
   - tls < 2.1.0                         # 2024-07-19: requested by darcs == 2.18.3
   - extensions == 0.1.0.2               # 2024-10-20: for GHC 9.10/Cabal 3.12
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
+  - typst-symbols >=0.1.6 && <0.1.7     # 2024-11-20: for pandoc 3.5 and quarto
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, pandoc
+, pandoc_3_5
 , typst
 , esbuild
 , deno
@@ -16,7 +16,6 @@
 , extraPythonPackages ? ps: []
 , sysctl
 }:
-
 stdenv.mkDerivation (final: {
   pname = "quarto";
   version = "1.6.33";
@@ -39,7 +38,7 @@ stdenv.mkDerivation (final: {
   preFixup = ''
     wrapProgram $out/bin/quarto \
       --prefix QUARTO_DENO : ${lib.getExe deno} \
-      --prefix QUARTO_PANDOC : ${lib.getExe pandoc} \
+      --prefix QUARTO_PANDOC : ${lib.getExe pandoc_3_5} \
       --prefix QUARTO_ESBUILD : ${lib.getExe esbuild} \
       --prefix QUARTO_DART_SASS : ${lib.getExe dart-sass} \
       --prefix QUARTO_TYPST : ${lib.getExe typst} \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4850,6 +4850,8 @@ with pkgs;
 
   pakcs = callPackage ../development/compilers/pakcs { };
 
+  pandoc_3_5 = callPackage ../by-name/pa/pandoc/package.nix { selectPandocCLI = (p: p.pandoc-cli_3_5); };
+
   paperwork = callPackage ../applications/office/paperwork/paperwork-gtk.nix { };
 
   parallel = callPackage ../tools/misc/parallel { };


### PR DESCRIPTION

Following up after the work done in https://github.com/NixOS/nixpkgs/pull/349683, we're updating the version of pandoc to 3.5 outside of Haskell's normal release cycle in order to improve compatibility with quarto.

## Things done

Built and tested the result against the example given by @shriv https://github.com/shriv/quarto-1-6-30-pdf-reprex to make sure 3.5 renders the PDF document correctly.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
