### PR TITLE
nixos/users-groups: split isSystemUser/isNormalUser and uid check into two

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -907,8 +907,17 @@ in {
             Please check the value of option `users.users."${user.name}".hashedPassword`.'';
           }
           {
+            assertion = user.isNormalUser && user.uid != null -> user.uid >= 1000;
+            message = ''
+              A user cannot have a users.users.${user.name}.uid set below 1000 and set users.users.${user.name}.isNormalUser.
+              Either users.users.${user.name}.isSystemUser must be set to true instead of users.users.${user.name}.isNormalUser
+              or users.users.${user.name}.uid must be changed to 1000 or above.
+            '';
+          }
+          {
             assertion = let
-              isEffectivelySystemUser = user.isSystemUser || (user.uid != null && user.uid < 1000);
+              # we do an extra check on isNormalUser here, to not trigger this assertion when isNormalUser is set and uid to < 1000
+              isEffectivelySystemUser = user.isSystemUser || (user.uid != null && user.uid < 1000 && !user.isNormalUser);
             in xor isEffectivelySystemUser user.isNormalUser;
             message = ''
               Exactly one of users.users.${user.name}.isSystemUser and users.users.${user.name}.isNormalUser must be set.


### PR DESCRIPTION
Before the error message only mentioned isSystemUser/isNormalUser which
lead to a confusing situation when setting isNormalUser and an uid like
500 which would generate an error like:

error:
Failed assertions:
- Exactly one of users.users.other.isSystemUser and users.users.other.isNormalUser must be set.

from which you cannot know that setting the uid to 500 *and* setting
isNormalUser is the actual problem.

With this patch the error looks like:

error:
Failed assertions:
- A user cannot have a users.users.fixme.uid set below 1000 and set users.users.fixme.isNormalUser.
Either users.users.fixme.isSystemUser must be set to true instead of users.users.fixme.isNormalUser
or users.users.fixme.uid must be changed to 1000 or above.


---

I tested this via the config where I before ran into this error and it now produced a better error message and none after fixing it like before.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
