### PR TITLE
python312Packages.pyobjc-core: init at 10.3.1

### DIFF
--- a/pkgs/development/python-modules/pyobjc-core/default.nix
+++ b/pkgs/development/python-modules/pyobjc-core/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  fetchFromGitHub,
+  fetchpatch,
+  darwin,
+  unittestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-core";
+  version = "10.3.1";
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    rev = "v${version}";
+    hash = "sha256-1IpOaXQpBUxpErC5KR5k7bru6mbxNQSaiJLk9iz5tpg=";
+  };
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+  build-system = [ setuptools ];
+
+  sourceRoot = "${src.name}/pyobjc-core";
+
+  patches = [
+    # Two patches from upstream that will be incorporated in the next release
+    ./patches/upstream-splitsig-nsurl.patch
+    (fetchpatch {
+      name = "002-splitsig.patch";
+      url = "https://github.com/ronaldoussoren/pyobjc/commit/190fe5368a431e518921b9fc2dc9d9f221333924.patch";
+      stripLen = 1;
+      sha256 = "sha256-lzhPwN8SnLYmFWofsgX5lG6Kh6288xFRvFlmgN+exCM=";
+    })
+    # Fix or skip problematic tests
+    ./patches/001-test_sockaddr.patch
+    ./patches/002-test_no_such_selector.patch
+    ./patches/003-test_struct_pickling.patch
+    ./patches/004-test_assertPickleRoundTrips.patch
+    ./patches/005-test_assert_opaque.patch
+    # Some tests have an embedded class definition. Loading issues with these cause a segfault.
+    ./patches/006-rm_embedded_classes.patch
+  ];
+
+  buildInputs = [
+    darwin.libffi
+  ];
+
+  hardeningDisable = [ "strictoverflow" ]; # -fno-strict-overflow is not supported in clang on darwin
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
+
+  # IMPORTANT: unittest discovery segfaults when run in the sandbox. So disable it first, please.
+  nativeCheckInputs = [
+    darwin.DarwinTools
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [
+    "-s"
+    "PyObjCTest"
+    "-v"
+  ];
+
+  preCheck = ''
+    # unittest doesn't have disabled tests or test paths and several tests won't
+    # load even with the custom test runner. Time for the sledge-o-matic.
+
+    # Depends on missing test.pickletester
+    rm PyObjCTest/test_archive_python.py
+    # ImportError: cannot import name 'list_tests' from 'test'
+    rm PyObjCTest/test_array_interface.py
+    # ModuleNotFoundError: No module named 'distutils'. Supplying distutils causes a circular dependency on jaraco-path
+    rm PyObjCTest/test_bridgesupport.py
+    # 'PyObjCTest.test_object_property' not found on path
+    rm PyObjCTest/test_array_property.py
+    rm PyObjCTest/test_dict_property.py
+    rm PyObjCTest/test_set_property.py
+
+    # ImportError: attempted relative import with no known parent package
+    rm PyObjCTest/test_bundleFunctions.py
+    rm PyObjCTest/test_bundleVariables.py
+    rm PyObjCTest/test_categories.py
+    rm PyObjCTest/test_conversion.py
+    rm PyObjCTest/test_enumerator.py
+    rm PyObjCTest/test_generic_new.py
+    rm PyObjCTest/test_methodaccess.py
+    rm PyObjCTest/test_nsunavailable.py
+    rm PyObjCTest/test_objc.py
+    rm PyObjCTest/test_subclass.py
+    rm PyObjCTest/test_vector_proxy.py
+    rm PyObjCTest/test_weakref.py
+    # ImportError: cannot import name 'mapping_tests' from 'test'
+    rm PyObjCTest/test_dict_interface.py
+    # ModuleNotFoundError: No module named 'test.test_set'
+    rm PyObjCTest/test_set_interface.py
+    # Py_MetaDataTest_AllArgs is overriding existing Objective-C class
+    rm PyObjCTest/test_metadata_py2py.py
+    # AttributeError: module 'decimal' has no attribute 'Decimal'
+    rm PyObjCTest/test_nsdecimal.py
+    # OCCopy is overriding existing Objective-C class
+    rm PyObjCTest/test_object_property.py
+
+    # Depends on the Quartz graphics framework being available
+    rm PyObjCTest/test_transform.py
+    rm PyObjCTest/test_vectorcall.py
+
+    # Uncomment if you're getting segfaults when testing w/ sandbox = false
+    # export PYOBJC_NO_AUTORELEASE=1
+
+    export PYTHONPATH=$PYTHONPATH:Lib/PyObjCTools:Lib/objc
+  '';
+
+  pythonImportsCheck = [ "pyobjc-core" ];
+
+  meta = {
+    description = "Python <-> Objective-C Bridge with bindings for macOS frameworks";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    changelog = "https://github.com/ronaldoussoren/pyobjc/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = [
+      lib.maintainers.ferrine
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-core/patches/001-test_sockaddr.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/001-test_sockaddr.patch
@@ -1,0 +1,29 @@
+diff --git a/PyObjCTest/test_sockaddr.py b/pyobjc-core/PyObjCTest/test_sockaddr.py
+index fef833dd5..20e4ef364 100644
+--- a/PyObjCTest/test_sockaddr.py
++++ b/PyObjCTest/test_sockaddr.py
+@@ -82,15 +82,15 @@ class TestSockAddrSupport(TestCase):
+         v = o.sockAddrToValue_(("", 100, 0))
+         self.assertEqual(v, ("IPv6", "::", 100, 0, 0))
+ 
+-        with self.assertRaisesRegex(
+-            socket.gaierror, "nodename nor servname provided, or not known"
+-        ):
+-            o.sockAddrToValue_(("nosuchhost.python.org", 99, 0))
+-
+-        with self.assertRaisesRegex(
+-            socket.gaierror, "nodename nor servname provided, or not known"
+-        ):
+-            o.sockAddrToValue_(("nosuchhost.python.org", 99))
++        # with self.assertRaisesRegex(
++        #     socket.gaierror, "nodename nor servname provided, or not known"
++        # ):
++        #     o.sockAddrToValue_(("nosuchhost.python.org", 99, 0))
++
++        # with self.assertRaisesRegex(
++        #     socket.gaierror, "nodename nor servname provided, or not known"
++        # ):
++        #     o.sockAddrToValue_(("nosuchhost.python.org", 99))
+ 
+         with self.assertRaisesRegex(
+             TypeError,

--- a/pkgs/development/python-modules/pyobjc-core/patches/002-test_no_such_selector.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/002-test_no_such_selector.patch
@@ -1,0 +1,13 @@
+diff --git a/PyObjCTest/test_object_proxy.py b/pyobjc-core/PyObjCTest/test_object_proxy.py
+index c606f7b39..602da3417 100644
+--- a/PyObjCTest/test_object_proxy.py
++++ b/PyObjCTest/test_object_proxy.py
+@@ -171,7 +171,7 @@ class TestPlainPythonMethods(TestCase):
+ 
+         self.assertEqual(forwarder.calls, [("selectorWithArg:andArg:", "x", "y")])
+ 
+-    def test_no_such_selector(self):
++    def notest_no_such_selector(self):
+         forwarder = Forwarder()
+ 
+         with self.assertRaisesRegex(

--- a/pkgs/development/python-modules/pyobjc-core/patches/003-test_struct_pickling.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/003-test_struct_pickling.patch
@@ -1,0 +1,13 @@
+diff --git a/PyObjCTest/test_structs.py b/pyobjc-core/PyObjCTest/test_structs.py
+index 925451931..84367d7cb 100644
+--- a/PyObjCTest/test_structs.py
++++ b/PyObjCTest/test_structs.py
+@@ -694,7 +694,7 @@ class TestStructs(TestCase):
+             class MyStruct(tp0):
+                 pass
+ 
+-    def test_struct_pickling(self):
++    def notest_struct_pickling(self):
+         orig = GlobalType(9, 10)
+         self.assertEqual(orig.a, 9.0)
+         self.assertEqual(orig.b, 10.0)

--- a/pkgs/development/python-modules/pyobjc-core/patches/004-test_assertPickleRoundTrips.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/004-test_assertPickleRoundTrips.patch
@@ -1,0 +1,13 @@
+diff --git a/PyObjCTest/test_testsupport.py b/pyobjc-core/PyObjCTest/test_testsupport.py
+index d9e0c9881..b7500499d 100644
+--- a/PyObjCTest/test_testsupport.py
++++ b/PyObjCTest/test_testsupport.py
+@@ -1508,7 +1508,7 @@ class TestTestSupport(TestCase):
+         else:
+             self.fail("Have FooBar protocol")
+ 
+-    def test_assertPickleRoundTrips(self):
++    def notest_assertPickleRoundTrips(self):
+         try:
+             self.assertPickleRoundTrips(42)
+         except self.failureException:

--- a/pkgs/development/python-modules/pyobjc-core/patches/005-test_assert_opaque.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/005-test_assert_opaque.patch
@@ -1,0 +1,13 @@
+diff --git a/PyObjCTest/test_testsupport.py b/pyobjc-core/PyObjCTest/test_testsupport.py
+index d9e0c9881..9807e2c1e 100644
+--- a/PyObjCTest/test_testsupport.py
++++ b/PyObjCTest/test_testsupport.py
+@@ -552,7 +552,7 @@ class TestTestSupport(TestCase):
+         except self.failureException:
+             self.fail("assertIsEnumType unexpectedly failed")
+ 
+-    def test_assert_opaque(self):
++    def notest_assert_opaque(self):
+         with self.assertRaisesRegex(
+             self.failureException, "<class 'int'> is not an opaque-pointer"
+         ):

--- a/pkgs/development/python-modules/pyobjc-core/patches/006-rm_embedded_classes.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/006-rm_embedded_classes.patch
@@ -1,0 +1,141 @@
+diff --git a/PyObjCTest/test_protocol.py b/PyObjCTest/test_protocol.py
+index fd63a2d..ff216d9 100644
+--- a/PyObjCTest/test_protocol.py
++++ b/PyObjCTest/test_protocol.py
+@@ -86,29 +86,29 @@ class TestInformalProtocols(TestCase):
+                 ),
+             )
+ 
+-    def testMissingProto(self):
+-        class ProtoClass1(NSObject):
+-            def testMethod(self):
+-                pass
++    # def testMissingProto(self):
++    #     class ProtoClass1(NSObject):
++    #         def testMethod(self):
++    #             pass
+ 
+-        self.assertEqual(ProtoClass1.testMethod.signature, b"I@:")
++    #     self.assertEqual(ProtoClass1.testMethod.signature, b"I@:")
+ 
+-    def testIncompleteClass(self):
+-        with self.assertRaisesRegex(
+-            TypeError,
+-            "class does not fully implemented protocol 'MyProto': "
+-            "no implementation for instance method 'testMethod'",
+-        ):
++    # def testIncompleteClass(self):
++    #     with self.assertRaisesRegex(
++    #         TypeError,
++    #         "class does not fully implemented protocol 'MyProto': "
++    #         "no implementation for instance method 'testMethod'",
++    #     ):
+ 
+-            class ProtoClass2A(NSObject, protocols=[MyProto]):
+-                def testMethod2_(self, x):
+-                    pass
++    #         class ProtoClass2A(NSObject, protocols=[MyProto]):
++    #             def testMethod2_(self, x):
++    #                 pass
+ 
+-        with self.assertRaisesRegex(objc.error, "^ProtoClass2A$"):
+-            objc.lookUpClass("ProtoClass2A")
++    #     with self.assertRaisesRegex(objc.error, "^ProtoClass2A$"):
++    #         objc.lookUpClass("ProtoClass2A")
+ 
+-        for cls in objc.getClassList():
+-            self.assertNotEqual(cls.__name__, "ProtoClass2")
++    #     for cls in objc.getClassList():
++    #         self.assertNotEqual(cls.__name__, "ProtoClass2")
+ 
+     def testInvalidMethodType(self):
+         with self.assertRaisesRegex(
+@@ -131,31 +131,31 @@ class TestInformalProtocols(TestCase):
+         for cls in objc.getClassList():
+             self.assertNotEqual(cls.__name__, "ProtoClass2")
+ 
+-    def test_cleanup_protocol(self):
+-        SomeProto = objc.informal_protocol(
+-            "SomeProto",
+-            (
+-                objc.selector(
+-                    None, selector=b"cleanupMethod", signature=b"I@:", isRequired=1
+-                ),
+-            ),
+-        )
++    # def test_cleanup_protocol(self):
++    #     SomeProto = objc.informal_protocol(
++    #         "SomeProto",
++    #         (
++    #             objc.selector(
++    #                 None, selector=b"cleanupMethod", signature=b"I@:", isRequired=1
++    #             ),
++    #         ),
++    #     )
+ 
+-        class ClassImplementingSomeProto1(NSObject):
+-            def cleanupMethod(self):
+-                return 1
++    #     class ClassImplementingSomeProto1(NSObject):
++    #         def cleanupMethod(self):
++    #             return 1
+ 
+-        self.assertResultHasType(ClassImplementingSomeProto1.cleanupMethod, b"I")
++    #     self.assertResultHasType(ClassImplementingSomeProto1.cleanupMethod, b"I")
+ 
+-        # XXX: This won't cause GC for the value due to how
+-        #      the bridge is implemented...
+-        del SomeProto
++    #     # XXX: This won't cause GC for the value due to how
++    #     #      the bridge is implemented...
++    #     del SomeProto
+ 
+-        class ClassImplementingSomeProto2(NSObject):
+-            def cleanupMethod(self):
+-                return 1
++    #     class ClassImplementingSomeProto2(NSObject):
++    #         def cleanupMethod(self):
++    #             return 1
+ 
+-        self.assertResultHasType(ClassImplementingSomeProto2.cleanupMethod, b"I")
++    #     self.assertResultHasType(ClassImplementingSomeProto2.cleanupMethod, b"I")
+ 
+ 
+ EmptyProtocol = objc.formal_protocol("EmptyProtocol", None, ())
+diff --git a/PyObjCTest/test_regr.py b/PyObjCTest/test_regr.py
+index 98b17f0..f55d380 100644
+--- a/PyObjCTest/test_regr.py
++++ b/PyObjCTest/test_regr.py
+@@ -165,19 +165,19 @@ class TestRegressions(TestCase):
+         v = o.compP_aRect_anOp_((1, 2), ((3, 4), (5, 6)), 7)
+         self.assertEqual(v, "aP:{1, 2} aR:{{3, 4}, {5, 6}} anO:7")
+ 
+-    def testInitialize(self):
+-        calls = []
+-        self.assertEqual(len(calls), 0)
+-
+-        class InitializeTestClass(NSObject):
+-            @classmethod
+-            def initialize(cls):
+-                calls.append(repr(cls))
+-
+-        InitializeTestClass.new()
+-        self.assertEqual(len(calls), 1)
+-        InitializeTestClass.new()
+-        self.assertEqual(len(calls), 1)
++    # def testInitialize(self):
++    #     calls = []
++    #     self.assertEqual(len(calls), 0)
++
++    #     class InitializeTestClass(NSObject):
++    #         @classmethod
++    #         def initialize(cls):
++    #             calls.append(repr(cls))
++
++    #     InitializeTestClass.new()
++    #     self.assertEqual(len(calls), 1)
++    #     InitializeTestClass.new()
++    #     self.assertEqual(len(calls), 1)
+ 
+     def testStructReturnPy(self):
+         o = ReturnAStruct.alloc().init()

--- a/pkgs/development/python-modules/pyobjc-core/patches/upstream-splitsig-nsurl.patch
+++ b/pkgs/development/python-modules/pyobjc-core/patches/upstream-splitsig-nsurl.patch
@@ -1,0 +1,11 @@
+--- a/PyObjCTest/test_splitsig.py
++++ b/PyObjCTest/test_splitsig.py
+@@ -102,6 +102,7 @@ def testSignatureCount(self):
+             # Unclear why this signature isn't correct, possibly due to the 'queue'.
+             # method is private anyway...
+             "SCN_setupDisplayLinkWithQueue_screen_policy_",
++            "isNSURL__",
+         ]
+ 
+         for cls in objc.getClassList():
+         

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12216,6 +12216,8 @@ self: super: with self; {
 
   pyobihai = callPackage ../development/python-modules/pyobihai { };
 
+  pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };


### PR DESCRIPTION
Builds on the excellent work done by @ferrine in #336801 and completes the patch. 

Changes from #336801:
- Build pyobjc source from github (replaced pypi)
- Applies upstream patches to fix multiple tests
- Applies test-specific patches to make them work
- Uses the new `darwin.libffi` build'
- Uses the `unittestCheckHook` in place of deprecated `python setup.py test`. This requires setting `PYTHONPATH` in `preCheck`.
- Injects `sw_vers` into testing instead of editing files
- Fills out the `meta` entries
- Adds @sarahec as a co-maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  NOTE: Requires `sandbox=false` or `doCheck=false` as test discovery segfaults in the sandbox.
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
