### PR TITLE
nixos/couchdb: Add support for additional config files

### DIFF
--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -1,36 +1,58 @@
-{ config, options, lib, pkgs, ... }:
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.services.couchdb;
   opt = options.services.couchdb;
-  configFile = pkgs.writeText "couchdb.ini" (
+
+  optionsConfigFile = pkgs.writeText "couchdb.ini" (
     ''
       [couchdb]
       database_dir = ${cfg.databaseDir}
       uri_file = ${cfg.uriFile}
       view_index_dir = ${cfg.viewIndexDir}
-    '' + (lib.optionalString (cfg.adminPass != null) ''
-      [admins]
-      ${cfg.adminUser} = ${cfg.adminPass}
-    '' + ''
-      [chttpd]
-    '') +
     ''
+    + (
+      lib.optionalString (cfg.adminPass != null) ''
+        [admins]
+        ${cfg.adminUser} = ${cfg.adminPass}
+      ''
+      + ''
+        [chttpd]
+      ''
+    )
+    + ''
       port = ${toString cfg.port}
       bind_address = ${cfg.bindAddress}
 
       [log]
       file = ${cfg.logFile}
-    '');
+    ''
+    + (lib.optionalString (cfg.extraConfig != "") ''
+      ${cfg.extraConfig}
+    '')
+  );
+
+  # we are actually specifying 5 configuration files:
+  # 1. the preinstalled default.ini
+  # 2. the module configuration
+  # 3. the extraConfigFiles from the module options
+  # 4. the locally writable config file, which couchdb itself writes to
+  configFiles = [
+    "${cfg.package}/etc/default.ini"
+    optionsConfigFile
+  ] ++ cfg.extraConfigFiles ++ [ cfg.configFile ];
   executable = "${cfg.package}/bin/couchdb";
-
-in {
-
+in
+{
   ###### interface
 
   options = {
-
     services.couchdb = {
-
       enable = lib.mkEnableOption "CouchDB Server";
 
       package = lib.mkPackageOption pkgs "couchdb3" { };
@@ -134,6 +156,13 @@ in {
           Extra configuration. Overrides any other configuration.
         '';
       };
+      extraConfigFiles = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [ ];
+        description = ''
+          Extra configuration files. Overrides any other configuration. You can use this to setup the Admin user without putting the password in your nix store.
+        '';
+      };
 
       argsFile = lib.mkOption {
         type = lib.types.path;
@@ -146,23 +175,19 @@ in {
 
       configFile = lib.mkOption {
         type = lib.types.path;
+        default = "/var/lib/couchdb/local.ini";
         description = ''
           Configuration file for persisting runtime changes. File
           needs to be readable and writable from couchdb user/group.
         '';
       };
-
     };
-
   };
 
   ###### implementation
 
-  config = lib.mkIf config.services.couchdb.enable {
-
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-
-    services.couchdb.configFile = lib.mkDefault "/var/lib/couchdb/local.ini";
 
     systemd.tmpfiles.rules = [
       "d '${dirOf cfg.uriFile}' - ${cfg.user} ${cfg.group} - -"
@@ -185,15 +210,10 @@ in {
       '';
 
       environment = {
-        # we are actually specifying 5 configuration files:
-        # 1. the preinstalled default.ini
-        # 2. the module configuration
-        # 3. the extraConfig from the module options
-        # 4. the locally writable config file, which couchdb itself writes to
-        ERL_FLAGS= ''-couch_ini ${cfg.package}/etc/default.ini ${configFile} ${pkgs.writeText "couchdb-extra.ini" cfg.extraConfig} ${cfg.configFile}'';
+        ERL_FLAGS = ''-couch_ini ${lib.concatStringsSep " " configFiles}'';
         # 5. the vm.args file
-        COUCHDB_ARGS_FILE=''${cfg.argsFile}'';
-        HOME =''${cfg.databaseDir}'';
+        COUCHDB_ARGS_FILE = ''${cfg.argsFile}'';
+        HOME = ''${cfg.databaseDir}'';
       };
 
       serviceConfig = {
@@ -210,6 +230,5 @@ in {
     };
 
     users.groups.couchdb.gid = config.ids.gids.couchdb;
-
   };
 }


### PR DESCRIPTION
## Things done
Adds a new option to the couchdb module to specify additional config files. This allows users to set the Admin Password via secrets. `configFile` must be writable which is why it isn't sufficient.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
