### PR TITLE
Add warning for configuration file copy in flake systems

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -135,11 +135,11 @@ in
       type = types.bool;
       default = false;
       description = ''
-        If enabled, copies the NixOS configuration file
-        (usually {file}`/etc/nixos/configuration.nix`)
-        and links it from the resulting system
-        (getting to {file}`/run/current-system/configuration.nix`).
-        Note that only this single file is copied, even if it imports others.
+       If enabled, this option copies the NixOS 
+       configuration file (usually {file}/etc/nixos/configuration.nix) 
+       and links it from the resulting system (resulting in {file}/run/current-system/configuration.nix). 
+       Note that only this single file is copied, even if it imports others.
+       Warning: This feature cannot be used when the system is configured as a flake. 
       '';
     };
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -137,7 +137,7 @@ in
       description = ''
        If enabled, this option copies the NixOS 
        configuration file (usually {file}/etc/nixos/configuration.nix) 
-       and links it from the resulting system (resulting in {file}/run/current-system/configuration.nix). 
+       and links it from the resulting system ({file} to /run/current-system/configuration.nix). 
        Note that only this single file is copied, even if it imports others.
        Warning: This feature cannot be used when the system is configured as a flake. 
       '';


### PR DESCRIPTION
This update adds a warning to the documentation regarding the use of the  configuration file copy feature. It clarifies that this feature cannot  be used when the system is configured as a flake.

This change aims to prevent confusion.

# Changes

Added a warning in the documentation that the configuration file copy feature cannot be used with flake-based systems.

Motivation:

The intention of this change is to prevent confusion among users who may attempt to use the configuration file copy feature while operating within a flake-based environment. By providing clear guidance, we aim to enhance the user experience and ensure that users are aware of the limitations associated with flakes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
