### PR TITLE
factorio: fix `updateScript` definition

### DIFF
--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -201,15 +201,7 @@ let
         $out/bin/factorio
     '';
 
-    passthru.updateScript =
-      if (username != "" && token != "") then
-        [
-          ./update.py
-          "--username=${username}"
-          "--token=${token}"
-        ]
-      else
-        null;
+    passthru.updateScript = ./update.py;
 
     meta = {
       description = "Game in which you build and maintain factories";


### PR DESCRIPTION
Updated `factorio.passthru.updateScript` following 44754ac517ceecf2a8b95318c45e28192e813a8b.

With this fix, @r-ryantm should be able to automatically keep (all versions and variants of) factorio up-to-date.

## Things done

- [x] Tested derivation outputs were not changed
- [x] `nix-update -u factorio`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
