### PR TITLE
otree: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ot/otree/package.nix
+++ b/pkgs/by-name/ot/otree/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "otree";
+  version = "v0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "fioncat";
+    repo = "otree";
+    rev = version;
+    hash = "sha256-WvoiTu6erNI5Cb9PSoHgL6+coIGWLe46pJVXBZHOLTE=";
+  };
+
+  cargoHash = "sha256-2eFGTpI4yevcxtgtGH+AufMDqsuhOH9CiyXUpjtdTDE=";
+
+  meta = {
+    description = "Command line tool to view objects (json/yaml/toml) in TUI tree widget";
+    homepage = "https://github.com/fioncat/otree";
+    changelog = "https://github.com/fioncat/otree/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "otree";
+    maintainers = with lib.maintainers; [
+      anas
+      kiara
+    ];
+  };
+}


### PR DESCRIPTION
adds [`otree`](https://github.com/fioncat/otree), a command line tool to view objects (JSON/YAML/TOML) in a TUI tree widget.

supersedes #316252.

to try the package:

```
nix run github:KiaraGrouwstra/nixpkgs/by-name/otree#otree
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
