### PR TITLE
postgresql: 13.17 -> 13.18, 14.14 -> 14.15, 15.9 -> 15.10, 16.5 -> 16.6, 17.1 -> 17.2

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "13.17";
-  hash = "sha256-AisKbnvDdKd37s4zcIiV17YMrgfUkrKGspaknXOV14s=";
+  version = "13.18";
+  hash = "sha256-zuqSq+4qjBlAjSeLaN5qeLa9PbtPotZT+nynRdZmqrE=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "14.14";
-  hash = "sha256-hHJ/vM29Hv4B2N5kvBszCV23c60kV8787cLYJY68CdY=";
+  version = "14.15";
+  hash = "sha256-AuiR4xS06e4ky9eAKNq3xz+cG6PjCDW8vvcf4iBAH8U=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "15.9";
-  hash = "sha256-dPLUVlA18M9ynssFmUn6rxECy9k3WbNZgi+Y+CGYx4M=";
+  version = "15.10";
+  hash = "sha256-VavnONRB8OWGWLPsb4gJenE7XjtzE59iMNe1xMOJ5XM=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "16.5";
-  hash = "sha256-psu7cDf5jLivp9OXC3xIBAzwKxFeOSU6DAN6i7jnePA=";
+  version = "16.6";
+  hash = "sha256-Izac2szUUnCsXcww+p2iBdW+M/pQXh8XoEGNLK7KR3s=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "17.1";
-  hash = "sha256-eEnbdO9qhVXQcj+H6BU5MBQi+pyOnyHM5h/cFOkZnc0=";
+  version = "17.2";
+  hash = "sha256-gu8nwK83UWldf2Ti2WNYMAX7tqDD32PQ5LQiEdcCEWQ=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
New PostgreSQL minor versions released: https://www.postgresql.org/about/news/postgresql-172-166-1510-1415-1318-and-1222-released-2965/

There are no critical changes, so targeting staging for all of them at the same time.

Also see https://github.com/NixOS/nixpkgs/pull/355965#issuecomment-2477322630 for the reason for those new versions so quickly after the last ones.

This is *very* unlikely to break anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (on master, without JIT, no extensions)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
