### PR TITLE
edk2: 202408.01 -> 202411

### DIFF
--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -35,14 +35,14 @@ buildType = if stdenv.hostPlatform.isDarwin then
 
 edk2 = stdenv.mkDerivation {
   pname = "edk2";
-  version = "202408.01";
+  version = "202411";
 
   srcWithVendoring = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-tome7S8k2vgEFg7CsXnrg9yxCx1kCypc5BkQzDPyFBc=";
+    hash = "sha256-KYaTGJ3DHtWbPEbP+n8MTk/WwzLv5Vugty/tvzuEUf0=";
   };
 
   src = applyPatches {


### PR DESCRIPTION
## Description of changes

https://github.com/tianocore/edk2/releases/tag/edk2-stable202411
https://github.com/tianocore/edk2/compare/refs/tags/edk2-stable202408.01...refs/tags/edk2-stable202411

## `nixpkgs-review` result

`quickgui` is already broken on master

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>qubes-core-vchan-xen</li>
    <li>vagrant</li>
  </ul>
</details>
<details>
  <summary>:x: 3 packages failed to build:</summary>
  <ul>
    <li>quickgui</li>
    <li>quickgui.debug</li>
    <li>quickgui.pubcache</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 74 packages built:</summary>
  <ul>
    <li>OVMF</li>
    <li>OVMF-cloud-hypervisor</li>
    <li>OVMF-cloud-hypervisor.fd</li>
    <li>OVMF.fd</li>
    <li>OVMFFull</li>
    <li>OVMFFull.fd</li>
    <li>appvm</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>docker-machine-kvm2</li>
    <li>edk2</li>
    <li>edk2-uefi-shell</li>
    <li>fdroidserver</li>
    <li>fdroidserver.dist</li>
    <li>garble</li>
    <li>gnome-boxes</li>
    <li>guestfs-tools</li>
    <li>htcondor</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>libguestfs-with-appliance.guestfsd</li>
    <li>libguestfs.guestfsd</li>
    <li>librenms</li>
    <li>libvirt</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>libvmi</li>
    <li>libvmi.dev</li>
    <li>libvmi.lib</li>
    <li>lxd-lts</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>multipass</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl538Packages.SysVirt</li>
    <li>perl538Packages.SysVirt.devdoc</li>
    <li>perl540Packages.SysVirt</li>
    <li>perl540Packages.SysVirt.devdoc</li>
    <li>python311Packages.guestfs</li>
    <li>python311Packages.guestfs.dist</li>
    <li>python311Packages.libvirt</li>
    <li>python311Packages.libvirt.dist</li>
    <li>python311Packages.xen</li>
    <li>python311Packages.xen.boot</li>
    <li>python311Packages.xen.dev</li>
    <li>python311Packages.xen.doc</li>
    <li>python311Packages.xen.man</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.dist</li>
    <li>python312Packages.libvirt</li>
    <li>python312Packages.libvirt.dist</li>
    <li>xen (python312Packages.xen)</li>
    <li>xen.boot (python312Packages.xen.boot)</li>
    <li>xen.dev (python312Packages.xen.dev)</li>
    <li>xen.doc (python312Packages.xen.doc)</li>
    <li>xen.man (python312Packages.xen.man)</li>
    <li>qemu_xen</li>
    <li>qemu_xen.debug</li>
    <li>qemu_xen.ga</li>
    <li>quickemu</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_1.ruby-libvirt</li>
    <li>rubyPackages_3_2.ruby-libvirt</li>
    <li>rubyPackages_3_4.ruby-libvirt</li>
    <li>virt-manager</li>
    <li>virt-manager-qt</li>
    <li>virt-manager.dist</li>
    <li>virt-top</li>
    <li>virt-v2v</li>
    <li>virt-viewer</li>
    <li>xen-guest-agent</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc