### PR TITLE
shader-slang: init at 2025.2

### DIFF
--- a/pkgs/by-name/sh/shader-slang/1-find-packages.patch
+++ b/pkgs/by-name/sh/shader-slang/1-find-packages.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dc281211..c36b9bcb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,6 +154,8 @@ advanced_option(
+     "Build using system unordered dense"
+     OFF
+ )
++advanced_option(SLANG_USE_SYSTEM_SPIRV_TOOLS "Build using system SPIR-V tools library" OFF)
++advanced_option(SLANG_USE_SYSTEM_GLSLANG "Build using system glslang library" OFF)
+ 
+ option(
+     SLANG_SPIRV_HEADERS_INCLUDE_DIR
+@@ -289,6 +291,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
+     find_package(unordered_dense CONFIG QUIET)
+ endif()
+ 
++if(${SLANG_USE_SYSTEM_MINIZ})
++    find_package(miniz REQUIRED)
++    add_library(miniz ALIAS miniz::miniz)
++endif()
++
++if(${SLANG_USE_SYSTEM_LZ4})
++    find_package(lz4 REQUIRED)
++    add_library(lz4_static ALIAS LZ4::lz4)
++endif()
++
++if(${SLANG_USE_SYSTEM_VULKAN_HEADERS})
++    find_package(VulkanHeaders REQUIRED)
++endif()
++
++if(${SLANG_USE_SYSTEM_SPIRV_HEADERS})
++    find_package(SPIRV-Headers REQUIRED)
++    add_library(SPIRV-Headers ALIAS SPIRV-Headers::SPIRV-Headers)
++endif()
++
++if(${SLANG_USE_SYSTEM_SPIRV_TOOLS})
++    find_package(SPIRV-Tools REQUIRED)
++endif()
++
++if(${SLANG_USE_SYSTEM_GLSLANG})
++    find_package(glslang REQUIRED)
++    add_library(glslang ALIAS glslang::glslang)
++endif()
++
+ add_subdirectory(external)
+ 
+ # webgpu_dawn is only available as a fetched shared library, since Dawn's nested source
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 43105a5f..8b9c0f14 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -73,19 +73,24 @@ if(NOT ${SLANG_USE_SYSTEM_SPIRV_HEADERS})
+ endif()
+ 
+ if(SLANG_ENABLE_SLANG_GLSLANG)
++if(NOT ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
+     # SPIRV-Tools
+     set(SPIRV_TOOLS_BUILD_STATIC ON)
+     set(SPIRV_WERROR OFF)
+     set(SPIRV_HEADER_DIR "${CMAKE_CURRENT_LIST_DIR}/spirv-headers/")
+     set(SPIRV_SKIP_TESTS ON)
+     add_subdirectory(spirv-tools EXCLUDE_FROM_ALL ${system})
++endif()
+ 
++if(NOT ${SLANG_USE_SYSTEM_GLSLANG})
+     # glslang
+     set(SKIP_GLSLANG_INSTALL ON)
+     set(ENABLE_OPT ON)
+     set(ENABLE_PCH OFF)
++    set(ALLOW_EXTERNAL_SPIRV_TOOLS ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
+     add_subdirectory(glslang EXCLUDE_FROM_ALL ${system})
+ endif()
++endif()
+ 
+ # imgui
+ add_library(imgui INTERFACE)

--- a/pkgs/by-name/sh/shader-slang/2-shared-llvm.patch
+++ b/pkgs/by-name/sh/shader-slang/2-shared-llvm.patch
@@ -1,0 +1,27 @@
+diff --git a/cmake/LLVM.cmake b/cmake/LLVM.cmake
+index 3c7c1b54..7f66d6bd 100644
+--- a/cmake/LLVM.cmake
++++ b/cmake/LLVM.cmake
+@@ -7,7 +7,7 @@ function(llvm_target_from_components target_name)
+         ${components}
+     )
+     add_library(${target_name} INTERFACE)
+-    target_link_libraries(${target_name} INTERFACE ${llvm_libs})
++    target_link_libraries(${target_name} INTERFACE LLVM)
+     target_include_directories(
+         ${target_name}
+         SYSTEM
+@@ -66,12 +66,7 @@ function(fetch_or_build_slang_llvm)
+         llvm_target_from_components(llvm-dep filecheck native orcjit)
+         clang_target_from_libs(
+             clang-dep
+-            clangBasic
+-            clangCodeGen
+-            clangDriver
+-            clangLex
+-            clangFrontend
+-            clangFrontendTool
++            clang-cpp
+         )
+         slang_add_target(
+             source/slang-llvm

--- a/pkgs/by-name/sh/shader-slang/3-glslang-15.patch
+++ b/pkgs/by-name/sh/shader-slang/3-glslang-15.patch
@@ -1,0 +1,45 @@
+diff --git a/source/slang-glslang/slang-glslang.cpp b/source/slang-glslang/slang-glslang.cpp
+index 4abcada6..0f63a64e 100644
+--- a/source/slang-glslang/slang-glslang.cpp
++++ b/source/slang-glslang/slang-glslang.cpp
+@@ -1,8 +1,7 @@
+ // slang-glslang.cpp
+ #include "slang-glslang.h"
+ 
+-#include "SPIRV/GlslangToSpv.h"
+-#include "glslang/MachineIndependent/localintermediate.h"
++#include "glslang/SPIRV/GlslangToSpv.h"
+ #include "glslang/Public/ShaderLang.h"
+ #include "slang.h"
+ #include "spirv-tools/libspirv.h"
+@@ -17,6 +16,7 @@
+ #include <memory>
+ #include <mutex>
+ #include <sstream>
++#include <cassert>
+ 
+ // This is a wrapper to allow us to run the `glslang` compiler
+ // in a controlled fashion.
+@@ -718,6 +718,11 @@ static int glslang_compileGLSLToSPIRV(glslang_CompileRequest_1_2 request)
+             return 1;
+         }
+ 
++        if (debugLevel == SLANG_DEBUG_INFO_LEVEL_MAXIMAL)
++        {
++            shader->addSourceText(sourceText, sourceTextLength);
++        }
++
+         if (request.entryPointName && strlen(request.entryPointName))
+             shader->setEntryPoint(request.entryPointName);
+ 
+@@ -741,10 +746,6 @@ static int glslang_compileGLSLToSPIRV(glslang_CompileRequest_1_2 request)
+         auto stageIntermediate = program->getIntermediate((EShLanguage)stage);
+         if (!stageIntermediate)
+             continue;
+-        if (debugLevel == SLANG_DEBUG_INFO_LEVEL_MAXIMAL)
+-        {
+-            stageIntermediate->addSourceText(sourceText, sourceTextLength);
+-        }
+ 
+         std::vector<unsigned int> spirv;
+         spv::SpvBuildLogger logger;

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  miniz,
+  lz4,
+  libxml2,
+  libX11,
+  spirv-headers,
+  glslang,
+  llvmPackages_13,
+  versionCheckHook,
+  gitUpdater,
+
+  # Required for compiling to SPIR-V or GLSL
+  withGlslang ? true,
+  # Can be used for compiling shaders to CPU targets, see:
+  # https://github.com/shader-slang/slang/blob/master/docs/cpu-target.md
+  # If `withLLVM` is disabled, Slang will fall back to the C++ compiler found
+  # in the environment, if one exists.
+  withLLVM ? false,
+  # Dynamically link against libllvm and libclang++ (upstream defaults to static)
+  withSharedLLVM ? withLLVM,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "shader-slang";
+  version = "2025.2";
+
+  src = fetchFromGitHub {
+    owner = "shader-slang";
+    repo = "slang";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H/ePYu6o926M22zussW1f15iYRJCq29TeNJzBD0eAao=";
+    fetchSubmodules = true;
+  };
+
+  patches =
+    [
+      # Slang's build definitions do not support using system provided cmake packages
+      # for its dependencies.
+      # While it does come with "SLANG_USE_SYSTEM_XYZ" flags, these expect Slang to be
+      # imported into some other CMake build that already provides the necessary target.
+      # This patch adds the required `find_package` calls and sets up target aliases where needed.
+      ./1-find-packages.patch
+    ]
+    ++ lib.optionals withSharedLLVM [
+      # Upstream statically links libllvm and libclang++, resulting in a ~5x increase in binary size.
+      ./2-shared-llvm.patch
+    ]
+    ++ lib.optionals withGlslang [
+      # Upstream depends on glslang 13 and there are minor breaking changes in glslang 15, the version
+      # we ship in nixpkgs.
+      ./3-glslang-15.patch
+    ];
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+
+  buildInputs =
+    [
+      miniz
+      lz4
+      libxml2
+      spirv-headers
+    ]
+    ++ (lib.optionals stdenv.hostPlatform.isLinux [
+      libX11
+    ])
+    ++ (lib.optionals withLLVM [
+      # Slang only supports LLVM 13:
+      # https://github.com/shader-slang/slang/blob/master/docs/building.md#llvm-support
+      llvmPackages_13.llvm
+      llvmPackages_13.libclang
+    ])
+    ++ (lib.optionals withGlslang [
+      # SPIRV-tools is included in glslang.
+      glslang
+    ]);
+
+  separateDebugInfo = true;
+
+  # Required for spaces in cmakeFlags, see https://github.com/NixOS/nixpkgs/issues/114044
+  __structuredAttrs = true;
+
+  preConfigure =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      # required to handle LTO objects
+      export AR="${stdenv.cc.targetPrefix}gcc-ar"
+      export NM="${stdenv.cc.targetPrefix}gcc-nm"
+      export RANLIB="${stdenv.cc.targetPrefix}gcc-ranlib"
+    ''
+    + ''
+      # cmake setup hook only sets CMAKE_AR and CMAKE_RANLIB, but not these
+      prependToVar cmakeFlags "-DCMAKE_CXX_COMPILER_AR=$(command -v $AR)"
+      prependToVar cmakeFlags "-DCMAKE_CXX_COMPILER_RANLIB=$(command -v $RANLIB)"
+    '';
+
+  cmakeFlags =
+    [
+      "-GNinja Multi-Config"
+      # The cmake setup hook only specifies `-DCMAKE_BUILD_TYPE=Release`,
+      # which does nothing for "Ninja Multi-Config".
+      "-DCMAKE_CONFIGURATION_TYPES=RelWithDebInfo"
+      # Handled by separateDebugInfo so we don't need special installation handling
+      "-DSLANG_ENABLE_SPLIT_DEBUG_INFO=OFF"
+      "-DSLANG_VERSION_FULL=v${finalAttrs.version}-nixpkgs"
+      # slang-rhi tries to download WebGPU dawn binaries, and as stated on
+      # https://github.com/shader-slang/slang-rhi is "under active refactoring
+      # and development, and is not yet ready for general use."
+      "-DSLANG_ENABLE_SLANG_RHI=OFF"
+      "-DSLANG_USE_SYSTEM_MINIZ=ON"
+      "-DSLANG_USE_SYSTEM_LZ4=ON"
+      "-DSLANG_SPIRV_HEADERS_INCLUDE_DIR=${spirv-headers}/include"
+      "-DSLANG_SLANG_LLVM_FLAVOR=${if withLLVM then "USE_SYSTEM_LLVM" else "DISABLE"}"
+    ]
+    # Currently depends on unreleased op type `SpvOpTypeNodePayloadArrayAMDX`,
+    # which will be included in next release >1.3.296
+    ++ lib.optional (lib.versionAtLeast spirv-headers.version "1.3.297.0") "-DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON"
+    ++ (lib.optionals withGlslang [
+      "-DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON"
+      "-DSLANG_USE_SYSTEM_GLSLANG=ON"
+    ])
+    ++ lib.optional (!withGlslang) "-DSLANG_ENABLE_SLANG_GLSLANG=OFF";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/slangc";
+  versionCheckProgramArg = [ "-v" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    ignoredVersions = "*-draft";
+  };
+
+  meta = {
+    description = "A shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion";
+    homepage = "https://github.com/shader-slang/slang";
+    license = lib.licenses.asl20-llvm;
+    maintainers = with lib.maintainers; [ niklaskorz ];
+    mainProgram = "slangc";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #359925

[Slang](https://shader-slang.com/) is a cross-platform and cross-graphics-API shading language that compiles to SPIR-V, HLSL, Metal, WGSL, and other targets. This PR packages the Slang command line tools (the compiler and the language server) as well as its libraries.

~~Currently using Slang's own vendored version of glslang as it is not compatible with version 15 (which we have in nixpkgs) yet. Considered disabling glslang altogether after some discussion on Matrix, but that would mean not being able to compile shaders to SPIR-V, which heavily reduces the usefulness of Slang (although that still leaves Metal and WebGPU, for example).~~ Patching in glslang 15 compatibility wasn't too hard after I knew where to look (see `3-glslang-15.patch`).

LLVM is disabled by default as all Slang features except JIT for "host-callable" work without it. If LLVM is enabled through `withLLVM = true;`, the `2-shared-llvm.patch` ensures libllvm and libclang are dynamically linked (can be disabled using `withSharedLLVM = false;`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
