### PR TITLE
cloudquery: init at 6.11.2

### DIFF
--- a/pkgs/by-name/cl/cloudquery/package.nix
+++ b/pkgs/by-name/cl/cloudquery/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   stdenvNoCC,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -27,9 +28,6 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  # Some checks fail to download deps
-  doCheck = false;
-
   ldflags = [
     "-s"
     "-w"
@@ -47,6 +45,12 @@ buildGoModule rec {
         --fish <($out/bin/cloudquery completion fish) \
         --zsh <($out/bin/cloudquery completion zsh)
     '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Data movement tool to sync data from any source to any destination";

--- a/pkgs/by-name/cl/cloudquery/package.nix
+++ b/pkgs/by-name/cl/cloudquery/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "cloudquery";
+  version = "6.11.2";
+
+  src = fetchFromGitHub {
+    owner = "cloudquery";
+    repo = "cloudquery";
+    rev = "refs/tags/cli-v${version}";
+    hash = "sha256-zVzHPAN/UAVQF56qcoIFOqtX/Aek3+1lO2O965UYxPM=";
+  };
+
+  vendorHash = "sha256-9YvsVflHr4QSVCYCcWg1Okmncc1sNteMJEAdz92BIgI=";
+
+  CGO_ENABLED = 0;
+
+  modRoot = "cli";
+
+  # Some checks fail to download deps
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/cloudquery/cloudquery/cli/cmd.Version=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/cloudquery
+    rm $out/bin/gen
+  '';
+
+  meta = {
+    description = "Data movement tool to sync data from any source to any destination";
+    mainProgram = "cloudquery";
+    longDescription = ''
+      CloudQuery is a versatile open-source data movement tool built for developers
+      that allows you to sync data from any source to any destination.
+    '';
+    homepage = "https://www.cloudquery.io";
+    changelog = "https://github.com/cloudquery/cloudquery/releases/tag/v${version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      mrgiles
+    ];
+  };
+}


### PR DESCRIPTION
Add [CloudQuery](https://www.cloudquery.io/) to Nix Packages.

CloudQuery is a versatile [open-source](https://github.com/cloudquery/cloudquery) data movement tool built for developers that allows you to sync data from any [source](https://hub.cloudquery.io/plugins/source) to any [destination](https://hub.cloudquery.io/plugins/destination).
  
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>cloudquery</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
