### PR TITLE
python3Packages.specfile: init at 0.32.6

### DIFF
--- a/pkgs/development/python-modules/specfile/default.nix
+++ b/pkgs/development/python-modules/specfile/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  rpm,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "specfile";
+  version = "0.32.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "packit";
+    repo = "specfile";
+    rev = version;
+    hash = "sha256-rUrXlr0277r4XiOiNmq3FBfOKWZGVUSf+S8MBmUfl+8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [ rpm ];
+  pythonImportsCheck = [
+    "specfile"
+    "rpm"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A library for parsing and manipulating RPM spec files";
+    homepage = "https://packit.dev/specfile";
+    changelog = "https://github.com/packit/specfile/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sielicki ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14941,6 +14941,8 @@ self: super: with self; {
 
   speaklater3 = callPackage ../development/python-modules/speaklater3 { };
 
+  specfile = callPackage ../development/python-modules/specfile { };
+
   spectral-cube = callPackage ../development/python-modules/spectral-cube { };
 
   speechbrain = callPackage ../development/python-modules/speechbrain { };


### PR DESCRIPTION
## what is it?

This is a library from the packit project which provides a python interface for
parsing RPM spec files. It requires and uses pkgs.rpm/pkgs.python3Packages.rpm
under the hood for evaluation.

```
$ # grab a random spec from fedora rawhide
$ curl https://src.fedoraproject.org/rpms/libfabric/raw/rawhide/f/libfabric.spec -o libfabric.spec
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11785  100 11785    0     0  16847      0 --:--:-- --:--:-- --:--:-- 16859

$ # What version did I just download?
$ cat libfabric.spec | grep '^Source0'
Source0:        https://github.com/ofiwg/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.bz2

$ # argh, need to emulate the rpm macro rules to know what this expands to...

$ nix run --impure --expr 'let pkgs = import ./. {}; in pkgs.python3.withPackages (pp: [ pp.specfile ])'
Python 3.12.7 (main, Oct  1 2024, 02:05:46) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import specfile
>>> spec = specfile.Specfile("./libfabric.spec")
>>> with spec.sources() as sources:
...     source_list = [spec.expand(x.location) for x in sources]
...
>>> source_list
['https://github.com/ofiwg/libfabric/releases/download/v1.22.0/libfabric-1.22.0.tar.bz2']
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
