### PR TITLE
squeak: fix build

### DIFF
--- a/pkgs/development/compilers/squeak/cc-no-export-dynamic.patch
+++ b/pkgs/development/compilers/squeak/cc-no-export-dynamic.patch
@@ -1,0 +1,20 @@
+diff --git a/platforms/unix/config/make.prg.in b/platforms/unix/config/make.prg.in
+index 96a64a1..05f6114 100644
+--- a/platforms/unix/config/make.prg.in
++++ b/platforms/unix/config/make.prg.in
+@@ -8,13 +8,13 @@ o		= .o
+ a		= .a
+ x		=
+ COMPILE		= $(CC) $(CFLAGS) $(CPPFLAGS) $(XCFLAGS) \
+-		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -export-dynamic -c -o
++		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -c -o
+ COMPILEIFP	= $(CC) $(CFLAGS) $(XCFLAGS) \
+ 		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -export-dynamic -fno-omit-frame-pointer -c -o
+ CXXFLAGS	= $(CFLAGS) # Hack; can't be bothered to add CXXFLAGS to the configure mess
+ COMPILE.cpp = $(COMPILE.cc)
+ COMPILE.cc	= $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(XCFLAGS) \
+-		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -export-dynamic -c -o
++		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -c -o
+ LINK		= $(LIBTOOL) --mode=link \
+ 		  $(CC) $(CFLAGS) $(XCFLAGS) \
+ 		  $(LDFLAGS) $(XLDFLAGS) $(TARGET_ARCH) -export-dynamic -o

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -135,6 +135,9 @@ in stdenv.mkDerivation {
     ./squeak-configure-version.patch
     ./squeak-plugins-discovery.patch
     ./squeak-squeaksh-nixpkgs.patch
+    # it looks like -export-dynamic is being passed erroneously to the compiler,
+    # as it is a linker flag and at this step the build is just compiling notice the -c flag.
+    ./cc-no-export-dynamic.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes the squeak build for ZHF (https://github.com/NixOS/nixpkgs/issues/352882) by switching to LLVM 17, because LLVM 18 is broken because `clang` doesn't support `-export-dynamic` anymore. It [looks like](https://stackoverflow.com/a/21279573/6605742) `-rdynamic` should work, but I don't quite know how to patch it nicely. Ping @ehmry as the package maintainer.

Build: https://hydra.nixos.org/build/267872600
Broken since the switch to LLVM 18 in https://github.com/nixos/nixpkgs/pull/312981

This is the bi-yearly demo fix for the #ZurichZHF Hackathon! 🎉

## Things done
- [x] Built on `x86_64-linux`
- [x] Ran a squeak image successfully

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
