### PR TITLE
nixos/stage-1.init.sh: Prevent unsafe remount and correct fstab syntax

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -392,7 +392,7 @@ mountFS() {
     # Filter out x- options, which busybox doesn't do yet.
     local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n $i,; fi; done)"
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
-    local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
+    local optionsPrefixed="$( echo "${optionsFiltered%,}" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
 
     echo "$device /mnt-root$mountPoint $fsType $optionsPrefixed" >> /etc/fstab
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -423,8 +423,16 @@ mountFS() {
 
     # For bind mounts, busybox has a tendency to ignore options, which can be a
     # security issue (e.g. "nosuid"). Remounting the partition seems to fix the
-    # issue.
-    mount "/mnt-root$mountPoint" -o "remount,$optionsPrefixed"
+    # issue. This should only be done for bind and rbind mountpoints because other
+    # filesystems may have limitations or may not support remount.
+    local IFS=,
+    for opt in $options; do
+        if [[ "$opt" = bind || "$opt" = rbind ]]; then
+            mount "/mnt-root$mountPoint" -o "remount,$optionsPrefixed"
+            break
+        fi
+    done
+    unset IFS
 
     [ "$mountPoint" == "/" ] &&
         [ -f "/mnt-root/etc/NIXOS_LUSTRATE" ] &&


### PR DESCRIPTION
## Description
The legacy stage-1 generates the `/etc/fstab` from fsInfo but incorrectly adds a trailing `,` character to the mount options. While does not appear to have caused any issue yet we should trim the trailing `,` to be safe.

Generated `/etc/fstab` during stage-1:
```
tmpfs /mnt-root tmpfs mode=0755,
```

stage-1 also currently remounts all fileSystems as a fix for busybox not respecting mount options on bind (and rbind) mount points. This results in a unintended errors during stage-1 if a file system such as NFS is mounted which does allow remounting with all of the original options present (i.e some options can only be set during the initial mount). 

Error during stage-1 mounting NFS share:
```
mount: mounting server.example.test:/nix/store on /mnt-root/nix/.ro-store failed: Invalid argument
```

## Things done
Built and ran `legacyPackages.x86_64-linux.nixosTests.early-mount-options`.

- Built on platform(s)
  - [] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).