### PR TITLE
warp-terminal: 0.2024.11.12.08.02.stable_02 -> 0.2024.11.19.08.02.stable_01

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-7lxfxKiZ8VxXLGY7ma+ctJzGhKZZgUvtidJDoSjCEVA=",
-    "version": "0.2024.11.12.08.02.stable_02"
+    "hash": "sha256-zvM7CcWYFXMN9dLoJqXnQlENmWDGYRKXQACtUQnXmmE=",
+    "version": "0.2024.11.19.08.02.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-41icbHntPT52Tc8iW7Tgjr4Su2DkI0SI45d2mQF+9hg=",
-    "version": "0.2024.11.12.08.02.stable_02"
+    "hash": "sha256-4uYVA+6NI11X/rYwEzHeTiPnDyntpZcBBBCiZkc9ik8=",
+    "version": "0.2024.11.19.08.02.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-r4PYBhJXgB7tTxMP/W/ZuxdsrvVs1BOMpBQIJwZv8uI=",
-    "version": "0.2024.11.12.08.02.stable_02"
+    "hash": "sha256-3Tx/NcWV0zyTRp5FVqWTfnhXoxrW3ph/Ytc2tjfNhcs=",
+    "version": "0.2024.11.19.08.02.stable_01"
   }
 }


### PR DESCRIPTION
# You can now use Warp without login!

Changelog: https://docs.warp.dev/getting-started/changelog#id-2024.11.21-v0.2024.11.19.08.02

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc