### PR TITLE
ruff: Build as a standalone without Python

### DIFF
--- a/pkgs/by-name/ru/ruff-lsp/package.nix
+++ b/pkgs/by-name/ru/ruff-lsp/package.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
     pytest-asyncio
     python-lsp-jsonrpc
-    ruff.bin
+    ruff
     versionCheckHook
   ];
   versionCheckProgramArg = [ "--version" ];

--- a/pkgs/development/python-modules/ruff/default.nix
+++ b/pkgs/development/python-modules/ruff/default.nix
@@ -1,0 +1,35 @@
+{
+  buildPythonPackage,
+  pkgs,
+  rustPlatform,
+  installShellFiles,
+}:
+
+buildPythonPackage {
+  inherit (pkgs.ruff)
+    pname
+    version
+    src
+    cargoDeps
+    postInstall
+    meta
+    ;
+
+  # Do not rely on path lookup at runtime to find the ruff binary
+  postPatch = ''
+    substituteInPlace python/ruff/__main__.py \
+      --replace-fail \
+        'ruff_exe = "ruff" + sysconfig.get_config_var("EXE")' \
+        'return "${placeholder "out"}/bin/ruff"'
+  '';
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pythonImportsCheck = [ "ruff" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14282,9 +14282,7 @@ self: super: with self; {
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
-  ruff = toPythonModule (pkgs.ruff.override {
-    python3Packages = self;
-  });
+  ruff = callPackage ../development/python-modules/ruff { };
 
   ruff-api = callPackage ../development/python-modules/ruff-api { };
 


### PR DESCRIPTION
Using `buildPythonPackage` make `ruff` propagate the Python used for the build, which might not be the same Python as you want in your development shell.

https://github.com/NixOS/nixpkgs/pull/350654 changed the ruff top-level attribute to be built with Python modules. This doesn't actually make much sense, we have versioned Python sets, and including just the one Python in the top-level package isn't helpful, and causes issues downstream related to PATH & PYTHONPATH.

See my related [uv PR](https://github.com/NixOS/nixpkgs/pull/357113#issue-2670270577).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
