### PR TITLE
python312Packages.debugpy: 1.8.8 -> 1.8.9

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -13,16 +13,18 @@
   pytest-timeout,
   importlib-metadata,
   psutil,
+  untangle,
   django,
-  requests,
+  flask,
   gevent,
   numpy,
-  flask,
+  requests,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.8.8";
+  version = "1.8.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -31,7 +33,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "debugpy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-zkNV+tFRAxTdl+lCPD4XYI1Oz0dVyX4GGuNdfzy2sJU=";
+    hash = "sha256-JgYGdCGzzktigjEKMPbkcSJlFPYSEFEJvmIFfR0qSZM=";
   };
 
   patches =
@@ -104,6 +106,7 @@ buildPythonPackage rec {
     ## Used by test helpers:
     importlib-metadata
     psutil
+    untangle
 
     ## Used in Python code that is run/debugged by the tests:
     django
@@ -111,6 +114,7 @@ buildPythonPackage rec {
     gevent
     numpy
     requests
+    typing-extensions
   ];
 
   preCheck =

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,5 +1,5 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index a1a852a0..0bb91807 100644
+index 2e328f61..ba7221fe 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 @@ -412,7 +412,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show

--- a/pkgs/development/python-modules/debugpy/hardcode-lldb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-lldb.patch
@@ -1,5 +1,5 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index 0bb91807..8026a5ad 100644
+index ba7221fe..24efc1ed 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 @@ -503,7 +503,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index 1bfba237..414bb4d5 100644
+index d16a27c5..a7e407e1 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -12,7 +12,6 @@ import sys
@@ -27,7 +27,7 @@ index 1bfba237..414bb4d5 100644
          long_description=long_description,
          long_description_content_type="text/markdown",
 diff --git a/src/debugpy/public_api.py b/src/debugpy/public_api.py
-index 9d0f705a..ee0b26ca 100644
+index c61a2607..f26f8272 100644
 --- a/src/debugpy/public_api.py
 +++ b/src/debugpy/public_api.py
 @@ -7,8 +7,6 @@ from __future__ import annotations
@@ -39,7 +39,7 @@ index 9d0f705a..ee0b26ca 100644
  
  # Expose debugpy.server API from subpackage, but do not actually import it unless
  # and until a member is invoked - we don't want the server package loaded in the
-@@ -191,4 +189,4 @@ def trace_this_thread(__should_trace: bool):
+@@ -192,4 +190,4 @@ def trace_this_thread(__should_trace: bool):
      """
  
  

--- a/pkgs/development/python-modules/debugpy/skip-attach-pid-tests.patch
+++ b/pkgs/development/python-modules/debugpy/skip-attach-pid-tests.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/debug/runners.py b/tests/debug/runners.py
-index dc60d0ae..cf4a06a3 100644
+index cac4fbf5..079bb743 100644
 --- a/tests/debug/runners.py
 +++ b/tests/debug/runners.py
 @@ -163,7 +163,7 @@ def _attach_common_config(session, target, cwd):
@@ -12,10 +12,10 @@ index dc60d0ae..cf4a06a3 100644
  
      log.info("Attaching {0} to {1} by PID.", session, target)
 diff --git a/tests/debugpy/test_attach.py b/tests/debugpy/test_attach.py
-index 017d7f59..63e86328 100644
+index 78453bfe..458716af 100644
 --- a/tests/debugpy/test_attach.py
 +++ b/tests/debugpy/test_attach.py
-@@ -151,8 +151,7 @@ def test_reattach(pyfile, target, run):
+@@ -153,8 +153,7 @@ def test_reattach(pyfile, target, run):
  
  
  @pytest.mark.parametrize("pid_type", ["int", "str"])
@@ -24,4 +24,4 @@ index 017d7f59..63e86328 100644
 +@pytest.mark.skip(
      reason="https://github.com/microsoft/debugpy/issues/311",
  )
- def test_attach_pid_client(pyfile, target, pid_type):
+ @pytest.mark.flaky(retries=2, delay=1)


### PR DESCRIPTION
https://github.com/microsoft/debugpy/releases/tag/v1.8.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
