### PR TITLE
lib.types.functor: use payload for all composed types

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -11,6 +11,7 @@ let
     concatLists
     concatMap
     concatStringsSep
+    defaultTypeMerge
     elem
     filter
     foldl'
@@ -749,7 +750,7 @@ let
     foldl' (res: opt:
       let t  = res.type;
           t' = opt.options.type;
-          mergedType = t.typeMerge t'.functor;
+          mergedType = defaultTypeMerge loc t.functor t'.functor;
           typesMergeable = mergedType != null;
           typeSet = if (bothHave "type") && typesMergeable
                        then { type = mergedType; }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -82,7 +82,7 @@ rec {
 
   # Default type merging function
   # takes two type functors and return the merged type
-  defaultTypeMerge = f: f':
+  defaultTypeMerge = loc: f: f':
     let mergedWrapped = f.wrapped.typeMerge f'.wrapped.functor;
         mergedPayload = f.binOp f.payload f'.payload;
 
@@ -103,6 +103,8 @@ rec {
           Use either `functor.payload` or `functor.wrapped` but not both.
 
           If your code worked before remove `functor.payload` from the type definition.
+
+          Location: ${showOption loc}
         ''
       else
         # Has payload
@@ -182,7 +184,7 @@ rec {
     , # Function that merge type declarations.
       # internal, takes a functor as argument and returns the merged type.
       # returning null means the type is not mergeable
-      typeMerge ? defaultTypeMerge functor
+      typeMerge ? defaultTypeMerge ["unknown location"] functor
     , # The type functor.
       # internal, representation of the type as an attribute set.
       #   name: name of the type


### PR DESCRIPTION
Removes `functor.wrapped` in favor of using `functor.payload.elemType`.

There is no reason why `functor.wrapped` should exists since it can be fully represented using the more powerfull and extendable representation.

TODO: Add nice error message for downstream breakage. Nobody should use this attribute, but there are some people that do.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
