### PR TITLE
nim: fix nim mangling patch

### DIFF
--- a/pkgs/by-name/ni/nim-unwrapped-1_0/extra-mangling.patch
+++ b/pkgs/by-name/ni/nim-unwrapped-1_0/extra-mangling.patch
@@ -1,13 +1,17 @@
 diff --git a/compiler/modulepaths.nim b/compiler/modulepaths.nim
-index e80ea3fa6..8ecf27a85 100644
+index fa8fab08a..63b0cb44d 100644
 --- a/compiler/modulepaths.nim
 +++ b/compiler/modulepaths.nim
-@@ -70,6 +70,13 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
+@@ -73,6 +73,17 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
    else:
      result = fileInfoIdx(conf, fullPath)
  
 +proc rot13(result: var string) =
-+  for i, c in result:
++  # don't mangle .nim
++  let finalIdx =
++    if result.endsWith(".nim"): result.len - 4
++    else: result.len
++  for i, c in result[0..<finalIdx]:
 +    case c
 +    of 'a'..'m', 'A'..'M': result[i] = char(c.uint8 + 13)
 +    of 'n'..'z', 'N'..'Z': result[i] = char(c.uint8 - 13)
@@ -16,7 +20,7 @@ index e80ea3fa6..8ecf27a85 100644
  proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
    ## Mangle a relative module path to avoid path and symbol collisions.
    ##
-@@ -78,9 +85,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+@@ -81,9 +92,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
    ##
    ## Example:
    ## `foo-#head/../bar` becomes `@foo-@hhead@s..@sbar`
@@ -30,10 +34,10 @@ index e80ea3fa6..8ecf27a85 100644
    result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
 +  rot13(result)
 diff --git a/compiler/msgs.nim b/compiler/msgs.nim
-index 3f386cc61..054f7f647 100644
+index ae4bcfcb8..1ad7e5c08 100644
 --- a/compiler/msgs.nim
 +++ b/compiler/msgs.nim
-@@ -659,8 +659,10 @@ proc uniqueModuleName*(conf: ConfigRef; fid: FileIndex): string =
+@@ -661,8 +661,10 @@ proc uniqueModuleName*(conf: ConfigRef; fid: FileIndex): string =
    for i in 0..<trunc:
      let c = rel[i]
      case c

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/extra-mangling-2.patch
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/extra-mangling-2.patch
@@ -1,34 +1,3 @@
-diff --git a/compiler/modulepaths.nim b/compiler/modulepaths.nim
-index c9e6060e5..acb289498 100644
---- a/compiler/modulepaths.nim
-+++ b/compiler/modulepaths.nim
-@@ -79,6 +79,13 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
-   else:
-     result = fileInfoIdx(conf, fullPath)
- 
-+proc rot13(result: var string) =
-+  for i, c in result:
-+    case c
-+    of 'a'..'m', 'A'..'M': result[i] = char(c.uint8 + 13)
-+    of 'n'..'z', 'N'..'Z': result[i] = char(c.uint8 - 13)
-+    else: discard
-+
- proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
-   ## Mangle a relative module path to avoid path and symbol collisions.
-   ##
-@@ -87,9 +94,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
-   ##
-   ## Example:
-   ## `foo-#head/../bar` becomes `@foo-@hhead@s..@sbar`
--  "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
-+  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
-     {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
-+  rot13(result)
- 
- proc demangleModuleName*(path: string): string =
-   ## Demangle a relative module path.
-   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
-+  rot13(result)
 diff --git a/compiler/modulegraphs.nim b/compiler/modulegraphs.nim
 index 77762d23a..59dd8903a 100644
 --- a/compiler/modulegraphs.nim
@@ -46,3 +15,38 @@ index 77762d23a..59dd8903a 100644
        result.add c
      of {os.DirSep, os.AltSep}:
        result.add 'Z' # because it looks a bit like '/'
+diff --git a/compiler/modulepaths.nim b/compiler/modulepaths.nim
+index c9e6060e5..2b349f27c 100644
+--- a/compiler/modulepaths.nim
++++ b/compiler/modulepaths.nim
+@@ -79,6 +79,17 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
+   else:
+     result = fileInfoIdx(conf, fullPath)
+ 
++proc rot13(result: var string) =
++  # don't mangle .nim
++  let finalIdx =
++    if result.endsWith(".nim"): result.len - 4
++    else: result.len
++  for i, c in result[0..<finalIdx]:
++    case c
++    of 'a'..'m', 'A'..'M': result[i] = char(c.uint8 + 13)
++    of 'n'..'z', 'N'..'Z': result[i] = char(c.uint8 - 13)
++    else: discard
++
+ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+   ## Mangle a relative module path to avoid path and symbol collisions.
+   ##
+@@ -87,9 +98,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+   ##
+   ## Example:
+   ## `foo-#head/../bar` becomes `@foo-@hhead@s..@sbar`
+-  "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
++  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
+     {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
++  rot13(result)
+ 
+ proc demangleModuleName*(path: string): string =
+   ## Demangle a relative module path.
+   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
++  rot13(result)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The extra mangling of modules added by `extra-mangling.patch` and `extra-mangling-2.patch` was also mangling the extension which means when `nim` did a lookup for the file name to generate the compile cmd there was a mismatch with the mangled extension being `avz` instead of `nim`.

To fix this, I modified the `rot13` proc to only mangle up to the `.nim`.

Closes #356524

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
