### PR TITLE
uwsm: prefer user env binaries at runtime

### DIFF
--- a/pkgs/by-name/uw/uwsm/package.nix
+++ b/pkgs/by-name/uw/uwsm/package.nix
@@ -13,6 +13,7 @@
   libnotify,
   newt,
   python3Packages,
+  systemd,
   util-linux,
   fumonSupport ? true,
   uuctlSupport ? true,
@@ -49,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     newt # whiptail
     libnotify # notify
     bash # sh
+    systemd
     python
   ] ++ (lib.optionals uuctlSupport [ dmenu ]);
 

--- a/pkgs/by-name/uw/uwsm/package.nix
+++ b/pkgs/by-name/uw/uwsm/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall =
     let
       wrapperArgs = ''
-        --prefix PATH : "${lib.makeBinPath finalAttrs.propagatedBuildInputs}"
+        --suffix PATH : "${lib.makeBinPath finalAttrs.propagatedBuildInputs}"
       '';
     in
     ''


### PR DESCRIPTION
We are wrapping uwsm with bash and other packages, else it won't work because it won't find the dependencies at runtime (it's just a python script). However this also leaks the `PATH` to subprocesses/apps that are launched using UWSM. Leading to issues like https://github.com/NixOS/nixpkgs/issues/358805.

In this PR, we just change the path order of these runtime dependencies, so these are treated like fallbacks. Ideally we should not expect anything from user environment, and the wrapping approach isn't the best. Not like we have any other choice.

CC @Scrumplex @Atemu fellow UWSM users, they might have an idea to fix this.
CC @Vladimir-csp, UWSM dev

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
