### PR TITLE
readline: add library symlinks on OpenBSD

### DIFF
--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -68,6 +68,13 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # This install error is caused by a very old libtool. We can't autoreconfHook this package,
+  # so this is the best we've got!
+  postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
+    ln -s $out/lib/libhistory.so* $out/lib/libhistory.so
+    ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
+  '';
+
   meta = with lib; {
     description = "Library for interactive line editing";
 


### PR DESCRIPTION
This install error is caused by a very old libtool. We can't autoreconfHook this package, so this is the best we've got!

Before:

```
$ ll /nix/store/q4xfivjrnjhshp0khjy66nq5ljjdmfv1-readline-x86_64-unknown-openbsd-8.2p13/lib
total 448K
-r--r--r-- 1 root root  48K Dec 31  1969 libhistory.so.8.2
-r--r--r-- 1 root root 399K Dec 31  1969 libreadline.so.8.2
```

After:

```
$ ll /nix/store/q9986qvm5jhnlxckp972cmhdgp5v52km-readline-x86_64-unknown-openbsd-8.2p13/lib
total 448K
lrwxrwxrwx 1 root root   17 Dec 31  1969 libhistory.so -> libhistory.so.8.2
-r--r--r-- 1 root root  48K Dec 31  1969 libhistory.so.8.2
lrwxrwxrwx 1 root root   18 Dec 31  1969 libreadline.so -> libreadline.so.8.2
-r--r--r-- 1 root root 399K Dec 31  1969 libreadline.so.8.2
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (openbsd cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
