### PR TITLE
[WIP] deno.fetchDeps: init

### DIFF
--- a/pkgs/by-name/de/deno/fetch-deps/default.nix
+++ b/pkgs/by-name/de/deno/fetch-deps/default.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  deno,
+  jq,
+}:
+{
+  hash ? "",
+  pname,
+  denoLock ? "",
+  denoJson ? "",
+  denoEntrypoints ? [ ],
+  preDenoInstall ? "",
+  denoInstallFlags ? [ ],
+  ...
+}@args:
+let
+  args' = builtins.removeAttrs args [
+    "hash"
+    "pname"
+  ];
+in
+stdenv.mkDerivation (
+  args'
+  // {
+    name = "${pname}-deno-deps";
+
+    nativeBuildInputs = [
+      deno
+      jq
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    denoInstallFlags =
+      (lib.cli.toGNUCommandLine { } {
+        vendor = true;
+        frozen = true;
+        node-modules-dir = true;
+        entrypoint = if denoEntrypoints == [ ] then null else denoEntrypoints;
+      })
+      ++ denoInstallFlags;
+
+    inherit denoLock denoJson denoEntrypoints;
+
+    installPhase = ''
+      export DENO_DIR=$(mktemp -d)
+      export DENO_NO_UPDATE_CHECK=true
+
+      if [[ -z "$denoLock" ]]; then
+        echo "autodetecting lock file"
+      else
+        if [[ ! -f "$denoLock" ]]; then
+          echo "error: lock file '$denoLock' is specified but not found" >&2
+          exit 1
+        fi
+        cp "$denoLock" deno.lock
+      fi
+
+      if [[ -z "$denoJson" ]]; then
+        echo "autodetecting Deno config"
+      else
+        if [[ ! -f "$denoJson" ]]; then
+          echo "error: Deno config '$denoJson' is specified but not found" >&2
+          exit 1
+        fi
+        cp "$denoJson" deno.json
+      fi
+
+      for entrypoint in "''${denoEntrypoints[@]}"; do
+        if [[ -n "$entrypoint" && ! -f "$entrypoint" ]]; then
+          echo "error: entrypoint '$entrypoint' is specified but not found" >&2
+          exit 1
+        fi
+      done
+
+      ${preDenoInstall}
+
+      deno install ''${denoInstallFlags[@]}
+
+      # Remove redundant & unreproducible files
+      rm -f node_modules/.deno/.deno.lock{,.poll}
+
+      # TODO: I'm not exactly sure if this is necessary anymore
+      if [[ -f vendor/manifest.json ]]; then
+        jq -S '.' vendor/manifest.json > vendor/manifest.json.tmp
+        mv vendor/manifest.json.tmp vendor/manifest.json
+      fi
+
+
+      mkdir -p $out
+      [[ -d node_modules ]] && cp -a node_modules -t $out || true
+      [[ -d vendor ]] && cp -a vendor -t $out || true
+      [[ -n deno.json ]] && cp deno.json -t $out || true
+      [[ -n deno.lock ]] && cp deno.lock -t $out || true
+    '';
+
+    dontFixup = true;
+
+    outputHash = hash;
+    outputHashMode = "recursive";
+  }
+  // lib.optionalAttrs (hash == "") {
+    outputHashAlgo = "sha256";
+  }
+)

--- a/pkgs/by-name/de/deno/hooks/compile-hook.sh
+++ b/pkgs/by-name/de/deno/hooks/compile-hook.sh
@@ -1,0 +1,51 @@
+# shellcheck shell=bash
+
+denoCompileBuildPhase() {
+    export DENORT_BIN="@deno@/bin/denort"
+    export DENO_COMPILE_OUT=$(mktemp -d)
+
+    if [[ -z "${denoCompileEntrypoints[@]}" ]]; then
+        if [[ -z "${denoEntrypoints[@]}" ]]; then
+            echo "error: neither denoEntrypoints nor denoCompileEntrypoints is set - can't compile anything!" >&2
+            exit 1
+        fi
+
+        denoCompileEntrypoints=("${denoEntrypoints[@]}")
+    fi
+    for entrypoint in "${denoCompileEntrypoints[@]}"; do
+      if [[ -n "$entrypoint" && ! -f "$entrypoint" ]]; then
+        echo "error: entrypoint '$entrypoint' is specified but not found" >&2
+        exit 1
+      fi
+    done
+
+    deno compile \
+        --output $DENO_COMPILE_OUT/ \
+        --cached-only \
+        --vendor \
+        --node-modules-dir \
+        ${denoCompileFlags[@]} \
+        ${denoCompileEntrypoints[@]}
+
+    # `deno compile` works by inserting JavaScript in the data segments of the executables.
+    # Stripping them would just completely defeat the point and render the executable unusable.
+    for file in $DENO_COMPILE_OUT/*; do
+        stripExclude+=("${file#"$DENO_COMPILE_OUT/"}")
+    done
+}
+
+denoCompileInstallPhase() {
+    mkdir -p $out/bin
+    cp -a $DENO_COMPILE_OUT/. -t $out/bin
+}
+
+# Why don't we have any kind of dontDenoCompile flag? Because if you don't want to run `deno compile`,
+# you shouldn't include this hook in your nativeBuildInputs. Simple as.
+if [[ -z "${buildPhase-}" ]]; then
+    setOutputFlags=
+    buildPhase=denoCompileBuildPhase
+fi
+if [[ -z "${installPhase-}" ]]; then
+    setOutputFlags=
+    installPhase=denoCompileInstallPhase
+fi

--- a/pkgs/by-name/de/deno/hooks/setup-hook.sh
+++ b/pkgs/by-name/de/deno/hooks/setup-hook.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+
+denoConfigHook() {
+    echo "Executing denoConfigHook"
+
+    if [[ -n "${denoRoot-}" ]]; then
+      pushd "$denoRoot"
+    fi
+
+    if [[ -z "${denoDeps-}" ]]; then
+      echo "denoDeps not set - skipping"
+      exit 0
+    fi
+
+    export DENO_DIR=$(mktemp -d)
+
+    if [[ -d $denoDeps/node_modules ]]; then
+        cp -a $denoDeps/node_modules -t .
+        chmod -R +w node_modules
+
+        echo "Patching scripts"
+        patchShebangs node_modules/{*,.*}
+    fi
+
+    [[ -d $denoDeps/vendor ]] && cp -a $denoDeps/vendor -t . || true
+    [[ -f $denoDeps/deno.json ]] && cp $denoDeps/deno.json deno.json || true
+    [[ -f $denoDeps/deno.lock ]] && cp $denoDeps/deno.lock deno.lock || true
+
+    if [[ -n "${denoRoot-}" ]]; then
+      popd
+    fi
+
+    echo "Finished denoConfigHook"
+}
+
+postConfigureHooks+=(denoConfigHook)

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -93,6 +93,11 @@ rustPlatform.buildRustPackage rec {
       name = "deno-setup-hook";
       propagatedBuildInputs = [ deno ];
     } ./hooks/setup-hook.sh;
+    compileHook = makeSetupHook {
+      name = "deno-compile-hook";
+      propagatedBuildInputs = [ deno ];
+      substitutions.deno = deno;
+    } ./hooks/compile-hook.sh;
   };
 
   meta = with lib; {

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -83,8 +83,11 @@ rustPlatform.buildRustPackage rec {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = ./update/update.ts;
-  passthru.tests = callPackage ./tests { };
+  passthru = {
+    updateScript = ./update/update.ts;
+    tests = callPackage ./tests { };
+    fetchDeps = callPackage ./fetch-deps { };
+  };
 
   meta = with lib; {
     homepage = "https://deno.land/";

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -12,6 +12,8 @@
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
   },
+  makeSetupHook,
+  deno,
 }:
 
 let
@@ -87,6 +89,10 @@ rustPlatform.buildRustPackage rec {
     updateScript = ./update/update.ts;
     tests = callPackage ./tests { };
     fetchDeps = callPackage ./fetch-deps { };
+    setupHook = makeSetupHook {
+      name = "deno-setup-hook";
+      propagatedBuildInputs = [ deno ];
+    } ./hooks/setup-hook.sh;
   };
 
   meta = with lib; {


### PR DESCRIPTION
This PR is like #326003, but considerably more minimal and based on Deno 2.0. 

I believe the other PR is doing way too much than what is strictly necessary at this point, and a more composable design with hooks and dependency fetchers is more in line with what Nixpkgs is gravitating towards with tools like cargo-tauri and pnpm.

Note that the closure size with Deno deps might be considerably bigger than the same dependencies fetched with either `fetchNpmDeps` and `pnpm.fetchDeps`, due to the lack of a content-addressible mechanism. `fetchNpmDeps` has its own code that generates a content-addressible closure but I'm a) not exactly sure how it works and b) how it is restored to a normal node_modules structure, and pnpm is designed around CA stores as a core design. Still, this is possibly a future problem to solve.

Marking as draft for now as there's some more polishing that can be done for the scripts, and maybe a build/install hook should be added like the other PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
