### PR TITLE
python312Packages.watchdog: disable flaky test everywhere

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -47,12 +47,12 @@ buildPythonPackage rec {
     [
       "--deselect=tests/test_emitter.py::test_create_wrong_encoding"
       "--deselect=tests/test_emitter.py::test_close"
+      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
+      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       # fails to stop process in teardown
       "--deselect=tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
-      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
-      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
       # FileCreationEvent != FileDeletionEvent


### PR DESCRIPTION
I've had this test fail in a regular x86_64-linux build. Upstream already disables the test for Windows, Darwin and Pypy.

Besides that, it seems weird to make checks conditional on the host platform. But I suppose it doesn't matter much, since tests are only executed if build == host (or was it canExecute?).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc