### PR TITLE
desktopToDarwinBundle: fix 16x, 32x app icons

### DIFF
--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -92,6 +92,7 @@ convertIconTheme() {
 
         echo "desktopToDarwinBundle: resizing icon $in to $out, size $dim" >&2
         magick convert -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
+        convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
     }
 
     function synthesizeIcon() {
@@ -107,8 +108,24 @@ convertIconTheme() {
             echo "desktopToDarwinBundle: rasterizing svg $in to $out, size $dim" >&2
             rsvg-convert --keep-aspect-ratio --width "$dim" --height "$dim" "$in" --output "$out"
             magick convert -density "$density" -units PixelsPerInch "$out" "$out"
+            convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
         else
             return 1
+        fi
+    }
+
+    # macOS does not correctly display 16x and 32x png icons on app bundles
+    # they need to be converted to rgb+mask (argb is supported only from macOS 11)
+    function convertIfUnsupportedIcon() {
+        local -r in=$1
+        local -r iconSize=$2
+        local -r scale=$3
+        local -r out=${in%.png}.rgb
+
+        if [[ ($scale -eq 1) && ($iconSize -eq 32 || $iconSize -eq 16) ]]; then
+            echo "desktopToDarwinBundle: converting ${iconSize}x icon to rgb" >&2
+            icnsutil convert "$out" "$in"
+            rm "$in"
         fi
     }
 
@@ -151,6 +168,7 @@ convertIconTheme() {
                     fixed)
                         local density=$((72 * scale))x$((72 * scale))
                         magick convert -density "$density" -units PixelsPerInch "$icon" "$result"
+                        convertIfUnsupportedIcon "$result" "$iconSize" "$scale"
                         foundIcon=OTHER
                         ;;
                     threshold)

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   python,
   pythonOlder,
+  pillow,
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,8 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-tiq8h6s2noWLBIOIWcj8jfSqJFN01ee2uoHN4aFwn7s=";
   };
+
+  dependencies = [ pillow ];
 
   checkPhase = ''
     ${python.interpreter} tests/test_icnsutil.py


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/358210

Example using `pulseview` icon (`Applications/PulseView/Contents/Resources/pusleview.icns`) when viewed through [Icns Image Viewer](https://relikd.github.io/icnsutil/html/viewer.html)

| Before | After |
| ------ | ----- |
| ![relikd github io_icnsutil_html_viewer html (1)](https://github.com/user-attachments/assets/05616873-b1ee-4cd4-b81c-560f9ed5c564) | ![relikd github io_icnsutil_html_viewer html](https://github.com/user-attachments/assets/5cefc8a6-3530-464f-9baa-87344cd40ba1) |

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
