### PR TITLE
nixos/user-groups: add a toggle for user account creation

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -462,7 +462,10 @@
 
 - `gerbera` now has wavpack support.
 
+- A toggle has been added under `users.users.<name>.enable` to allow toggling individual users conditionally. If set to false, the user account will not be created.
+
 - `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)
+
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -466,7 +466,6 @@
 
 - `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)
 
-
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ```{=include=} sections

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -124,6 +124,16 @@ let
 
     options = {
 
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = ''
+          If set to false, the user account will not be created. This is useful for when you wish to conditionally
+          disable user accounts.
+        '';
+      };
+
       name = mkOption {
         type = types.passwdEntry types.str;
         apply = x: assert (stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"); x;
@@ -557,7 +567,7 @@ let
           autoSubUidGidRange subUidRanges subGidRanges
           initialPassword initialHashedPassword expires;
         shell = utils.toShellPath u.shell;
-      }) cfg.users;
+      }) (filterAttrs (_: u: u.enable) cfg.users);
     groups = attrValues cfg.groups;
   });
 

--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -31,7 +31,7 @@ let
         ;
       isNormal = opts.isNormalUser;
       shell = utils.toShellPath opts.shell;
-    }) config.users.users;
+    }) (lib.filterAttrs (_: u: u.enable) config.users.users);
   };
 
   userbornConfigJson = pkgs.writeText "userborn.json" (builtins.toJSON userbornConfig);
@@ -95,16 +95,23 @@ in
 
       # Create home directories, do not create /var/empty even if that's a user's
       # home.
-      tmpfiles.settings.home-directories = lib.mapAttrs' (
-        username: opts:
-        lib.nameValuePair (toString opts.home) {
-          d = {
-            mode = opts.homeMode;
-            user = opts.name;
-            inherit (opts) group;
-          };
-        }
-      ) (lib.filterAttrs (_username: opts: opts.createHome && opts.home != "/var/empty") userCfg.users);
+      tmpfiles.settings.home-directories =
+        lib.mapAttrs'
+          (
+            username: opts:
+            lib.nameValuePair (toString opts.home) {
+              d = {
+                mode = opts.homeMode;
+                user = opts.name;
+                inherit (opts) group;
+              };
+            }
+          )
+          (
+            lib.filterAttrs (
+              _username: opts: opts.enable && opts.createHome && opts.home != "/var/empty"
+            ) userCfg.users
+          );
 
       services.userborn = {
         wantedBy = [ "sysinit.target" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1145,6 +1145,7 @@ in {
   userborn-mutable-etc = runTest ./userborn-mutable-etc.nix;
   userborn-immutable-etc = runTest ./userborn-immutable-etc.nix;
   user-activation-scripts = handleTest ./user-activation-scripts.nix {};
+  user-enable-option = runTest ./user-enable-option.nix;
   user-expiry = runTest ./user-expiry.nix;
   user-home-mode = handleTest ./user-home-mode.nix {};
   ustreamer = handleTest ./ustreamer.nix {};

--- a/nixos/tests/user-enable-option.nix
+++ b/nixos/tests/user-enable-option.nix
@@ -1,0 +1,82 @@
+let
+  normal-enabled = "username-normal-enabled";
+  normal-disabled = "username-normal-disabled";
+  system-enabled = "username-system-enabled";
+  system-disabled = "username-system-disabled";
+  passwd = "enableOptionPasswd";
+in
+{
+  name = "user-enable-option";
+
+  nodes.machine = {
+    users = {
+      groups.test-group = { };
+      users = {
+        # User is enabled (default behaviour).
+        ${normal-enabled} = {
+          enable = true;
+          isNormalUser = true;
+          initialPassword = passwd;
+        };
+
+        # User is disabled.
+        ${normal-disabled} = {
+          enable = false;
+          isNormalUser = true;
+          initialPassword = passwd;
+        };
+
+        # User is a system user, and is enabled.
+        ${system-enabled} = {
+          enable = true;
+          isSystemUser = true;
+          initialPassword = passwd;
+          group = "test-group";
+        };
+
+        # User is a system user, and is disabled.
+        ${system-disabled} = {
+          enable = false;
+          isSystemUser = true;
+          initialPassword = passwd;
+          group = "test-group";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    def switch_to_tty(tty_number):
+        machine.fail(f"pgrep -f 'agetty.*tty{tty_number}'")
+        machine.send_key(f"alt-f{tty_number}")
+        machine.wait_until_succeeds(f"[ $(fgconsole) = {tty_number} ]")
+        machine.wait_for_unit(f"getty@tty{tty_number}.service")
+        machine.wait_until_succeeds(f"pgrep -f 'agetty.*tty{tty_number}'")
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("getty@tty1.service")
+
+    with subtest("${normal-enabled} exists"):
+        check_fn = f"id ${normal-enabled}"
+        machine.succeed(check_fn)
+        machine.wait_until_tty_matches("1", "login: ")
+        machine.send_chars("${normal-enabled}\n")
+        machine.wait_until_tty_matches("1", "Password: ")
+        machine.send_chars("${passwd}\n")
+
+    with subtest("${normal-disabled} does not exist"):
+        switch_to_tty(2)
+        check_fn = f"id ${normal-disabled}"
+        machine.fail(check_fn)
+
+    with subtest("${system-enabled} exists"):
+        switch_to_tty(3)
+        check_fn = f"id ${system-enabled}"
+        machine.succeed(check_fn)
+
+    with subtest("${system-disabled} does not exist"):
+        switch_to_tty(4)
+        check_fn = f"id ${system-disabled}"
+        machine.fail(check_fn)
+  '';
+}

--- a/nixos/tests/userborn.nix
+++ b/nixos/tests/userborn.nix
@@ -66,6 +66,10 @@ in
             isNormalUser = true;
             hashedPassword = newNormaloHashedPassword;
           };
+          normalo-disabled = {
+            enable = false;
+            isNormalUser = true;
+          };
         };
         groups = {
           new-group = { };
@@ -95,6 +99,11 @@ in
       print(machine.succeed("getent passwd sysuser"))
       assert 1000 > int(machine.succeed("id --user sysuser")), "sysuser user doesn't have a system UID"
       assert "${sysuserInitialHashedPassword}" in machine.succeed("getent shadow sysuser"), "system user password is not correct"
+
+    with subtest("normalo-disabled is NOT created"):
+      machine.fail("id normalo-disabled")
+      # Check if user's home has been created
+      machine.fail("[ -d '/home/normalo-disabled' ]")
 
     with subtest("sysusers group is created"):
       print(machine.succeed("getent group sysusers"))


### PR DESCRIPTION
Microscopic change that allows users to toggle user accounts, per user, conditionally
under `users.users.<name>.enable`. If set to false, the user account will not be
created.

Allows for user accounts to be disabled in-line (similar to systemd services)
with minimum effort and itches a very specific scratch that I had, which I imagine
others might have as well. 

A similar mechanism can be implemented for groups as well, but I have omitted
such a change until I receive feedback.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
