### PR TITLE
coreboot-utils: turn into package set

### DIFF
--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -11,7 +11,7 @@
 , pkexecPath ? "pkexec"
 , pkg-config
 , yaml-cpp
-, nvramtool
+, coreboot-utils
 , systemd
 , qtbase
 , qtsvg
@@ -36,10 +36,10 @@ mkDerivation {
     substituteInPlace src/application/*.cpp \
       --replace '/usr/bin/pkexec' '${pkexecPath}' \
       --replace '/usr/bin/systemctl' '${lib.getBin systemd}/systemctl' \
-      --replace '/usr/sbin/nvramtool' '${lib.getExe nvramtool}'
+      --replace '/usr/sbin/nvramtool' '${lib.getExe coreboot-utils.nvramtool}'
 
     substituteInPlace src/resources/org.coreboot.nvramtool.policy \
-      --replace '/usr/sbin/nvramtool' '${lib.getExe nvramtool}'
+      --replace '/usr/sbin/nvramtool' '${lib.getExe coreboot-utils.nvramtool}'
 
     substituteInPlace src/resources/org.coreboot.reboot.policy \
       --replace '/usr/sbin/reboot' '${lib.getBin systemd}/reboot'

--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -56,6 +56,8 @@ let
           patchShebangs .
         '';
 
+        postFixup = "rm -rf $out/sbin";
+
         makeFlags = [
           "INSTALL=install"
           "PREFIX=${placeholder "out"}"
@@ -128,7 +130,6 @@ let
         "x86_64-linux"
         "i686-linux"
       ];
-      preInstall = "mkdir -p $out/sbin";
     };
     inteltool = generic {
       pname = "inteltool";
@@ -168,7 +169,7 @@ let
 
         runHook postInstall
       '';
-      postFixup = ''
+      fixupPhase = ''
         wrapProgram $out/bin/acpidump-all \
           --set PATH ${
             lib.makeBinPath [
@@ -179,21 +180,21 @@ let
               file
             ]
           }
+        runHook postFixup
       '';
     };
   };
 
 in
-utils
-// {
-  coreboot-utils =
+{
+  full =
     (buildEnv {
       name = "coreboot-utils-${version}";
       paths = lib.filter (lib.meta.availableOn stdenv.hostPlatform) (lib.attrValues utils);
-      postBuild = "rm -rf $out/sbin";
     })
     // {
       inherit version;
       meta = commonMeta;
     };
 }
+// utils

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -9,10 +9,10 @@
   apktool,
   binutils-unwrapped-all-targets,
   bzip2,
-  cbfstool,
   cdrkit,
   colord,
   colordiff,
+  coreboot-utils,
   coreutils,
   cpio,
   db,
@@ -211,7 +211,7 @@ python.pkgs.buildPythonApplication rec {
         apksigcopier
         apksigner
         apktool
-        cbfstool
+        coreboot-utils.cbfstool
         colord
         enjarify
         ffmpeg

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2111,19 +2111,7 @@ with pkgs;
     protobuf = protobuf_21;
   };
 
-  inherit (callPackages ../tools/misc/coreboot-utils { })
-    msrtool
-    cbmem
-    ifdtool
-    intelmetool
-    cbfstool
-    nvramtool
-    superiotool
-    ectool
-    inteltool
-    amdfwtool
-    acpidump-all
-    coreboot-utils;
+  coreboot-utils = callPackage ../tools/misc/coreboot-utils { };
 
   coreboot-configurator = libsForQt5.callPackage ../tools/misc/coreboot-configurator { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
After discussing it with @felixsinger, we came to the conclusion that coreboot-utils should be a package set.

Looking for feedback on the implementation as well as how I should handle the breaking changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
