### PR TITLE
cloud-init: 24.2 -> 24.3

### DIFF
--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -16,7 +16,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cloud-init";
-  version = "24.2";
+  version = "24.3";
   pyproject = true;
 
   namePrefix = "";
@@ -25,7 +25,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "canonical";
     repo = "cloud-init";
     rev = "refs/tags/${version}";
-    hash = "sha256-BhTcOeSKZ1XRIx+xJQkqkSw9M8ilr+BRKXDy5MUXB6E=";
+    hash = "sha256-NQwZ9Y/lEJ9woijt9ycuDwLXo0fX0Y7zevZ5hLFSEfg=";
   };
 
   patches = [


### PR DESCRIPTION

meta.changelog for cloud-init is: https://github.com/canonical/cloud-init/raw/24.3/ChangeLog

Current version of `cloud-init` (24.2) has a version parsing issue for btrfs filesystems (https://github.com/canonical/cloud-init/issues/5614). The fix was added in version 24.3 (https://github.com/canonical/cloud-init/pull/5618). Currently the `cloud-init` service is failing on btrfs file systems.  