### PR TITLE
add actionlint script and fix linting errors

### DIFF
--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -107,7 +107,7 @@ jobs:
                   echo "$errors"
                 else
                   # just print in plain text
-                  echo "$errors" | sed 's/^:://'
+                  echo "${errors/::/}"
                   echo # add one empty line
                 fi
                 failedFiles+=("$dest")

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -38,7 +38,7 @@ jobs:
         nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/c473cc8714710179df205b153f4e9fa007107ff9.tar.gz
     - name: Checking EditorConfig
       run: |
-        cat "$HOME/changed_files" | nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -disable-indent-size'
+        < "$HOME/changed_files" nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -disable-indent-size'
     - if: ${{ failure() }}
       run: |
         echo "::error :: Hey! It looks like your changes don't follow our editorconfig settings. Read https://editorconfig.org/#download to configure your editor so you never see this error again."

--- a/.github/workflows/lint-actions.sh
+++ b/.github/workflows/lint-actions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash actionlint shellcheck -I nixpkgs=../..
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/../.."
+actionlint


### PR DESCRIPTION
While it might be worth adding this in future as a separate CI step, it seems overkill given how often it would need to run on nixpkgs (could be circumvented by filtering, but it would still add a check line in each PR). This script is also easier to run local.