### PR TITLE
lockbook: init at 0.9.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16771,6 +16771,11 @@
     githubId = 33826198;
     name = "Philipp Arras";
   };
+  parth = {
+    github = "parth";
+    githubId = 821972;
+    name = "Parth Mehrotra";
+  };
   pashashocky = {
     email = "pashashocky@gmail.com";
     github = "pashashocky";

--- a/pkgs/by-name/lo/lockbook/package.nix
+++ b/pkgs/by-name/lo/lockbook/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "lockbook";
+  version = "0.9.15";
+
+  src = fetchFromGitHub {
+    owner = "lockbook";
+    repo = "lockbook";
+    rev = "refs/tags/${version}";
+    hash = "sha256-hqBjA/6MWlhVjV4m+cIcnoRTApHuzbPzivMsaQHfRcc=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+M+wL26KDbLKhcujPyWAsTlXwLrQVCUbTnnu/7sXul4=";
+
+  doCheck = false; # there are no cli tests
+  cargoBuildFlags = [
+    "--package"
+    "lockbook-cli"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --bash --name lockbook.bash <($out/bin/lockbook completions bash)
+    installShellCompletion --zsh --name _lockbook <($out/bin/lockbook completions zsh)
+    installShellCompletion --fish --name lockbook.fish <($out/bin/lockbook completions fish)
+  '';
+
+  meta = {
+    description = "Private, polished note-taking platform";
+    longDescription = ''
+      Write notes, sketch ideas, and store files in one secure place.
+      Share seamlessly, keep data synced, and access it on any
+      platform—even offline. Lockbook encrypts files so even we
+      can’t see them, but don’t take our word for it:
+      Lockbook is 100% open-source.
+    '';
+    homepage = "https://lockbook.net";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.all;
+    changelog = "https://github.com/lockbook/lockbook/releases";
+    maintainers = [ lib.maintainers.parth ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

👋 [Lockbook](https://lockbook.net) is an [open source](https://github.com/lockbook/lockbook) secure note taking app. This packages our CLI. Soon we'll have another pr for our desktop app. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
