### PR TITLE
prometheus-sabnzbd-exporter: 0.1.73 -> 0.1.78

### DIFF
--- a/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sabnzbd_exporter";
-  version = "0.1.73";
+  version = "0.1.78";
 
   format = "other";
 
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
     owner = "msroest";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-c+NbaHYr/CzZ94/i92W2g7+RBSPSmkE2yszNE6L6M6Y=";
+    hash = "sha256-BLqG2I7D/bqRj6+/LUKOimmTRTH/kRdukkGdOJT3+PA=";
   };
 
   propagatedBuildInputs = with python3Packages; [ prometheus-client requests ];

--- a/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, python3Packages, nixosTests }:
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nixosTests,
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "sabnzbd_exporter";
@@ -13,7 +18,10 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-BLqG2I7D/bqRj6+/LUKOimmTRTH/kRdukkGdOJT3+PA=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ prometheus-client requests ];
+  propagatedBuildInputs = with python3Packages; [
+    prometheus-client
+    requests
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -27,7 +35,9 @@ python3Packages.buildPythonApplication rec {
     runHook postInstall
   '';
 
-  passthru.tests = { inherit (nixosTests.prometheus-exporters) sabnzbd; };
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) sabnzbd;
+  };
 
   meta = with lib; {
     description = "Prometheus exporter for sabnzbd";

--- a/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, fetchFromGitHub, python3Packages, nixosTests }:
 
 python3Packages.buildPythonApplication rec {
   pname = "sabnzbd_exporter";
@@ -26,6 +26,8 @@ python3Packages.buildPythonApplication rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) sabnzbd; };
 
   meta = with lib; {
     description = "Prometheus exporter for sabnzbd";


### PR DESCRIPTION
Changes: https://github.com/msroest/sabnzbd_exporter/compare/0.1.73...0.1.78

Release Notes:
https://github.com/msroest/sabnzbd_exporter/releases/tag/0.1.76
https://github.com/msroest/sabnzbd_exporter/releases/tag/0.1.78

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
