### PR TITLE
tree-sitter: update webui fix-paths.patch

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/fix-paths.patch
+++ b/pkgs/development/tools/parsing/tree-sitter/fix-paths.patch
@@ -1,11 +1,11 @@
 diff --git a/cli/loader/src/lib.rs b/cli/loader/src/lib.rs
-index 9c1d8dfc..a5cfc74c 100644
+index 4e3effed..74b4d3e3 100644
 --- a/cli/loader/src/lib.rs
 +++ b/cli/loader/src/lib.rs
-@@ -747,7 +747,7 @@ impl Loader {
-             Podman,
+@@ -969,7 +969,7 @@ impl Loader {
          }
  
+         let root_path = root_path.unwrap_or(src_path);
 -        let emcc_name = if cfg!(windows) { "emcc.bat" } else { "emcc" };
 +        let emcc_name = if cfg!(windows) { "emcc.bat" } else { "@emcc@" };
  


### PR DESCRIPTION
Currently, if you enable `webUISupport`, you'll get the following error:

```
applying patch /nix/store/j2x51yqkckjmm8yn4s9nm66ba3d187y2-fix-paths.patch
patching file cli/loader/src/lib.rs
Hunk #1 FAILED at 747.
1 out of 1 hunk FAILED -- saving rejects to file cli/loader/src/lib.rs.rej
```

This PR updates the patch to work on the latest version. There is also the option of using like a sed instead of a patch to be more reliable? Just going with what is already here though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc maintainer @Profpatsch

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
