### PR TITLE
adminer-pematon: init at 4.12

### DIFF
--- a/pkgs/by-name/ad/adminer-pematon/index.php
+++ b/pkgs/by-name/ad/adminer-pematon/index.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace nixos {
+    use AdminerPlugin;
+
+    use function sprintf;
+
+    function adminer_object(): object
+    {
+        require_once __DIR__ . '/plugins/plugin.php';
+
+        if (!file_exists(__DIR__ . '/plugins.json')) {
+            return new AdminerPlugin();
+        }
+
+        $plugins = array_map(
+            static function (string $name): ?object {
+                $plugin = sprintf('%s/plugins/%s.php', __DIR__, $name);
+
+                if (!is_readable($plugin)) {
+                    return null;
+                }
+
+                require $plugin;
+
+                preg_match_all('/(\w+)/', $name, $matches);
+
+                return new sprintf('Adminer%s', implode('', array_map('ucfirst', $matches[1])));
+            },
+            json_decode(file_get_contents(sprintf('%s/plugins.json', __DIR__), true))
+        );
+
+        return new AdminerPlugin(array_filter($plugins));
+    }
+}
+
+namespace {
+	function adminer_object() {
+		return \nixos\adminer_object();
+	}
+
+	require(__DIR__ . '/adminer.php');
+}

--- a/pkgs/by-name/ad/adminer-pematon/package.nix
+++ b/pkgs/by-name/ad/adminer-pematon/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  php,
+  writeText,
+  nix-update-script,
+  theme ? null,
+  plugins ? [ ],
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "adminer-pematon";
+  version = "4.12";
+
+  src = fetchFromGitHub {
+    owner = "pematon";
+    repo = "adminer";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-ExCHEsZ+VFmrom3632/1OOjb3zbZgiaZJDapBkBGUnQ=";
+  };
+
+  nativeBuildInputs = [
+    php
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    php compile.php
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp temp/adminer-${finalAttrs.version}.php $out/adminer.php
+    cp ${./index.php} $out/index.php
+
+    ${lib.optionalString (theme != null) ''
+      cp designs/${theme}/adminer.css $out/adminer.css
+    ''}
+
+    # Copy base plugin
+    mkdir -p $out/plugins
+    cp plugins/plugin.php $out/plugins/plugin.php
+
+    ${lib.optionalString (plugins != [ ]) ''
+      cp plugins/*.php $out/plugins/
+      cp ${writeText "$out/plugins.json" ''
+        ${toString (builtins.toJSON plugins)}
+      ''} $out/plugins.json
+    ''}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Database management in a single PHP file (Pematon fork)";
+    homepage = "https://github.com/pematon/adminer";
+    license = with lib.licenses; [
+      asl20
+      gpl2Only
+    ];
+    maintainers = with lib.maintainers; [
+      johnrtitor
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Link: https://github.com/pematon/adminer

This is an active fork of adminer by pematon.
Seems to be in rapid development.

The index.php is required for plugins to work, and the upstream provides an example, but not a ".php" file in the src. We need to modify it for NixOS use anyway.

The index.php file is the same one used by `adminerevo`, I wasn't sure if I should reference a file out of the package's dir, so I copied it here.

Closes https://github.com/NixOS/nixpkgs/issues/353454

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
