### PR TITLE
python312Packages.slack-sdk: 3.33.3 -> 3.33.4

### DIFF
--- a/pkgs/development/python-modules/slack-bolt/default.nix
+++ b/pkgs/development/python-modules/slack-bolt/default.nix
@@ -1,41 +1,48 @@
 {
   lib,
-  aiohttp,
-  bottle,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  slack-sdk,
+
+  # optional-dependencies
+  # - async
+  aiohttp,
+  websockets,
+  # - adapter
+  bottle,
   chalice,
   cherrypy,
   django,
-  docker,
   falcon,
   fastapi,
-  fetchFromGitHub,
   flask,
   flask-sockets,
   gunicorn,
   moto,
   pyramid,
-  pytest-asyncio,
-  pytestCheckHook,
-  pythonOlder,
   sanic,
-  setuptools,
   sanic-testing,
-  slack-sdk,
   starlette,
   tornado,
   uvicorn,
   websocket-client,
-  websockets,
   werkzeug,
+
+  # tests
+  docker,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "slack-bolt";
   version = "1.21.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "slackapi";
@@ -80,6 +87,8 @@ buildPythonPackage rec {
     ];
   };
 
+  pythonImportsCheck = [ "slack_bolt" ];
+
   nativeCheckInputs = [
     docker
     pytest-asyncio
@@ -90,30 +99,23 @@ buildPythonPackage rec {
     export HOME="$(mktemp -d)"
   '';
 
+  __darwinAllowLocalNetworking = true;
+
   disabledTestPaths = [
     # boddle is not packaged as of 2023-07-15
     "tests/adapter_tests/bottle/"
-    # Tests are blocking at some point. Blocking could be performance-related.
-    "tests/scenario_tests_async/"
-    "tests/slack_bolt_async/"
   ];
 
   disabledTests = [
     # Require network access
-    "test_events"
-    "test_interactions"
-    "test_lazy_listener_calls"
-    "test_lazy_listeners"
     "test_failure"
   ];
 
-  pythonImportsCheck = [ "slack_bolt" ];
-
-  meta = with lib; {
+  meta = {
     description = "Framework to build Slack apps using Python";
     homepage = "https://github.com/slackapi/bolt-python";
     changelog = "https://github.com/slackapi/bolt-python/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ samuela ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ samuela ];
   };
 }

--- a/pkgs/development/python-modules/slack-sdk/default.nix
+++ b/pkgs/development/python-modules/slack-sdk/default.nix
@@ -8,7 +8,6 @@
   flake8,
   flask-sockets,
   moto,
-  pythonOlder,
   psutil,
   pytest-asyncio,
   pytestCheckHook,
@@ -20,16 +19,14 @@
 
 buildPythonPackage rec {
   pname = "slack-sdk";
-  version = "3.33.3";
+  version = "3.33.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "slackapi";
     repo = "python-slack-sdk";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ewNEo8kcxdrd6mVze/UbKdnTIIf59s7OnMP42St1www=";
+    hash = "sha256-WIUhkIFWbIcxjTjzZ2C3VNFhGftBmyYO3iaHpz6d+Sc=";
   };
 
   postPatch = ''
@@ -48,6 +45,8 @@ buildPythonPackage rec {
     websockets
   ];
 
+  pythonImportsCheck = [ "slack_sdk" ];
+
   nativeCheckInputs = [
     flake8
     flask-sockets
@@ -61,26 +60,20 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  disabledTestPaths = [
-    # Exclude tests that requires network features
-    "integration_tests"
-  ];
-
   disabledTests = [
-    # Requires network features
+    # Requires internet access (to slack API)
     "test_start_raises_an_error_if_rtm_ws_url_is_not_returned"
-    "test_org_installation"
-    "test_interactions"
-    "test_issue_690_oauth_access"
+    # Requires network access: [Errno 111] Connection refused
+    "test_send_message_while_disconnection"
   ];
 
-  pythonImportsCheck = [ "slack_sdk" ];
+  __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Slack Developer Kit for Python";
     homepage = "https://slack.dev/python-slack-sdk/";
     changelog = "https://github.com/slackapi/python-slack-sdk/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
## Things done

- **python312Packages.slack-sdk: 3.33.3 -> 3.33.4**
- **python312Packages.slack-bolt: fix on darwin; clean**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
