### PR TITLE
haskellPackages: fixes for pkgsCross.ucrt64

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -248,6 +248,14 @@
             ./Cabal-3.12-paths-fix-cycle-aarch64-darwin.patch
         )
       ]
+      ++ lib.optionals stdenv.targetPlatform.isWindows [
+        # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13919
+        (fetchpatch {
+          name = "include-modern-utimbuf.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/7e75928ed0f1c4654de6ddd13d0b00bf4b5c6411.patch";
+          hash = "sha256-sb+AHdkGkCu8MW0xoQIpD5kEc0zYX8udAMDoC+TWc0Q=";
+        })
+      ]
       # Prevents passing --hyperlinked-source to haddock. Note that this can
       # be configured via a user defined flavour now. Unfortunately, it is
       # impossible to import an existing flavour in UserSettings, so patching

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -403,6 +403,8 @@ let
           ld = cc.bintools;
           "ld.gold" = cc.bintools;
 
+          windres = cc.bintools;
+
           otool = cc.bintools.bintools;
 
           # GHC needs install_name_tool on all darwin platforms. The same one can
@@ -820,6 +822,10 @@ stdenv.mkDerivation (
             else
               "${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
           }"
+      ''
+      + lib.optionalString stdenv.targetPlatform.isWindows ''
+        ghc-settings-edit "$settingsFile" \
+        "windres command" "${toolPath "windres" installCC}"
       ''
       + ''
 

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -110,7 +110,7 @@
         # While split sections are now enabled by default in ghc 8.8 for windows,
         # they seem to lead to `too many sections` errors when building base for
         # profiling.
-        ++ lib.optionals (!stdenv.targetPlatform.isWindows) [ "split_sections" ];
+        ++ (if stdenv.targetPlatform.isWindows then [ "no_split_sections" ] else [ "split_sections" ]);
     in
     baseFlavour + lib.concatMapStrings (t: "+${t}") transformers,
 

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -524,6 +524,14 @@ let
               };
             };
 
+        ucrt64.haskell.packages.ghc912 = {
+          inherit (packagePlatforms pkgs.pkgsCross.ucrt64.haskell.packages.ghc912)
+            ghc
+            # hello # executables don't build yet
+            microlens
+            ;
+        };
+
         riscv64 = {
           # Cross compilation of GHC
           haskell.compiler = {


### PR DESCRIPTION
Allows building a ton of non-TH libs under `pkgsCross.ucrt64.haskell.packages.ghc910`, with TH libs triggering the same error as in #355543. But linking seems pretty broken for `ucrt64.haskell.packages`.

`pkgsCross.ucrt64.haskell.packages.ghc910.hello` fails with a gazillion `undefined reference to` what look like RTS symbols.

```
Preprocessing executable 'hello' for hello-1.0.0.2...
Building executable 'hello' for hello-1.0.0.2...
[1 of 1] Compiling Main             ( src/hello.hs, dist/build/hello/hello-tmp/Main.o )
[2 of 2] Linking dist/build/hello/hello.exe
/nix/store/gzr1ys4rd4mfrvlx9pl915q3km7asjaf-x86_64-w64-mingw32-binutils-2.43.1/bin/x86_64-w64-mingw32-ld: /nix/store/25nmznm3z4wpvz3l41kxzncrgjxaal9j-x86_64-w64-mingw32-ghc-9.10.1/lib/x86_64-w64-mingw32-ghc-9.10.1/lib/../lib/x86_64-windows-ghc-9.10.1/ghc-internal-9.1001.0-inplace/libHSghc-internal-9.1001.0-inplace.a(Base.o):fake:(.text+0x1b): undefined reference to `__imp_ghczmprim_GHCziTypes_True_closure'
/nix/store/gzr1ys4rd4mfrvlx9pl915q3km7asjaf-x86_64-w64-mingw32-binutils-2.43.1/bin/x86_64-w64-mingw32-ld: /nix/store/25nmznm3z4wpvz3l41kxzncrgjxaal9j-x86_64-w64-mingw32-ghc-9.10.1/lib/x86_64-w64-mingw32-ghc-9.10.1/lib/../lib/x86_64-windows-ghc-9.10.1/ghc-internal-9.1001.0-inplace/libHSghc-internal-9.1001.0-inplace.a(Base.o):fake:(.text+0x43): undefined reference to `__imp_ghczmprim_GHCziTypes_True_closure'
/nix/store/gzr1ys4rd4mfrvlx9pl915q3km7asjaf-x86_64-w64-mingw32-binutils-2.43.1/bin/x86_64-w64-mingw32-ld: /nix/store/25nmznm3z4wpvz3l41kxzncrgjxaal9j-x86_64-w64-mingw32-ghc-9.10.1/lib/x86_64-w64-mingw32-ghc-9.10.1/lib/../lib/x86_64-windows-ghc-9.10.1/ghc-internal-9.1001.0-inplace/libHSghc-internal-9.1001.0-inplace.a(Base.o):fake:(.text+0x6b): undefined reference to `__imp_ghczmprim_GHCziTypes_True_closure'
/nix/store/gzr1ys4rd4mfrvlx9pl915q3km7asjaf-x86_64-w64-mingw32-binutils-2.43.1/bin/x86_64-w64-mingw32-ld: /nix/store/25nmznm3z4wpvz3l41kxzncrgjxaal9j-x86_64-w64-mingw32-ghc-9.10.1/lib/x86_64-w64-mingw32-ghc-9.10.1/lib/../lib/x86_64-windows-ghc-9.10.1/ghc-internal-9.1001.0-inplace/libHSghc-internal-9.1001.0-inplace.a(Base.o):fake:(.text+0xb1): undefined reference to `__imp_newCAF'
/nix/store/gzr1ys4rd4mfrvlx9pl915q3km7asjaf-x86_64-w64-mingw32-binutils-2.43.1/bin/x86_64-w64-mingw32-ld: /nix/store/25nmznm3z4wpvz3l41kxzncrgjxaal9j-x86_64-w64-mingw32-ghc-9.10.1/lib/x86_64-w64-mingw32-ghc-9.10.1/lib/../lib/x86_64-windows-ghc-9.10.1/ghc-internal-9.1001.0-inplace/libHSghc-internal-9.1001.0-inplace.a(Base.o):fake:(.text+0xc3): undefined reference to `__imp_stg_bh_upd_frame_info'
...
~ 50k lines
...
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
