### PR TITLE
blender: 4.2.3 -> 4.3.0

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -72,10 +72,13 @@
   python3Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
   rocmPackages, # comes with a significantly larger closure size
   runCommand,
+  shaderc,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
   sse2neon,
   stdenv,
   tbb,
+  vulkan-headers,
+  vulkan-loader,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -90,6 +93,7 @@ let
   openImageDenoiseSupport =
     (!stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) || stdenv.hostPlatform.isDarwin;
   openUsdSupport = !stdenv.hostPlatform.isDarwin;
+  vulkanSupport = !stdenv.hostPlatform.isDarwin;
 
   python3 = python3Packages.python;
   pyPkgsOpenusd = python3Packages.openusd.override { withOsl = false; };
@@ -108,20 +112,20 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blender";
-  version = "4.2.3";
+  version = "4.3.0";
 
   srcs = [
     (fetchzip {
       name = "source";
       url = "https://download.blender.org/source/blender-${finalAttrs.version}.tar.xz";
-      hash = "sha256-58wgduTHGfuYohaPjNuAnLFrpXOosEYOk5gJvbxTlQk=";
+      hash = "sha256-eB67wn5TXiB1+yS3ZF40uzliO/jcm55anffdJT++O24=";
     })
     (fetchgit {
       name = "assets";
       url = "https://projects.blender.org/blender/blender-assets.git";
       rev = "v${finalAttrs.version}";
       fetchLFS = true;
-      hash = "sha256-vepK0inPMuleAJBSipwoI99nMBBiFaK/eSMHDetEtjY=";
+      hash = "sha256-3w/SHhbwXkHp8UlCGjxvm1znT1yfuZSnXSWWRTe/C0s=";
     })
   ];
 
@@ -325,7 +329,12 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional colladaSupport opencollada
     ++ lib.optional jackaudioSupport libjack2
-    ++ lib.optional spaceNavSupport libspnav;
+    ++ lib.optional spaceNavSupport libspnav
+    ++ lib.optionals vulkanSupport [
+      shaderc
+      vulkan-headers
+      vulkan-loader
+    ];
 
   pythonPath =
     let

--- a/pkgs/applications/misc/blender/draco.patch
+++ b/pkgs/applications/misc/blender/draco.patch
@@ -1,26 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 97596dbee8d..d1ad6ac5de0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -898,11 +898,6 @@ set_and_warn_dependency(WITH_PYTHON WITH_CYCLES        OFF)
+@@ -1237,13 +1237,6 @@ set_and_warn_dependency(WITH_PYTHON WITH_CYCLES        OFF)
  set_and_warn_dependency(WITH_PYTHON WITH_DRACO         OFF)
  set_and_warn_dependency(WITH_PYTHON WITH_MOD_FLUID     OFF)
  
--if(WITH_DRACO AND NOT WITH_PYTHON_INSTALL)
--  message(STATUS "WITH_DRACO requires WITH_PYTHON_INSTALL to be ON, disabling WITH_DRACO for now")
--  set(WITH_DRACO OFF)
+-if(NOT WITH_PYTHON_MODULE)
+-  if(WITH_DRACO AND NOT WITH_PYTHON_INSTALL)
+-    message(STATUS "WITH_DRACO requires WITH_PYTHON_INSTALL to be ON, disabling WITH_DRACO for now")
+-    set(WITH_DRACO OFF)
+-  endif()
 -endif()
 -
  # enable boost for cycles, audaspace or i18n
  # otherwise if the user disabled
  
---- a/scripts/addons_core/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
-+++ b/scripts/addons_core/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
-@@ -17,7 +17,7 @@ def dll_path() -> Path:
+diff --git a/scripts/addons_core/io_scene_gltf2/io/com/draco.py b/scripts/addons_core/io_scene_gltf2/io/com/draco.py
+index 75e23162c67..875596c3d2f 100644
+--- a/scripts/addons_core/io_scene_gltf2/io/com/draco.py
++++ b/scripts/addons_core/io_scene_gltf2/io/com/draco.py
+@@ -31,8 +31,8 @@ def dll_path() -> Path:
+     :return: DLL path.
      """
      lib_name = 'extern_draco'
 -    blender_root = Path(bpy.app.binary_path).parent
-+    blender_root = Path(bpy.app.binary_path).parent.parent
 -    python_lib = Path('{v[0]}.{v[1]}/python/lib'.format(v=bpy.app.version))
-+    python_lib = Path('share/blender/{v[0]}.{v[1]}/python-ext/lib'.format(v=bpy.app.version))
++    blender_root = Path(bpy.app.binary_path).parent.parent
++    python_lib = Path('share/blender/{v[0]}.{v[1]}/python/lib'.format(v=bpy.app.version))
      python_version = 'python{v[0]}.{v[1]}'.format(v=sys.version_info)
  
      path = os.environ.get('BLENDER_EXTERN_DRACO_LIBRARY_PATH')


### PR DESCRIPTION
Bump Blender to latest release `4.3.0`

This adds `vulkan` as a dependency and I was a bit unsure if this is needed on all platforms. If this is only needed for the linux platforms I will move the buildIput accordingly.

Also I am a but unsure if we should split the `draco.patch` in a <4.3.0 and a >=4.3.0 version?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
