### PR TITLE
caddy: add suport for compiling Caddy with plugins

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -160,6 +160,21 @@
 
 - `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
+- Caddy can now be built with plugins by using `caddy.withPlugins`, a `passthru` function that accepts an attribute set as a parameter. The `plugins` argument represents a list of Caddy plugins, with each Caddy plugin being a versioned module. The `hash` argument represents the `vendorHash` of the resulting Caddy source code with the plugins added.
+
+  Example:
+  ```nix
+  services.caddy = {
+    enable = true;
+    package = pkgs.caddy.withPlugins {
+      plugins = [ "github.com/caddy-dns/powerdns@v1.0.1" ];
+      hash = "sha256-F/jqR4iEsklJFycTjSaW8B/V3iTGqqGOzwYBUXxRKrc=";
+    };
+  };
+  ```
+
+  To get the necessary hash of the vendored dependencies, omit `hash`. The build will fail and tell you the correct value.
+
 - `programs.fzf.keybindings` now supports the fish shell.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -6,6 +6,10 @@
 , testers
 , installShellFiles
 , stdenv
+, go
+, xcaddy
+, cacert
+, git
 }:
 let
   version = "2.8.4";
@@ -32,7 +36,8 @@ buildGoModule {
   subPackages = [ "cmd/caddy" ];
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X github.com/caddyserver/caddy/v2.CustomVersion=${version}"
   ];
 
@@ -61,12 +66,83 @@ buildGoModule {
       --zsh <($out/bin/caddy completion zsh)
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) caddy;
-    version = testers.testVersion {
-      command = "${caddy}/bin/caddy version";
-      package = caddy;
+  passthru = {
+    tests = {
+      inherit (nixosTests) caddy;
+      version = testers.testVersion {
+        command = "${caddy}/bin/caddy version";
+        package = caddy;
+      };
     };
+    withPlugins =
+      { plugins
+      , hash ? lib.fakeHash
+      }: caddy.overrideAttrs (finalAttrs: prevAttrs:
+      let
+        pluginsSorted = builtins.sort builtins.lessThan plugins;
+        pluginsList = lib.concatMapStrings (plugin: "${plugin}-") pluginsSorted;
+        pluginsHash = builtins.hashString "md5" pluginsList;
+        pluginsWithoutVersion = builtins.filter (p: !lib.hasInfix "@" p) pluginsSorted;
+      in
+      assert lib.assertMsg (builtins.length pluginsWithoutVersion == 0)
+        "All plugins should have a version (eg ${builtins.elemAt pluginsWithoutVersion 0}@x.y.z)!";
+      {
+        vendorHash = null;
+        subPackages = [ "." ];
+
+        src = stdenv.mkDerivation {
+          pname = "caddy-src-with-plugins-${pluginsHash}";
+          version = finalAttrs.version;
+
+          nativeBuildInputs = [
+            go
+            xcaddy
+            cacert
+            git
+          ];
+          dontUnpack = true;
+          buildPhase =
+            let
+              withArgs = lib.concatMapStrings (plugin: "--with ${plugin} ") pluginsSorted;
+            in
+            ''
+              export GOCACHE=$TMPDIR/go-cache
+              export GOPATH="$TMPDIR/go"
+              XCADDY_SKIP_BUILD=1 TMPDIR="$PWD" xcaddy build v${finalAttrs.version} ${withArgs}
+              (cd buildenv* && go mod vendor)
+            '';
+          installPhase = ''
+            mv buildenv* $out
+          '';
+
+          outputHashMode = "recursive";
+          outputHash = hash;
+          outputHashAlgo = "sha256";
+        };
+
+
+        doInstallCheck = true;
+        installCheckPhase = ''
+          runHook preInstallCheck
+
+          ${lib.toShellVar "notfound" pluginsSorted}
+          while read kind module version; do
+            [[ "$kind" = "dep" ]] || continue
+            module="''${module}@''${version}"
+            for i in "''${!notfound[@]}"; do
+              if [[ ''${notfound[i]} = ''${module} ]]; then
+                unset 'notfound[i]'
+              fi
+            done
+          done < <($out/bin/caddy build-info)
+          if (( ''${#notfound[@]} )); then
+            >&2 echo "Plugins not found: ''${notfound[@]}"
+            exit 1
+          fi
+
+          runHook postInstallCheck
+        '';
+      });
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -1,5 +1,6 @@
 { lib
 , buildGoModule
+, callPackage
 , fetchFromGitHub
 , nixosTests
 , caddy
@@ -74,75 +75,7 @@ buildGoModule {
         package = caddy;
       };
     };
-    withPlugins =
-      { plugins
-      , hash ? lib.fakeHash
-      }: caddy.overrideAttrs (finalAttrs: prevAttrs:
-      let
-        pluginsSorted = builtins.sort builtins.lessThan plugins;
-        pluginsList = lib.concatMapStrings (plugin: "${plugin}-") pluginsSorted;
-        pluginsHash = builtins.hashString "md5" pluginsList;
-        pluginsWithoutVersion = builtins.filter (p: !lib.hasInfix "@" p) pluginsSorted;
-      in
-      assert lib.assertMsg (builtins.length pluginsWithoutVersion == 0)
-        "All plugins should have a version (eg ${builtins.elemAt pluginsWithoutVersion 0}@x.y.z)!";
-      {
-        vendorHash = null;
-        subPackages = [ "." ];
-
-        src = stdenv.mkDerivation {
-          pname = "caddy-src-with-plugins-${pluginsHash}";
-          version = finalAttrs.version;
-
-          nativeBuildInputs = [
-            go
-            xcaddy
-            cacert
-            git
-          ];
-          dontUnpack = true;
-          buildPhase =
-            let
-              withArgs = lib.concatMapStrings (plugin: "--with ${plugin} ") pluginsSorted;
-            in
-            ''
-              export GOCACHE=$TMPDIR/go-cache
-              export GOPATH="$TMPDIR/go"
-              XCADDY_SKIP_BUILD=1 TMPDIR="$PWD" xcaddy build v${finalAttrs.version} ${withArgs}
-              (cd buildenv* && go mod vendor)
-            '';
-          installPhase = ''
-            mv buildenv* $out
-          '';
-
-          outputHashMode = "recursive";
-          outputHash = hash;
-          outputHashAlgo = "sha256";
-        };
-
-
-        doInstallCheck = true;
-        installCheckPhase = ''
-          runHook preInstallCheck
-
-          ${lib.toShellVar "notfound" pluginsSorted}
-          while read kind module version; do
-            [[ "$kind" = "dep" ]] || continue
-            module="''${module}@''${version}"
-            for i in "''${!notfound[@]}"; do
-              if [[ ''${notfound[i]} = ''${module} ]]; then
-                unset 'notfound[i]'
-              fi
-            done
-          done < <($out/bin/caddy build-info)
-          if (( ''${#notfound[@]} )); then
-            >&2 echo "Plugins not found: ''${notfound[@]}"
-            exit 1
-          fi
-
-          runHook postInstallCheck
-        '';
-      });
+    withPlugins = callPackage ./plugins.nix { inherit caddy; };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ca/caddy/plugins.nix
+++ b/pkgs/by-name/ca/caddy/plugins.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  go,
+  xcaddy,
+  cacert,
+  git,
+  caddy,
+}:
+{
+  plugins,
+  hash ? lib.fakeHash,
+}:
+let
+  pluginsSorted = builtins.sort builtins.lessThan plugins;
+  pluginsList = lib.concatMapStrings (plugin: "${plugin}-") pluginsSorted;
+  pluginsHash = builtins.hashString "md5" pluginsList;
+  pluginsWithoutVersion = builtins.filter (p: !lib.hasInfix "@" p) pluginsSorted;
+in
+assert lib.assertMsg (
+  builtins.length pluginsWithoutVersion == 0
+) "All plugins should have a version (eg ${builtins.elemAt pluginsWithoutVersion 0}@x.y.z)!";
+caddy.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    vendorHash = null;
+    subPackages = [ "." ];
+
+    src = stdenv.mkDerivation {
+      pname = "caddy-src-with-plugins-${pluginsHash}";
+      version = finalAttrs.version;
+
+      nativeBuildInputs = [
+        go
+        xcaddy
+        cacert
+        git
+      ];
+      dontUnpack = true;
+      buildPhase =
+        let
+          withArgs = lib.concatMapStrings (plugin: "--with ${plugin} ") pluginsSorted;
+        in
+        ''
+          export GOCACHE=$TMPDIR/go-cache
+          export GOPATH="$TMPDIR/go"
+          XCADDY_SKIP_BUILD=1 TMPDIR="$PWD" xcaddy build v${finalAttrs.version} ${withArgs}
+          (cd buildenv* && go mod vendor)
+        '';
+      installPhase = ''
+        mv buildenv* $out
+      '';
+
+      outputHashMode = "recursive";
+      outputHash = hash;
+      outputHashAlgo = "sha256";
+    };
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      ${lib.toShellVar "notfound" pluginsSorted}
+      while read kind module version; do
+        [[ "$kind" = "dep" ]] || continue
+        module="''${module}@''${version}"
+        for i in "''${!notfound[@]}"; do
+          if [[ ''${notfound[i]} = ''${module} ]]; then
+            unset 'notfound[i]'
+          fi
+        done
+      done < <($out/bin/caddy build-info)
+      if (( ''${#notfound[@]} )); then
+        >&2 echo "Plugins not found: ''${notfound[@]}"
+        exit 1
+      fi
+
+      runHook postInstallCheck
+    '';
+  }
+)

--- a/pkgs/by-name/ca/caddy/plugins.nix
+++ b/pkgs/by-name/ca/caddy/plugins.nix
@@ -12,14 +12,14 @@
   hash ? lib.fakeHash,
 }:
 let
-  pluginsSorted = builtins.sort builtins.lessThan plugins;
+  pluginsSorted = lib.sort lib.lessThan plugins;
   pluginsList = lib.concatMapStrings (plugin: "${plugin}-") pluginsSorted;
   pluginsHash = builtins.hashString "md5" pluginsList;
-  pluginsWithoutVersion = builtins.filter (p: !lib.hasInfix "@" p) pluginsSorted;
+  pluginsWithoutVersion = lib.filter (p: !lib.hasInfix "@" p) pluginsSorted;
 in
 assert lib.assertMsg (
-  builtins.length pluginsWithoutVersion == 0
-) "All plugins should have a version (eg ${builtins.elemAt pluginsWithoutVersion 0}@x.y.z)!";
+  lib.length pluginsWithoutVersion == 0
+) "All plugins should have a version (eg ${lib.elemAt pluginsWithoutVersion 0}@x.y.z)!";
 caddy.overrideAttrs (
   finalAttrs: prevAttrs: {
     vendorHash = null;


### PR DESCRIPTION
This adds a `withPlugins` function to Caddy package.

```nix
services.caddy = {
  enable = true;
  package = pkgs.caddy.withPlugins {
    plugins = [ "github.com/caddy-dns/powerdns@v1.0.1" ];
    hash = "sha256-F/jqR4iEsklJFycTjSaW8B/V3iTGqqGOzwYBUXxRKrc=";
  };
};
```

Fix: #14671 

This is an alternative to #317881 and it relies on xcaddy. Looking at https://github.com/NixOS/nixpkgs/pull/317881#issuecomment-2258807399, I am still missing tests. I am unsure if this is a build test (in `checkPhase`) or a NixOS test. The remaining requirements should be OK (notably use of xcaddy and FOD).

The release notes are missing, I'll add them once this gets a chance to be accepted.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
