### PR TITLE
google-cloud-sdk: fix gsutil

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -43,6 +43,8 @@ in stdenv.mkDerivation rec {
     ./gcloud-path.patch
     # Disable checking for updates for the package
     ./gsutil-disable-updates.patch
+    # Revert patch including extended Python version constraint
+    ./gsutil-revert-version-constraint.patch
   ];
 
   installPhase = ''
@@ -120,6 +122,7 @@ in stdenv.mkDerivation rec {
     # Avoid trying to write logs to homeless-shelter
     export HOME=$(mktemp -d)
     $out/bin/gcloud version --format json | jq '."Google Cloud SDK"' | grep "${version}"
+    $out/bin/gsutil version | grep -w "$(cat platform/gsutil/VERSION)"
   '';
 
   passthru = {

--- a/pkgs/tools/admin/google-cloud-sdk/gsutil-revert-version-constraint.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/gsutil-revert-version-constraint.patch
@@ -1,0 +1,21 @@
+diff --git a/platform/gsutil/gsutil.py b/platform/gsutil/gsutil.py
+index 30b8a5ac..a02f0ba5 100755
+--- a/platform/gsutil/gsutil.py
++++ b/platform/gsutil/gsutil.py
+@@ -27,14 +27,8 @@ import warnings
+ # TODO: gsutil-beta: Distribute a pylint rc file.
+ 
+ ver = sys.version_info
+-if (ver.major == 2 and ver.minor < 7) or (ver.major == 3 and (ver.minor < 5 or ver.minor > 11)):
+-  sys.exit(
+-    "Error: gsutil requires Python version 2.7 or 3.5-3.11, but a different version is installed.\n"
+-    "You are currently running Python {}.{}\n"
+-    "Follow the steps below to resolve this issue:\n"
+-    "\t1. Switch to Python 3.5-3.11 using your Python version manager or install an appropriate version.\n"
+-    "\t2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.".format(ver.major, ver.minor)
+-  )
++if (ver.major == 2 and ver.minor < 7) or (ver.major == 3 and ver.minor < 5):
++  sys.exit('gsutil requires python 2.7 or 3.5+.')
+ 
+ # setup a string to load the correct httplib2
+ if sys.version_info.major == 2:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes a runtime issue with gsutil introduced by #356927. It is an alternative fix to #357355.

This happened due to a more strict Python version constraint that was added to gsutil as part of this new release:
https://github.com/GoogleCloudPlatform/gsutil/commit/c8e270933ad925ab30bba63b23e9bf7410ed6b25

`gsutil` is working on Python 3.12 support:
- https://github.com/GoogleCloudPlatform/gsutil/pulls

`gsutil` has been running with Python 3.12 for some time and other people indicate that it works "fine".
- https://github.com/GoogleCloudPlatform/gsutil/pull/1797#issuecomment-2424137557

I added a `gsutil` check to the install check phase to avoid a similar error happening in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
