### PR TITLE
build-support: fix nix-prefetch-* on macOS

### DIFF
--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -123,7 +123,7 @@ sourceUrl="docker://$imageName@$imageDigest"
 
 # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
 # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/skopeo-copy-tmp-XXXXXXXX")")"
+tmpPath="$(realpath "$(mktemp -d --tmpdir skopeo-copy-tmp-XXXXXXXX)")"
 trap "rm -rf \"$tmpPath\"" EXIT
 
 tmpFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -121,7 +121,9 @@ fi
 
 sourceUrl="docker://$imageName@$imageDigest"
 
-tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/skopeo-copy-tmp-XXXXXXXX")"
+# nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+# to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/skopeo-copy-tmp-XXXXXXXX")")"
 trap "rm -rf \"$tmpPath\"" EXIT
 
 tmpFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"

--- a/pkgs/build-support/docker/nix-prefetch-docker.nix
+++ b/pkgs/build-support/docker/nix-prefetch-docker.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeWrapper, nix, skopeo, jq }:
+{ lib, stdenv, makeWrapper, nix, skopeo, jq, coreutils }:
 
 stdenv.mkDerivation {
   name = "nix-prefetch-docker";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   installPhase = ''
     install -vD ${./nix-prefetch-docker} $out/bin/$name;
     wrapProgram $out/bin/$name \
-      --prefix PATH : ${lib.makeBinPath [ nix skopeo jq ]} \
+      --prefix PATH : ${lib.makeBinPath [ nix skopeo jq coreutils ]} \
       --set HOME /homeless-shelter
   '';
 

--- a/pkgs/build-support/fetchbzr/nix-prefetch-bzr
+++ b/pkgs/build-support/fetchbzr/nix-prefetch-bzr
@@ -44,7 +44,7 @@ fi
 if test -z "$finalPath"; then
     # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
     # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/bzr-checkout-tmp-XXXXXXXX")")"
+    tmpPath="$(realpath "$(mktemp -d --tmpdir bzr-checkout-tmp-XXXXXXXX)")"
     trap "rm -rf \"$tmpPath\"" EXIT
 
     tmpFile="$tmpPath/$dstFile"

--- a/pkgs/build-support/fetchbzr/nix-prefetch-bzr
+++ b/pkgs/build-support/fetchbzr/nix-prefetch-bzr
@@ -42,7 +42,9 @@ fi
 # If we don't know the hash or a path with that hash doesn't exist,
 # download the file and add it to the store.
 if test -z "$finalPath"; then
-    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/bzr-checkout-tmp-XXXXXXXX")"
+    # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+    # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/bzr-checkout-tmp-XXXXXXXX")")"
     trap "rm -rf \"$tmpPath\"" EXIT
 
     tmpFile="$tmpPath/$dstFile"

--- a/pkgs/build-support/fetchcvs/nix-prefetch-cvs
+++ b/pkgs/build-support/fetchcvs/nix-prefetch-cvs
@@ -22,7 +22,7 @@ fi
 mkTempDir() {
     # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
     # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/nix-prefetch-cvs-XXXXXXXX")")"
+    tmpPath="$(realpath "$(mktemp -d --tmpdir nix-prefetch-csv-XXXXXXXX)")"
     trap removeTempDir EXIT
 }
 

--- a/pkgs/build-support/fetchcvs/nix-prefetch-cvs
+++ b/pkgs/build-support/fetchcvs/nix-prefetch-cvs
@@ -20,7 +20,9 @@ fi
 
 
 mkTempDir() {
-    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/nix-prefetch-cvs-XXXXXXXX")"
+    # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+    # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/nix-prefetch-cvs-XXXXXXXX")")"
     trap removeTempDir EXIT
 }
 

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -453,10 +453,9 @@ else
     # If we don't know the hash or a path with that hash doesn't exist,
     # download the file and add it to the store.
     if test -z "$finalPath"; then
-
         # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
         # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-        tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")")"
+        tmpPath="$(realpath "$(mktemp -d --tmpdir git-checkout-tmp-XXXXXXXX)")"
         exit_handlers+=(remove_tmpPath)
 
         tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -454,7 +454,9 @@ else
     # download the file and add it to the store.
     if test -z "$finalPath"; then
 
-        tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")"
+        # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+        # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+        tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")")"
         exit_handlers+=(remove_tmpPath)
 
         tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -42,10 +42,9 @@ fi
 # If we don't know the hash or a path with that hash doesn't exist,
 # download the file and add it to the store.
 if [[ -z "$finalPath" ]]; then
-
     # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
     # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/hg-checkout-tmp-XXXXXXXX")")"
+    tmpPath="$(realpath "$(mktemp -d --tmpdir hg-checkout-tmp-XXXXXXXX)")"
     cleanup() { x=$?; rm -rf "$tmpPath"; exit $x; }; trap cleanup EXIT
 
     tmpArchive="$tmpPath/hg-archive"

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -43,7 +43,9 @@ fi
 # download the file and add it to the store.
 if [[ -z "$finalPath" ]]; then
 
-    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/hg-checkout-tmp-XXXXXXXX")"
+    # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+    # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/hg-checkout-tmp-XXXXXXXX")")"
     cleanup() { x=$?; rm -rf "$tmpPath"; exit $x; }; trap cleanup EXIT
 
     tmpArchive="$tmpPath/hg-archive"

--- a/pkgs/build-support/fetchsvn/nix-prefetch-svn
+++ b/pkgs/build-support/fetchsvn/nix-prefetch-svn
@@ -43,7 +43,7 @@ fi
 if test -z "$finalPath"; then
     # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
     # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
-    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/svn-checkout-tmp-XXXXXXXX")")"
+    tmpPath="$(realpath "$(mktemp -d --tmpdir svn-checkout-tmp-XXXXXXXX)")"
     trap "rm -rf \"$tmpPath\"" EXIT
 
     tmpFile="$tmpPath/$dstFile"

--- a/pkgs/build-support/fetchsvn/nix-prefetch-svn
+++ b/pkgs/build-support/fetchsvn/nix-prefetch-svn
@@ -41,7 +41,9 @@ fi
 # If we don't know the hash or a path with that hash doesn't exist,
 # download the file and add it to the store.
 if test -z "$finalPath"; then
-    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/svn-checkout-tmp-XXXXXXXX")"
+    # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
+    # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
+    tmpPath="$(realpath "$(mktemp -d "${TMPDIR:-/tmp}/svn-checkout-tmp-XXXXXXXX")")"
     trap "rm -rf \"$tmpPath\"" EXIT
 
     tmpFile="$tmpPath/$dstFile"

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -13,7 +13,7 @@ let mkPrefetchScript = tool: src: deps:
     installPhase = ''
       install -vD ${src} $out/bin/$name;
       wrapProgram $out/bin/$name \
-        --prefix PATH : ${lib.makeBinPath (deps ++ [ gnused nix ])} \
+        --prefix PATH : ${lib.makeBinPath (deps ++ [ coreutils gnused nix ])} \
         --set HOME /homeless-shelter
     '';
 
@@ -28,7 +28,7 @@ let mkPrefetchScript = tool: src: deps:
 in rec {
   nix-prefetch-bzr = mkPrefetchScript "bzr" ../../../build-support/fetchbzr/nix-prefetch-bzr [ breezy ];
   nix-prefetch-cvs = mkPrefetchScript "cvs" ../../../build-support/fetchcvs/nix-prefetch-cvs [ cvs ];
-  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [ coreutils findutils gawk git git-lfs ];
+  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [ findutils gawk git git-lfs ];
   nix-prefetch-hg  = mkPrefetchScript "hg"  ../../../build-support/fetchhg/nix-prefetch-hg   [ mercurial ];
   nix-prefetch-svn = mkPrefetchScript "svn" ../../../build-support/fetchsvn/nix-prefetch-svn [ subversion ];
 


### PR DESCRIPTION
Since nix 2.20, `nix-store --add-fixed` doesn't accept paths where the parent directory is a symlink. On macOS, /tmp is a symlink to /private/tmp, which causes a `'/tmp' is a symlink` error:

```
$ nix run github:nixos/nixpkgs/24.11-beta#nix-prefetch-git -- --url https://github.com/IFTTT/polo.git --rev 316aa2ac210a45a7fc400ab921831493d5dd21b8 --hash sha256
Initialized empty Git repository in /private/tmp/git-checkout-tmp-1Bf9bIv7/polo-316aa2a/.git/
remote: Enumerating objects: 51, done.
remote: Counting objects: 100% (51/51), done.
remote: Compressing objects: 100% (42/42), done.
remote: Total 51 (delta 8), reused 19 (delta 5), pack-reused 0 (from 0)
Unpacking objects: 100% (51/51), 19.57 KiB | 541.00 KiB/s, done.
From https://github.com/IFTTT/polo
 * branch            HEAD       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...
error: path '/tmp' is a symlink
```

Avoid this by resolving /tmp to a real directory in all the prefetch scripts

Fixes #358113

---

I don't see mention of the symlink-change in the nix 2.20 release notes, but I tested with this to narrow down the point where things started breaking:

```
nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296.tar.gz \
  --packages 'nix-prefetch-git.override { nix = pkgs.nixVersions.nix_2_20; }' \
  --command 'nix-prefetch-git --url https://github.com/IFTTT/polo.git --rev 316aa2ac210a45a7fc400ab921831493d5dd21b8 --hash sha256'
```

Substitute nix_2_20 with nix_2_19 to see the old behavior which happily accepted symlinked directories.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
