### PR TITLE
[Backport release-24.11] libresprite: 1.0 -> 1.1

### DIFF
--- a/nixos/tests/libresprite.nix
+++ b/nixos/tests/libresprite.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       machine.wait_for_x()
       machine.succeed("convert -font DejaVu-Sans +antialias label:'IT WORKS' image.png")
       machine.execute("libresprite image.png >&2 &")
-      machine.wait_for_window("LibreSprite v${pkgs.libresprite.version}")
+      machine.wait_for_window("LibreSprite ${pkgs.libresprite.version}-dev")
       machine.wait_for_text("IT WORKS")
       machine.screenshot("screen")
     '';

--- a/pkgs/applications/editors/libresprite/default.nix
+++ b/pkgs/applications/editors/libresprite/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 
 , cmake
 , pkg-config
@@ -14,8 +13,9 @@
 , libjpeg
 , libpng
 , libwebp
+, libarchive
 , pixman
-, tinyxml
+, tinyxml-2
 , zlib
 , SDL2
 , SDL2_image
@@ -29,24 +29,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libresprite";
-  version = "1.0";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "LibreSprite";
     repo = "LibreSprite";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-d8GmVHYomDb74iSeEhJEVTHvbiVXggXg7xSqIKCUSzY=";
+    hash = "sha256-piA/hLQqdfyVH4GPu5ElXZtowQL9AGaK7GhZOME4L0Q=";
   };
-
-  # Backport GCC 13 build fix
-  # FIXME: remove in next release
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/LibreSprite/LibreSprite/commit/6ffe8472194bf5d0a73b4b2cd7f6804d3c80aa0c.patch";
-      hash = "sha256-5chXt0H+koofIspYsCJ7/eUxMGcCBVXJcXe3U/7F9Vc=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -62,8 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libpng
     libwebp
+    libarchive
     pixman
-    tinyxml
+    tinyxml-2
     zlib
     SDL2
     SDL2_image
@@ -95,10 +87,10 @@ stdenv.mkDerivation (finalAttrs: {
     libresprite-can-open-png = nixosTests.libresprite;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://libresprite.github.io/";
     description = "Animated sprite editor & pixel art tool, fork of Aseprite";
-    license = licenses.gpl2Only;
+    license = lib.licenses.gpl2Only;
     longDescription = ''
         LibreSprite is a program to create animated sprites. Its main features are:
 
@@ -113,8 +105,8 @@ stdenv.mkDerivation (finalAttrs: {
           - Pixel-art specific tools like filled Contour, Polygon, Shading mode, etc.
           - Onion skinning.
       '';
-    maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
     # https://github.com/LibreSprite/LibreSprite/issues/308
     broken = stdenv.hostPlatform.isDarwin;
   };


### PR DESCRIPTION
Backport #356557

(cherry picked from commit 6fa830fc0de2b532b6e54767a1239db1ebf700d5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
