### PR TITLE
ant: introduce `ant.home`, change ant home to $out/share

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
 
     echo "tarring jdk"
     tar --checkpoint=10000 -czf build/linux/jdk-17.0.8-${arch}.tgz ${jdk}
-    cp ${ant}/lib/ant/lib/{ant.jar,ant-launcher.jar} app/lib/
+    cp ${ant.home}/lib/{ant.jar,ant-launcher.jar} app/lib/
     mkdir -p core/library
     ln -s ${jogl}/share/java/* core/library/
     ln -s ${vaqua} app/lib/VAqua9.jar

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -461,7 +461,7 @@ in stdenv.mkDerivation (finalAttrs: {
     "--enable-dbus"
     "--enable-release-build"
     "--enable-epm"
-    "--with-ant-home=${getLib ant}/lib/ant"
+    "--with-ant-home=${ant.home}"
 
     # Without these, configure does not finish
     "--without-junit"

--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -24,27 +24,27 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib/ant
-    mv * $out/lib/ant/
+    mkdir -p $out/bin $out/share/ant
+    mv * $out/share/ant/
 
     # Get rid of the manual (35 MiB).  Maybe we should put this in a
     # separate output.  Keep the antRun script since it's vanilla sh
     # and needed for the <exec/> task (but since we set ANT_HOME to
     # a weird value, we have to move antRun to a weird location).
     # Get rid of the other Ant scripts since we provide our own.
-    mv $out/lib/ant/bin/antRun $out/bin/
-    rm -rf $out/lib/ant/{manual,bin,WHATSNEW}
-    mkdir $out/lib/ant/bin
-    mv $out/bin/antRun $out/lib/ant/bin/
+    mv $out/share/ant/bin/antRun $out/bin/
+    rm -rf $out/share/ant/{manual,bin,WHATSNEW}
+    mkdir $out/share/ant/bin
+    mv $out/bin/antRun $out/share/ant/bin/
 
     # Install ant-contrib.
     unpackFile $contrib
-    cp -p ant-contrib/ant-contrib-*.jar $out/lib/ant/lib/
+    cp -p ant-contrib/ant-contrib-*.jar $out/share/ant/lib/
 
     cat >> $out/bin/ant <<EOF
     #! ${stdenv.shell} -e
 
-    ANT_HOME=$out/lib/ant
+    ANT_HOME=$out/share/ant
 
     # Find the JDK by looking for javac.  As a fall-back, find the
     # JRE by looking for java.  The latter allows just the JRE to be
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    home = "${finalAttrs.finalPackage}/lib/ant";
+    home = "${finalAttrs.finalPackage}/share/ant";
     updateScript = gitUpdater {
       rev-prefix = "rel/";
       url = "https://gitbox.apache.org/repos/asf/ant";

--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    home = "${finalAttrs.finalPackage}/lib/ant";
     updateScript = gitUpdater {
       rev-prefix = "rel/";
       url = "https://gitbox.apache.org/repos/asf/ant";


### PR DESCRIPTION
Everything in the Ant home is platform-agnostic (JARs),
so it should go to $out/share.

Debian puts the Ant home into /usr/share as well, so this
is not unprecedented:
https://salsa.debian.org/java-team/ant/-/blob/31d9fc0a76ac991509fcfc537ffc3dbf61ebc41d/debian/README.Debian

Fedora does too:
https://src.fedoraproject.org/rpms/ant/blob/20b8a9a5596a5fd2b12c1d6f922f4502450db674/f/ant.spec#_39

And Arch Linux:
https://gitlab.archlinux.org/archlinux/packaging/packages/ant/-/blob/e8e0ddb82105f16cd7d8153091c2c6f527d9b371/PKGBUILD#L59

And Gentoo:
https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-java/ant/ant-1.10.15.ebuild?id=55bcd350a89469eac0af4bfafe464050d01154e0#n381

And probably more, I stopped looking :)

This PR also changes a few packages to use the new `passthru.ant_home` variable so we can stay DRY, in case this was to change again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
