### PR TITLE
archivebox: fix build and add singlefile

### DIFF
--- a/pkgs/by-name/ar/archivebox/package.nix
+++ b/pkgs/by-name/ar/archivebox/package.nix
@@ -10,7 +10,6 @@
 , postlight-parser
 , readability-extractor
 , chromium
-, yt-dlp
 }:
 
 let
@@ -34,6 +33,7 @@ let
             "CVE-2022-28346"
           ];
         };
+        dependencies = (old.dependencies or [ ]) ++ (lib.optionals (python.pythonAtLeast "3.12") [ python.pkgs.distutils ]);
       });
       django-extensions = super.django-extensions.overridePythonAttrs (old: rec {
         version = "3.1.5";
@@ -44,6 +44,8 @@ let
           rev = "e43f383dae3a35237e42f6acfe1207a8e7e7bdf5";
           hash = "sha256-NAMa78KhAuoJfp0Cb0Codz84sRfRQ1JhSLNYRI4GBPM=";
         };
+        patches = [ ];
+        postPatch = null;
 
         # possibly a real issue, but that version is not supported anymore
         doCheck = false;
@@ -62,11 +64,11 @@ python.pkgs.buildPythonApplication rec {
     hash = "sha256-hdBUEX2tOWN2b11w6aG3x7MP7KQTj4Rwc2w8XvABGf4=";
   };
 
-  nativeBuildInputs = with python.pkgs; [
+  build-system = with python.pkgs; [
     pdm-backend
   ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  dependencies = with python.pkgs; [
     croniter
     dateparser
     django
@@ -87,7 +89,7 @@ python.pkgs.buildPythonApplication rec {
     "--set RIPGREP_BINARY ${lib.meta.getExe ripgrep}"
     "--set WGET_BINARY ${lib.meta.getExe wget}"
     "--set GIT_BINARY ${lib.meta.getExe git}"
-    "--set YOUTUBEDL_BINARY ${lib.meta.getExe yt-dlp}"
+    "--set YOUTUBEDL_BINARY ${lib.meta.getExe python.pkgs.yt-dlp}"
   ] ++ (if (lib.meta.availableOn stdenv.hostPlatform chromium) then [
     "--set CHROME_BINARY ${chromium}/bin/chromium-browser"
   ] else [

--- a/pkgs/by-name/ar/archivebox/package.nix
+++ b/pkgs/by-name/ar/archivebox/package.nix
@@ -7,6 +7,7 @@
 , wget
 , git
 , ripgrep
+, single-file-cli
 , postlight-parser
 , readability-extractor
 , chromium
@@ -90,6 +91,7 @@ python.pkgs.buildPythonApplication rec {
     "--set WGET_BINARY ${lib.meta.getExe wget}"
     "--set GIT_BINARY ${lib.meta.getExe git}"
     "--set YOUTUBEDL_BINARY ${lib.meta.getExe python.pkgs.yt-dlp}"
+    "--set SINGLEFILE_BINARY ${lib.meta.getExe single-file-cli}"
   ] ++ (if (lib.meta.availableOn stdenv.hostPlatform chromium) then [
     "--set CHROME_BINARY ${chromium}/bin/chromium-browser"
   ] else [


### PR DESCRIPTION
Fixes #358580.

Override any django-extensions patches.
~~Downgrade to Python 3.11 as django needs distutils.~~

Avoid a scoping error with yt-dlp. If `pkgs.yt-dlp` is in dependencies instead of `python.pkgs.yt-dlp`, there is
a cryptic error about 'pdm.backend' not being available. Change to just using `python.pkgs.yt-dlp` everywhere.

Also update `buildPythonApplication` to use `build-system` and `dependencies`. 

Add SingleFile support too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
