### PR TITLE
vimPlugins: Remove the nvim-cmp dependency on cmp-sources

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -335,233 +335,113 @@ in
 
   cmp-ai = super.cmp-ai.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       plenary-nvim
     ];
-    nvimRequireCheck = "cmp_ai";
-  };
-
-  cmp-async-path = super.cmp-async-path.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-  };
-
-  cmp-beancount = super.cmp-beancount.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
   };
 
   cmp-clippy = super.cmp-clippy.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       plenary-nvim
     ];
-    nvimRequireCheck = "cmp_clippy";
-  };
-
-  cmp-cmdline = super.cmp-cmdline.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
   };
 
   cmp-conjure = super.cmp-conjure.overrideAttrs {
     dependencies = with self; [
       conjure
-      nvim-cmp
     ];
   };
 
   cmp-copilot = super.cmp-copilot.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       copilot-vim
     ];
-    nvimRequireCheck = "cmp_copilot";
-  };
-
-  cmp-ctags = super.cmp-ctags.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_ctags";
   };
 
   cmp-dap = super.cmp-dap.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       nvim-dap
     ];
-    nvimRequireCheck = "cmp_dap";
-  };
-
-  cmp-dictionary = super.cmp-dictionary.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_dictionary";
-  };
-
-  cmp-digraphs = super.cmp-digraphs.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_digraphs";
-  };
-
-  cmp-fish = super.cmp-fish.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_fish";
   };
 
   cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       fuzzy-nvim
     ];
-    nvimRequireCheck = "cmp_fuzzy_buffer";
   };
 
   cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       fuzzy-nvim
     ];
-    nvimRequireCheck = "cmp_fuzzy_path";
   };
 
   cmp-git = super.cmp-git.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       plenary-nvim
     ];
-    nvimRequireCheck = "cmp_git";
-  };
-
-  cmp-greek = super.cmp-greek.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-    nvimRequireCheck = "cmp_greek";
-  };
-
-  cmp-look = super.cmp-look.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-    nvimRequireCheck = "cmp_look";
   };
 
   cmp_luasnip = super.cmp_luasnip.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       luasnip
     ];
   };
 
   cmp-neosnippet = super.cmp-neosnippet.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       neosnippet-vim
     ];
-    nvimRequireCheck = "cmp_neosnippet";
-  };
-
-  cmp-nixpkgs-maintainers = super.cmp-nixpkgs-maintainers.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_nixpkgs_maintainers";
   };
 
   cmp-npm = super.cmp-npm.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       plenary-nvim
     ];
-    nvimRequireCheck = "cmp-npm";
-  };
-
-  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_nvim_lsp_signature_help";
-  };
-
-  cmp-nvim-lua = super.cmp-nvim-lua.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-  };
-
-  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_nvim_tags";
-  };
-
-  cmp-nvim-ultisnips = super.cmp-nvim-ultisnips.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
   };
 
   cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       plenary-nvim
     ];
-    nvimRequireCheck = "cmp_pandoc";
-  };
-
-  cmp-pandoc-references = super.cmp-pandoc-references.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-  };
-
-  cmp-path = super.cmp-path.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
-  };
-
-  cmp-rg = super.cmp-rg.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp-rg";
   };
 
   cmp-snippy = super.cmp-snippy.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       nvim-snippy
     ];
-    nvimRequireCheck = "cmp_snippy";
-  };
-
-  cmp-tabby = super.cmp-tabby.overrideAttrs {
-    dependencies = with self; [ nvim-cmp ];
-    nvimRequireCheck = "cmp_tabby";
   };
 
   cmp-tabnine = super.cmp-tabnine.overrideAttrs {
     buildInputs = [ tabnine ];
-    dependencies = with self; [ nvim-cmp ];
 
     postFixup = ''
       mkdir -p $target/binaries/${tabnine.version}
       ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
-    nvimRequireCheck = "cmp_tabnine";
   };
 
   cmp-tmux = super.cmp-tmux.overrideAttrs {
-    dependencies = with self; [
-      nvim-cmp
+    dependencies = [
       tmux
     ];
-    nvimRequireCheck = "cmp_tmux";
   };
 
   cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       vim-lsp
     ];
   };
 
   cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs {
     dependencies = with self; [
-      nvim-cmp
       vimwiki
     ];
-    nvimRequireCheck = "cmp_vimwiki_tags";
-  };
-
-  cmp-vsnip = super.cmp-vsnip.overrideAttrs {
-    dependencies = [ self.nvim-cmp ];
   };
 
   cmp-zsh = super.cmp-zsh.overrideAttrs {
-    dependencies = with self; [
-      nvim-cmp
+    dependencies = [
       zsh
     ];
-    nvimRequireCheck = "cmp_zsh";
   };
 
   coc-clangd = buildVimPlugin {
@@ -631,7 +511,6 @@ in
     in
     super.codeium-nvim.overrideAttrs {
       dependencies = with self; [
-        nvim-cmp
         plenary-nvim
       ];
       buildPhase = ''


### PR DESCRIPTION
The `blink.cmp` neovim plugin provides a shim to use sources initially developped for `nvim-cmp` by using the `blink.compat` plugin.

This plugin implements a `cmp` lua module, so that `nvim-cmp` sources register with `blink.cmp` instead of registering with `nvim-cmp`.

If we have a hard dependency on nvim-cmp for cmp sources this means we can't use them with `blink.cmp`

This also means that we can't easily require the plugin in the check phase, as we would need to add nvim-cmp (or blink.compat) to provide the 'cmp' lua module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
