### PR TITLE
k2pdfopt: pin tesseract version

### DIFF
--- a/pkgs/by-name/k2/k2pdfopt/package.nix
+++ b/pkgs/by-name/k2/k2pdfopt/package.nix
@@ -1,22 +1,30 @@
-{ lib
-, stdenv
-, runCommand
-, fetchzip
-, fetchurl
-, fetchFromGitHub
-, cmake
-, jbig2dec
-, libjpeg_turbo
-, libpng
-, makeWrapper
-, pkg-config
-, zlib
-, enableGSL ? true, gsl
-, enableGhostScript ? true, ghostscript
-, enableMuPDF ? true, mupdf
-, enableDJVU ? true, djvulibre
-, enableGOCR ? false, gocr # Disabled by default due to crashes
-, enableTesseract ? true, leptonica, tesseract
+{
+  lib,
+  stdenv,
+  runCommand,
+  fetchzip,
+  fetchurl,
+  fetchFromGitHub,
+  cmake,
+  jbig2dec,
+  libjpeg_turbo,
+  libpng,
+  makeWrapper,
+  pkg-config,
+  zlib,
+  enableGSL ? true,
+  gsl,
+  enableGhostScript ? true,
+  ghostscript,
+  enableMuPDF ? true,
+  mupdf,
+  enableDJVU ? true,
+  djvulibre,
+  enableGOCR ? false,
+  gocr, # Disabled by default due to crashes
+  enableTesseract ? true,
+  leptonica,
+  tesseract,
 }:
 
 # k2pdfopt is a pain to package. It requires modified versions of mupdf,
@@ -45,20 +53,26 @@
 
 let
   # Create a patch against src based on changes applied in patchCommands
-  mkPatch = { name, src, patchCommands }: runCommand "${name}-k2pdfopt.patch" { inherit src; } ''
-    source $stdenv/setup
-    unpackPhase
+  mkPatch =
+    {
+      name,
+      src,
+      patchCommands,
+    }:
+    runCommand "${name}-k2pdfopt.patch" { inherit src; } ''
+      source $stdenv/setup
+      unpackPhase
 
-    orig=$sourceRoot
-    new=$sourceRoot-modded
-    cp -r $orig/. $new/
+      orig=$sourceRoot
+      new=$sourceRoot-modded
+      cp -r $orig/. $new/
 
-    pushd $new >/dev/null
-    ${patchCommands}
-    popd >/dev/null
+      pushd $new >/dev/null
+      ${patchCommands}
+      popd >/dev/null
 
-    diff -Naur $orig $new > $out || true
-  '';
+      diff -Naur $orig $new > $out || true
+    '';
 
   pname = "k2pdfopt";
   version = "2.55";
@@ -66,7 +80,8 @@ let
     url = "http://www.willus.com/${pname}/src/${pname}_v${version}_src.zip";
     hash = "sha256-orQNDXQkkcCtlA8wndss6SiJk4+ImiFCG8XRLEg963k=";
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   inherit pname version;
   src = k2pdfopt_src;
 
@@ -79,88 +94,118 @@ in stdenv.mkDerivation rec {
       --replace "<djvu.h>" "<libdjvu/ddjvuapi.h>"
   '';
 
-  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
 
   buildInputs =
-  let
-    # We use specific versions of these sources below to match the versions
-    # used in the k2pdfopt source. Note that this does _not_ need to match the
-    # version used elsewhere in nixpkgs, since it is only used to create the
-    # patch that can then be applied to the version in nixpkgs.
-    mupdf_patch = mkPatch {
-      name = "mupdf";
-      src = fetchurl {
-        url = "https://mupdf.com/downloads/archive/mupdf-1.23.7-source.tar.gz";
-        hash = "sha256-NaVJM/QA6JZnoImkJfHGXNadRiOU/tnAZ558Uu+6pWg=";
-      };
-      patchCommands = ''
-        cp ${k2pdfopt_src}/mupdf_mod/{filter-basic,font,stext-device,string}.c ./source/fitz/
-        cp ${k2pdfopt_src}/mupdf_mod/pdf-* ./source/pdf/
-      '';
-    };
-    mupdf_modded = mupdf.overrideAttrs ({ patches ? [], ... }: {
-      patches = patches ++ [ mupdf_patch ];
-      # This function is missing in font.c, see font-win32.c
-      postPatch = ''
-        echo "void pdf_install_load_system_font_funcs(fz_context *ctx) {}" >> source/fitz/font.c
-      '';
-    });
-
-    leptonica_patch = mkPatch {
-      name = "leptonica";
-      src = fetchurl {
-        url = "http://www.leptonica.org/source/leptonica-1.83.0.tar.gz";
-        hash = "sha256-IGWR3VjPhO84CDba0TO1jJ0a+SSR9amCXDRqFiBEvP4=";
-      };
-      patchCommands = "cp -r ${k2pdfopt_src}/leptonica_mod/. ./src/";
-    };
-    leptonica_modded = leptonica.overrideAttrs ({ patches ? [], ... }: {
-      patches = patches ++ [ leptonica_patch ];
-    });
-
-    tesseract_patch = mkPatch {
-      name = "tesseract";
-      src = fetchFromGitHub {
-        owner = "tesseract-ocr";
-        repo = "tesseract";
-        rev = "5.3.3";
-        hash = "sha256-/aGzwm2+0y8fheOnRi/OJXZy3o0xjY1cCq+B3GTzfos=";
-      };
-      patchCommands = ''
-        cp ${k2pdfopt_src}/tesseract_mod/tesseract.* include/tesseract/
-        cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h include/tesseract/
-        cp ${k2pdfopt_src}/tesseract_mod/{baseapi,config_auto,tesscapi,tesseract}.* src/api/
-        cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h src/api/
-        cp ${k2pdfopt_src}/tesseract_mod/{tesscapi,tessedit,tesseract}.* src/ccmain/
-        cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h src/ccmain/
-        cp ${k2pdfopt_src}/tesseract_mod/dotproduct{avx,fma,sse}.* src/arch/
-        cp ${k2pdfopt_src}/tesseract_mod/{intsimdmatrixsse,simddetect}.* src/arch/
-        cp ${k2pdfopt_src}/tesseract_mod/{errcode,genericvector,mainblk,params,serialis,tessdatamanager,tess_version,tprintf,unicharset}.* src/ccutil/
-        cp ${k2pdfopt_src}/tesseract_mod/{input,lstmrecognizer}.* src/lstm/
-        cp ${k2pdfopt_src}/tesseract_mod/openclwrapper.* src/opencl/
-      '';
-    };
-    tesseract_modded = tesseract.override {
-      tesseractBase = tesseract.tesseractBase.overrideAttrs ({ patches ? [], ... }: {
-        patches = patches ++ [ tesseract_patch ];
-        # Additional compilation fixes
-        postPatch = ''
-          echo libtesseract_la_SOURCES += src/api/tesscapi.cpp >> Makefile.am
-          substituteInPlace src/api/tesseract.h \
-            --replace "#include <leptonica.h>" "//#include <leptonica.h>"
-          substituteInPlace include/tesseract/tesseract.h \
-            --replace "#include <leptonica.h>" "//#include <leptonica.h>"
+    let
+      # We use specific versions of these sources below to match the versions
+      # used in the k2pdfopt source. Note that this does _not_ need to match the
+      # version used elsewhere in nixpkgs, since it is only used to create the
+      # patch that can then be applied to the version in nixpkgs.
+      mupdf_patch = mkPatch {
+        name = "mupdf";
+        src = fetchurl {
+          url = "https://mupdf.com/downloads/archive/mupdf-1.23.7-source.tar.gz";
+          hash = "sha256-NaVJM/QA6JZnoImkJfHGXNadRiOU/tnAZ558Uu+6pWg=";
+        };
+        patchCommands = ''
+          cp ${k2pdfopt_src}/mupdf_mod/{filter-basic,font,stext-device,string}.c ./source/fitz/
+          cp ${k2pdfopt_src}/mupdf_mod/pdf-* ./source/pdf/
         '';
-      });
-    };
-  in
-    [ jbig2dec libjpeg_turbo libpng zlib ] ++
-    lib.optional enableGSL gsl ++
-    lib.optional enableGhostScript ghostscript ++
-    lib.optional enableMuPDF mupdf_modded ++
-    lib.optional enableDJVU djvulibre ++
-    lib.optional enableGOCR gocr ++
-    lib.optionals enableTesseract [ leptonica_modded tesseract_modded ];
+      };
+      mupdf_modded = mupdf.overrideAttrs (
+        {
+          patches ? [ ],
+          ...
+        }:
+        {
+          patches = patches ++ [ mupdf_patch ];
+          # This function is missing in font.c, see font-win32.c
+          postPatch = ''
+            echo "void pdf_install_load_system_font_funcs(fz_context *ctx) {}" >> source/fitz/font.c
+          '';
+        }
+      );
+
+      leptonica_patch = mkPatch {
+        name = "leptonica";
+        src = fetchurl {
+          url = "http://www.leptonica.org/source/leptonica-1.83.0.tar.gz";
+          hash = "sha256-IGWR3VjPhO84CDba0TO1jJ0a+SSR9amCXDRqFiBEvP4=";
+        };
+        patchCommands = "cp -r ${k2pdfopt_src}/leptonica_mod/. ./src/";
+      };
+      leptonica_modded = leptonica.overrideAttrs (
+        {
+          patches ? [ ],
+          ...
+        }:
+        {
+          patches = patches ++ [ leptonica_patch ];
+        }
+      );
+
+      tesseract_patch = mkPatch {
+        name = "tesseract";
+        src = fetchFromGitHub {
+          owner = "tesseract-ocr";
+          repo = "tesseract";
+          rev = "5.3.3";
+          hash = "sha256-/aGzwm2+0y8fheOnRi/OJXZy3o0xjY1cCq+B3GTzfos=";
+        };
+        patchCommands = ''
+          cp ${k2pdfopt_src}/tesseract_mod/tesseract.* include/tesseract/
+          cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h include/tesseract/
+          cp ${k2pdfopt_src}/tesseract_mod/{baseapi,config_auto,tesscapi,tesseract}.* src/api/
+          cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h src/api/
+          cp ${k2pdfopt_src}/tesseract_mod/{tesscapi,tessedit,tesseract}.* src/ccmain/
+          cp ${k2pdfopt_src}/tesseract_mod/tesseract/baseapi.h src/ccmain/
+          cp ${k2pdfopt_src}/tesseract_mod/dotproduct{avx,fma,sse}.* src/arch/
+          cp ${k2pdfopt_src}/tesseract_mod/{intsimdmatrixsse,simddetect}.* src/arch/
+          cp ${k2pdfopt_src}/tesseract_mod/{errcode,genericvector,mainblk,params,serialis,tessdatamanager,tess_version,tprintf,unicharset}.* src/ccutil/
+          cp ${k2pdfopt_src}/tesseract_mod/{input,lstmrecognizer}.* src/lstm/
+          cp ${k2pdfopt_src}/tesseract_mod/openclwrapper.* src/opencl/
+        '';
+      };
+      tesseract_modded = tesseract.override {
+        tesseractBase = tesseract.tesseractBase.overrideAttrs (
+          {
+            patches ? [ ],
+            ...
+          }:
+          {
+            patches = patches ++ [ tesseract_patch ];
+            # Additional compilation fixes
+            postPatch = ''
+              echo libtesseract_la_SOURCES += src/api/tesscapi.cpp >> Makefile.am
+              substituteInPlace src/api/tesseract.h \
+                --replace "#include <leptonica.h>" "//#include <leptonica.h>"
+              substituteInPlace include/tesseract/tesseract.h \
+                --replace "#include <leptonica.h>" "//#include <leptonica.h>"
+            '';
+          }
+        );
+      };
+    in
+    [
+      jbig2dec
+      libjpeg_turbo
+      libpng
+      zlib
+    ]
+    ++ lib.optional enableGSL gsl
+    ++ lib.optional enableGhostScript ghostscript
+    ++ lib.optional enableMuPDF mupdf_modded
+    ++ lib.optional enableDJVU djvulibre
+    ++ lib.optional enableGOCR gocr
+    ++ lib.optionals enableTesseract [
+      leptonica_modded
+      tesseract_modded
+    ];
 
   dontUseCmakeBuildDir = true;
 
@@ -182,7 +227,9 @@ in stdenv.mkDerivation rec {
     changelog = "https://www.willus.com/k2pdfopt/k2pdfopt_version.txt";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bosu danielfullmer ];
+    maintainers = with maintainers; [
+      bosu
+      danielfullmer
+    ];
   };
 }
-


### PR DESCRIPTION
This pins the tesseract version of k2pdfopt to  the one expected upstream. Due to the unusual setup of k2pdf it is uncompatible with any updated version. So unless upstream reworks their patches this is the best we can do.

Should then still work when #353902 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
