### PR TITLE
nixos/installer: Allow setting a password on cmdline for pxe boot

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -146,9 +146,13 @@ with lib;
         # Allows using nixos-anywhere in headless environments
         for o in $(</proc/cmdline); do
           case "$o" in
-            live.nixos.passwd=*)
+            live.nixos.passwordHash=*)
               set -- $(IFS==; echo $o)
-              echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
+              sed -i "s/nixos::/nixos:$2:/" /etc/shadow
+              ;;
+            live.nixos.password=*)
+              set -- $(IFS==; echo $o)
+              sed -i "s/nixos::/nixos:$(echo $2 | mkpasswd -m sha-512 -s):/" /etc/shadow
               ;;
           esac
         done

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -141,6 +141,17 @@ with lib;
         # /etc/NIXOS tag.
         touch /etc/NIXOS
         ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+
+        # Set password for user nixos if specified on cmdline
+        # Allows using nixos-anywhere in headless environments
+        for o in $(</proc/cmdline); do
+          case "$o" in
+            live.nixos.passwd=*)
+              set -- $(IFS==; echo $o)
+              echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
+              ;;
+          esac
+        done
       '';
 
   };

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -131,33 +131,30 @@ with lib;
 
     boot.loader.timeout = 10;
 
-    boot.postBootCommands =
-      ''
-        # After booting, register the contents of the Nix store
-        # in the Nix database in the tmpfs.
-        ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
+    boot.postBootCommands = ''
+      # After booting, register the contents of the Nix store
+      # in the Nix database in the tmpfs.
+      ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
 
-        # nixos-rebuild also requires a "system" profile and an
-        # /etc/NIXOS tag.
-        touch /etc/NIXOS
-        ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+      # nixos-rebuild also requires a "system" profile and an
+      # /etc/NIXOS tag.
+      touch /etc/NIXOS
+      ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
 
-        # Set password for user nixos if specified on cmdline
-        # Allows using nixos-anywhere in headless environments
-        for o in $(</proc/cmdline); do
-          case "$o" in
-            live.nixos.passwordHash=*)
-              set -- $(IFS==; echo $o)
-              sed -i "s/nixos::/nixos:$2:/" /etc/shadow
-              ;;
-            live.nixos.password=*)
-              set -- $(IFS==; echo $o)
-              sed -i "s/nixos::/nixos:$(echo $2 | mkpasswd -m sha-512 -s):/" /etc/shadow
-              ;;
-          esac
-        done
-      '';
-
+      # Set password for user nixos if specified on cmdline
+      # Allows using nixos-anywhere in headless environments
+      for o in $(</proc/cmdline); do
+        case "$o" in
+          live.nixos.passwordHash=*)
+            set -- $(IFS==; echo $o)
+            ${pkgs.gnugrep}/bin/grep -q "root::" /etc/shadow && ${pkgs.shadow}/bin/usermod -p "$2" root
+            ;;
+          live.nixos.password=*)
+            set -- $(IFS==; echo $o)
+            ${pkgs.gnugrep}/bin/grep -q "root::" /etc/shadow && echo "root:$2" | ${pkgs.shadow}/bin/chpasswd
+            ;;
+        esac
+      done
+    '';
   };
-
 }

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -111,34 +111,39 @@ let
         pxe = ipxeBootDir;
       } // extraConfig);
     in
-      makeTest {
-        name = "boot-netboot-" + name;
-        nodes = { };
-        testScript = ''
-            machine = create_machine("${startCommand}")
-            machine.start()
-            machine.wait_for_unit("multi-user.target")
-            machine.shutdown()
-          '';
-      };
-in {
-    uefiCdrom = makeBootTest "uefi-cdrom" {
-      uefi = true;
-      cdrom = "${iso}/iso/${iso.isoName}";
+    makeTest {
+      name = "boot-netboot-" + name;
+      nodes = { };
+      testScript = ''
+        machine = create_machine("${startCommand}")
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        machine.succeed("grep 'serial' /proc/cmdline")
+        machine.succeed("grep 'live.nixos.passwordHash' /proc/cmdline")
+        machine.succeed("grep '$6$jnwR50SkbLYEq/Vp$wmggwioAkfmwuYqd5hIfatZWS/bO6hewzNIwIrWcgdh7k/fhUzZT29Vil3ioMo94sdji/nipbzwEpxecLZw0d0' /etc/shadow")
+        machine.shutdown()
+      '';
     };
+in
+{
+  uefiCdrom = makeBootTest "uefi-cdrom" {
+    uefi = true;
+    cdrom = "${iso}/iso/${iso.isoName}";
+  };
 
-    uefiUsb = makeBootTest "uefi-usb" {
-      uefi = true;
-      usb = "${iso}/iso/${iso.isoName}";
-    };
+  uefiUsb = makeBootTest "uefi-usb" {
+    uefi = true;
+    usb = "${iso}/iso/${iso.isoName}";
+  };
 
-    uefiNetboot = makeNetbootTest "uefi" {
-      uefi = true;
-    };
-} // lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
-    biosCdrom = makeBootTest "bios-cdrom" {
-      cdrom = "${iso}/iso/${iso.isoName}";
-    };
+  uefiNetboot = makeNetbootTest "uefi" {
+    uefi = true;
+  };
+}
+// lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
+  biosCdrom = makeBootTest "bios-cdrom" {
+    cdrom = "${iso}/iso/${iso.isoName}";
+  };
 
     biosUsb = makeBootTest "bios-usb" {
       usb = "${iso}/iso/${iso.isoName}";

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -85,11 +85,19 @@ let
     let
       config = (import ../lib/eval-config.nix {
           inherit system;
-          modules =
-            [ ../modules/installer/netboot/netboot.nix
-              ../modules/testing/test-instrumentation.nix
-              { key = "serial"; }
-            ];
+          modules = [
+            ../modules/installer/netboot/netboot.nix
+            ../modules/testing/test-instrumentation.nix
+            {
+              boot.kernelParams = [
+                "serial"
+                "live.nixos.passwordHash=$6$jnwR50SkbLYEq/Vp$wmggwioAkfmwuYqd5hIfatZWS/bO6hewzNIwIrWcgdh7k/fhUzZT29Vil3ioMo94sdji/nipbzwEpxecLZw0d0" # "password"
+              ];
+            }
+            {
+              key = "serial";
+            }
+          ];
         }).config;
       ipxeBootDir = pkgs.symlinkJoin {
         name = "ipxeBootDir";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Copied isoImage-functionality for setting a password on boot for the nixos-user to the pxe image. 

The pxe images come without passwords for the `nixos` and `root` accounts. This works great when doing local installations, but it prevents you from using ssh into the live-system without setting a password first. Adding `live.nixos.passwd=somesecretpassword` to the cmdline in any pxe configuration eliminates this requirement. This change also eliminates the need to build own images to achive this goal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
