### PR TITLE
freebsd: Add support for aarch64

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -13,7 +13,7 @@ let
     "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin"
 
     # FreeBSD
-    "i686-freebsd" "x86_64-freebsd"
+    "i686-freebsd" "x86_64-freebsd" "aarch64-freebsd"
 
     # Genode
     "aarch64-genode" "i686-genode" "x86_64-genode"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -334,6 +334,11 @@ rec {
 
   # BSDs
 
+  aarch64-freebsd = {
+    config = "aarch64-unknown-freebsd";
+    useLLVM = true;
+  };
+
   x86_64-freebsd = {
     config = "x86_64-unknown-freebsd";
     useLLVM = true;

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -52,7 +52,7 @@ lib.runTests (
 
   testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];
   testdarwin = mseteq darwin [ "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin" ];
-  testfreebsd = mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ];
+  testfreebsd = mseteq freebsd [ "aarch64-freebsd" "i686-freebsd" "x86_64-freebsd" ];
   testgenode = mseteq genode [ "aarch64-genode" "i686-genode" "x86_64-genode" ];
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);

--- a/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   mkDerivation,
   buildPackages,
@@ -14,6 +15,8 @@ mkDerivation {
     "contrib/libc-vis"
     "etc/mtree/BSD.include.dist"
     "sys"
+    # Used for aarch64-freebsd
+    "lib/msun/arm"
   ];
 
   extraNativeBuildInputs = [

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
@@ -106,6 +106,9 @@ mkDerivation {
       "include/paths.h"
 
       "lib/libdl"
+
+      # Used for aarch64-freebsd
+      "contrib/arm-optimized-routines"
     ];
 
   postPatch = ''


### PR DESCRIPTION
Add a new `aarch64-freebsd` double and example system, then fix include and libc to work.
This is enough to build packages like `hello`,
either static or dynamic.

This is useful for testing nix FreeBSD on a Raspberry Pi.

Most of the challenging parts around compiler_rt were already upstreamed months ago.

If you'd like to test, it's easy to cross build a static binary (`nix build .#pkgsCross.aarch64-freebsd.pkgsStatic.hello`) and copy it to a FreeBSD raspberry pi and run it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
