### PR TITLE
fastapi-dls: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -796,6 +796,7 @@
   ./services/misc/etesync-dav.nix
   ./services/misc/evdevremapkeys.nix
   ./services/misc/evremap.nix
+  ./services/misc/fastapi-dls.nix
   ./services/misc/felix.nix
   ./services/misc/flaresolverr.nix
   ./services/misc/forgejo.nix

--- a/nixos/modules/services/misc/fastapi-dls.nix
+++ b/nixos/modules/services/misc/fastapi-dls.nix
@@ -1,0 +1,102 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fastapi-dls;
+  stateDir = "/var/lib/fastapi-dls";
+  dls_privkey = "${stateDir}/instance.private.pem";
+  dls_pubkey = "${stateDir}/instance.public.pem";
+  https_privkey = "${stateDir}/webserver.key";
+  https_cert = "${stateDir}/webserver.crt";
+in
+{
+  options = {
+    services.fastapi-dls = {
+      enable = lib.mkEnableOption "fastapi-dls";
+
+      package = lib.mkPackageOption pkgs "fastapi-dls" { };
+
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "The IP address on which `fastapi-dls` listens.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8081;
+        description = "The port on which `fastapi-dls` listens.";
+      };
+
+      dlsAddress = lib.mkOption {
+        type = lib.types.str;
+        default = cfg.listenAddress;
+        defaultText = lib.literalExpression "config.services.fastapi-dls.listenAddress";
+        description = ''
+          The HTTPS domain name that DLS clients should connect to.
+          Useful when you put `fastapi-dls` behind a reverse proxy.
+        '';
+      };
+
+      dlsPort = lib.mkOption {
+        type = lib.types.port;
+        default = cfg.port;
+        defaultText = lib.literalExpression "config.services.fastapi-dls.port";
+        description = "The port that DLS clients should connect to.";
+      };
+
+      openFirewall = lib.mkEnableOption "opening the firewall for `fastapi-dls`";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.services.fastapi-dls = {
+      description = "fastapi-dls daemon";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      preStart = ''
+        if [ ! -f "${dls_privkey}" ]; then
+          ${lib.getExe pkgs.openssl} genrsa -out "${dls_privkey}" 2048
+        fi
+        if [ ! -f "${dls_pubkey}" ]; then
+          ${lib.getExe pkgs.openssl} rsa -in "${dls_privkey}" -outform PEM -pubout -out "${dls_pubkey}"
+        fi
+        if [ ! -f "${https_privkey}" ] || [ ! -f "${https_cert}" ]; then
+          ${lib.getExe pkgs.openssl} req -x509 -nodes \
+            -days 3650 -newkey rsa:2048 -subj "/CN=fastapi-dls" \
+            -keyout "${https_privkey}" -out "${https_cert}"
+        fi
+      '';
+      environment = {
+        DLS_URL = cfg.dlsAddress;
+        DLS_PORT = builtins.toString cfg.dlsPort;
+        LEASE_EXPIRE_DAYS = builtins.toString 90;
+        LEASE_RENEWAL_PERIOD = builtins.toString 0.2;
+        DATABASE = "sqlite:///${stateDir}/db.sqlite";
+        INSTANCE_KEY_RSA = dls_privkey;
+        INSTANCE_KEY_PUB = dls_pubkey;
+      };
+      script = ''
+        ${lib.getExe cfg.package} \
+          --host ${cfg.listenAddress} \
+          --port ${builtins.toString cfg.port} \
+          --ssl-keyfile ${https_privkey} \
+          --ssl-certfile ${https_cert}
+      '';
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = builtins.baseNameOf stateDir;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ MakiseKurisu ];
+}

--- a/pkgs/by-name/fa/fastapi-dls/package.nix
+++ b/pkgs/by-name/fa/fastapi-dls/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  python3,
+  fetchFromGitLab,
+  gitUpdater,
+  makeWrapper,
+}:
+
+let
+
+  pythonEnv = python3.withPackages (
+    packages:
+    with packages;
+    [
+      fastapi
+      uvicorn
+      python-jose
+      pycryptodome
+      python-dateutil
+      sqlalchemy
+      markdown
+      python-dotenv
+    ]
+    ++ uvicorn.optional-dependencies.standard
+  );
+
+  version = "1.5.2";
+
+in
+python3.pkgs.buildPythonApplication {
+  pname = "fastapi-dls";
+  inherit version;
+  pyproject = false;
+
+  src = fetchFromGitLab {
+    domain = "git.collinwebdesigns.de";
+    owner = "oscar.krause";
+    repo = "fastapi-dls";
+    rev = "refs/tags/${version}";
+    hash = "sha256-0j4VQT+aVq3vzJM8atuCW9pSAhGqcjjehTM/EAX5egM=";
+  };
+
+  # Don't create .orig files if the patch isn't an exact match.
+  patchFlags = [
+    "--no-backup-if-mismatch"
+    "-p1"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin $out/share/fastapi-dls
+    cp -r README.md app $out/share/fastapi-dls
+
+    makeWrapper ${pythonEnv}/bin/uvicorn $out/bin/fastapi-dls \
+      --add-flags "--app-dir $out/share/fastapi-dls/app" \
+      --add-flags "--proxy-headers" \
+      --add-flags "main:app"
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Minimal Delegated License Service (DLS)";
+    homepage = "https://git.collinwebdesigns.de/oscar.krause/fastapi-dls";
+    changelog = "https://git.collinwebdesigns.de/oscar.krause/fastapi-dls/-/releases/${version}";
+    license = lib.licenses.unfree;
+    mainProgram = "fastapi-dls";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ MakiseKurisu ];
+  };
+}


### PR DESCRIPTION
Add fastapi-dls and associated NixOS module.

fastapi-dls is an open source implementation of NVIDIA Delegated License Service (DLS).

I'm dogfooding this PR on [my own machine](https://github.com/MakiseKurisu/nixos-config/commit/e33c1300a23b2b099bc75f2dbe135a35b8ba3903) currently.

Project homepage: https://git.collinwebdesigns.de/oscar.krause/fastapi-dls

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
