### PR TITLE
prusa-slicer: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
+++ b/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
@@ -1,0 +1,70 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 31cb4c0ff..42c38102c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -247,6 +247,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     find_package(Threads REQUIRED)
+ 
+     find_package(DBus REQUIRED)
++    pkg_check_modules(DBUS REQUIRED dbus-1)
++    include_directories(${DBUS_INCLUDE_DIRS})
+ endif()
+ 
+ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUXX)
+@@ -347,7 +349,7 @@ if(WIN32)
+     add_definitions(-D_USE_MATH_DEFINES -D_WIN32 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
+     if(MSVC)
+         # BOOST_ALL_NO_LIB: Avoid the automatic linking of Boost libraries on Windows. Rather rely on explicit linking.
+-        add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_USE_WINAPI_VERSION=0x601 -DBOOST_SYSTEM_USE_UTF8 )
++        add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_USE_WINAPI_VERSION=0x601 -DBOOST_SYSTEM_USE_UTF8 -DBOOST_LOG_DYN_LINK)
+         # Force the source code encoding to UTF-8. See PrusaSlicer GH pull request #5583
+         add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+         add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+@@ -371,10 +373,13 @@ endif()
+ # boost::process was introduced first in version 1.64.0,
+ # boost::beast::detail::base64 was introduced first in version 1.66.0
+ set(MINIMUM_BOOST_VERSION "1.66.0")
+-set(_boost_components "system;filesystem;thread;log;locale;regex;chrono;atomic;date_time;iostreams;nowide")
++# set(Boost_USE_STATIC_LIBS ON)
++find_package(Boost REQUIRED COMPONENTS log)
++set(_boost_components "system;filesystem;thread;log;log_setup;locale;regex;chrono;atomic;date_time;iostreams;nowide")
+ find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS ${_boost_components})
++include_directories(${BOOST_INCLUDE_DIRS})
+ 
+-find_package(Eigen3 3.3.7 REQUIRED)
++find_package(Eigen3 3.3.7 REQUIRED NO_MODULE)
+ 
+ add_library(boost_libs INTERFACE)
+ add_library(boost_headeronly INTERFACE)
+diff --git a/src/slic3r/CMakeLists.txt b/src/slic3r/CMakeLists.txt
+index 78369233d..1f9c40aaf 100644
+--- a/src/slic3r/CMakeLists.txt
++++ b/src/slic3r/CMakeLists.txt
+@@ -383,6 +383,7 @@ set(SLIC3R_GUI_SOURCES
+ )
+ 
+ find_package(NanoSVG REQUIRED)
++find_package(OpenSSL REQUIRED)
+ 
+ if (APPLE)
+     list(APPEND SLIC3R_GUI_SOURCES
+@@ -438,6 +439,9 @@ target_link_libraries(
+     NanoSVG::nanosvgrast
+     stb_dxt
+     fastfloat
++    Boost::log
++    OpenSSL::SSL
++    OpenSSL::Crypto
+ )
+ 
+ if (MSVC)
+diff --git a/tests/sla_print/CMakeLists.txt b/tests/sla_print/CMakeLists.txt
+index b244e76ac..b23f6d4bc 100644
+--- a/tests/sla_print/CMakeLists.txt
++++ b/tests/sla_print/CMakeLists.txt
+@@ -18,3 +18,5 @@ endif()
+ 
+ # catch_discover_tests(${_TEST_NAME}_tests TEST_PREFIX "${_TEST_NAME}: ")
+ add_test(${_TEST_NAME}_tests ${_TEST_NAME}_tests ${CATCH_EXTRA_ARGS})
++
++add_definitions(-DBOOST_LOG_DYN_LINK)

--- a/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
+++ b/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
@@ -11,15 +11,6 @@ index 31cb4c0ff..42c38102c 100644
  endif()
  
  if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUXX)
-@@ -347,7 +349,7 @@ if(WIN32)
-     add_definitions(-D_USE_MATH_DEFINES -D_WIN32 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
-     if(MSVC)
-         # BOOST_ALL_NO_LIB: Avoid the automatic linking of Boost libraries on Windows. Rather rely on explicit linking.
--        add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_USE_WINAPI_VERSION=0x601 -DBOOST_SYSTEM_USE_UTF8 )
-+        add_definitions(-DBOOST_ALL_NO_LIB -DBOOST_USE_WINAPI_VERSION=0x601 -DBOOST_SYSTEM_USE_UTF8 -DBOOST_LOG_DYN_LINK)
-         # Force the source code encoding to UTF-8. See PrusaSlicer GH pull request #5583
-         add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-         add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 @@ -371,10 +373,13 @@ endif()
  # boost::process was introduced first in version 1.64.0,
  # boost::beast::detail::base64 was introduced first in version 1.66.0

--- a/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
+++ b/pkgs/applications/misc/prusa-slicer/281-dependencies.patch
@@ -58,13 +58,3 @@ index 78369233d..1f9c40aaf 100644
  )
  
  if (MSVC)
-diff --git a/tests/sla_print/CMakeLists.txt b/tests/sla_print/CMakeLists.txt
-index b244e76ac..b23f6d4bc 100644
---- a/tests/sla_print/CMakeLists.txt
-+++ b/tests/sla_print/CMakeLists.txt
-@@ -18,3 +18,5 @@ endif()
- 
- # catch_discover_tests(${_TEST_NAME}_tests TEST_PREFIX "${_TEST_NAME}: ")
- add_test(${_TEST_NAME}_tests ${_TEST_NAME}_tests ${CATCH_EXTRA_ARGS})
-+
-+add_definitions(-DBOOST_LOG_DYN_LINK)

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -77,14 +77,6 @@ let
   wxGTK-override' = if wxGTK-override == null then wxGTK-prusa else wxGTK-override;
 
   patches = [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/master/media-gfx/prusaslicer/files/prusaslicer-2.8.0-missing-includes.patch";
-      hash = "sha256-/R9jv9zSP1lDW6IltZ8V06xyLdxfaYrk3zD6JRFUxHg=";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/master/media-gfx/prusaslicer/files/prusaslicer-2.8.0-fixed-linking.patch";
-      hash = "sha256-G1JNdVH+goBelag9aX0NctHFVqtoYFnqjwK/43FVgvM=";
-    })
   ];
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -39,7 +39,15 @@
 , wxGTK-override ? null
 }:
 let
-  opencascade-occt = opencascade-occt_7_6;
+  opencascade-occt = opencascade-occt_7_6.overrideAttrs (old: {
+    version = "7.6.1";
+    src = fetchFromGitHub {
+      owner = "Open-Cascade-SAS";
+      repo = "OCCT";
+      rev = "V7_6_1";
+      sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
+    };
+  });
   wxGTK-prusa = wxGTK32.overrideAttrs (old: rec {
     pname = "wxwidgets-prusa3d-patched";
     version = "3.2.0";

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -80,13 +80,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prusa-slicer";
-  version = "2.8.0";
+  version = "2.8.1";
   inherit patches;
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "PrusaSlicer";
-    hash = "sha256-A/uxNIEXCchLw3t5erWdhqFAeh6nudcMfASi+RoJkFg=";
+    hash = "sha256-nMLZvvZLIOChCLn8A9sOph1lqWsHb00eTG8z98/l0C8=";
     rev = "version_${finalAttrs.version}";
   };
 

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -35,6 +35,7 @@
 , libbgcode
 , heatshrink
 , catch2
+, webkitgtk_4_0
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 , wxGTK-override ? null
 }:
@@ -134,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     libbgcode
     heatshrink
     catch2
+    webkitgtk_4_0
   ] ++ lib.optionals withSystemd [
     systemd
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -167,6 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSLIC3R_STATIC=0"
     "-DSLIC3R_FHS=1"
     "-DSLIC3R_GTK=3"
+    "-DCMAKE_CXX_FLAGS=-DBOOST_LOG_DYN_LINK"
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -25,7 +25,7 @@
 , mpfr
 , nanosvg
 , nlopt
-, opencascade-occt_7_6
+, opencascade-occt_7_6_1
 , openvdb
 , pcre
 , qhull
@@ -40,15 +40,6 @@
 , wxGTK-override ? null
 }:
 let
-  opencascade-occt = opencascade-occt_7_6.overrideAttrs (old: {
-    version = "7.6.1";
-    src = fetchFromGitHub {
-      owner = "Open-Cascade-SAS";
-      repo = "OCCT";
-      rev = "V7_6_1";
-      sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
-    };
-  });
   wxGTK-prusa = wxGTK32.overrideAttrs (old: rec {
     pname = "wxwidgets-prusa3d-patched";
     version = "3.2.0";
@@ -118,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpfr
     nanosvg-fltk
     nlopt
-    opencascade-occt
+    opencascade-occt_7_6_1
     openvdb_tbb_2021_8
     pcre
     qhull

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -167,6 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSLIC3R_STATIC=0"
     "-DSLIC3R_FHS=1"
     "-DSLIC3R_GTK=3"
+    "-DSLIC3R_BUILD_TESTS=0"
     "-DCMAKE_CXX_FLAGS=-DBOOST_LOG_DYN_LINK"
   ];
 

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -77,6 +77,7 @@ let
   wxGTK-override' = if wxGTK-override == null then wxGTK-prusa else wxGTK-override;
 
   patches = [
+    ./281-dependencies.patch
   ];
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10571,6 +10571,17 @@ with pkgs;
     ];
   };
 
+  opencascade-occt_7_6_1 = opencascade-occt.overrideAttrs {
+    pname = "opencascade-occt";
+    version = "7.6.1";
+    src = fetchFromGitHub {
+      owner = "Open-Cascade-SAS";
+      repo = "OCCT";
+      rev = "V7_6_1";
+      sha256 = "sha256-C02P3D363UwF0NM6R4D4c6yE5ZZxCcu5CpUaoTOxh7E=";
+    };
+  };
+
   opencsg = callPackage ../development/libraries/opencsg {
     inherit (qt5) qmake;
     inherit (darwin.apple_sdk.frameworks) GLUT;


### PR DESCRIPTION
This PR brings PrusaSlicer in line with the latest public release 2.8.1. Several new features such as UI improvements and a new infill type were added in this version. A full changelog can be found here:
  - https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.8.1
  - https://files.prusa3d.com/?latest=slicer-stable&lng=en

I've also provided a patch file to fix some of the build issues I experienced whilst upgrading this package, however I'm still new to NixOS so any feedback is very welcome. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
