### PR TITLE
[24.11] duti: update to new darwin SDK pattern and add n-hass maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15560,6 +15560,13 @@
     githubId = 399535;
     name = "Niklas Hambüchen";
   };
+  n-hass = {
+    email = "nick@hassan.host";
+    github = "n-hass";
+    githubId = 72363381;
+    name = "n-hass";
+    keys = [ { fingerprint = "FDEE 6116 DBA7 8840 7323  4466 A371 5973 2728 A6A6"; } ];
+  };
   nhnn = {
     matrix = "@nhnn:nhnn.dev";
     github = "thenhnn";

--- a/pkgs/os-specific/darwin/duti/buildConfigure.patch
+++ b/pkgs/os-specific/darwin/duti/buildConfigure.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile.in b/Makefile.in
+index d5c9fda..a596462 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -14,10 +14,7 @@ DUTI_BUILD_DATE=@build_date@
+ 
+ CC=		@CC@
+ FRAMEWORKS=	-framework ApplicationServices -framework CoreFoundation
+-OPTOPTS=	-isysroot @macosx_sdk@ \
+-			@macosx_arches@ \
+-			-mmacosx-version-min=@macosx_dep_target@ \
+-			@OPTOPTS@
++OPTOPTS=	@OPTOPTS@
+ 
+ LIBS=		@LIBS@
+ LDFLAGS=	@LDFLAGS@ ${LIBS}
+diff --git a/configure.ac b/configure.ac
+index 815f395..05caaed 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -15,8 +15,8 @@ AC_PROG_CC
+ AC_PROG_INSTALL
+ 
+ AC_CANONICAL_SYSTEM
+-DUTI_CHECK_SDK
+-DUTI_CHECK_DEPLOYMENT_TARGET
++#DUTI_CHECK_SDK
++#DUTI_CHECK_DEPLOYMENT_TARGET
+ 
+ # function checks
+ AC_CHECK_FUNC(strlcpy,have_strlcpy=yes,)

--- a/pkgs/os-specific/darwin/duti/default.nix
+++ b/pkgs/os-specific/darwin/duti/default.nix
@@ -1,4 +1,9 @@
-{stdenv, lib, fetchFromGitHub, autoreconfHook, ApplicationServices}:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
 
 stdenv.mkDerivation rec {
   pname = "duti";
@@ -10,15 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "1pg4i6ghpib2gy1sqpml7dbnhr1vbr43fs2pqkd09i4w3nmgpic9";
   };
 
-  nativeBuildInputs = [autoreconfHook];
-  buildInputs = [ApplicationServices];
-  configureFlags = [
-    "--with-macosx-sdk=/homeless-shelter"
-
-    # needed to prevent duti from trying to guess our sdk
-    # NOTE: this is different than stdenv.hostPlatform.config!
-    "--host=x86_64-apple-darwin18"
+  patches = [
+    ./buildConfigure.patch
   ];
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
     description = "Command-line tool to select default applications for document types and URL schemes on Mac OS X";
@@ -29,7 +30,10 @@ stdenv.mkDerivation rec {
       a Microsoft Word document has a UTI of com.microsoft.word.doc. Using duti, the
       user can change which application acts as the default handler for a given UTI.
     '';
-    maintainers = with maintainers; [matthewbauer];
+    maintainers = with maintainers; [
+      matthewbauer
+      n-hass
+    ];
     platforms = platforms.darwin;
     license = licenses.publicDomain;
     homepage = "https://github.com/moretension/duti/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19100,9 +19100,7 @@ with pkgs;
 
   compressDrvWeb = callPackage ../build-support/compress-drv/web.nix { };
 
-  duti = callPackage ../os-specific/darwin/duti {
-    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
-  };
+  duti = callPackage ../os-specific/darwin/duti { };
 
   dnstracer = callPackage ../tools/networking/dnstracer {
     inherit (darwin) libresolv;


### PR DESCRIPTION
Manual backport of #357745
(cherry picked from commit ed8e72640cb29a8792e99b7aabc740ccd7ebb7fb)

and dependency #357747
(cherry picked from commit e2264471522f5ab2ca2942e8b4410e2ce0b749fd)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
