### PR TITLE
Revert "[Backport release-24.11] fwupd: 1.9.25 -> 2.0.1"

### DIFF
--- a/pkgs/by-name/fw/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,26 +1,20 @@
-commit e798ff19cd36daaed68b86edc7ebdb9dcfe1c057
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Tue Oct 15 11:46:38 2024 +0200
-
-    Add option for installation sysconfdir
-
 diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
-index b0ff5b106..29b60a3be 100644
+index b0ff5b106..13ac380d0 100644
 --- a/data/bios-settings.d/meson.build
 +++ b/data/bios-settings.d/meson.build
 @@ -1,5 +1,5 @@
  if build_standalone and host_machine.system() == 'linux'
  install_data('README.md',
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'bios-settings.d')
-+  install_dir: join_paths(datadir, 'fwupd', 'bios-settings.d')
++  install_dir: join_paths(sysconfdir_install, 'fwupd', 'bios-settings.d')
  )
  endif
 diff --git a/data/meson.build b/data/meson.build
-index 9db5cd756..cf3181c8b 100644
+index e13da4adf..6858c240f 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -27,7 +27,7 @@ endif
- 
+@@ -26,7 +26,7 @@ endif
+
  if build_standalone
    install_data(['fwupd.conf'],
 -    install_dir: join_paths(sysconfdir, 'fwupd'),
@@ -29,10 +23,10 @@ index 9db5cd756..cf3181c8b 100644
    )
    plugin_quirks += files([
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 686064195..72ae401bd 100644
+index 3649fecea..c3462744b 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -7,13 +7,13 @@ install_data([
+@@ -12,13 +12,13 @@ install_data([
      'GPG-KEY-Linux-Foundation-Firmware',
      'GPG-KEY-Linux-Vendor-Firmware-Service',
    ],
@@ -47,8 +41,8 @@ index 686064195..72ae401bd 100644
 +  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
  )
  endif
- 
-@@ -21,11 +21,11 @@ if supported_pkcs7
+
+@@ -26,11 +26,11 @@ if supported_pkcs7
  install_data([
      'LVFS-CA.pem',
    ],
@@ -63,10 +57,10 @@ index 686064195..72ae401bd 100644
  )
  endif
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 10201bc9a..fba712491 100644
+index c20a1a05e..5354bac7f 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
-@@ -11,14 +11,14 @@ if build_standalone and get_option('lvfs') != 'false'
+@@ -15,14 +15,14 @@ if build_standalone and get_option('lvfs') != 'false'
      output: 'lvfs.conf',
      configuration: con3,
      install: true,
@@ -83,7 +77,7 @@ index 10201bc9a..fba712491 100644
    )
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
-@@ -52,12 +52,12 @@ configure_file(
+@@ -56,12 +56,12 @@ configure_file(
    output: 'vendor.conf',
    configuration: con2,
    install: get_option('vendor_metadata'),
@@ -98,68 +92,14 @@ index 10201bc9a..fba712491 100644
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
-diff --git a/docs/meson.build b/docs/meson.build
-index 5693edcc8..181c359a4 100644
---- a/docs/meson.build
-+++ b/docs/meson.build
-@@ -124,7 +124,7 @@ if build_docs
-     ],
-     build_by_default: true,
-     install: true,
--    install_dir: join_paths(datadir, 'doc'),
-+    install_dir: join_paths(sysconfdir_install, 'doc'),
-   )
- 
-   subdir('hsi-tests.d')
-@@ -182,7 +182,7 @@ if build_docs
-     ],
-     build_by_default: true,
-     install: true,
--    install_dir: join_paths(datadir, 'doc'),
-+    install_dir: join_paths(sysconfdir_install, 'doc'),
-   )
-   man_cmd = []
-   foreach man: man_md
-@@ -196,7 +196,7 @@ if build_docs
-       man_cmd,
-     ],
-     install: true,
--    install_dir: join_paths(datadir, 'doc', 'fwupd')
-+    install_dir: join_paths(sysconfdir_install, 'doc', 'fwupd')
-   )
-   if hsi
-     install_data(['hsi.html'],
-@@ -204,18 +204,18 @@ if build_docs
-     )
-   endif
-   install_data(['urlmap_fwupd.js'],
--    install_dir: join_paths(datadir, 'doc', 'libfwupd')
-+    install_dir: join_paths(sysconfdir_install, 'doc', 'libfwupd')
-   )
-   install_data(['urlmap_fwupdplugin.js'],
--    install_dir: join_paths(datadir, 'doc', 'libfwupdplugin')
-+    install_dir: join_paths(sysconfdir_install, 'doc', 'libfwupdplugin')
-   )
-   #make devhelp work
-   install_symlink('libfwupd',
--    install_dir: join_paths(datadir, 'doc', 'fwupd'),
-+    install_dir: join_paths(sysconfdir_install, 'doc', 'fwupd'),
-     pointing_to: join_paths('..', 'libfwupd'),
-   )
-   install_symlink('libfwupdplugin',
--    install_dir: join_paths(datadir, 'doc', 'fwupd'),
-+    install_dir: join_paths(sysconfdir_install, 'doc', 'fwupd'),
-     pointing_to: join_paths('..', 'libfwupdplugin'),
-   )
- endif
 diff --git a/meson.build b/meson.build
-index 2ceaf531c..e4e764b97 100644
+index ca6ccdf92..0a3097d90 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -201,6 +201,12 @@ endif
+@@ -195,6 +195,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
- 
+
 +if get_option('sysconfdir_install') != ''
 +  sysconfdir_install = join_paths(prefix, get_option('sysconfdir_install'))
 +else
@@ -167,16 +107,14 @@ index 2ceaf531c..e4e764b97 100644
 +endif
 +
  diffcmd = find_program('diff')
- gio = dependency('gio-2.0', version: '>= 2.72.0')
- giounix = dependency('gio-unix-2.0', version: '>= 2.72.0', required: false)
+ gio = dependency('gio-2.0', version: '>= 2.68.0')
+ giounix = dependency('gio-unix-2.0', version: '>= 2.68.0', required: false)
+
 diff --git a/meson_options.txt b/meson_options.txt
-index a4a211fbb..6197fe502 100644
+index 877891126..986d0ee31 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -7,6 +7,11 @@ option('bluez',
-   type: 'feature',
-   description: 'BlueZ support',
- )
+@@ -1,3 +1,8 @@
 +option('sysconfdir_install',
 +  type: 'string',
 +  value: '',
@@ -186,7 +124,7 @@ index a4a211fbb..6197fe502 100644
    type: 'combo',
    choices: [
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index 2dfc4d2f0..e5ac73edd 100644
+index eb196c21e..c9a29f680 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
 @@ -20,7 +20,7 @@ if host_machine.system() == 'linux'
@@ -198,17 +136,3 @@ index 2dfc4d2f0..e5ac73edd 100644
    )
  elif host_machine.system() == 'freebsd'
    backend_srcs += 'fu-uefi-backend-freebsd.c'
-@@ -93,7 +93,7 @@ if get_option('plugin_uefi_capsule_splash')
-       '--out', '@OUTPUT@',
-     ],
-     install: true,
--    install_dir: join_paths(datadir, 'fwupd'),
-+    install_dir: join_paths(sysconfdir_install, 'fwupd'),
-   )
- endif
- 
-@@ -146,4 +146,3 @@ summary({
-   'capsule splash': get_option('plugin_uefi_capsule_splash'),
- }, section:'uefi capsule options')
- endif
--

--- a/pkgs/by-name/fw/fwupd/efi-app-path.patch
+++ b/pkgs/by-name/fw/fwupd/efi-app-path.patch
@@ -1,15 +1,9 @@
-commit 1770b1871a567dfa78ae1e32094b6007bb7639e9
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Mon Oct 28 12:08:49 2024 +0100
-
-    Get the efi app from fwupd-efi
-
 diff --git a/meson.build b/meson.build
-index e4e764b97..8acaa3d2d 100644
+index b18108c74..7e674b4d2 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -482,7 +482,7 @@ endif
- 
+@@ -404,7 +404,7 @@ endif
+
  # EFI
  if build_standalone
 -  efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')

--- a/pkgs/by-name/fw/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/by-name/fw/fwupd/install-fwupdplugin-to-out.patch
@@ -1,19 +1,14 @@
-commit 50827b154728a97e5dfcb7d41e5c7155752919c3
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Mon Oct 28 12:07:51 2024 +0100
-
-    Install fwupdplugin to out
-
 diff --git a/meson.build b/meson.build
-index 250b76107..62c127c35 100644
+index 9ae278b66..7cddf1a0d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -553,7 +553,7 @@ if build_standalone
+@@ -507,7 +507,7 @@ if build_standalone
  if host_machine.system() == 'windows'
-   libdir_pkg = bindir
+   libdir_pkg = 'fwupd-@0@'.format(fwupd_version)
  else
 -  libdir_pkg = join_paths(libdir, 'fwupd-@0@'.format(fwupd_version))
 +  libdir_pkg = join_paths(prefix, 'lib', 'fwupd-@0@'.format(fwupd_version))
  endif
  conf.set_quoted('FWUPD_LIBDIR_PKG', libdir_pkg)
  endif
+

--- a/pkgs/by-name/fw/fwupd/installed-tests-path.patch
+++ b/pkgs/by-name/fw/fwupd/installed-tests-path.patch
@@ -1,47 +1,19 @@
-commit 27ddb6910ec9027f8f502f5240fb33cddd9fd16b
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Tue Oct 15 14:49:53 2024 +0200
-
-    Add output for installed tests
-
-diff --git a/data/device-tests/meson.build b/data/device-tests/meson.build
-index 4f3a5f2da..b0d21c8bd 100644
---- a/data/device-tests/meson.build
-+++ b/data/device-tests/meson.build
-@@ -67,5 +67,5 @@ install_data([
-     'wacom-intuos-bt-s.json',
-     'wistron-dock-40b7.json',
-   ],
--  install_dir: join_paths(datadir, 'fwupd', 'device-tests'),
-+  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'device-tests'),
- )
-diff --git a/data/tests/meson.build b/data/tests/meson.build
-index 3da184010..8606c9280 100644
---- a/data/tests/meson.build
-+++ b/data/tests/meson.build
-@@ -2,7 +2,7 @@ con2 = configuration_data()
- con2.set('installedtestsdir', installed_test_datadir)
- con2.set('installedtestsbindir', installed_test_bindir)
- con2.set('installedtestsdatadir', installed_test_datadir)
--con2.set('devicetestdir', join_paths(datadir, 'fwupd', 'device-tests'))
-+con2.set('devicetestdir', join_paths(installed_test_datadir, 'fwupd', 'device-tests'))
- con2.set('bindir', bindir)
- con2.set('libexecdir', libexecdir)
- 
-@@ -105,7 +105,7 @@ configure_file(
+diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
+index dfce86b1c..5e34c4fa6 100644
+--- a/data/installed-tests/meson.build
++++ b/data/installed-tests/meson.build
+@@ -86,5 +86,5 @@ configure_file(
    output: 'fwupd-tests.conf',
    configuration: con2,
    install: true,
 -  install_dir: join_paths(datadir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
- 
- if umockdev_integration_tests.allowed()
 diff --git a/meson.build b/meson.build
-index 62c127c35..2ceaf531c 100644
+index ca6ccdf92..36b1b47b0 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -194,8 +194,8 @@ else
+@@ -188,8 +188,8 @@ else
    datadir = join_paths(prefix, get_option('datadir'))
    sysconfdir = join_paths(prefix, get_option('sysconfdir'))
    localstatedir = join_paths(prefix, get_option('localstatedir'))
@@ -52,7 +24,7 @@ index 62c127c35..2ceaf531c 100644
    daemon_dir = join_paths(libexecdir, 'fwupd')
  endif
  mandir = join_paths(prefix, get_option('mandir'))
-@@ -541,6 +541,7 @@ gnome = import('gnome')
+@@ -497,6 +497,7 @@ gnome = import('gnome')
  i18n = import('i18n')
  
  conf.set_quoted('FWUPD_PREFIX', prefix)
@@ -61,12 +33,12 @@ index 62c127c35..2ceaf531c 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index 769a5b655..a4a211fbb 100644
+index 877891126..bfc5d1afd 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -328,6 +328,10 @@ option('systemd_unit_user',
-   value: 'fwupd-refresh',
-   description: 'User account to use for fwupd-refresh.service (empty for DynamicUser)',
+@@ -452,6 +452,10 @@ option('elogind',
+     'false': 'disabled',
+   },
  )
 +option('installed_test_prefix',
 +  type: 'string',
@@ -75,16 +47,3 @@ index 769a5b655..a4a211fbb 100644
  option('tests',
    type: 'boolean',
    value: true,
-diff --git a/src/tests/host-emulate/meson.build b/src/tests/host-emulate/meson.build
-index 4bc02e46e..17bc2270d 100644
---- a/src/tests/host-emulate/meson.build
-+++ b/src/tests/host-emulate/meson.build
-@@ -9,7 +9,7 @@ if build_standalone
-       capture: true,
-       command: [gzip, '-k', '--stdout', '@INPUT@'],
-       install: true,
--      install_dir: join_paths(datadir, 'fwupd', 'host-emulate.d'),
-+      install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'host-emulate.d'),
-     )
-   endforeach
- endif

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -1,69 +1,65 @@
 # Updating? Keep $out/etc synchronized with passthru keys
 
-{
-  stdenv,
-  lib,
-  fetchFromGitHub,
-  fetchpatch,
-  gi-docgen,
-  pkg-config,
-  gobject-introspection,
-  gettext,
-  libgudev,
-  libdrm,
-  polkit,
-  libxmlb,
-  gusb,
-  sqlite,
-  libarchive,
-  libredirect,
-  curl,
-  libjcat,
-  elfutils,
-  valgrind,
-  meson,
-  libuuid,
-  ninja,
-  gnutls,
-  protobufc,
-  python3,
-  wrapGAppsNoGuiHook,
-  ensureNewerSourcesForZipFilesHook,
-  json-glib,
-  bash-completion,
-  shared-mime-info,
-  vala,
-  makeFontsConf,
-  freefont_ttf,
-  pango,
-  tpm2-tss,
-  bubblewrap,
-  efibootmgr,
-  flashrom,
-  tpm2-tools,
-  fwupd-efi,
-  nixosTests,
-  runCommand,
-  unstableGitUpdater,
-  modemmanager,
-  libqmi,
-  libmbim,
-  libcbor,
-  xz,
-  hwdata,
-  nix-update-script,
-  enableFlashrom ? false,
-  enablePassim ? false,
+{ stdenv
+, lib
+, fetchFromGitHub
+, gi-docgen
+, pkg-config
+, gobject-introspection
+, gettext
+, libgudev
+, libdrm
+, polkit
+, libxmlb
+, gusb
+, sqlite
+, libarchive
+, libredirect
+, curl
+, libjcat
+, elfutils
+, valgrind
+, meson
+, libuuid
+, ninja
+, gnutls
+, protobufc
+, python3
+, wrapGAppsNoGuiHook
+, ensureNewerSourcesForZipFilesHook
+, json-glib
+, bash-completion
+, shared-mime-info
+, umockdev
+, vala
+, makeFontsConf
+, freefont_ttf
+, pango
+, tpm2-tss
+, bubblewrap
+, efibootmgr
+, flashrom
+, tpm2-tools
+, fwupd-efi
+, nixosTests
+, runCommand
+, unstableGitUpdater
+, modemmanager
+, libqmi
+, libmbim
+, libcbor
+, xz
+, nix-update-script
+, enableFlashrom ? false
+, enablePassim ? false
 }:
 
 let
-  python = python3.withPackages (
-    p: with p; [
-      jinja2
-      pygobject3
-      setuptools
-    ]
-  );
+  python = python3.withPackages (p: with p; [
+    jinja2
+    pygobject3
+    setuptools
+  ]);
 
   isx86 = stdenv.hostPlatform.isx86;
 
@@ -82,9 +78,11 @@ let
   haveFlashrom = isx86 && enableFlashrom;
 
   runPythonCommand =
-    name: buildCommandPython:
+    name:
+    buildCommandPython:
 
-    runCommand name
+    runCommand
+      name
       {
         nativeBuildInputs = [ python3 ];
         inherit buildCommandPython;
@@ -110,8 +108,7 @@ let
         };
       };
     in
-    src
-    // {
+    src // {
       meta = src.meta // {
         # For update script
         position =
@@ -124,28 +121,28 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.0.1";
+  version = "1.9.25";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
   # CLI programs go to out
-  outputs = [
-    "out"
-    "lib"
-    "dev"
-    "devdoc"
-    "man"
-    "installedTests"
-  ];
+  outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
   src = fetchFromGitHub {
     owner = "fwupd";
     repo = "fwupd";
     rev = finalAttrs.version;
-    hash = "sha256-cIkbYoSqVZtEEIh0iTr+Ovu5BWGh6d2NfImTJoc69QU=";
+    hash = "sha256-Yfj2Usto4BSnnBSvffdF02UeK4Ys8ZKzEsxrd2/XZe8=";
   };
 
   patches = [
+    # Since /etc is the domain of NixOS, not Nix,
+    # we cannot install files there.
+    # Let’s install the files to $prefix/etc
+    # while still reading them from /etc.
+    # NixOS module for fwupd will take take care of copying the files appropriately.
+    ./add-option-for-installation-sysconfdir.patch
+
     # Install plug-ins and libfwupdplugin to $out output,
     # they are not really part of the library.
     ./install-fwupdplugin-to-out.patch
@@ -154,20 +151,8 @@ stdenv.mkDerivation (finalAttrs: {
     # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
     ./installed-tests-path.patch
 
-    # Since /etc is the domain of NixOS, not Nix,
-    # we cannot install files there.
-    # Let’s install the files to $prefix/etc
-    # while still reading them from /etc.
-    # NixOS module for fwupd will take take care of copying the files appropriately.
-    ./add-option-for-installation-sysconfdir.patch
-
     # EFI capsule is located in fwupd-efi now.
     ./efi-app-path.patch
-
-    (fetchpatch {
-      url = "https://github.com/fwupd/fwupd/pull/7994.diff?full_index=1";
-      hash = "sha256-fRM033aCoj11Q5u9Yfi3BSD/zpm2kIqf5qabs60nEoM=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -188,74 +173,61 @@ stdenv.mkDerivation (finalAttrs: {
     vala
   ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
+    polkit
+    libxmlb
+    gusb
+    sqlite
+    libarchive
+    libdrm
+    curl
+    elfutils
+    libgudev
+    libjcat
+    libuuid
     json-glib
+    umockdev
+    bash-completion
+    pango
+    tpm2-tss
+    fwupd-efi
+    protobufc
+    modemmanager
+    libmbim
+    libcbor
+    libqmi
+    xz # for liblzma
+  ] ++ lib.optionals haveFlashrom [
+    flashrom
   ];
 
-  buildInputs =
-    [
-      polkit
-      libxmlb
-      gusb
-      sqlite
-      libarchive
-      libdrm
-      curl
-      elfutils
-      libgudev
-      libjcat
-      libuuid
-      bash-completion
-      pango
-      tpm2-tss
-      fwupd-efi
-      protobufc
-      modemmanager
-      libmbim
-      libcbor
-      libqmi
-      xz # for liblzma
-    ]
-    ++ lib.optionals haveFlashrom [
-      flashrom
-    ];
-
-  mesonFlags =
-    [
-      "-Ddocs=enabled"
-      # We are building the official releases.
-      "-Dsupported_build=enabled"
-      "-Dlaunchd=disabled"
-      "-Dsystemd_root_prefix=${placeholder "out"}"
-      "-Dinstalled_test_prefix=${placeholder "installedTests"}"
-      "--localstatedir=/var"
-      "--sysconfdir=/etc"
-      "-Dsysconfdir_install=${placeholder "out"}/etc"
-      "-Defi_os_dir=nixos"
-      "-Dplugin_modem_manager=enabled"
-      "-Dvendor_metadata=true"
-      "-Dplugin_uefi_capsule_splash=false"
-      # TODO: what should this be?
-      "-Dvendor_ids_dir=${hwdata}/share/hwdata"
-      "-Dumockdev_tests=disabled"
-      # We do not want to place the daemon into lib (cyclic reference)
-      "--libexecdir=${placeholder "out"}/libexec"
-    ]
-    ++ lib.optionals (!enablePassim) [
-      "-Dpassim=disabled"
-    ]
-    ++ lib.optionals (!haveDell) [
-      "-Dplugin_synaptics_mst=disabled"
-    ]
-    ++ lib.optionals (!haveRedfish) [
-      "-Dplugin_redfish=disabled"
-    ]
-    ++ lib.optionals (!haveFlashrom) [
-      "-Dplugin_flashrom=disabled"
-    ]
-    ++ lib.optionals (!haveMSR) [
-      "-Dplugin_msr=disabled"
-    ];
+  mesonFlags = [
+    "-Ddocs=enabled"
+    # We are building the official releases.
+    "-Dsupported_build=enabled"
+    "-Dlaunchd=disabled"
+    "-Dudevdir=lib/udev"
+    "-Dsystemd_root_prefix=${placeholder "out"}"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "-Dsysconfdir_install=${placeholder "out"}/etc"
+    "-Defi_os_dir=nixos"
+    "-Dplugin_modem_manager=enabled"
+    "-Dvendor_metadata=true"
+    # We do not want to place the daemon into lib (cyclic reference)
+    "--libexecdir=${placeholder "out"}/libexec"
+  ] ++ lib.optionals (!enablePassim) [
+    "-Dpassim=disabled"
+  ] ++ lib.optionals (!haveDell) [
+    "-Dplugin_synaptics_mst=disabled"
+  ] ++ lib.optionals (!haveRedfish) [
+    "-Dplugin_redfish=disabled"
+  ] ++ lib.optionals (!haveFlashrom) [
+    "-Dplugin_flashrom=disabled"
+  ] ++ lib.optionals (!haveMSR) [
+    "-Dplugin_msr=disabled"
+  ];
 
   # TODO: wrapGAppsHook3 wraps efi capsule even though it is not ELF
   dontWrapGApps = true;
@@ -263,20 +235,19 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   # Environment variables
-  env = {
-    # Fontconfig error: Cannot load default config file
-    FONTCONFIG_FILE =
-      let
-        fontsConf = makeFontsConf {
-          fontDirectories = [ freefont_ttf ];
-        };
-      in
-      fontsConf;
 
-    # error: “PolicyKit files are missing”
-    # https://github.com/NixOS/nixpkgs/pull/67625#issuecomment-525788428
-    PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
-  };
+  # Fontconfig error: Cannot load default config file
+  FONTCONFIG_FILE =
+    let
+      fontsConf = makeFontsConf {
+        fontDirectories = [ freefont_ttf ];
+      };
+    in
+    fontsConf;
+
+  # error: “PolicyKit files are missing”
+  # https://github.com/NixOS/nixpkgs/pull/67625#issuecomment-525788428
+  PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
 
   # Phase hooks
 
@@ -286,8 +257,22 @@ stdenv.mkDerivation (finalAttrs: {
       contrib/generate-man.py \
       po/test-deps
 
+    # tests fail with: Failed to load SMBIOS: neither SMBIOS or DT found
+    sed -i 's/test(.*)//' plugins/lenovo-thinklmi/meson.build
+    sed -i 's/test(.*)//' plugins/mtd/meson.build
+    # fails on amd cpu
+    sed -i 's/test(.*)//' libfwupdplugin/meson.build
     # in nixos test tries to chmod 0777 $out/share/installed-tests/fwupd/tests/redfish.conf
     sed -i "s/get_option('tests')/false/" plugins/redfish/meson.build
+
+    # Device tests use device emulation and need to download emulation data from
+    # the internet, which does not work on our test VMs.
+    # It's probably better to disable these tests for NixOS by setting
+    # the device-tests directory to /dev/null.
+    # For more info on device emulation, see:
+    #   https://github.com/fwupd/fwupd/blob/eeeac4e9ba8a6513428b456a551bffd95d533e50/docs/device-emulation.md
+    substituteInPlace data/installed-tests/meson.build \
+      --replace "join_paths(datadir, 'fwupd', 'device-tests')" "'/dev/null'"
   '';
 
   preBuild = ''
@@ -336,7 +321,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     moveToOutput "share/doc" "$devdoc"
-    moveToOutput "etc/doc" "$devdoc"
   '';
 
   separateDebugInfo = true;
@@ -344,6 +328,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     filesInstalledToEtc = [
+      "fwupd/bios-settings.d/README.md"
       "fwupd/fwupd.conf"
       "fwupd/remotes.d/lvfs-testing.conf"
       "fwupd/remotes.d/lvfs.conf"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#358659.

A breaking change isn't what we want so close to a release. (I should've known better, thought systemd maintainers approved this)