### PR TITLE
treewide: add mainProgram attribute to lisp compilers

### DIFF
--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -83,12 +83,13 @@ in stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = with lib; {
-    description = "Clozure Common Lisp";
-    homepage    = "https://ccl.clozure.com/";
-    maintainers = lib.teams.lisp.members;
-    platforms   = attrNames options;
     # assembler failures during build, x86_64-darwin broken since 2020-10-14
     broken      = (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64);
+    description = "Clozure Common Lisp";
+    homepage    = "https://ccl.clozure.com/";
     license     = licenses.asl20;
+    mainProgram = "ccl";
+    maintainers = lib.teams.lisp.members;
+    platforms   = attrNames options;
   };
 }

--- a/pkgs/development/compilers/cmucl/binary.nix
+++ b/pkgs/development/compilers/cmucl/binary.nix
@@ -48,14 +48,15 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://www.cons.org/cmucl/";
     description = "CMU implementation of Common Lisp";
+    homepage = "http://www.cons.org/cmucl/";
+    license = licenses.publicDomain;
     longDescription = ''
       CMUCL is a free implementation of the Common Lisp programming language
       which runs on most major Unix platforms.  It mainly conforms to the
       ANSI Common Lisp standard.
     '';
-    license = licenses.publicDomain;
+    mainProgram = "lisp";
     maintainers = lib.teams.lisp.members;
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/development/compilers/mkcl/default.nix
+++ b/pkgs/development/compilers/mkcl/default.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation rec {
     description = "ANSI Common Lisp Implementation";
     homepage = "https://common-lisp.net/project/mkcl/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    mainProgram = "mkcl";
     maintainers = lib.teams.lisp.members;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Added mainProgram attribute to the meta section of the following compilers:
- Clozure Common Lisp (ccl)
- CMU Common Lisp (cmucl)
- MKCL (mkcl)

This change helps in identifying the main executable for each compiler.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
