### PR TITLE
amazon-cloudwatch-agent: let users specify configuration file paths

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -134,14 +134,16 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/modules/installer/sd-card/
 
 # Amazon
-/nixos/modules/virtualisation/amazon-init.nix     @arianvp
-/nixos/modules/virtualisation/ec2-data.nix        @arianvp
-/nixos/modules/virtualisation/amazon-options.nix  @arianvp
-/nixos/modules/virtualisation/amazon-image.nix    @arianvp
-/nixos/maintainers/scripts/ec2/                   @arianvp
-/nixos/modules/services/misc/amazon-ssm-agent.nix @arianvp
-/nixos/tests/amazon-ssm-agent.nix                 @arianvp
-/nixos/modules/system/boot/grow-partition.nix     @arianvp
+/nixos/modules/virtualisation/amazon-init.nix                  @arianvp
+/nixos/modules/virtualisation/ec2-data.nix                     @arianvp
+/nixos/modules/virtualisation/amazon-options.nix               @arianvp
+/nixos/modules/virtualisation/amazon-image.nix                 @arianvp
+/nixos/maintainers/scripts/ec2/                                @arianvp
+/nixos/modules/services/misc/amazon-ssm-agent.nix              @arianvp
+/nixos/tests/amazon-ssm-agent.nix                              @arianvp
+/nixos/modules/system/boot/grow-partition.nix                  @arianvp
+/nixos/modules/services/monitoring/amazon-cloudwatch-agent.nix @philipmw
+/nixos/tests/amazon-cloudwatch-agent.nix                       @philipmw
 
 # nixos-rebuild-ng
 /pkgs/by-name/ni/nixos-rebuild-ng                 @thiagokokada

--- a/nixos/tests/amazon-cloudwatch-agent.nix
+++ b/nixos/tests/amazon-cloudwatch-agent.nix
@@ -27,7 +27,6 @@ import ./make-test-python.nix (
   in
   {
     name = "amazon-cloudwatch-agent";
-    meta.maintainers = pkgs.amazon-cloudwatch-agent.meta.maintainers;
 
     nodes.machine =
       { config, pkgs, ... }:

--- a/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
+++ b/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
@@ -16,13 +16,13 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-cloudwatch-agent";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-gJrK+ai+EEKvBErjOyvu677WykUPuxYy9NrR+qV2yyo=";
   };
 
   vendorHash = "sha256-OQSl7nFvnDjJbs756QN5ZE/Dx/AZqxsijG0Ks7FYCB8=";
 
-  # See the list in https://github.com/aws/amazon-cloudwatch-agent/blob/v1.300048.1/Makefile#L68-L77.
+  # See the list in https://github.com/aws/amazon-cloudwatch-agent/blob/v1.300049.1/Makefile#L68-L77.
   subPackages = [
     "cmd/config-downloader"
     "cmd/config-translator"
@@ -32,7 +32,7 @@ buildGoModule rec {
     "cmd/amazon-cloudwatch-agent-config-wizard"
   ];
 
-  # See https://github.com/aws/amazon-cloudwatch-agent/blob/v1.300048.1/Makefile#L57-L64.
+  # See https://github.com/aws/amazon-cloudwatch-agent/blob/v1.300049.1/Makefile#L57-L64.
   #
   # Needed for "amazon-cloudwatch-agent -version" to not show "Unknown".
   postInstall = ''
@@ -42,6 +42,8 @@ buildGoModule rec {
   doInstallCheck = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgram = "${builtins.placeholder "out"}/bin/amazon-cloudwatch-agent";
 
   versionCheckProgramArg = "-version";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Let users specify configuration file paths.

This is to allow dynamic configuration at runtime (mostly during boot since the systemd unit won't restart unless something runs `nixos-rebuild switch`/`test`).

Without this feature, users creating NixOS VM images need to create 1 image per agent configuration permutation if they want immutable images (i.e. don't run `nixos-rebuild switch` on boot).

This can result in a lot of near-identical images whose only difference is a few options in their CloudWatch Agent configuration (e.g. region option for multi-region AWS deployments). Since VM images are usually on the order of GBs, we end up with a lot of wasted space in Nix stores.

With this feature, users can write their own systemd units that dynamically create configurations (e.g. using information from IMDS, AWS SSM Parameter Store, or AWS Secrets Manager) and write them to a static path.

The tradeoff, however, is that mutable configuration files can cause drift if a change isn't followed by a `systemctl restart amazon-cloudwatch-agent.service`. `nixos-rebuild` won't work because we can't access files outside the Nix store in restricted evaluation mode (e.g. can't hash the file and feed it into `restartTriggers`).

Also doing some small cleanup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

#### Maintainer Pings

@philipmw 