### PR TITLE
Make all version metadata fields configurable

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -30,7 +30,7 @@ let
       BUILD_ID = cfg.version;
       PRETTY_NAME = "${cfg.distroName} ${cfg.release} (${cfg.codeName})";
       CPE_NAME = "cpe:/o:${cfg.vendorId}:${cfg.distroId}:${cfg.release}";
-      LOGO = "nix-snowflake";
+      LOGO = optionalString (cfg.logo != null) cfg.logo;
       HOME_URL = optionalString isNixos "https://nixos.org/";
       VENDOR_URL = optionalString isNixos "https://nixos.org/";
       DOCUMENTATION_URL = optionalString isNixos "https://nixos.org/learn.html";
@@ -42,7 +42,7 @@ let
       VARIANT = optionalString (cfg.variantName != null) cfg.variantName;
       VARIANT_ID = optionalString (cfg.variant_id != null) cfg.variant_id;
       DEFAULT_HOSTNAME = config.networking.fqdnOrHostName;
-      SUPPORT_END = "2025-06-30";
+      SUPPORT_END = cfg.supportEnd;
     };
 
   initrdReleaseContents = (removeAttrs osReleaseContents [ "BUILD_ID" ]) // {
@@ -75,7 +75,7 @@ in
       };
 
       release = mkOption {
-        readOnly = true;
+        internal = true;
         type = types.str;
         default = trivial.release;
         description = "The NixOS release (e.g. `16.03`).";
@@ -96,7 +96,7 @@ in
       };
 
       codeName = mkOption {
-        readOnly = true;
+        internal = true;
         type = types.str;
         default = trivial.codeName;
         description = "The NixOS release code name (e.g. `Emu`).";
@@ -142,6 +142,20 @@ in
         type = types.str;
         default = "NixOS";
         description = "The name of the operating system vendor";
+      };
+
+      logo = mkOption {
+        internal = true;
+        type = types.nullOr types.str;
+        default = "nix-snowflake";
+        description = "The name of an icon that can be used by graphical applications to display the operating system's logo";
+      };
+
+      supportEnd = mkOption {
+        internal = true;
+        type = types.strMatching "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+        default = "2025-06-30";
+        description = "The date when support for this OS version ends.";
       };
     };
 


### PR DESCRIPTION
Downstream users of NixOS may adapt it for their own products or distro variants. Customizing the version information is ideal so users of these downstream derivatives can see the correct branding, version, and lifecycle support dates of these derivative projects. NixOS is an ideal platform for spin off distros like [RedNixOS](https://github.com/redcode-labs/RedNixOS) and  [NixNG](https://github.com/nix-community/NixNG/) and they can provide their own logo and EOL dates.

Add options for SUPPORT_END and LOGO os-release fields. Make release and codeName internal options instead of readOnly.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).