### PR TITLE
nixos/etesync-dav: update default apiurl

### DIFF
--- a/nixos/modules/services/misc/etesync-dav.nix
+++ b/nixos/modules/services/misc/etesync-dav.nix
@@ -20,7 +20,7 @@ in
 
       apiUrl = lib.mkOption {
         type = lib.types.str;
-        default = "https://api.etesync.com/";
+        default = "https://api.etebase.com/partner/etesync/";
         description = "The url to the etesync API.";
       };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


I updated the default api url of etesync-dav to correspond with the upstream default. This was changed upstream in September 2020: https://github.com/etesync/etesync-dav/commit/c9f89e761a914b3fe562917c732dadd275b54bbf and https://github.com/etesync/etesync-dav/commit/dd5440972d1ef6e61887abae9c0f96f2793919b2

Fixes #251635
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Fixed during #ZurichZHF

