### PR TITLE
redisTestHook,memcachedTestHook: init; prevent hanging Darwin build after test failures

### DIFF
--- a/doc/hooks/memcached-test-hook.section.md
+++ b/doc/hooks/memcached-test-hook.section.md
@@ -1,0 +1,53 @@
+
+# `memcachedTestHook` {#sec-memcachedTestHook}
+
+This hook starts a Memcached server during `checkPhase`. Example:
+
+```nix
+{
+  stdenv,
+  memcachedTestHook,
+}:
+stdenv.mkDerivation {
+
+  # ...
+
+  nativeCheckInputs = [
+    memcachedTestHook
+  ];
+}
+```
+
+If you use a custom `checkPhase`, remember to add the `runHook` calls:
+```nix
+  checkPhase ''
+    runHook preCheck
+
+    # ... your tests
+
+    runHook postCheck
+  ''
+```
+
+## Variables {#sec-memcachedTestHook-variables}
+
+Bash-only variables:
+
+ - `memcachedTestPort`: Port to use by Memcached. Defaults to `11211`
+
+Example usage:
+
+```nix
+{ stdenv, memcachedTestHook }:
+stdenv.mkDerivation {
+
+  # ...
+
+  nativeCheckInputs = [
+    memcachedTestHook
+  ];
+
+  preCheck = ''
+    memcachedTestPort=1234
+  ''
+}

--- a/doc/hooks/redis-test-hook.section.md
+++ b/doc/hooks/redis-test-hook.section.md
@@ -1,0 +1,60 @@
+
+# `redisTestHook` {#sec-redisTestHook}
+
+This hook starts a Redis server during `checkPhase`. Example:
+
+```nix
+{
+  stdenv,
+  redis,
+  redisTestHook
+}:
+stdenv.mkDerivation {
+
+  # ...
+
+  nativeCheckInputs = [
+    redisTestHook
+  ];
+}
+```
+
+If you use a custom `checkPhase`, remember to add the `runHook` calls:
+```nix
+  checkPhase ''
+    runHook preCheck
+
+    # ... your tests
+
+    runHook postCheck
+  ''
+```
+
+## Variables {#sec-redisTestHook-variables}
+
+The hook logic will read the following variables and set them to a default value if unset or empty.
+
+Exported variables:
+
+- `REDIS_SOCKET`: UNIX domain socket path
+
+Bash-only variables:
+
+ - `redisTestPort`: Port to use by Redis. Defaults to `6379`
+
+Example usage:
+
+```nix
+{ stdenv, redis, redisTestHook }:
+stdenv.mkDerivation {
+
+  # ...
+
+  nativeCheckInputs = [
+    redisTestHook
+  ];
+
+  preCheck = ''
+    redisTestPort=6390
+  ''
+}

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -7,6 +7,7 @@
 , postgresql
 , postgresqlTestHook
 , redis
+, redisTestHook
 }:
 
 let
@@ -85,6 +86,7 @@ py.pkgs.buildPythonPackage rec {
   nativeCheckInputs = [
     git
     redis
+    redisTestHook
     postgresql
     postgresqlTestHook
   ] ++ (with py.pkgs; [
@@ -141,14 +143,6 @@ py.pkgs.buildPythonPackage rec {
   ] ++ py.pkgs.uvicorn.optional-dependencies.standard;
 
   preCheck = ''
-    redis-server &
-    REDIS_PID=$!
-
-    while ! redis-cli --scan ; do
-      echo waiting for redis
-      sleep 1
-    done
-
     export SMTPD_HOST=127.0.0.1
     export IRRD_DATABASE_URL="postgres:///$PGDATABASE"
     export IRRD_REDIS_URL="redis://localhost/1"

--- a/pkgs/by-name/me/memcachedTestHook/memcached-test-hook.sh
+++ b/pkgs/by-name/me/memcachedTestHook/memcached-test-hook.sh
@@ -1,0 +1,27 @@
+preCheckHooks+=('memcachedStart')
+postCheckHooks+=('memcachedStop')
+
+
+memcachedStart() {
+  if [[ "${memcachedTestPort:-}" == "" ]]; then
+    memcachedTestPort=11211
+  fi
+
+  echo 'starting memcached'
+
+  # Note about Darwin: unless the output is redirected, the parent process becomes launchd instead of bash.
+  # This would leave the memcached process running in case of a test failure (the postCheckHook would not be executed),
+  # hanging the Nix build forever.
+  @memcached@ -p "$memcachedTestPort" >/dev/null 2>&1 &
+  MEMCACHED_PID=$!
+
+  echo 'waiting for memcached to be ready'
+  while ! (echo 'quit' | @nc@ localhost "$memcachedTestPort") ; do
+    sleep 1
+  done
+}
+
+memcachedStop() {
+  echo 'stopping memcached'
+  kill "$MEMCACHED_PID"
+}

--- a/pkgs/by-name/me/memcachedTestHook/package.nix
+++ b/pkgs/by-name/me/memcachedTestHook/package.nix
@@ -1,0 +1,18 @@
+{
+  callPackage,
+  makeSetupHook,
+  lib,
+  memcached,
+  netcat,
+}:
+
+makeSetupHook {
+  name = "memcached-test-hook";
+  substitutions = {
+    memcached = lib.getExe memcached;
+    nc = lib.getExe netcat;
+  };
+  passthru.tests = {
+    simple = callPackage ./test.nix { };
+  };
+} ./memcached-test-hook.sh

--- a/pkgs/by-name/me/memcachedTestHook/test.nix
+++ b/pkgs/by-name/me/memcachedTestHook/test.nix
@@ -1,0 +1,41 @@
+{
+  memcachedTestHook,
+  netcat,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  name = "memcached-test-hook-test";
+
+  nativeCheckInputs = [
+    memcachedTestHook
+    netcat
+  ];
+
+  dontUnpack = true;
+  doCheck = true;
+
+  preCheck = ''
+    memcachedTestPort=11212
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo "running test"
+    if echo -e "stats\nquit" | nc localhost $memcachedTestPort; then
+      echo "connected to memcached"
+      TEST_RAN=1
+    fi
+
+    runHook postCheck
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  installPhase = ''
+    [[ $TEST_RAN == 1 ]]
+    echo "test passed"
+    touch $out
+  '';
+}

--- a/pkgs/by-name/re/redisTestHook/package.nix
+++ b/pkgs/by-name/re/redisTestHook/package.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  callPackage,
+  makeSetupHook,
+  redis,
+}:
+
+makeSetupHook {
+  name = "redis-test-hook";
+  substitutions = {
+    cli = lib.getExe' redis "redis-cli";
+    server = lib.getExe' redis "redis-server";
+  };
+  passthru.tests = {
+    simple = callPackage ./test.nix { };
+  };
+} ./redis-test-hook.sh

--- a/pkgs/by-name/re/redisTestHook/redis-test-hook.sh
+++ b/pkgs/by-name/re/redisTestHook/redis-test-hook.sh
@@ -1,0 +1,33 @@
+preCheckHooks+=('redisStart')
+postCheckHooks+=('redisStop')
+
+
+redisStart() {
+  if [[ "${redisTestPort:-}" == "" ]]; then
+    redisTestPort=6379
+  fi
+
+  if [[ "${REDIS_SOCKET:-}" == "" ]]; then
+    mkdir -p "$NIX_BUILD_TOP/run/"
+    REDIS_SOCKET="$NIX_BUILD_TOP/run/redis.sock"
+  fi
+  export REDIS_SOCKET
+
+  echo 'starting redis'
+
+  # Note about Darwin: unless the output is redirected, the parent process becomes launchd instead of bash.
+  # This would leave the Redis process running in case of a test failure (the postCheckHook would not be executed),
+  # hanging the Nix build forever.
+  @server@ --unixsocket "$REDIS_SOCKET" --port "$redisTestPort" > /dev/null 2>&1 &
+  REDIS_PID=$!
+
+  echo 'waiting for redis to be ready'
+  while ! @cli@ --scan -s "$REDIS_SOCKET" ; do
+    sleep 1
+  done
+}
+
+redisStop() {
+  echo 'stopping redis'
+  kill "$REDIS_PID"
+}

--- a/pkgs/by-name/re/redisTestHook/test.nix
+++ b/pkgs/by-name/re/redisTestHook/test.nix
@@ -1,0 +1,47 @@
+{
+  redis,
+  redisTestHook,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  name = "redis-test-hook-test";
+
+  nativeCheckInputs = [
+    redis
+    redisTestHook
+  ];
+
+  dontUnpack = true;
+  doCheck = true;
+
+  preCheck = ''
+    redisTestPort=6380
+    REDIS_SOCKET=/tmp/customredis.sock
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo "running test"
+    if redis-cli --scan -p $redisTestPort; then
+      echo "connected to redis via localhost"
+      PORT_TEST_RAN=1
+    fi
+
+    if redis-cli --scan -s $REDIS_SOCKET; then
+      echo "connected to redis via domain socket"
+      SOCKET_TEST_RAN=1
+    fi
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    [[ $PORT_TEST_RAN == 1 && $SOCKET_TEST_RAN == 1 ]]
+    echo "test passed"
+    touch $out
+  '';
+
+  __darwinAllowLocalNetworking = true;
+}

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -5,8 +5,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   marshmallow,
+  memcachedTestHook,
   msgpack,
-  pkgs,
   pytest-asyncio,
   pytest-cov-stub,
   pytest-mock,
@@ -14,6 +14,7 @@
   pythonAtLeast,
   pythonOlder,
   redis,
+  redisTestHook,
   setuptools,
 }:
 
@@ -42,10 +43,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aiohttp
     marshmallow
+    memcachedTestHook
     pytest-asyncio
     pytest-cov-stub
     pytest-mock
     pytestCheckHook
+    redisTestHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [
@@ -69,19 +72,6 @@ buildPythonPackage rec {
     # Benchmark and performance tests are not relevant for Nixpkgs
     "tests/performance/"
   ];
-
-  preCheck = ''
-    ${lib.getBin pkgs.redis}/bin/redis-server &
-    REDIS_PID=$!
-
-    ${lib.getBin pkgs.memcached}/bin/memcached &
-    MEMCACHED_PID=$!
-  '';
-
-  postCheck = ''
-    kill $REDIS_PID
-    kill $MEMCACHED_PID
-  '';
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/django-cacheops/default.nix
+++ b/pkgs/development/python-modules/django-cacheops/default.nix
@@ -5,6 +5,7 @@
   django,
   funcy,
   redis,
+  redisTestHook,
   six,
   pytestCheckHook,
   pytest-django,
@@ -53,20 +54,8 @@ buildPythonPackage rec {
     before-after
     nettools
     pkgs.redis
+    redisTestHook
   ];
-
-  preCheck = ''
-    redis-server &
-    REDIS_PID=$!
-    while ! redis-cli --scan ; do
-      echo waiting for redis to be ready
-      sleep 1
-    done
-  '';
-
-  postCheck = ''
-    kill $REDIS_PID
-  '';
 
   DJANGO_SETTINGS_MODULE = "tests.settings";
 

--- a/pkgs/development/python-modules/fakeredis/default.nix
+++ b/pkgs/development/python-modules/fakeredis/default.nix
@@ -12,7 +12,7 @@
   pytestCheckHook,
   pythonOlder,
   redis,
-  redis-server,
+  redisTestHook,
   sortedcontainers,
 }:
 
@@ -50,6 +50,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-mock
     pytestCheckHook
+    redisTestHook
   ];
 
   pythonImportsCheck = [ "fakeredis" ];
@@ -57,12 +58,7 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "-m 'not slow'" ];
 
   preCheck = ''
-    ${lib.getExe' redis-server "redis-server"} --port 6390 &
-    REDIS_PID=$!
-  '';
-
-  postCheck = ''
-    kill $REDIS_PID
+    redisTestPort=6390
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/flask-session/default.nix
+++ b/pkgs/development/python-modules/flask-session/default.nix
@@ -15,12 +15,13 @@
   # tests
   boto3,
   flask-sqlalchemy,
+  memcachedTestHook,
   pytestCheckHook,
   redis,
+  redisTestHook,
   pymongo,
   pymemcache,
   python-memcached,
-  pkgs,
 }:
 
 buildPythonPackage rec {
@@ -45,23 +46,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     flask-sqlalchemy
+    memcachedTestHook
     pytestCheckHook
     redis
+    redisTestHook
     pymongo
     pymemcache
     python-memcached
     boto3
   ];
-
-  preCheck = ''
-    ${lib.getExe' pkgs.redis "redis-server"} &
-    ${lib.getExe pkgs.memcached} &
-  '';
-
-  postCheck = ''
-    kill %%
-    kill %%
-  '';
 
   disabledTests = [
     # unfree

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
-  stdenv,
 
   # build-system
   hatchling,
@@ -29,7 +27,7 @@
   pytest-cov-stub,
   pytestCheckHook,
   redis,
-  redis-server,
+  redisTestHook,
   requests,
   sure,
 
@@ -70,18 +68,10 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
     redis
+    redisTestHook
     requests
     sure
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
-
-  preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
-    ${redis-server}/bin/redis-server &
-    REDIS_PID=$!
-  '';
-
-  postCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
-    kill $REDIS_PID
-  '';
 
   # Skip http tests, they require network access
   env.SKIP_TRUE_HTTP = true;
@@ -97,8 +87,6 @@ buildPythonPackage rec {
     # httpx read failure
     "test_no_dangling_fds"
   ];
-
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_redis.py" ];
 
   pythonImportsCheck = [ "mocket" ];
 

--- a/pkgs/development/python-modules/redis-om/default.nix
+++ b/pkgs/development/python-modules/redis-om/default.nix
@@ -12,9 +12,9 @@
   pydantic,
   python-ulid,
   redis,
+  redisTestHook,
   types-redis,
   typing-extensions,
-  pkgs,
   pytest-asyncio,
   pytestCheckHook,
 }:
@@ -61,16 +61,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
+    redisTestHook
   ];
-
-  preCheck = ''
-    ${pkgs.redis}/bin/redis-server &
-    REDIS_PID=$!
-  '';
-
-  postCheck = ''
-    kill $REDIS_PID
-  '';
 
   # probably require redisearch
   # https://github.com/redis/redis-om-python/issues/532

--- a/pkgs/development/python-modules/rq/default.nix
+++ b/pkgs/development/python-modules/rq/default.nix
@@ -14,7 +14,7 @@
   # tests
   psutil,
   pytestCheckHook,
-  redis-server,
+  redisTestHook,
   sentry-sdk,
 }:
 
@@ -42,17 +42,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     psutil
     pytestCheckHook
+    redisTestHook
     sentry-sdk
   ];
-
-  preCheck = ''
-    PATH=$out/bin:$PATH
-    ${redis-server}/bin/redis-server &
-  '';
-
-  postCheck = ''
-    kill %%
-  '';
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/walrus/default.nix
+++ b/pkgs/development/python-modules/walrus/default.nix
@@ -2,9 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pkgs,
   pythonOlder,
   redis,
+  redisTestHook,
   setuptools,
   unittestCheckHook,
 }:
@@ -27,16 +27,10 @@ buildPythonPackage rec {
 
   dependencies = [ redis ];
 
-  nativeCheckInputs = [ unittestCheckHook ];
-
-  preCheck = ''
-    ${pkgs.redis}/bin/redis-server &
-    REDIS_PID=$!
-  '';
-
-  postCheck = ''
-    kill $REDIS_PID
-  '';
+  nativeCheckInputs = [
+    unittestCheckHook
+    redisTestHook
+  ];
 
   pythonImportsCheck = [ "walrus" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4543,9 +4543,7 @@ self: super: with self; {
 
   faker = callPackage ../development/python-modules/faker { };
 
-  fakeredis = callPackage ../development/python-modules/fakeredis {
-    redis-server = pkgs.redis;
-  };
+  fakeredis = callPackage ../development/python-modules/fakeredis { };
 
   falcon = callPackage ../development/python-modules/falcon { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14655,9 +14655,7 @@ self: super: with self; {
 
   rpyc = callPackage ../development/python-modules/rpyc { };
 
-  rq = callPackage ../development/python-modules/rq {
-    redis-server = pkgs.redis;
-  };
+  rq = callPackage ../development/python-modules/rq { };
 
   rsa = callPackage ../development/python-modules/rsa { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8561,9 +8561,7 @@ self: super: with self; {
 
   mobly = callPackage ../development/python-modules/mobly { };
 
-  mocket = callPackage ../development/python-modules/mocket {
-    redis-server = pkgs.redis;
-  };
+  mocket = callPackage ../development/python-modules/mocket { };
 
   mock = callPackage ../development/python-modules/mock { };
 


### PR DESCRIPTION
Looking at Hydra's "timed out jobs" list, I noticed many Darwin timeouts where the last log lines were all about Redis. It turns out the background Redis job is not terminated correctly on macOS when `checkPhase` fails (thus `postCheck` never runs).

I reviewed all Redis test usage in pkgs and added the same workaround, as well as connection retry where it was missing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
