### PR TITLE
xdg-desktop-portal-termfilechooser: init at 0-unstable-2021-07-14

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  fetchpatch,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-protocols,
+  wayland-scanner,
+  inih,
+  libdrm,
+  mesa,
+  scdoc,
+  systemd,
+  wayland,
+}:
+
+stdenv.mkDerivation {
+  pname = "xdg-desktop-portal-termfilechooser";
+  version = "0-unstable-2021-07-14";
+
+  src = fetchFromGitHub {
+    owner = "GermainZ";
+    repo = "xdg-desktop-portal-termfilechooser";
+    rev = "71dc7ab06751e51de392b9a7af2b50018e40e062";
+    hash = "sha256-645hoLhQNncqfLKcYCgWLbSrTRUNELh6EAdgUVq3ypM=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+    makeWrapper
+  ];
+
+  buildInputs = [
+    inih
+    libdrm
+    mesa
+    systemd
+    wayland
+    wayland-protocols
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "sd-bus-provider" "libsystemd")
+    (lib.mesonOption "sysconfdir" "/etc")
+  ];
+
+  patches = [
+    # Allow using the default version, by removing hard-coded paths in the ranger wrapper
+    # https://github.com/GermainZ/xdg-desktop-portal-termfilechooser/pull/9
+    (fetchpatch {
+      name = "dont_hardcode_kitty.patch";
+      url = "https://github.com/GermainZ/xdg-desktop-portal-termfilechooser/commit/af0ae142f54dbf9b480b5c886bfb1319cd6ff25b.patch";
+      hash = "sha256-AgLetBd9sP3G3OPpweVA0Qp9njfPVFXJi4m/rZsSxJc=";
+    })
+    (fetchpatch {
+      name = "dont_hardcode_ranger.patch";
+      url = "https://github.com/GermainZ/xdg-desktop-portal-termfilechooser/commit/4e0db3d4c1639582420847393884ca6bb990cfe5.patch";
+      hash = "sha256-jMNVcwm6zEdOvaTRbw5bfaJ2sLuxfuk7+6DlB1HOkYo=";
+    })
+  ];
+
+  postPatch = ''
+    # Allow using ranger out of the box without any configuration.
+    substituteInPlace src/core/config.c \
+      --replace-fail '"/usr/share/xdg-desktop-portal-termfilechooser/ranger-wrapper.sh"' '"${placeholder "out"}/share/xdg-desktop-portal-termfilechooser/ranger-wrapper.sh"'
+
+    # Fix comparison between char and int
+    substituteInPlace src/filechooser/filechooser.c \
+      --replace-fail 'char cr' 'int cr'
+  '';
+
+  meta = {
+    homepage = "https://github.com/GermainZ/xdg-desktop-portal-termfilechooser";
+    description = "Xdg-desktop-portal backend for wlroots and the likes of ranger";
+    maintainers = with lib.maintainers; [ soispha ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
This is the patch of the termfilechooser package from #277531 applied to current master.
Closes #213438.
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
