### PR TITLE
nixos/containers: new registries.settings option, deprecate others

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -83,6 +83,12 @@
 
 - Apache Kafka has dropped support for ZooKeeper mode. The `apacheKafka_3_9` and `apacheKafka_4_0` packages have been removed, as every remaining packaged version is KRaft-only. The `services.apache-kafka.zookeeper` option (previously an alias for `services.apache-kafka.settings."zookeeper.connect"`) has been removed; migrate your cluster to [KRaft](#module-services-apache-kafka-kraft) mode instead.
 
+- `virtualisation.registries.block` / `insecure` / `search` were deprecated,
+  because they mapped to the deprecated V1 `registries.conf` format.
+  See the new option {option}`virtualisation.registries.settings`
+  and [containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)
+  to migrate to the new configuration format.
+
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
 
 - String values passed to `services.phpfpm.settings`, `services.phpfpm.pools.<name>.phpEnv`, and `services.phpfpm.pools.<name>.settings` are now properly quoted and escaped, except for the `${}` syntax that is left as-is. If you are manually escaping these values, please adjust accordingly.


### PR DESCRIPTION
Those options mapped to the deprecated V1 format, and didn't allow using the newer format.

If any of the older options are used, a warning is displayed, and the generated `registries.conf` file follows the old V1 format.

For more information about the new format, see https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md

Tested by building the `/etc/containers/registries.conf` file, and checked that I could match both the old and the newer format.

Examine the first commit to ignore formatting changes.

cc @NixOS/podman 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
