### PR TITLE
openjpeg: disable more tests

### DIFF
--- a/pkgs/by-name/op/openjpeg/exclude-tests
+++ b/pkgs/by-name/op/openjpeg/exclude-tests
@@ -6,6 +6,7 @@ NR-C1P1-p1_03.j2k-compare2base
 NR-C1P1-p1_04.j2k-compare2base
 NR-C1P1-p1_05.j2k-compare2base
 NR-JP2-file2.jp2-compare2base
+NR-JP2-file3.jp2-compare2base
 NR-RIC-subsampling_1.jp2-compare2base
 NR-RIC-subsampling_2.jp2-compare2base
 NR-RIC-zoo1.jp2-compare2base
@@ -28,6 +29,7 @@ NR-DEC-issue208.jp2-69-decode-md5
 NR-DEC-issue211.jp2-70-decode-md5
 NR-DEC-issue226.j2k-74-decode
 NR-DEC-issue226.j2k-74-decode-md5
+NR-DEC-issue414.jp2-110-decode-md5
 NR-DEC-p1_04.j2k-124-decode-md5
 NR-DEC-p1_04.j2k-125-decode-md5
 NR-DEC-p1_04.j2k-126-decode-md5
@@ -35,6 +37,7 @@ NR-DEC-p1_04.j2k-127-decode-md5
 NR-DEC-p1_04.j2k-128-decode-md5
 NR-DEC-p1_04.j2k-129-decode-md5
 NR-DEC-p1_04.j2k-131-decode-md5
+NR-DEC-p1_04.j2k-134-decode-md5
 NR-DEC-p1_04.j2k-138-decode-md5
 NR-DEC-p1_04.j2k-140-decode-md5
 NR-DEC-p0_04.j2k-166-decode-md5


### PR DESCRIPTION
These were missed in #355345, I guess.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).