### PR TITLE
nixos/scx: cleanup

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  utils,
   ...
 }:
 let
@@ -61,6 +62,7 @@ in
 
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.singleLineStr;
+      default = [ ];
       example = [
         "--slice-us 5000"
         "--verbose"
@@ -90,9 +92,13 @@ in
 
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${lib.getExe' cfg.package cfg.scheduler} ${lib.concatStringsSep " " cfg.extraArgs}";
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            (lib.getExe' cfg.package cfg.scheduler)
+          ]
+          ++ cfg.extraArgs
+        );
         Restart = "on-failure";
-        StandardError = "journal";
       };
 
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Followup of https://github.com/NixOS/nixpkgs/pull/352300#discussion_r1850835967
- use utils.escapeSystemdExecArgs in systemd service

- remove StandardError="journal" as it's already default

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - With my own configuration
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
