### PR TITLE
timewall: init at 1.2.0

### DIFF
--- a/pkgs/by-name/ti/timewall/package.nix
+++ b/pkgs/by-name/ti/timewall/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+  libheif,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "timewall";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "bcyran";
+    repo = "timewall";
+    rev = version;
+    hash = "sha256-OVLiuYxldk59TbggKNfPtaADz0B6pZ91gP6B6aEjEV8=";
+  };
+
+  cargoHash = "sha256-2Ij5bv/M6QXXugMg+tvsXc/38hWzk9lrz990+o+3igI=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ libheif ];
+
+  SHELL_COMPLETIONS_DIR = "completions";
+
+  preBuild = ''
+    mkdir ${SHELL_COMPLETIONS_DIR}
+  '';
+
+  postInstall = ''
+    installShellCompletion \
+      --bash ${SHELL_COMPLETIONS_DIR}/timewall.bash \
+      --zsh ${SHELL_COMPLETIONS_DIR}/_timewall \
+      --fish ${SHELL_COMPLETIONS_DIR}/timewall.fish
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Apple dynamic HEIF wallpapers on GNU/Linux";
+    homepage = "https://github.com/bcyran/timewall";
+    changelog = "https://github.com/bcyran/timewall/releases/tag/${version}";
+    license = lib.licenses.mit;
+    mainProgram = "timewall";
+    maintainers = with lib.maintainers; [ bcyran ];
+  };
+}


### PR DESCRIPTION
Adding [`timewall`](https://github.com/bcyran/timewall) - a program for using Apple's dynamic HEIF wallpaper files on Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
