### PR TITLE
opentofu: patch plugins to use opentofu plugin registry

### DIFF
--- a/pkgs/by-name/op/opentofu/package.nix
+++ b/pkgs/by-name/op/opentofu/package.nix
@@ -1,18 +1,19 @@
-{ stdenv
-, lib
-, buildGoModule
-, fetchFromGitHub
-, makeWrapper
-, coreutils
-, runCommand
-, runtimeShell
-, writeText
-, terraform-providers
-, installShellFiles
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  coreutils,
+  runCommand,
+  runtimeShell,
+  writeText,
+  terraform-providers,
+  installShellFiles,
 }:
 
 let
-  package =  buildGoModule rec {
+  package = buildGoModule rec {
     pname = "opentofu";
     version = "1.8.6";
 
@@ -24,7 +25,12 @@ let
     };
 
     vendorHash = "sha256-MHdEY2nlUGTKybMPran5mTXlAlTFilfrY5K2sMlPe5U=";
-    ldflags = [ "-s" "-w" "-X" "github.com/opentofu/opentofu/version.dev=no" ];
+    ldflags = [
+      "-s"
+      "-w"
+      "-X"
+      "github.com/opentofu/opentofu/version.dev=no"
+    ];
 
     postConfigure = ''
       # speakeasy hardcodes /bin/stty https://github.com/bgentry/speakeasy/issues/22
@@ -37,7 +43,9 @@ let
 
     passthru = {
       inherit full plugins withPlugins;
-      tests = { inherit opentofu_plugins_test; };
+      tests = {
+        inherit opentofu_plugins_test;
+      };
     };
 
     # https://github.com/posener/complete/blob/9a4745ac49b29530e07dc2581745a218b646b7a3/cmd/install/bash.go#L8
@@ -67,29 +75,28 @@ let
 
   full = withPlugins (p: lib.filter lib.isDerivation (lib.attrValues p.actualProviders));
 
-  opentofu_plugins_test = let
-    mainTf = writeText "main.tf" ''
-      terraform {
-        required_providers {
-          random = {
-            source  = "registry.terraform.io/hashicorp/random"
+  opentofu_plugins_test =
+    let
+      mainTf = writeText "main.tf" ''
+        terraform {
+          required_providers {
+            random = {
+              source  = "registry.terraform.io/hashicorp/random"
+            }
           }
         }
-      }
 
-      resource "random_id" "test" {}
-    '';
-    opentofu = package.withPlugins (p: [ p.random ]);
-    test = runCommand "opentofu-plugin-test" {
-      buildInputs = [ opentofu ];
-    } ''
-      # make it fail outside of sandbox
-      export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0
-      cp ${mainTf} main.tf
-      tofu init
-      touch $out
-    '';
-  in
+        resource "random_id" "test" {}
+      '';
+      opentofu = package.withPlugins (p: [ p.random ]);
+      test = runCommand "opentofu-plugin-test" { buildInputs = [ opentofu ]; } ''
+        # make it fail outside of sandbox
+        export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0
+        cp ${mainTf} main.tf
+        tofu init
+        touch $out
+      '';
+    in
     test;
 
   plugins = removeAttrs terraform-providers [
@@ -98,18 +105,18 @@ let
     "recurseForDerivations"
   ];
 
-  withPlugins = plugins:
+  withPlugins =
+    plugins:
     let
       actualPlugins = plugins package.plugins;
 
       # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-      wrapperInputs = lib.unique (lib.flatten
-        (lib.catAttrs "propagatedBuildInputs"
-          (builtins.filter (x: x != null) actualPlugins)));
+      wrapperInputs = lib.unique (
+        lib.flatten (lib.catAttrs "propagatedBuildInputs" (builtins.filter (x: x != null) actualPlugins))
+      );
 
       passthru = {
-        withPlugins = newplugins:
-          withPlugins (x: newplugins x ++ actualPlugins);
+        withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);
 
         # Expose wrappers around the override* functions of the terraform
         # derivation.
@@ -131,21 +138,20 @@ let
         # 3. Specifying overrides on the wrapper is unsupported.
         #
         # See nixpkgs#158620 for details.
-        overrideDerivation = f:
-          (package.overrideDerivation f).withPlugins plugins;
-        overrideAttrs = f:
-          (package.overrideAttrs f).withPlugins plugins;
-        override = x:
-          (package.override x).withPlugins plugins;
+        overrideDerivation = f: (package.overrideDerivation f).withPlugins plugins;
+        overrideAttrs = f: (package.overrideAttrs f).withPlugins plugins;
+        override = x: (package.override x).withPlugins plugins;
       };
-      # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
-      # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
     in
-      if actualPlugins == [ ] then
-        package.overrideAttrs
-          (orig: { passthru = orig.passthru // passthru; })
-      else
-        lib.appendToName "with-plugins" (stdenv.mkDerivation {
+    # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
+    # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
+    if actualPlugins == [ ] then
+      package.overrideAttrs (orig: {
+        passthru = orig.passthru // passthru;
+      })
+    else
+      lib.appendToName "with-plugins" (
+        stdenv.mkDerivation {
           inherit (package) meta pname version;
           nativeBuildInputs = [ makeWrapper ];
 
@@ -178,6 +184,7 @@ let
               --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
               --prefix PATH : "${lib.makeBinPath wrapperInputs}"
           '';
-        });
+        }
+      );
 in
 package

--- a/pkgs/by-name/op/opentofu/package.nix
+++ b/pkgs/by-name/op/opentofu/package.nix
@@ -99,11 +99,24 @@ let
     in
     test;
 
-  plugins = removeAttrs terraform-providers [
-    "override"
-    "overrideDerivation"
-    "recurseForDerivations"
-  ];
+  plugins =
+    lib.mapAttrs
+      (
+        _: provider:
+        # use opentofu plugin registry over terraform's
+        provider.override (oldArgs: {
+          provider-source-address = lib.replaceStrings [ "https://registry.terraform.io/providers" ] [
+            "registry.opentofu.org"
+          ] oldArgs.homepage;
+        })
+      )
+      (
+        removeAttrs terraform-providers [
+          "override"
+          "overrideDerivation"
+          "recurseForDerivations"
+        ]
+      );
 
   withPlugins =
     plugins:


### PR DESCRIPTION
Patch `opentofu`'s plugins so as to use its own registry, rather than Terraform's, as per @yajo's comment at https://github.com/NixOS/nixpkgs/issues/283015#issuecomment-2009610478.

closes #283015.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
