### PR TITLE
bun: fix darwin build and runtime issues

### DIFF
--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -4,11 +4,13 @@
 , autoPatchelfHook
 , unzip
 , installShellFiles
+, makeWrapper
 , openssl
 , writeShellScript
 , curl
 , jq
 , common-updater-scripts
+, darwin
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -18,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
   src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   strictDeps = true;
-  nativeBuildInputs = [ unzip installShellFiles ] ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [ unzip installShellFiles makeWrapper ] ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
   buildInputs = [ openssl ];
 
   dontConfigure = true;
@@ -33,14 +35,17 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-
-  # We currently cannot generate completions for x86_64-darwin because bun requires avx support to run, which is:
-  # 1. Not currently supported by the version of Rosetta on our aarch64 builders
-  # 2. Is not correctly detected even on macOS 15+, where it is available through Rosetta
-  #
-  # The baseline builds are no longer an option because they too now require avx support.
   postInstall =
-    lib.optionalString
+    lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      wrapProgram $out/bin/bun \
+        --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ darwin.ICU ]}
+    ''
+    # We currently cannot generate completions for x86_64-darwin because bun requires avx support to run, which is:
+    # 1. Not currently supported by the version of Rosetta on our aarch64 builders
+    # 2. Is not correctly detected even on macOS 15+, where it is available through Rosetta
+    #
+    # The baseline builds are no longer an option because they too now require avx support.
+    + lib.optionalString
       (
         stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform
         && !(stdenvNoCC.hostPlatform.isDarwin && stdenvNoCC.hostPlatform.isx86_64)

--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -35,7 +35,8 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall =
+  postPhases = [ "postPatchelf"];
+  postPatchelf =
     lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
       wrapProgram $out/bin/bun \
         --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ darwin.ICU ]}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

#### Fix runtime crash on macOS 12

Commit: https://github.com/NixOS/nixpkgs/commit/25bd3f09719570e02c33f834a4e71f7a102b9d01
Upstream issue: https://github.com/oven-sh/bun/issues/6035

Wraps the pre-built binary to add `darwin.ICU` to the library path.
This fixes the missing symbol crashes seen on macOS 12:

```
 > Running phase: postPatchelf
       > dyld[69576]: Symbol not found: _ubrk_clone
       >   Referenced from: /nix/store/zz94xy01809rlwp70hakg5ws10acma3v-bun-1.1.36/bin/bun
       >   Expected in: /usr/lib/libicucore.A.dylib
       > /nix/store/nwvga652738sh96zj456ry0xfnh9sjzv-stdenv-darwin/setup: line 1725: 69576 Abort trap: 6           SHELL="bash" $out/bin/bun completions $completions_dir
       For full logs, run 'nix log /nix/store/zhlf2ps8dp2khlk6xpyzhc0mnfif9m15-bun-1.1.36.drv'.
```

`install_name_tool --change` also works, but isn't available with `stdenvNoCC`.

Tested on 12.0.1 and 15.1.

#### Fix hanging build on x86_64-darwin

Commit: https://github.com/NixOS/nixpkgs/commit/07a431c62f30da45b92df914489dd9497c05402e

Skips generating shell completions on x86_64-darwin, which currently causes the "build" to hang in hydra.
Bun requires AVX support to run, which is not available in the version of Rosetta on our builders.
Even if the builders were on macOS 15, which comes with a version of Rosetta _with_ AVX-support, cursory testing suggests that common AVX detection methods do not work under Rosetta.
The [baseline builds of bun now also require AVX support](https://github.com/oven-sh/bun/issues/15139#issuecomment-2482010120) and can't be used to generate completions.

After some discussion with @emilazy, the most reasonable solution we have for now is to disable completions on x86_64-darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (builds and runs via rosetta in a vm 😂)
  - [x] aarch64-linux
  - [x] x86_64-darwin (build only, via rosetta)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
