### PR TITLE
[24.05] vikunja: add patches for 0.24.5 security fixes

### DIFF
--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, stdenv, stdenvNoCC,  nodePackages, buildGoModule, jq, mage, writeShellScriptBin, nixosTests, buildNpmPackage, moreutils, cacert }:
+{ lib, fetchFromGitHub, fetchpatch, stdenv, stdenvNoCC,  nodePackages, buildGoModule, jq, mage, writeShellScriptBin, nixosTests, buildNpmPackage, moreutils, cacert }:
 
 let
   version = "0.23.0";
@@ -9,9 +9,23 @@ let
     hash = "sha256-DGdJ/qO86o4LDB2Soio6/zd5S0su6ffrtT+iOn1eQnA=";
   };
 
+  patches = [
+    # security patches from 0.24.5
+    (fetchpatch {
+      name = "security-check-saved-filters-permissions.patch";
+      url = "https://github.com/go-vikunja/vikunja/commit/bbbd936868f73a73e37d0f40313274e9e0ba30ac.patch";
+      hash = "sha256-xEsecgmfxx3M92Bpe/cDYNghP5gvEDN5D0xDZEeETuU=";
+    })
+    (fetchpatch {
+      name = "security-check-saved-filters-permissions.patch";
+      url = "https://github.com/go-vikunja/vikunja/commit/3659b7b58d4405452f3e806e12b0e3dfb4577503.patch";
+      hash = "sha256-1TQFe1N3/gwbamN5ZzKgP04oRbx5x+Tlmrt8H7V/Q2A=";
+    })
+  ];
+
   frontend = stdenv.mkDerivation (finalAttrs: {
     pname = "vikunja-frontend";
-    inherit version src;
+    inherit version src patches;
 
     postPatch = ''
       cd frontend
@@ -103,7 +117,7 @@ let
     '';
 in
 buildGoModule {
-  inherit src version;
+  inherit src version patches;
   pname = "vikunja";
 
   nativeBuildInputs =


### PR DESCRIPTION
backport of #357992

https://vikunja.io/changelog/vikunja-v0.24.5-was-released

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
