### PR TITLE
ocamlPackages.menhir: support --suggest-menhirLib

### DIFF
--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage
+{ buildDunePackage, substituteAll, ocaml
 , menhirLib, menhirSdk
 }:
 
@@ -10,6 +10,13 @@ buildDunePackage rec {
   inherit (menhirLib) version src;
 
   buildInputs = [ menhirLib menhirSdk ];
+
+  patches = [
+    (substituteAll {
+      src = ./menhir-suggest-menhirLib.patch;
+      libdir = "${menhirLib}/lib/ocaml/${ocaml.version}/site-lib/menhirLib";
+    })
+  ];
 
   meta = menhirSdk.meta // {
     description = "LR(1) parser generator for OCaml";

--- a/pkgs/development/ocaml-modules/menhir/menhir-suggest-menhirLib.patch
+++ b/pkgs/development/ocaml-modules/menhir/menhir-suggest-menhirLib.patch
@@ -1,0 +1,19 @@
+diff --git a/src/installation.ml b/src/installation.ml
+index 3c64e395..be7d6e7b 100644
+--- a/src/installation.ml
++++ b/src/installation.ml
+@@ -39,13 +39,4 @@ let rec normalize fn =
+    and hope that it is of the form [.../bin/menhir]. We change this to
+    [.../lib/menhirLib], and hope that this is where MenhirLib is installed. *)
+ 
+-let libdir () =
+-  let root =
+-    Sys.executable_name
+-    |> normalize
+-    |> Filename.dirname (* remove [menhir] *)
+-    |> Filename.dirname (* remove [bin] *)
+-  in
+-  Filename.concat
+-    root
+-    (Filename.concat "lib" "menhirLib")
++let libdir () = ignore normalize; "@libdir@"


### PR DESCRIPTION
menhir provides a `--suggest-menhirLib` option that tries to infer the path of the menhir library from the path of the menhir binary.

Since the menhir library and the menhir binary are built as different derivations, this does not work.

This patch hardcodes the location of the menhir library into the menhir binary, making `--suggest-menhirLib` work.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).