### PR TITLE
nixos/borgbackup: support to limit access to repos to read-only

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -177,18 +177,22 @@ let
   };
 
   mkRepoService = name: cfg:
-    lib.nameValuePair "borgbackup-repo-${name}" {
-      description = "Create BorgBackup repository ${name} directory";
-      script = ''
-        mkdir -p ${lib.escapeShellArg cfg.path}
-        chown ${cfg.user}:${cfg.group} ${lib.escapeShellArg cfg.path}
-      '';
-      serviceConfig = {
-        # The service's only task is to ensure that the specified path exists
-        Type = "oneshot";
-      };
-      wantedBy = [ "multi-user.target" ];
-    };
+    lib.nameValuePair "borgbackup-repo-${name}" (
+      if cfg.createPath then
+        {
+          description = "Create BorgBackup repository ${name} directory";
+          script = ''
+            mkdir -p ${lib.escapeShellArg cfg.path}
+            chown ${cfg.user}:${cfg.group} ${lib.escapeShellArg cfg.path}
+          '';
+          serviceConfig = {
+            # The service's only task is to ensure that the specified path exists
+            Type = "oneshot";
+          };
+          wantedBy = [ "multi-user.target" ];
+        }
+      else { }
+    );
 
   mkAuthorizedKey = cfg: appendOnly: key:
     let
@@ -197,7 +201,8 @@ let
       restrictedArg = "--restrict-to-${if cfg.allowSubRepos then "path" else "repository"} .";
       appendOnlyArg = lib.optionalString appendOnly "--append-only";
       quotaArg = lib.optionalString (cfg.quota != null) "--storage-quota ${cfg.quota}";
-      serveCommand = "borg serve ${restrictedArg} ${appendOnlyArg} ${quotaArg}";
+      umaskArg = lib.optionalString (cfg.umask != null) "--umask=${cfg.umask}";
+      serveCommand = "borg serve ${restrictedArg} ${appendOnlyArg} ${quotaArg} ${umaskArg}";
     in
       ''command="${cdCommand} && ${serveCommand}",restrict ${key}'';
 
@@ -692,10 +697,18 @@ in {
           path = lib.mkOption {
             type = lib.types.path;
             description = ''
-              Where to store the backups. Note that the directory
-              is created automatically, with correct permissions.
+              Where to store the backups.
             '';
             default = "/var/lib/borgbackup";
+          };
+
+          createPath = lib.mkOption {
+            type = lib.types.bool;
+            description = ''
+              Create {option}`path` directory automatically, with correct
+              permissions.
+            '';
+            default = true;
           };
 
           user = lib.mkOption {
@@ -762,6 +775,19 @@ in {
             '';
             default = null;
             example = "100G";
+          };
+
+          umask = lib.mkOption {
+            type = with lib.types; nullOr str;
+            description = ''
+              umask value {command}`borg serve` should use when creating files.
+              Can be used to make the repository readable to members of the
+              {option}`group` which can be useful to give read only access to
+              the repository.
+              See also [Borg issue #4756](https://github.com/borgbackup/borg/issues/4756#issuecomment-1746754554).
+              '';
+            default = null;
+            example = "0027";
           };
 
         };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Example usage:

```
services.borgbackup.repos = {
  main = {
    umask = "0027";
    authorizedKeys = [
      "... read-write key"
    ] ;
  };
  main_readonly = {
    user = "borg-readonly";
    authorizedKeysAppendOnly = [
      "... read-only key"
    ] ;
    createPath = false;
  };
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc