### PR TITLE
nixos/mjolnir: add configuration options for native encryption

### DIFF
--- a/nixos/modules/services/matrix/mjolnir.md
+++ b/nixos/modules/services/matrix/mjolnir.md
@@ -37,10 +37,31 @@ you'll need to make the Mjolnir user a Matrix server admin.
 
 Now invite the Mjolnir user to the management room.
 
-It is recommended to use [Pantalaimon](https://github.com/matrix-org/pantalaimon),
-so your management room can be encrypted. This also applies if you are looking to moderate an encrypted room.
+It is recommended to enable encryption so your management room can be encrypted. This also applies
+if you are looking to moderate an encrypted room. This can be done by enabling
+[services.mjolnir.encryption](#opt-services.mjolnir.encryption.enable) and configuring a password
+in [services.mjolnir.passwordFile](#opt-services.mjolnir.passwordFile).
 
-To enable the Pantalaimon E2E Proxy for mjolnir, enable
+```nix
+{
+  services.mjolnir = {
+    enable = true;
+    homeserverUrl = "https://matrix.domain.tld";
+    passwordFile = "/run/secrets/mjolnir-password";
+    encryption = {
+      enable = true;
+      username = "mjolnir";
+    };
+    protectedRooms = [
+      "https://matrix.to/#/!xxx:domain.tld"
+    ];
+    managementRoom = "!yyy:domain.tld";
+  };
+}
+```
+
+Alternatively, using [Pantalaimon](https://github.com/matrix-org/pantalaimon) for encryption is
+still supported, but deprecated. To enable the Pantalaimon E2E Proxy for mjolnir, enable
 [services.mjolnir.pantalaimon](#opt-services.mjolnir.pantalaimon.enable). This will
 autoconfigure a new Pantalaimon instance, which will connect to the homeserver
 set in [services.mjolnir.homeserverUrl](#opt-services.mjolnir.homeserverUrl) and Mjolnir itself
@@ -51,10 +72,10 @@ will be configured to connect to the new Pantalaimon instance.
   services.mjolnir = {
     enable = true;
     homeserverUrl = "https://matrix.domain.tld";
+    passwordFile = "/run/secrets/mjolnir-password";
     pantalaimon = {
-       enable = true;
-       username = "mjolnir";
-       passwordFile = "/run/secrets/mjolnir-password";
+      enable = true;
+      username = "mjolnir";
     };
     protectedRooms = [
       "https://matrix.to/#/!xxx:domain.tld"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

this adds support for native encryption in mjolnir. without these changes, using native encryption support would require setting `accessTokenFile` and `pantalaimon.username` to satisfy assertions and fix evaluation of the generated yaml config. it would also require manually changing a placeholder for the user password.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC: @jojosch 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
