### PR TITLE
postgresql: add new feature options

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -59,6 +59,10 @@ let
       , nukeReferences
       , overrideCC
 
+      # LDAP
+      , ldapSupport ? false
+      , openldap
+
       # PAM
       , pamSupport ? stdenv.hostPlatform.isLinux
       , linux-pam
@@ -145,7 +149,8 @@ let
       ++ lib.optionals pythonSupport [ python3 ]
       ++ lib.optionals gssSupport [ libkrb5 ]
       ++ lib.optionals pamSupport [ linux-pam ]
-      ++ lib.optionals perlSupport [ perl ];
+      ++ lib.optionals perlSupport [ perl ]
+      ++ lib.optionals ldapSupport [ openldap ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -187,7 +192,8 @@ let
       # This could be removed once the upstream issue is resolved:
       # https://postgr.es/m/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
-      ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ];
+      ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
+      ++ lib.optionals ldapSupport [ "--with-ldap" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -63,6 +63,10 @@ let
       , ldapSupport ? false
       , openldap
 
+      # NLS
+      , nlsSupport ? false
+      , gettext
+
       # PAM
       , pamSupport ? stdenv.hostPlatform.isLinux
       , linux-pam
@@ -160,7 +164,8 @@ let
       ++ lib.optionals perlSupport [ perl ]
       ++ lib.optionals ldapSupport [ openldap ]
       ++ lib.optionals tclSupport [ tcl ]
-      ++ lib.optionals selinuxSupport [ libselinux ];
+      ++ lib.optionals selinuxSupport [ libselinux ]
+      ++ lib.optionals nlsSupport [ gettext ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -205,7 +210,8 @@ let
       ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
       ++ lib.optionals ldapSupport [ "--with-ldap" ]
       ++ lib.optionals tclSupport [ "--with-tcl" ]
-      ++ lib.optionals selinuxSupport [ "--with-selinux" ];
+      ++ lib.optionals selinuxSupport [ "--with-selinux" ]
+      ++ lib.optionals nlsSupport [ "--enable-nls" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -33,7 +33,6 @@ let
       , flex
       , libxslt
       , makeWrapper
-      , perl
       , pkg-config
       , removeReferencesTo
 
@@ -63,6 +62,10 @@ let
       # PAM
       , pamSupport ? stdenv.hostPlatform.isLinux
       , linux-pam
+
+      # PL/Perl
+      , perlSupport ? false
+      , perl
 
       # PL/Python
       , pythonSupport ? false
@@ -141,7 +144,8 @@ let
       ++ lib.optionals systemdSupport [ systemdLibs ]
       ++ lib.optionals pythonSupport [ python3 ]
       ++ lib.optionals gssSupport [ libkrb5 ]
-      ++ lib.optionals pamSupport [ linux-pam ];
+      ++ lib.optionals pamSupport [ linux-pam ]
+      ++ lib.optionals perlSupport [ perl ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -183,7 +187,7 @@ let
       # This could be removed once the upstream issue is resolved:
       # https://postgr.es/m/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
-      ++ lib.optionals (atLeast "17") [ "--without-perl" ];
+      ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -75,6 +75,10 @@ let
       , pythonSupport ? false
       , python3
 
+      # PL/Tcl
+      , tclSupport ? false
+      , tcl
+
       # Systemd
       , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
       , systemdLibs
@@ -150,7 +154,8 @@ let
       ++ lib.optionals gssSupport [ libkrb5 ]
       ++ lib.optionals pamSupport [ linux-pam ]
       ++ lib.optionals perlSupport [ perl ]
-      ++ lib.optionals ldapSupport [ openldap ];
+      ++ lib.optionals ldapSupport [ openldap ]
+      ++ lib.optionals tclSupport [ tcl ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -193,7 +198,8 @@ let
       # https://postgr.es/m/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
       ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
-      ++ lib.optionals ldapSupport [ "--with-ldap" ];
+      ++ lib.optionals ldapSupport [ "--with-ldap" ]
+      ++ lib.optionals tclSupport [ "--with-tcl" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -17,7 +17,6 @@ let
       # runtime dependencies
       , darwin
       , glibc
-      , icu
       , libuuid
       , libxml2
       , lz4
@@ -50,6 +49,10 @@ let
       # GSSAPI
       , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
       , libkrb5
+
+      # icu
+      , icuSupport ? true
+      , icu
 
       # JIT
       , jitSupport # not default on purpose, this is set via "_jit or not" attributes
@@ -129,9 +132,9 @@ let
       readline
       openssl
       (libxml2.override {enableHttp = true;})
-      icu
       libuuid
     ]
+      ++ lib.optionals icuSupport [ icu ]
       ++ lib.optionals jitSupport [ llvmPackages.llvm ]
       ++ lib.optionals lz4Enabled [ lz4 ]
       ++ lib.optionals zstdEnabled [ zstd ]
@@ -162,10 +165,10 @@ let
     env.CFLAGS = "-fdata-sections -ffunction-sections"
       + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
 
-    configureFlags = [
+    configureFlags = let inherit (lib) withFeature; in [
       "--with-openssl"
       "--with-libxml"
-      "--with-icu"
+      (withFeature icuSupport "icu")
       "--sysconfdir=/etc"
       "--with-system-tzdata=${tzdata}/share/zoneinfo"
       "--enable-debug"

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -20,7 +20,6 @@ let
       , icu
       , libuuid
       , libxml2
-      , linux-pam
       , lz4
       , openssl
       , readline
@@ -57,6 +56,10 @@ let
       , llvmPackages
       , nukeReferences
       , overrideCC
+
+      # PAM
+      , pamSupport ? stdenv.hostPlatform.isLinux
+      , linux-pam
 
       # PL/Python
       , pythonSupport ? false
@@ -135,7 +138,7 @@ let
       ++ lib.optionals systemdSupport [ systemdLibs ]
       ++ lib.optionals pythonSupport [ python3 ]
       ++ lib.optionals gssSupport [ libkrb5 ]
-      ++ lib.optionals stdenv'.hostPlatform.isLinux [ linux-pam ];
+      ++ lib.optionals pamSupport [ linux-pam ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -173,7 +176,7 @@ let
       ++ lib.optionals gssSupport [ "--with-gssapi" ]
       ++ lib.optionals pythonSupport [ "--with-python" ]
       ++ lib.optionals jitSupport [ "--with-llvm" ]
-      ++ lib.optionals stdenv'.hostPlatform.isLinux [ "--with-pam" ]
+      ++ lib.optionals pamSupport [ "--with-pam" ]
       # This could be removed once the upstream issue is resolved:
       # https://postgr.es/m/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -79,6 +79,10 @@ let
       , tclSupport ? false
       , tcl
 
+      # SELinux
+      , selinuxSupport ? false
+      , libselinux
+
       # Systemd
       , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
       , systemdLibs
@@ -155,7 +159,8 @@ let
       ++ lib.optionals pamSupport [ linux-pam ]
       ++ lib.optionals perlSupport [ perl ]
       ++ lib.optionals ldapSupport [ openldap ]
-      ++ lib.optionals tclSupport [ tcl ];
+      ++ lib.optionals tclSupport [ tcl ]
+      ++ lib.optionals selinuxSupport [ libselinux ];
 
     nativeBuildInputs = [
       makeWrapper
@@ -199,7 +204,8 @@ let
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
       ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
       ++ lib.optionals ldapSupport [ "--with-ldap" ]
-      ++ lib.optionals tclSupport [ "--with-tcl" ];
+      ++ lib.optionals tclSupport [ "--with-tcl" ]
+      ++ lib.optionals selinuxSupport [ "--with-selinux" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -45,6 +45,9 @@ let
       , stdenvNoCC
       , testers
 
+      # bonjour
+      , bonjourSupport ? false
+
       # GSSAPI
       , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
       , libkrb5
@@ -211,7 +214,8 @@ let
       ++ lib.optionals ldapSupport [ "--with-ldap" ]
       ++ lib.optionals tclSupport [ "--with-tcl" ]
       ++ lib.optionals selinuxSupport [ "--with-selinux" ]
-      ++ lib.optionals nlsSupport [ "--enable-nls" ];
+      ++ lib.optionals nlsSupport [ "--enable-nls" ]
+      ++ lib.optionals bonjourSupport [ "--with-bonjour" ];
 
     patches = [
       (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -1,34 +1,70 @@
 let
 
   generic =
-      # dependencies
-      { stdenv, lib, fetchurl, fetchpatch, makeWrapper
-      , glibc, zlib, readline, openssl, icu, lz4, zstd, systemdLibs, libuuid
-      , pkg-config, libxml2, tzdata, libkrb5, substituteAll, darwin
-      , linux-pam, bison, flex, perl, docbook_xml_dtd_45, docbook-xsl-nons, libxslt
-
-      , removeReferencesTo, writeShellScriptBin
-
-      , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
-      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
-
-      # for postgresql.pkgs
-      , self, newScope, buildEnv
-      , stdenvNoCC, postgresqlTestHook
+      # utils
+      { stdenv
+      , fetchpatch
+      , fetchurl
+      , lib
+      , substituteAll
+      , writeShellScriptBin
 
       # source specification
-      , version, hash, muslPatches ? {}
+      , hash
+      , muslPatches ? {}
+      , version
 
-      # for tests
-      , testers, nixosTests
+      # runtime dependencies
+      , darwin
+      , glibc
+      , icu
+      , libuuid
+      , libxml2
+      , linux-pam
+      , lz4
+      , openssl
+      , readline
+      , tzdata
+      , zlib
+      , zstd
+
+      # build dependencies
+      , bison
+      , docbook-xsl-nons
+      , docbook_xml_dtd_45
+      , flex
+      , libxslt
+      , makeWrapper
+      , perl
+      , pkg-config
+      , removeReferencesTo
+
+      # passthru
+      , buildEnv
+      , newScope
+      , nixosTests
+      , postgresqlTestHook
+      , self
+      , stdenvNoCC
+      , testers
+
+      # GSSAPI
+      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
+      , libkrb5
 
       # JIT
-      , jitSupport
-      , nukeReferences, llvmPackages, overrideCC
+      , jitSupport # not default on purpose, this is set via "_jit or not" attributes
+      , llvmPackages
+      , nukeReferences
+      , overrideCC
 
       # PL/Python
       , pythonSupport ? false
       , python3
+
+      # Systemd
+      , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
+      , systemdLibs
     } @args:
   let
     atLeast = lib.versionAtLeast version;


### PR DESCRIPTION
This makes almost everything that PostgreSQL supports to be built with available as `xSupport` flags. Bonjour only works on darwin, selinux only on Linux - all others seem to work fine on both, except for a failed output check on darwin with ldap enabled. I don't consider that critical for now, though.

The idea here is to provide those options - and then have separate discussions and much more tests if we decide to turn any of them on by default.

Supersedes #218934 and makes #345289 a tiny bit nicer to implement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
