### PR TITLE
Use nix 2.24 for eval ci task

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -5,7 +5,7 @@
   linkFarm,
   time,
   procps,
-  nix,
+  nixVersions,
   jq,
   sta,
 }:
@@ -28,6 +28,8 @@ let
         ]
       );
     };
+
+  nix = nixVersions.nix_2_24;
 
   supportedSystems = import ../supportedSystems.nix;
 


### PR DESCRIPTION
We are currently seeing occasional "Stack overflows". Nix 2.24 has a better mechanism for detecting stack overflows because it's not using the segfault handler to primarily detect it:

Depends on https://github.com/NixOS/nixpkgs/pull/357753