### PR TITLE
evaluated: introduce nixpkgs package list evaluation as a package

### DIFF
--- a/pkgs/by-name/ev/evaluated/evaluator.nix
+++ b/pkgs/by-name/ev/evaluated/evaluator.nix
@@ -1,0 +1,40 @@
+let
+
+  pkgs = import <nixpkgs> { };
+  inherit (pkgs.lib)
+    concatStringsSep
+    isDerivation
+    isFunction
+    isAttrs
+    mapAttrs
+    ;
+  /**
+    Helper for package tree introspection.
+
+    It emits the position of all functions
+    and derivations using `builtins.trace`
+    so that another program can quickly calculate
+    the difference of packages between two commits.
+  */
+  traceTree =
+    let
+      traceTree' =
+        tree: path:
+        let
+          pathStr = concatStringsSep "." path;
+          evaluated = builtins.tryEval tree;
+        in
+        if isFunction tree then
+          builtins.trace ":tree: function ${pathStr} :tree:" null
+        else if !evaluated.success then
+          builtins.trace ":tree: exception ${pathStr} :tree:" null
+        else if isDerivation tree then
+          builtins.trace (builtins.unsafeDiscardStringContext ":tree: derivation ${pathStr} ${tree.drvPath} :tree:") null
+        else if isAttrs tree && (tree.recurseForDerivations or false) then
+          mapAttrs (k: v: traceTree' v (path ++ [ k ])) (pkgs.recurseIntoAttrs tree)
+        else
+          null;
+    in
+    tree: traceTree' tree [ ];
+in
+traceTree (pkgs.recurseIntoAttrs pkgs)

--- a/pkgs/by-name/ev/evaluated/package.nix
+++ b/pkgs/by-name/ev/evaluated/package.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  nix,
+  runCommand,
+  path,
+}:
+
+runCommand "evaluated"
+  {
+    nixpkgs = path;
+    meta = {
+      description = "Proof of concept of using a remote builder to evaluate the package list";
+    };
+  }
+  ''
+
+    ${lib.getExe nix} eval \
+      --store ./store \
+      --extra-experimental-features nix-command \
+      -f ${./evaluator.nix} -I nixpkgs=$nixpkgs 2>&1 | tee raw.txt
+      grep ':tree:' raw.txt | sed 's;^.*:tree: *\(.*\) *:tree:.*$;\1;' > $out
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a package that basically takes a nixpkgs tree and evaluates the package, and function, list to a file so comparing different releases is faster.

It runs as a nix derivation so the expensive evaluation could be offloaded to a worker node.

It returns a text file with the item path from pkgs, the type and the outPath if it's a derivation.

Implementation may be suboptimal but suggestions are welcome.

Consider this a experiment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
