### PR TITLE
neovim: fix ruby provider warning

### DIFF
--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'neovim'
+gem 'logger'

--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    msgpack (1.7.2)
+    logger (1.6.1)
+    msgpack (1.7.5)
     multi_json (1.15.0)
     neovim (0.10.0)
       msgpack (~> 1.1)
@@ -11,7 +12,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  logger
   neovim
 
 BUNDLED WITH
-   2.3.27
+   2.5.16

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -1,13 +1,23 @@
 {
+  logger = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lwncq2rf8gm79g2rcnnyzs26ma1f4wnfjm6gs4zf2wlsdz5in9s";
+      type = "gem";
+    };
+    version = "1.6.1";
+  };
   msgpack = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1a5adcb7bwan09mqhj3wi9ib52hmdzmqg7q08pggn3adibyn5asr";
+      sha256 = "1a5fsgchkpcca4wf3pipbb2jbj523l7fbaq37j10cr0yymwlkc7z";
       type = "gem";
     };
-    version = "1.7.2";
+    version = "1.7.5";
   };
   multi_json = {
     groups = ["default"];


### PR DESCRIPTION
Fixing this warning from checkhealth

```
provider.ruby: require("provider.ruby.health").check()

Ruby provider (optional) ~
- Ruby: ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
- Host: /nix/store/l354hgiahcjd81qazlc870104i26lm9b-neovim-0.10.2birdeevim/bin/birdeeVim-ruby
- OK Latest "neovim" gem is installed: /home/birdee/.local/share/gem/ruby/3.3.0/gems/neovim-0.10.0/lib/neovim/connection.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add logger to your Gemfile or gemspec to silence this warning. 0.10.0
```

steps taken:

added `gem 'logger'` to Gemfile

ran the following on the directory

nix run --no-write-lock-file github:BirdeeHub/neovim_ruby_updater

https://github.com/BirdeeHub/neovim_ruby_updater


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

Also currently using the same thing in my personal configuration [seen here](https://github.com/BirdeeHub/birdeeSystems/tree/main/common/birdeevim/overlays/ruby_provider) and it works
