### PR TITLE
ntfy-sh: add secret file support

### DIFF
--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -7,7 +7,7 @@ in
 
 {
   options.services.ntfy-sh = {
-    enable = lib.mkEnableOption "ntfy-sh, a push notification service";
+    enable = lib.mkEnableOption "[ntfy-sh](https://ntfy.sh), a push notification service";
 
     package = lib.mkPackageOption pkgs "ntfy-sh" { };
 
@@ -73,8 +73,7 @@ in
       '';
 
       description = ''
-        Configuration for ntfy.sh, supported values are documented at
-        <https://ntfy.sh/docs/config/#config-options>
+        Configuration for ntfy.sh, supported values are [here](https://ntfy.sh/docs/config/#config-options).
       '';
     };
   };
@@ -84,6 +83,7 @@ in
       configuration = settingsFormat.generate "server.yml" cfg.settings;
     in
     lib.mkIf cfg.enable {
+      # to configure access control via the cli
       environment = {
         etc."ntfy/server.yml".source = configuration;
         systemPackages = [ cfg.package ];
@@ -134,6 +134,7 @@ in
           RestrictNamespaces = true;
           RestrictRealtime = true;
           MemoryDenyWriteExecute = true;
+          # Upstream Recommandation
           LimitNOFILE = 20500;
         };
       };

--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -33,16 +33,6 @@ in
       '';
     };
 
-    webPushPrivateKey = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = ''
-        The private key for web push notifications.
-        For improved security, consider using 'webPushPrivateKeyFile' instead
-        which keeps credentials out of the Nix store.
-      '';
-    };
-
     webPushPrivateKeyFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;

--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -23,16 +23,6 @@ in
       description = "Primary group of ntfy-sh user.";
     };
 
-    smtpSenderPass = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = ''
-        The password for the SMTP sender.
-        For improved security, consider using 'smtpSenderPassFile' instead
-        which keeps credentials out of the Nix store.
-      '';
-    };
-
     smtpSenderPassFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

ADDED: smtpSenderPassFile and webPushPrivateKeyFile options
ADDED: systemd LoadCredential for secure runtime secret handling
ADDED: security hardening options for notification service
CHANGED: state directory handling

**Closes** #352461

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
