### PR TITLE
meteor: fix error detecting glibc/musl

### DIFF
--- a/pkgs/by-name/me/meteor/fibers-glibc.patch
+++ b/pkgs/by-name/me/meteor/fibers-glibc.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/fibers.js b/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/fibers.js
+index 96928630..25b6d82b 100644
+--- a/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/fibers.js
++++ b/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/fibers.js
+@@ -8,7 +8,7 @@ if (process.fiberLib) {
+ 
+ 	// Look for binary for this platform
+ 	var modPath = path.join(__dirname, 'bin', process.platform+ '-'+ process.arch+ '-'+ process.versions.modules+
+-		((process.platform === 'linux') ? '-'+ detectLibc.family : ''), 'fibers');
++		((process.platform === 'linux') ? '-'+ (detectLibc.family || 'glibc') : ''), 'fibers');
+ 	try {
+ 		// Pull in fibers implementation
+ 		process.fiberLib = module.exports = require(modPath).Fiber;

--- a/pkgs/by-name/me/meteor/package.nix
+++ b/pkgs/by-name/me/meteor/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation {
     # necessary.
     pushd $out
     patch -p1 < ${./main.patch}
+    patch -p1 < ${./fibers-glibc.patch}
     popd
     substituteInPlace $out/tools/cli/main.js \
       --replace "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \


### PR DESCRIPTION
I encountered this issue running `meteor`:
```
## There is an issue with `node-fibers` ##
`/nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/bin/linux-x64-83-/fibers.node` is missing.

Try running this to fix the issue: /nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node /nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/build
Error: Cannot find module '/nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/bin/linux-x64-83-/fibers'
Require stack:
- /nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/fibers.js
- /nix/store/bavm7rzjbyr97bayfm7gl3xi37scc1w4-meteor-2.7.3/packages/meteor-tool/.2.7.3.1mjjp3y.wu0o++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/tools/tool-env/wrap-fibers.js
```

and saw it has a missing `glibc`/`musl` part in the path to the fibers.node binary:
```
fibers/bin/linux-x64-83-/fibers.node
```
Found that it uses [detect-libc package](https://github.com/lovell/detect-libc/blob/88df1a5950bf3cd9bffa1e0137ab6471c4546118/lib/detect-libc.js), which doesn't seem to work well on nixos - so I decided to patch meteor's dev_bundle fibers script, adding a fallback to `glibc` if detection fails (this package anyways only works with glibc):
```patch
-		((process.platform === 'linux') ? '-'+ detectLibc.family : ''), 'fibers');
+		((process.platform === 'linux') ? '-'+ (detectLibc.family || 'glibc') : ''), 'fibers');
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
