### PR TITLE
codecov-cli: init at 9.1.1

### DIFF
--- a/pkgs/by-name/co/codecov-cli/package.nix
+++ b/pkgs/by-name/co/codecov-cli/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchPypi,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "codecov-cli";
+  version = "9.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-jaljYA2x2nZUOn9vy/CdtxfGjQKHtrtY13WmBdsICTA=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "httpx"
+    "responses"
+    "tree-sitter"
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    httpx
+    ijson
+    pyyaml
+    regex
+    responses
+    test-results-parser
+    tree-sitter
+  ];
+
+  meta = {
+    description = "Codecov Command Line Interface";
+    homepage = "https://github.com/codecov/codecov-cli";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/test-results-parser/default.nix
+++ b/pkgs/development/python-modules/test-results-parser/default.nix
@@ -1,0 +1,44 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  pytestCheckHook,
+  rustPlatform,
+}:
+
+buildPythonPackage rec {
+  pname = "test-results-parser";
+  version = "0.5.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "test_results_parser";
+    hash = "sha256-DaUSTu4Hg9SbJwBd3PlMcIAm/o63Q1yM5E7dVxbOwM8=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit pname version src;
+    hash = "sha256-dhreAWm/Hses/N3XocYX7IZru9nYJqDrmTnJPkKaOwY=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  pythonImpotsCheck = [
+    "test_results_parser"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Codecov test results parser";
+    homepage = "https://github.com/codecov/test-results-parser";
+    license = lib.licenses.fsl11Asl20;
+    maintainers = with lib.maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15767,6 +15767,8 @@ self: super: with self; {
 
   tesserocr = callPackage ../development/python-modules/tesserocr { };
 
+  test-results-parser = callPackage ../development/python-modules/test-results-parser { };
+
   testcontainers = callPackage ../development/python-modules/testcontainers { };
 
   testfixtures = callPackage ../development/python-modules/testfixtures { };


### PR DESCRIPTION
Adds two packages, `codecov-cli` and its dependency `test-results-parser`. NB: `codecov-cli` is free software, while `test-results-parser` is not.

Tested with the `binary` option of the [Codecov GitHub action](https://github.com/codecov/codecov-action) using a NixOS self-hosted GitHub runner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
