### PR TITLE
gradle: add udev to the JNA library path

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -37,6 +37,7 @@ rec {
     , unzip
     , ncurses5
     , ncurses6
+    , udev
     , testers
     , runCommand
     , writeText
@@ -91,6 +92,7 @@ rec {
           };
           varDefs = concatStringsSep "\n" (map (x: "  --set ${x} \\")
             ([ "JAVA_HOME ${java}" ] ++ toolchain.varDefs));
+          jnaLibraryPath = lib.makeLibraryPath [ udev ];
         in ''
           mkdir -pv $out/lib/gradle/
           cp -rv lib/ $out/lib/gradle/
@@ -99,6 +101,7 @@ rec {
           test -f $gradle_launcher_jar
           makeWrapper ${java}/bin/java $out/bin/gradle \
             ${varDefs}
+            --add-flags "-Djna.library.path=${jnaLibraryPath}" \
             --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain${toolchain.property}"
         '';
 
@@ -129,6 +132,7 @@ rec {
         # Gradle will refuse to start without _both_ 5 and 6 versions of ncurses.
         echo ${ncurses5} >> $out/nix-support/manual-runtime-dependencies
         echo ${ncurses6} >> $out/nix-support/manual-runtime-dependencies
+        echo ${udev} >> $out/nix-support/manual-runtime-dependencies
       '';
 
       passthru.tests = {


### PR DESCRIPTION
Running `gradle build --scan` results in this warning:

    Did not find udev library in operating system.
    Some features may not work.

The udev library is looked up using JNA, which searches
`jna.library.path` in addition to the standard locations. Adding
`udev` to the lookup path in the wrapper ensures that Gradle can find
the library.

Fixes: #358166.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
