### PR TITLE
llvmPackages.libclang{12,13,14,15,16}: ignore -nostd* flag when linking

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang/ignore-nostd-link-13.diff
+++ b/pkgs/development/compilers/llvm/common/clang/ignore-nostd-link-13.diff
@@ -1,0 +1,57 @@
+backported to clang-12 & clang-13 from https://github.com/llvm/llvm-project/commit/5b77e752dcd073846b89559d6c0e1a7699e58615
+diff --git a/include/clang/Driver/Options.td b/include/clang/Driver/Options.td
+index a0cbcae..8797646 100644
+--- a/include/clang/Driver/Options.td
++++ b/include/clang/Driver/Options.td
+@@ -2931,7 +2931,7 @@ def headerpad__max__install__names : Joined<["-"], "headerpad_max_install_names"
+ def help : Flag<["-", "--"], "help">, Flags<[CC1Option,CC1AsOption, FC1Option,
+     FlangOption]>, HelpText<"Display available options">,
+     MarshallingInfoFlag<FrontendOpts<"ShowHelp">>;
+-def ibuiltininc : Flag<["-"], "ibuiltininc">,
++def ibuiltininc : Flag<["-"], "ibuiltininc">, Group<clang_i_Group>,
+   HelpText<"Enable builtin #include directories even when -nostdinc is used "
+            "before or after -ibuiltininc. "
+            "Using -nobuiltininc after the option disables it">;
+@@ -3641,10 +3641,11 @@ def no_cpp_precomp : Flag<["-"], "no-cpp-precomp">, Group<clang_ignored_f_Group>
+ def no_integrated_cpp : Flag<["-", "--"], "no-integrated-cpp">, Flags<[NoXarchOption]>;
+ def no_pedantic : Flag<["-", "--"], "no-pedantic">, Group<pedantic_Group>;
+ def no__dead__strip__inits__and__terms : Flag<["-"], "no_dead_strip_inits_and_terms">;
+-def nobuiltininc : Flag<["-"], "nobuiltininc">, Flags<[CC1Option, CoreOption]>,
++def nobuiltininc : Flag<["-"], "nobuiltininc">, Flags<[CC1Option, CoreOption]>, Group<IncludePath_Group>,
+   HelpText<"Disable builtin #include directories">,
+   MarshallingInfoNegativeFlag<HeaderSearchOpts<"UseBuiltinIncludes">>;
+-def nogpuinc : Flag<["-"], "nogpuinc">, HelpText<"Do not add include paths for CUDA/HIP and"
++def nogpuinc : Flag<["-"], "nogpuinc">, Group<IncludePath_Group>,
++  HelpText<"Do not add include paths for CUDA/HIP and"
+   " do not include the default CUDA/HIP wrapper headers">;
+ def : Flag<["-"], "nocudainc">, Alias<nogpuinc>;
+ def nogpulib : Flag<["-"], "nogpulib">,
+@@ -3660,9 +3661,9 @@ def noprebind : Flag<["-"], "noprebind">;
+ def noprofilelib : Flag<["-"], "noprofilelib">;
+ def noseglinkedit : Flag<["-"], "noseglinkedit">;
+ def nostartfiles : Flag<["-"], "nostartfiles">, Group<Link_Group>;
+-def nostdinc : Flag<["-"], "nostdinc">, Flags<[CoreOption]>;
+-def nostdlibinc : Flag<["-"], "nostdlibinc">;
+-def nostdincxx : Flag<["-"], "nostdinc++">, Flags<[CC1Option]>,
++def nostdinc : Flag<["-"], "nostdinc">, Flags<[CoreOption]>, Group<IncludePath_Group>;
++def nostdlibinc : Flag<["-"], "nostdlibinc">, Group<IncludePath_Group>;
++def nostdincxx : Flag<["-"], "nostdinc++">, Flags<[CC1Option]>, Group<IncludePath_Group>,
+   HelpText<"Disable standard #include directories for the C++ standard library">,
+   MarshallingInfoNegativeFlag<HeaderSearchOpts<"UseStandardCXXIncludes">>;
+ def nostdlib : Flag<["-"], "nostdlib">, Group<Link_Group>;
+diff --git a/test/Driver/linker-opts.c b/test/Driver/linker-opts.c
+index e1673f7..b9beb91 100644
+--- a/test/Driver/linker-opts.c
++++ b/test/Driver/linker-opts.c
+@@ -16,9 +16,8 @@
+ //
+ // Make sure that we don't warn on unused compiler arguments.
+ // RUN: %clang -Xclang -I. -x c %s -c -o %t/tmp.o
+-// RUN: %clang -Xclang -I. %t/tmp.o -o %t/tmp -### 2>&1 | FileCheck %s --check-prefix=NO-UNUSED
+-// NO-UNUSED-NOT: warning:{{.*}}unused
+-//
++// RUN: %clang -### -I. -ibuiltininc -nobuiltininc -nostdinc -nostdinc++ -nostdlibinc -nogpuinc %t/tmp.o -o /dev/null 2>&1 | FileCheck /dev/null --implicit-check-not=warning:
++
+ // Make sure that we do warn in other cases.
+ // RUN: %clang %s -lfoo -c -o %t/tmp2.o -### 2>&1 | FileCheck %s --check-prefix=UNUSED
+ // UNUSED: warning:{{.*}}unused

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -534,6 +534,17 @@ let
             # mis-compilation in firefox.
             # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1741454
             (metadata.getVersionFile "clang/revert-malloc-alignment-assumption.patch")
+          ++ lib.optional (lib.versionOlder metadata.release_version "17") (
+            if lib.versionAtLeast metadata.release_version "14" then
+              fetchpatch {
+                name = "ignore-nostd-link.patch";
+                url = "https://github.com/llvm/llvm-project/commit/5b77e752dcd073846b89559d6c0e1a7699e58615.patch";
+                relative = "clang";
+                hash = "sha256-qzSAmoGY+7POkDhcGgQRPaNQ3+7PIcIc9cZuiE/eLkc=";
+              }
+            else
+              ./clang/ignore-nostd-link-13.diff
+          )
           ++ [
             (substituteAll {
               src =


### PR DESCRIPTION
apply
https://github.com/llvm/llvm-project/commit/5b77e752dcd073846b89559d6c0e1a7699e58615 to clang 14-16 and backport the patch to apply to clang 12-13

backported patch just drops the final change in Hunk 2 of Options.td as it doesn't exist until clang-14

testing: made sure patches applied to clangs 12-16. built irods on x64 linux (uses clang-13 and requires patch)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@emilazy @pwaller 