### PR TITLE
factoriolab: init at 3.8.1

### DIFF
--- a/pkgs/by-name/fa/factoriolab/package.nix
+++ b/pkgs/by-name/fa/factoriolab/package.nix
@@ -1,0 +1,56 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  vips,
+  lib,
+  pkg-config,
+  jq,
+  makeWrapper,
+  nix-update-script,
+}:
+buildNpmPackage rec {
+  pname = "factoriolab";
+  version = "3.8.1";
+
+  src = fetchFromGitHub {
+    owner = "factoriolab";
+    repo = "factoriolab";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ZI7nit+DBc1ULGDpGlee7v+NrHc5JhS7sgACGG5fB7I=";
+  };
+  buildInputs = [ vips ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  npmDepsHash = "sha256-FX9zxq3kIQ5nxEPW57X53novtCFBPV5w9jg882EC2Lo=";
+  # By default angular tries to optimize fonts by inlining them
+  # which needs internet access during building to download said fonts.
+  # Internet access during build would necessitate turning this into a fixed output derivation
+  # which is difficult as said fonts are not actually stable.
+  # This disables font inlining completely in which case the fonts will be loaded on demand by your browser
+  postPatch = ''
+    ${lib.getExe jq} '.projects.factoriolab.architect.build.options += { "optimization": {"fonts": false } }' ./angular.json > angular.json.new
+    mv -f angular.json.new angular.json
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+
+    cp -r dist/browser $out/share/factoriolab
+
+    runHook postInstall
+  '';
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/factoriolab/factoriolab";
+    changelog = "https://github.com/factoriolab/factoriolab/releases/tag/${version}";
+    description = "Angular-based calculator for factory games like Factorio and Dyson Sphere Program";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ patrickdag ];
+  };
+}


### PR DESCRIPTION
Closes: #356733 
[FactorioLab](https://factoriolab.github.io/) is a tool for calculating resource and factory requirements for factory games like Factorio, Dyson Sphere Program, Satisfactory, Captain of Industry, Techtonica and Final Factory.
## Things done

Packaged the project. Since it's a static website it doesn't do very much on its own you need some kind of webserver to host it, such as nginx, or for personal deployment `python -m http.server`.  Could write a nixos module for that but not sure that's necessary.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
