### PR TITLE
lan-mouse: 0.9.1 → 0.10.0

### DIFF
--- a/pkgs/by-name/la/lan-mouse/package.nix
+++ b/pkgs/by-name/la/lan-mouse/package.nix
@@ -3,7 +3,6 @@
   rustPlatform,
   fetchFromGitHub,
   lib,
-  darwin,
   glib,
   gtk4,
   libadwaita,
@@ -15,17 +14,27 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lan-mouse";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "feschber";
     repo = "lan-mouse";
     rev = "v${version}";
-    hash = "sha256-BadpYZnZJcifhe916/X+OGvTQ4FQeTLnoy0gP/i5cLA=";
+    hash = "sha256-ofiNgJbmf35pfRvZB3ZmMkCJuM7yYgNL+Dd5mZZqyNk=";
+  };
+
+  # lan-mouse uses `git` to determine the version at build time and
+  # has Cargo set the `GIT_DESCRIBE` environment variable. To improve
+  # build reproducibility, we define the variable based on the package
+  # version instead.
+  prePatch = ''
+    rm build.rs
+  '';
+  env = {
+    GIT_DESCRIBE = "${version}-nixpkgs";
   };
 
   nativeBuildInputs = [
-    glib # needed in both {b,nativeB}uildInptus
     pkg-config
     wrapGAppsHook4
   ];
@@ -36,9 +45,9 @@ rustPlatform.buildRustPackage rec {
     libadwaita
     libX11
     libXtst
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.CoreGraphics;
+  ];
 
-  cargoHash = "sha256-pDdpmZPaClU8KjFHO7v3FDQp9D83GQN+SnFg53q2fjs=";
+  cargoHash = "sha256-RP3Jw0b2h8KJlVdd8X/AkkmGdRlIfG2tkPtUKohDxvA=";
 
   meta = {
     description = "Software KVM switch for sharing a mouse and keyboard with multiple hosts through the network";

--- a/pkgs/by-name/la/lan-mouse/package.nix
+++ b/pkgs/by-name/la/lan-mouse/package.nix
@@ -1,15 +1,16 @@
-{ stdenv
-, rustPlatform
-, fetchFromGitHub
-, lib
-, darwin
-, glib
-, gtk4
-, libadwaita
-, libX11
-, libXtst
-, pkg-config
-, wrapGAppsHook4
+{
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+  darwin,
+  glib,
+  gtk4,
+  libadwaita,
+  libX11,
+  libXtst,
+  pkg-config,
+  wrapGAppsHook4,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,8 +36,7 @@ rustPlatform.buildRustPackage rec {
     libadwaita
     libX11
     libXtst
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.CoreGraphics;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.CoreGraphics;
 
   cargoHash = "sha256-pDdpmZPaClU8KjFHO7v3FDQp9D83GQN+SnFg53q2fjs=";
 


### PR DESCRIPTION
[ChangeLog for 0.10.0](https://github.com/feschber/lan-mouse/releases/tag/v0.10.0)

Close #357629

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
