### PR TITLE
stirling-pdf: use Gradle 8

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -419,15 +419,15 @@
   "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.8.0": {
    "pom": "sha256-LRFzQyMeKb4i5Im8H0gl4dS771RZBeeTJE6VIhlXFU8="
   },
-  "org/springframework#spring-core/6.0.23": {
-   "jar": "sha256-TOmcA/2FlH1DV/xCrN5OCAs2TVOjrLHPq52jmCQMQpE=",
-   "module": "sha256-eCrk9Me63PoSiLZ+lzw96kPqoMD4am2RCEIAn2i+l9w=",
-   "pom": "sha256-FU3YnVr9T1idQA4GJkk87ONTsYc2e/ODPvVx97KQ5kE="
+  "org/springframework#spring-core/6.1.14": {
+   "jar": "sha256-4VoRefyWQv/tE8pV4oY+LaUkzNEIO3xvG1z9VzPzssU=",
+   "module": "sha256-c5SoxHoyHbg43H3wtb7F9prMPMu7D4jn57eCdEpaahE=",
+   "pom": "sha256-7YrAnxeoq79chQmBgDdU1CSx2jYytN37Kl7K5Com1pE="
   },
-  "org/springframework#spring-jcl/6.0.23": {
-   "jar": "sha256-zCnuRaX/A2qZwLue0aCEBls2HvWiSeD0XxZYzMP0dQQ=",
-   "module": "sha256-4F58rXbbpxI0nJWB/wt3dyzJ9jiRsOtI9Feyq36ObtQ=",
-   "pom": "sha256-JAilcZX6oBf25+ye+N2K7InB3Qa5ZyBopMpWiALKl7I="
+  "org/springframework#spring-jcl/6.1.14": {
+   "jar": "sha256-mXXEYrrO56DBqnnlWqT67QK9KNx40SUkBNqH9ff7TLE=",
+   "module": "sha256-eVuSx7ppHm1vSPMy/IoKELVkJx1A/luRYEsT89XeBFo=",
+   "pom": "sha256-XS7hByyO0HjD5QkJVXnPKujOMBMFhthMz2q2LACN9WM="
   },
   "org/springframework/boot#org.springframework.boot.gradle.plugin/3.3.5": {
    "pom": "sha256-yGsKKmHOFuW2MK0UYJ3nS9dOFAX23odkPptBsbEojnc="
@@ -1076,8 +1076,8 @@
   "net/sf/launch4j#launch4j/3.50": {
    "pom": "sha256-1716EuPm1bR/Ou0p/4g89cTKnie3GWkQZnkzH6N+xy0="
   },
-  "net/sf/launch4j#launch4j/3.50/workdir-linux64": {
-   "jar": "sha256-/uvoOrT+Q5F+qn3/Jy3uDvP6hUvWgzRDRDDgjjoS8zA="
+  "net/sf/launch4j#launch4j/3.50/workdir-linux": {
+   "jar": "sha256-lIYQ+neeFs1zX+wI+d+NfIZmWsbND1Kobh1QYW/msdo="
   },
   "org/antlr#antlr4-master/4.13.0": {
    "pom": "sha256-IiBv17pJUVLlJvUO/sn8j03QX8tD38+PJk6Dffa2Qk8="

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -2,13 +2,13 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle_7,
+  gradle_8,
   makeWrapper,
   jre,
 }:
 
 let
-  gradle = gradle_7;
+  gradle = gradle_8;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stirling-pdf";


### PR DESCRIPTION
Used upstream as of v1.0.1:
https://github.com/Stirling-Tools/Stirling-PDF/commit/250c317155a4eca056c9113d0498a99d2f9aa32a

"Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."

Part of #358845 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
