### PR TITLE
common-updater-scripts: update-source-version option to update SOURCE_DATE_EPOCH

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -12,7 +12,8 @@ usage() {
     echo "Usage: $scriptName <attr> <version> [<new-source-hash>] [<new-source-url>]"
     echo "                              [--version-key=<version-key>] [--source-key=<source-key>]"
     echo "                              [--system=<system>] [--file=<file-to-update>] [--rev=<revision>]"
-    echo "                              [--ignore-same-hash] [--ignore-same-version] [--print-changes]"
+    echo "                              [--source-date-epoch=<source-date-epoch>] [--ignore-same-hash]"
+    echo "                              [--ignore-same-version] [--print-changes]"
     echo ""
     echo "The <version> positional argument is also optional when passing --ignore-same-version."
 }
@@ -40,6 +41,9 @@ for arg in "$@"; do
         ;;
         --rev=*)
             newRevision="${arg#*=}"
+        ;;
+        --source-date-epoch=*)
+            newSourceDateEpoch="${arg#*=}"
         ;;
         --ignore-same-hash)
             ignoreSameHash="true"
@@ -170,6 +174,13 @@ if [[ -n "$newRevision" ]]; then
     fi
 fi
 
+if [[ -n "$newSourceDateEpoch" ]]; then
+    oldSourceDateEpoch=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.SOURCE_DATE_EPOCH" | tr -d '"')
+    if [[ -z "$oldSourceDateEpoch" ]]; then
+        die "Couldn't evaluate source SOURCE_DATE_EPOCH from '$attr'!"
+    fi
+fi
+
 # Escape regex metacharacter that are allowed in store path names
 oldVersionEscaped=$(echo "$oldVersion" | sed -re 's|[.+]|\\&|g')
 
@@ -248,6 +259,14 @@ if [[ -n "$newRevision" ]]; then
     sed -i.cmp "$nixFile" -re "s|\"$oldRevision\"|\"$newRevision\"|"
     if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source revision '$oldRevision' to '$newRevision' in '$attr'!"
+    fi
+fi
+
+# Replace new SOURCE_DATE_EPOCH, if given
+if [[ -n "$newSourceDateEpoch" ]]; then
+    sed -i.cmp "$nixFile" -re "s|$oldSourceDateEpoch|$newSourceDateEpoch|"
+    if cmp -s "$nixFile" "$nixFile.cmp"; then
+        die "Failed to replace source SOURCE_DATE_EPOCH '$oldSourceDateEpoch' to '$newSourceDateEpoch' in '$attr'!"
     fi
 fi
 


### PR DESCRIPTION
Adds an update-source-version option to conveniently update the `SOURCE_DATE_EPOCH` attr.

This is useful for update scripts that need to update `SOURCE_DATE_EPOCH` with each version update. It can also be seen as a step in the direction mentioned in https://github.com/NixOS/nixpkgs/pull/256270#issuecomment-2492310370.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
