### PR TITLE
Playwright 1.50.1

### DIFF
--- a/nixos/tests/playwright-python.nix
+++ b/nixos/tests/playwright-python.nix
@@ -25,19 +25,20 @@ import ./make-test-python.nix (
               from playwright.sync_api import expect
 
               browsers = {
-                "chromium": ["--headless", "--disable-gpu"],
-                "firefox": [],
-                "webkit": []
+                "chromium": {'args': ["--headless", "--disable-gpu"], 'channel': 'chromium'},
+                "firefox": {},
+                "webkit": {}
               }
               if len(sys.argv) != 3 or sys.argv[1] not in browsers.keys():
                   print(f"usage: {sys.argv[0]} [{'|'.join(browsers.keys())}] <url>")
                   sys.exit(1)
               browser_name = sys.argv[1]
               url = sys.argv[2]
-              browser_args = browsers.get(browser_name)
-              print(f"Running test on {browser_name} {' '.join(browser_args)}")
+              browser_kwargs = browsers.get(browser_name)
+              args = ' '.join(browser_kwargs.get('args', []))
+              print(f"Running test on {browser_name} {args}")
               with sync_playwright() as p:
-                  browser = getattr(p, browser_name).launch(args=browser_args)
+                  browser = getattr(p, browser_name).launch(**browser_kwargs)
                   context = browser.new_context()
                   page = context.new_page()
                   page.goto(url)

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,15 +22,15 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.49.1";
+  version = "1.50.0";
   pyproject = true;
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-RwUjFofC/scwVClKncYWp3RbIUeKsWokVjcGibdrrtc=";
+    hash = "sha256-g32QwEA4Ofzh7gVEsC++uA/XqT1eIrUH+fQi15SRxko=";
   };
 
   patches = [
@@ -52,13 +52,12 @@ buildPythonPackage rec {
     git commit -m "workaround setuptools-scm"
 
     substituteInPlace pyproject.toml \
-      --replace 'requires = ["setuptools==75.5.0", "setuptools-scm==8.1.0", "wheel==0.45.0", "auditwheel==6.1.0"]' \
-                'requires = ["setuptools", "setuptools-scm", "wheel"]'
+      --replace-fail 'requires = ["setuptools==75.6.0", "setuptools-scm==8.1.0", "wheel==0.45.1", "auditwheel==6.2.0"]' \
+                     'requires = ["setuptools", "setuptools-scm", "wheel"]'
 
-    # Skip trying to download and extract the driver.
+    # setup.py downloads and extracts the driver.
     # This is done manually in postInstall instead.
-    substituteInPlace setup.py \
-      --replace "self._download_and_extract_local_driver(base_wheel_bundles)" ""
+    rm setup.py
 
     # Set the correct driver path with the help of a patch in patches
     substituteInPlace playwright/_impl/_driver.py \
@@ -101,6 +100,9 @@ buildPythonPackage rec {
       // lib.optionalAttrs stdenv.hostPlatform.isLinux {
         inherit (nixosTests) playwright-python;
       };
+    # Package and playwright driver versions are tightly coupled.
+    # Use the update script to ensure synchronized updates.
+    skipBulkUpdate = true;
     updateScript = ./update.sh;
   };
 

--- a/pkgs/development/python-modules/playwright/driver-location.patch
+++ b/pkgs/development/python-modules/playwright/driver-location.patch
@@ -18,23 +18,3 @@ index 22b53b8..2d86626 100644
  
  
  def get_driver_env() -> dict:
-diff --git a/setup.py b/setup.py
-index f4c93dc..15c2d06 100644
---- a/setup.py
-+++ b/setup.py
-@@ -113,7 +113,6 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
-         super().run()
-         os.makedirs("driver", exist_ok=True)
-         os.makedirs("playwright/driver", exist_ok=True)
--        self._download_and_extract_local_driver()
- 
-         wheel = None
-         if os.getenv("PLAYWRIGHT_TARGET_WHEEL", None):
-@@ -139,6 +138,7 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
-         self,
-         wheel_bundle: Dict[str, str],
-     ) -> None:
-+        return
-         assert self.dist_dir
-         base_wheel_location: str = glob.glob(os.path.join(self.dist_dir, "*.whl"))[0]
-         without_platform = base_wheel_location[:-7]

--- a/pkgs/development/web/playwright/browsers.json
+++ b/pkgs/development/web/playwright/browsers.json
@@ -2,27 +2,31 @@
   "comment": "This file is kept up to date via update.sh",
   "browsers": {
     "chromium": {
-      "revision": "1140",
-      "browserVersion": "130.0.6723.31"
+      "revision": "1155",
+      "browserVersion": "133.0.6943.16"
     },
     "firefox": {
-      "revision": "1465",
-      "browserVersion": "131.0"
+      "revision": "1471",
+      "browserVersion": "134.0"
     },
     "webkit": {
-      "revision": "2083",
+      "revision": "2123",
       "revisionOverrides": {
+        "debian11-x64": "2105",
+        "debian11-arm64": "2105",
         "mac10.14": "1446",
         "mac10.15": "1616",
         "mac11": "1816",
         "mac11-arm64": "1816",
         "mac12": "2009",
-        "mac12-arm64": "2009"
+        "mac12-arm64": "2009",
+        "ubuntu20.04-x64": "2092",
+        "ubuntu20.04-arm64": "2092"
       },
-      "browserVersion": "18.0"
+      "browserVersion": "18.2"
     },
     "ffmpeg": {
-      "revision": "1010",
+      "revision": "1011",
       "revisionOverrides": {
         "mac12": "1010",
         "mac12-arm64": "1010"

--- a/pkgs/development/web/playwright/chromium-headless-shell.nix
+++ b/pkgs/development/web/playwright/chromium-headless-shell.nix
@@ -1,0 +1,81 @@
+{
+  fetchzip,
+  revision,
+  suffix,
+  system,
+  throwSystem,
+  stdenv,
+  autoPatchelfHook,
+  patchelfUnstable,
+
+  alsa-lib,
+  at-spi2-atk,
+  glib,
+  libXcomposite,
+  libXdamage,
+  libXfixes,
+  libXrandr,
+  libgbm,
+  libgcc,
+  libxkbcommon,
+  nspr,
+  nss,
+  ...
+}:
+let
+  linux = stdenv.mkDerivation {
+    name = "playwright-chromium-headless-shell";
+    src = fetchzip {
+      url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-headless-shell-${suffix}.zip";
+      stripRoot = false;
+      hash =
+        {
+          x86_64-linux = "sha256-UNLSiI9jWLev2YwqiXuoHwJfdB4teNhEfQjQRBEo8uY=";
+          aarch64-linux = "sha256-aVGLcJHFER09frJdKsGW/pKPl5MXoXef2hy5WTA8rS4=";
+        }
+        .${system} or throwSystem;
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelfUnstable
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      glib
+      libXcomposite
+      libXdamage
+      libXfixes
+      libXrandr
+      libgbm
+      libgcc.lib
+      libxkbcommon
+      nspr
+      nss
+    ];
+
+    buildPhase = ''
+      cp -R . $out
+    '';
+  };
+
+  darwin = fetchzip {
+    url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-headless-shell-${suffix}.zip";
+    stripRoot = false;
+    hash =
+      {
+        x86_64-darwin = "sha256-c26ubAgM9gQPaYqobQyS3Y7wvMUmmdpDlrYmZJrUgho=";
+        aarch64-darwin = "sha256-XRFqlhVx+GuDxz/kDP8TtyPQfR0JbFD0qu5OSywGTX8=";
+      }
+      .${system} or throwSystem;
+  };
+in
+{
+  x86_64-linux = linux;
+  aarch64-linux = linux;
+  x86_64-darwin = darwin;
+  aarch64-darwin = darwin;
+}
+.${system} or throwSystem

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -34,8 +34,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-N/uh3Q2ivqeraAqRt80deVz1XEPyLTYI8L3DBfNQGWg=";
-        aarch64-darwin = "sha256-tR9PwGanPcsDQwi1BijeYJd9LhNIWgEoXs5u3gZpghU=";
+        x86_64-darwin = "sha256-seMHD+TmxrfgsN6sLN2Bp3WgAooDnlSxGN6CPw1Q790=";
+        aarch64-darwin = "sha256-SsIRzxTIuf/mwsYvRM2mv8PzWQAAflxOyoK5TuyhMAU=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/ffmpeg.nix
+++ b/pkgs/development/web/playwright/ffmpeg.nix
@@ -10,10 +10,10 @@ fetchzip {
   stripRoot = false;
   hash =
     {
-      x86_64-linux = "sha256-FEm62UvMv0h6Sav93WmbPLw3CW1L1xg4nD26ca5ol38=";
-      aarch64-linux = "sha256-jtQ+NS++VHRiKoIV++PIxEnyVnYtVwUyNlSILKSH4A4=";
-      x86_64-darwin = "sha256-ED6noxSDeEUt2DkIQ4gNe/kL+zHVeb2AD5klBk93F88=";
-      aarch64-darwin = "sha256-3Adnvb7zvMXKFOhb8uuj5kx0wEIFicmckYx9WLlNNf0=";
+      x86_64-linux = "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
+      aarch64-linux = "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
+      x86_64-darwin = "sha256-zJ8BMzdneV6LlEt4I034l5u86dwW4UmO/UazWikpKV4=";
+      aarch64-darwin = "sha256-ky10UQj+XPVGpaWAPvKd51C5brml0y9xQ6iKcrxAMRc=";
     }
     .${system} or throwSystem;
 }

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -17,8 +17,8 @@ let
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-L/CJVtj9bVXKuKSLWw0wAdNICiRTg5ek+fw4togBoSI=";
-          aarch64-linux = "sha256-DgCuX+6KSnoHNFoFUli6S20GGHOExARasiJY9fy3CCE=";
+          x86_64-linux = "sha256-53DXgD/OzGo7fEp/DBX1TiBBpFSHwiluqBji6rFKTtE=";
+          aarch64-linux = "sha256-CBg2PgAXU1ZWUob73riEkQmn/EmIqhvOgBPSAphkAyM=";
         }
         .${system} or throwSystem;
     };
@@ -41,8 +41,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-HJ0jBmTW/Zz2fkmSo1gEv5P58PGyhXKnJVxJ12Q4IiM=";
-        aarch64-darwin = "sha256-YnnG8BX06vQlJmzZGaCKq1wKGp3yRaUQ4RF+tEWoK6U=";
+        x86_64-darwin = "sha256-GbrbNMFv1dT8Duo2otoZvmZk4Sgj81aRNwPAGKkRlnI=";
+        aarch64-darwin = "sha256-/e51eJTCqr8zEeWWJNS2UgPT9Y+a33Dj619JkCVVeRs=";
       }
       .${system} or throwSystem;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The code is on top of https://github.com/NixOS/nixpkgs/pull/349469

Playwright 1.49 introduced new browser `chromium_shell` that used by default for chromium headless mode https://github.com/microsoft/playwright/issues/33566.
Looks like it's temporary while they are testing new headless version embeded into chrome. The new version can be enabled with channel=chrome (switched to it in test).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
