### PR TITLE
{gama-tui,gocovsh,golds,pkgsite,tcount}: init

### DIFF
--- a/pkgs/by-name/ga/gama-tui/package.nix
+++ b/pkgs/by-name/ga/gama-tui/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gama-tui";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "termkit";
+    repo = "gama";
+    tag = "v${version}";
+    hash = "sha256-laE3lW2MX3vYxsF5iHl0sLKCAPRAIZGQs72+vdbX4t0=";
+  };
+
+  vendorHash = "sha256-rx18df0iiYqQToydXcA6Kqsn3lePIL1RNMSvD+a4WrI=";
+
+  ldflags = [
+    "-s"
+    "-X main.Version=v${version}"
+  ];
+
+  # requires network access
+  doCheck = false;
+
+  meta = {
+    description = "Manage your GitHub Actions from Terminal with great UI";
+    homepage = "https://github.com/termkit/gama";
+    changelog = "https://github.com/termkit/gama/releases";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "gama";
+  };
+}

--- a/pkgs/by-name/go/gocovsh/package.nix
+++ b/pkgs/by-name/go/gocovsh/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  gocovsh, # self
+}:
+
+buildGoModule rec {
+  pname = "gocovsh";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "orlangure";
+    repo = "gocovsh";
+    tag = "v${version}";
+    hash = "sha256-VZNu1uecFVVDgF4xDLTgkCahUWbM+1XASV02PEUfmr0=";
+  };
+
+  vendorHash = "sha256-Fb7BIWojOSUIlBdjIt57CSvF1a+x33sB45Z0a86JMUg=";
+
+  ldflags = [
+    "-s"
+    "-X main.version=${version}"
+    "-X main.commit=v${version}"
+    "-X main.date=19700101T000000Z"
+  ];
+
+  passthru.tests.version = testers.testVersion { package = gocovsh; };
+
+  meta = {
+    description = "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line";
+    homepage = "https://github.com/orlangure/gocovsh";
+    changelog = "https://github.com/orlangure/gocovsh/releases";
+    # https://github.com/orlangure/gocovsh/blob/8880bc63283c13a1d630ce3817c7165a6c210d46/.goreleaser.yaml#L33
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "gocovsh";
+  };
+}

--- a/pkgs/by-name/go/golds/info_module-gover.patch
+++ b/pkgs/by-name/go/golds/info_module-gover.patch
@@ -1,0 +1,25 @@
+diff --git a/internal/server/info_module.go b/internal/server/info_module.go
+index d2513bd..ad2921e 100644
+--- a/internal/server/info_module.go
++++ b/internal/server/info_module.go
+@@ -8,6 +8,7 @@ import (
+ 	"io/ioutil"
+ 	"log"
+ 	"os"
++	"os/exec"
+ 	"path/filepath"
+ 	"regexp"
+ 	"strings"
+@@ -756,7 +757,11 @@ func findGoToolchainVersionFromGoRoot(goroot string) (string, error) {
+ 		versionData, err = ioutil.ReadFile(filepath.Join(goroot, "VERSION.cache"))
+ 	}
+ 	if err != nil {
+-		return "", fmt.Errorf("failed to get Go toolchain version in GOROOT (%s)", goroot)
++		cmd := exec.Command("go", "env", "GOVERSION")
++		versionData, err = cmd.Output()
++		if err != nil {
++			return "", fmt.Errorf("failed to get Go toolchain version in GOROOT (%s)", goroot)
++		}
+ 	}
+ 	matches := findGoVersionRegexp.FindSubmatch(versionData)
+ 	if len(matches) >= 1 {

--- a/pkgs/by-name/go/golds/package.nix
+++ b/pkgs/by-name/go/golds/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  golds, # self
+}:
+
+buildGoModule rec {
+  pname = "golds";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "go101";
+    repo = "golds";
+    tag = "v${version}";
+    hash = "sha256-6YkyKJtSAFFYidMlZXSjNpjyIIaTlibg/QMMin/NbU0=";
+  };
+
+  # nixpkgs is not using the go distpack archive and missing a VERSION file in the source
+  # but we can use go env to get the same information
+  # https://github.com/NixOS/nixpkgs/pull/358316#discussion_r1855322027
+  patches = [ ./info_module-gover.patch ];
+
+  vendorHash = "sha256-omjHRZB/4VzPhc6RrFY11s6BRD69+Y4RRZ2XdeKbZf0=";
+
+  ldflags = [ "-s" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = golds;
+    version = "v${version}";
+  };
+
+  meta = {
+    description = "Experimental Go local docs server/generator and code reader implemented with some fresh ideas";
+    homepage = "https://github.com/go101/golds";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "golds";
+  };
+}

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "pkgsite";
+  version = "0-unstable-2024-12-06";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "pkgsite";
+    rev = "37884bfc1a9e2aa46989ac56e671bcbd240bb4f7";
+    hash = "sha256-RZTRfB1mEM13x/vLrxu7877C7Zh/kJxpYMP9xR2OOXw=";
+  };
+
+  vendorHash = "sha256-Ijcj1Nq4WjXcUqmoDkpO9I4rl/4/TMXFMQVAlEK11R8=";
+
+  subPackages = [ "cmd/pkgsite" ];
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Official tool to extract and generate documentation for Go projects like pkg.go.dev";
+    homepage = "https://github.com/golang/pkgsite";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "pkgsite";
+  };
+}

--- a/pkgs/by-name/tc/tcount/package.nix
+++ b/pkgs/by-name/tc/tcount/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tcount";
+  version = "0-unstable-2023-04-20";
+
+  src = fetchFromGitHub {
+    owner = "rrethy";
+    repo = "tcount";
+    rev = "341d9aa29512257bf7dfd7e843d02fdcfd583387";
+    hash = "sha256-M4EvaX9qDBYeapeegp6Ki7FJLFosVR1B42QRAh5Eugo=";
+  };
+
+  useFetchCargoVendor = true;
+
+  cargoHash = "sha256-Sn7hu+2jQFd2u8tpfTxnEO+syrO96gfgz6ouHxJnpLg=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Count your code by tokens and patterns in the syntax tree. A tokei/scc/cloc alternative";
+    homepage = "https://github.com/rrethy/tcount";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "tcount";
+  };
+}


### PR DESCRIPTION
- go
  - gama-tui  (gama was taken)
  - golds
  - pkgsite
  - gocovsh
- rust
  - tcount

| package       | version                    | source                                        | reason                                                                              |
| ----------------- | -------------------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
| gama-tui      | 1.1.4  | https://github.com/termkit/gama               | github actions tui |
| gocovsh       | 0.6.1                                        | https://github.com/orlangure/gocovsh      | go code coverage tui |
| golds            | 0.7.1                                        | https://github.com/go101/golds                  | godoc/pkgsite alternative |
| pkgsite         | 0-unstable-2024-12-06        | https://github.com/golang/pkgsite             | official pkg.go.dev tool for rendering docs (godoc successor) |
| tcount          | 0-unstable-2023-04-20        | https://github.com/rrethy/tcount                 | code loc counter like tokei/scc |

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc