### PR TITLE
zinit: refactor and modernize; fix {manpage,_zinit} not found;

### DIFF
--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -1,48 +1,56 @@
-{ stdenvNoCC, lib, fetchFromGitHub, installShellFiles }:
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+}:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zinit";
   version = "3.13.1";
+
   src = fetchFromGitHub {
     owner = "zdharma-continuum";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-fnBV0LmC/wJm0pOITJ1mhiBqsg2F8AQJWvn0p/Bgo5Q=";
   };
-  # adapted from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zsh-zplugin-git
-  dontBuild = true;
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
   strictDeps = true;
+
   nativeBuildInputs = [ installShellFiles ];
+
   installPhase = ''
-    outdir="$out/share/$pname"
+    runHook preInstall
 
-    cd "$src"
+    # Source files
+    mkdir -p $out/share/zinit
+    install -m0644 zinit{,-side,-install,-autoload}.zsh $out/share/zinit
+    install -m0755 share/git-process-output.zsh $out/share/zinit
 
-    # Zplugin's source files
-    install -dm0755 "$outdir"
-    # Installing backward compatibility layer
-    install -m0644 zinit{,-side,-install,-autoload}.zsh "$outdir"
-    install -m0755 share/git-process-output.zsh "$outdir"
-
-    installManPage doc/zinit.1
-
-    # Zplugin autocompletion
+    # Autocompletion
     installShellCompletion --zsh _zinit
 
-    #TODO:Zplugin-module files
-    # find zmodules/ -type d -exec install -dm 755 "{}" "$outdir/{}" \;
-    # find zmodules/ -type f -exec install -m 744 "{}" "$outdir/{}" \;
-
-  '';
-  postInstall = ''
+    # Manpage
     installManPage doc/zinit.1
-  '';
-  #TODO:doc output
 
-  meta = with lib; {
+    runHook postInstall
+  '';
+
+  #TODO: output doc through zshelldoc
+
+  meta = {
     homepage = "https://github.com/zdharma-continuum/zinit";
     description = "Flexible zsh plugin manager";
-    license = licenses.mit;
-    maintainers = with maintainers; [ pasqui23 sei40kr ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pasqui23
+      sei40kr
+    ];
   };
-}
+})

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "zdharma-continuum";
     repo = finalAttrs.pname;
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fnBV0LmC/wJm0pOITJ1mhiBqsg2F8AQJWvn0p/Bgo5Q=";
   };
 

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -51,6 +52,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   #TODO: output doc through zshelldoc
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://github.com/zdharma-continuum/zinit";

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # Source files
     mkdir -p $out/share/zinit
-    install -m0644 zinit{,-side,-install,-autoload}.zsh $out/share/zinit
+    install -m0644 zinit{,-side,-install,-autoload}.zsh _zinit $out/share/zinit
     install -m0755 share/git-process-output.zsh $out/share/zinit
 
     # Autocompletion

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -59,6 +59,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       pasqui23
       sei40kr
+      moraxyc
     ];
   };
 })

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -37,9 +37,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     installShellCompletion --zsh _zinit
 
     # Manpage
+    mkdir -p ${placeholder "man"}/share/man/man{1..9}
     installManPage doc/zinit.1
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/zinit/zinit.zsh \
+      --replace-fail zinit.1 zinit.1.gz \
+      --replace-fail "\''${ZINIT[BIN_DIR]}/doc" ${placeholder "man"}/share/man/man1 \
+      --replace-fail "ZINIT[MAN_DIR]:=\''${ZPFX}/man" "ZINIT[MAN_DIR]:=${placeholder "man"}/share/man"
   '';
 
   #TODO: output doc through zshelldoc


### PR DESCRIPTION
 - zinit: fix manpage not found

```zsh
    [[ ! -d ${~ZINIT[MAN_DIR]}/man9 ]] && {
        # Create ZINIT[MAN_DIR]/man{1..9}
        command mkdir 2>/dev/null -p ${~ZINIT[MAN_DIR]}/man{1..9}
    }
    # Copy Zinit manpage so that man is able to find it
    [[ ! -f $ZINIT[MAN_DIR]/man1/zinit.1 || \
        $ZINIT[MAN_DIR]/man1/zinit.1 -ot $ZINIT[BIN_DIR]/doc/zinit.1 ]] && {
        command mkdir -p $ZINIT[MAN_DIR]/man1
        command cp -f $ZINIT[BIN_DIR]/doc/zinit.1 $ZINIT[MAN_DIR]/man1
    }
```
Zinit tries to locate `$ZINIT[MAN_DIR]/man1/zinit.1`, but the file we actually provide is `zinit.1.gz`.

 - zinit: fix _zinit not found
 ```zsh
         command ln -s "${ZINIT[BIN_DIR]}/_zinit" "${ZINIT[PLUGINS_DIR]}/_local---zinit"
```
Add `_zinit` to `BIN_DIR`($out/share/zinit/) too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
