### PR TITLE
ubports-pdk: init at 0-unstable-2024-08-28

### DIFF
--- a/pkgs/by-name/ub/ubports-pdk/package.nix
+++ b/pkgs/by-name/ub/ubports-pdk/package.nix
@@ -1,0 +1,69 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  bash,
+  coreutils,
+  dosfstools,
+  makeWrapper,
+  mtools,
+  wget,
+  which,
+  xz,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ubports-pdk";
+  version = "0-unstable-2024-08-28";
+
+  src = fetchFromGitHub {
+    owner = "ubports";
+    repo = "ubports-pdk";
+    rev = "ce16915f1ec2aa54bc0f010db7603fbb0deebf4b";
+    hash = "sha256-jxlia3RgH3DAUO5OK3jB4IH0vUoG2XZKmODq4VhwJFE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    bash
+    coreutils
+    dosfstools
+    mtools
+    wget
+    which
+    xz
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    install -Dm755 ubuntu-touch-pdk $out/share/ubuntu-touch-pdk/ubuntu-touch-pdk
+    cp -R scripts $out/share/ubuntu-touch-pdk/
+
+    makeWrapper $out/share/ubuntu-touch-pdk/ubuntu-touch-pdk $out/bin/ubuntu-touch-pdk \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.finalPackage.buildInputs}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Platform Development Kit for Ubuntu Touch";
+    homepage = "https://github.com/ubports/ubports-pdk";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "ubuntu-touch-pdk";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
+    # setup wants to use brew to install extra prerequisites
+    broken = stdenvNoCC.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
https://github.com/ubports/ubports-pdk

Allows launching a VM that is pre-setup for Ubuntu Touch development. Used this afew times to test upstream submissions for Lomiri, to make sure nothing breaks with their setups.

```sh
ubuntu-touch-pdk setup
ubuntu-touch-pdk pull
ubuntu-touch-pdk run
```

![Bildschirmfoto_2024-11-21_01-03-01](https://github.com/user-attachments/assets/8f6fe2d6-a227-4bfe-baa8-8e3a0fbd8a47)

(Requires docker to be enabled, and your user to be in the docker group)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
