### PR TITLE
torq: Pin Go to version 1.22

### DIFF
--- a/pkgs/by-name/to/torq/package.nix
+++ b/pkgs/by-name/to/torq/package.nix
@@ -1,7 +1,8 @@
-{ lib
-, buildGoModule
-, buildNpmPackage
-, fetchFromGitHub
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
 }:
 
 let
@@ -23,8 +24,8 @@ let
 
     # copied from upstream Dockerfile
     npmInstallFlags = [ "--legacy-peer-deps" ];
-    TSX_COMPILE_ON_ERROR="true";
-    ESLINT_NO_DEV_ERRORS="true";
+    TSX_COMPILE_ON_ERROR = "true";
+    ESLINT_NO_DEV_ERRORS = "true";
 
     # override npmInstallHook, we only care about the build/ directory
     installPhase = ''
@@ -55,7 +56,10 @@ buildGoModule rec {
     description = "Capital management tool for lightning network nodes";
     license = licenses.mit;
     homepage = "https://github.com/lncapital/torq";
-    maintainers = with maintainers; [ mmilata prusnak ];
+    maintainers = with maintainers; [
+      mmilata
+      prusnak
+    ];
     mainProgram = "torq";
   };
 }

--- a/pkgs/by-name/to/torq/package.nix
+++ b/pkgs/by-name/to/torq/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGo122Module,
   buildNpmPackage,
   fetchFromGitHub,
 }:
@@ -34,7 +34,7 @@ let
     '';
   };
 in
-buildGoModule rec {
+buildGo122Module rec {
   inherit pname version src;
 
   vendorHash = "sha256-bvisI589Gq9IdyJEqI+uzs3iDPOTUkq95P3n/KoFhF0=";

--- a/pkgs/by-name/to/torq/package.nix
+++ b/pkgs/by-name/to/torq/package.nix
@@ -9,6 +9,8 @@ let
   pname = "torq";
   version = "0.18.19";
 
+  # This specific tag doesn't exist anymore on Github and the newer tags don't
+  # contain the source anymore.
   src = fetchFromGitHub {
     owner = "lncapital";
     repo = pname;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The version of torq in Nixpkgs only builds with Go 1.22.
Broken since: https://hydra.nixos.org/build/274854033

I can't update it because doesn't contain any code anymore and the specific tag is missing on the repository: https://github.com/lncapital/torq/tags

Maybe @mmilata or @prusnak know where the source is now located?

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
