### PR TITLE
tidal-hifi: 5.16.0 -> 5.17.0

### DIFF
--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -38,11 +38,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tidal-hifi";
-  version = "5.16.0";
+  version = "5.17.0";
 
   src = fetchurl {
     url = "https://github.com/Mastermindzh/tidal-hifi/releases/download/${finalAttrs.version}/tidal-hifi_${finalAttrs.version}_amd64.deb";
-    sha256 = "sha256-gDinm7kILm4SKlWmaJ1grwRuketGs/aWlJfNEF+AIRo=";
+    sha256 = "sha256-oM0hXimXSrV33tntV+DeYdV0WyyRqioKSm+rL+Oce6Y=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper wrapGAppsHook3 ];


### PR DESCRIPTION
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
