### PR TITLE
swiftpm2nix: use nurl instead of nix-prefetch-git

### DIFF
--- a/pkgs/development/compilers/swift/swiftpm2nix/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm2nix/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, makeWrapper, jq, nix-prefetch-git }:
+{ lib, stdenv, callPackage, makeWrapper, jq, nurl }:
 
 stdenv.mkDerivation {
   name = "swiftpm2nix";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   installPhase = ''
     install -vD ${./swiftpm2nix.sh} $out/bin/swiftpm2nix
     wrapProgram $out/bin/$name \
-      --prefix PATH : ${lib.makeBinPath [ jq nix-prefetch-git ]} \
+      --prefix PATH : ${lib.makeBinPath [ jq nurl ]} \
   '';
 
   preferLocalBuild = true;

--- a/pkgs/development/compilers/swift/swiftpm2nix/swiftpm2nix.sh
+++ b/pkgs/development/compilers/swift/swiftpm2nix/swiftpm2nix.sh
@@ -23,9 +23,9 @@ hashes=""
 jq -r '.object.dependencies[] | "\(.subpath) \(.packageRef.location) \(.state.checkoutState.revision)"' $stateFile \
 | while read -r name url rev; do
   echo >&2 "-- Fetching $name"
-  sha256="$(nix-prefetch-git --fetch-submodules $url $rev | jq -r .sha256)"
-  hashes+="
-    \"$name\" = \"$sha256\";"
+  hash="$(nurl "$url" "$rev" --json --submodules=true --fetcher=fetchgit | jq -r .args.hash)"
+hashes+="
+    \"$name\" = \"$hash\";"
   echo >&2
 done
 hashes+=$'\n'"  "


### PR DESCRIPTION
Supersedes #358352 with the suggestion of @emilazy.

Use [nurl](https://github.com/nix-community/nurl) for fetching the dependencies and computing their hashes. Note that the old script used the non-SRI base32 hash output of `nix-prefetch-git`, while `nurl` returns the SRI base64 hash, so this PR results in different generated hash values , but this shouldn't cause an issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
