### PR TITLE
datadog-agent: 7.50.3 -> 7.56.2

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -13,7 +13,13 @@ let
   // lib.optionalAttrs (cfg.ddUrl != null) { dd_url = cfg.ddUrl; }
   // lib.optionalAttrs (cfg.site != null) { site = cfg.site; }
   // lib.optionalAttrs (cfg.tags != null ) { tags = lib.concatStringsSep ", " cfg.tags; }
-  // lib.optionalAttrs (cfg.enableLiveProcessCollection) { process_config = { enabled = "true"; }; }
+  // lib.optionalAttrs (cfg.enableLiveProcessCollection) {
+    process_config = {
+      dd_agent_bin = "${datadogPkg}/bin/agent";
+      process_collection.enabled = "true";
+      container_collection.enabled = "true";
+    };
+  }
   // lib.optionalAttrs (cfg.enableTraceAgent) { apm_config = { enabled = true; }; }
   // cfg.extraConfig;
 

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , cmake
-, buildGoModule
+, buildGo122Module
 , makeWrapper
 , fetchFromGitHub
 , pythonPackages
@@ -9,6 +9,7 @@
 , systemd
 , hostname
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+, withDocker ? true
 , extraTags ? [ ]
 , testers
 , datadog-agent
@@ -16,17 +17,17 @@
 
 let
   # keep this in sync with github.com/DataDog/agent-payload dependency
-  payloadVersion = "5.0.97";
+  payloadVersion = "5.0.124";
   python = pythonPackages.python;
   owner   = "DataDog";
   repo    = "datadog-agent";
   goPackagePath = "github.com/${owner}/${repo}";
-  version = "7.50.3";
+  version = "7.56.2";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev = version;
-    hash = "sha256-AN5BruLPyrpIGSUkcYkZC0VgItk9NHiZTXstv6j9TlY=";
+    hash = "sha256-rU3eg92MuGs/6r7oJho2roeUCZoyfqYt1xOERoRPqmQ=";
   };
   rtloader = stdenv.mkDerivation {
     pname = "datadog-agent-rtloader";
@@ -37,19 +38,20 @@ let
     cmakeFlags = ["-DBUILD_DEMO=OFF" "-DDISABLE_PYTHON2=ON"];
   };
 
-in buildGoModule rec {
+in buildGo122Module rec {
   pname = "datadog-agent";
   inherit src version;
 
   doCheck = false;
 
-  vendorHash = "sha256-Rn8EB/6FHQk9COlOaxm4TQXjGCIPZHJV2QQnPDcbRnM=";
+  vendorHash = if stdenv.isDarwin
+               then "sha256-3Piq5DPMTZUEjqNkw5HZY25An2kATX6Jac9unQfZnZc="
+               else "sha256-FR0Et3DvjJhbYUPy9mpN0QCJ7QDU4VRZFUTL0J1FSXw=";
 
   subPackages = [
     "cmd/agent"
     "cmd/cluster-agent"
     "cmd/dogstatsd"
-    "cmd/py-launcher"
     "cmd/trace-agent"
   ];
 
@@ -67,6 +69,7 @@ in buildGoModule rec {
     "zlib"
   ]
   ++ lib.optionals withSystemd [ "systemd" ]
+  ++ lib.optionals withDocker [ "docker" ]
   ++ extraTags;
 
   ldflags = [
@@ -74,19 +77,17 @@ in buildGoModule rec {
     "-X ${goPackagePath}/pkg/version.AgentVersion=${version}"
     "-X ${goPackagePath}/pkg/serializer.AgentPayloadVersion=${payloadVersion}"
     "-X ${goPackagePath}/pkg/collector/python.pythonHome3=${python}"
-    "-X ${goPackagePath}/pkg/config.DefaultPython=3"
+    "-X ${goPackagePath}/pkg/config/setup.DefaultPython=3"
     "-r ${python}/lib"
   ];
 
-  preBuild = ''
-    # Keep directories to generate in sync with tasks/go.py
-    go generate ./pkg/status ./cmd/agent/gui
-  '';
-
   # DataDog use paths relative to the agent binary, so fix these.
+  # We can't just point these to $out since that would introduce self-referential paths in the go modules,
+  # which are a fixed-output derivation. However, the patches aren't picked up if we skip them when building
+  # the modules. So we'll just traverse from the bin back to the out folder.
   postPatch = ''
-    sed -e "s|PyChecksPath =.*|PyChecksPath = \"$out/${python.sitePackages}\"|" \
-        -e "s|distPath =.*|distPath = \"$out/share/datadog-agent\"|" \
+    sed -e "s|PyChecksPath =.*|PyChecksPath = filepath.Join(_here, \"..\", \"${python.sitePackages}\")|" \
+        -e "s|distPath =.*|distPath = filepath.Join(_here, \"..\", \"share\", \"datadog-agent\")|" \
         -i cmd/agent/common/path/path_nix.go
     sed -e "s|/bin/hostname|${lib.getBin hostname}/bin/hostname|" \
         -i pkg/util/hostname/fqdn_nix.go
@@ -97,10 +98,8 @@ in buildGoModule rec {
   postInstall = ''
     mkdir -p $out/${python.sitePackages} $out/share/datadog-agent
     cp -R --no-preserve=mode $src/cmd/agent/dist/conf.d $out/share/datadog-agent
-    rm -rf $out/share/datadog-agent/conf.d/{apm.yaml.default,process_agent.yaml.default,winproc.d}
+    rm -rf $out/share/datadog-agent/conf.d/{apm.yaml.default,process_agent.yaml.default,winproc.d,agentcrashdetect.d,myapp.d}
     cp -R $src/cmd/agent/dist/{checks,utils,config.py} $out/${python.sitePackages}
-
-    cp -R $src/pkg/status/templates $out/share/datadog-agent
 
     wrapProgram "$out/bin/agent" \
       --set PYTHONPATH "$out/${python.sitePackages}"''
@@ -119,10 +118,5 @@ in buildGoModule rec {
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ thoughtpolice domenkozar ];
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    # broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
-
-    # Upstream does not support Go > 1.21; for update refer to https://github.com/NixOS/nixpkgs/issues/351119
-    broken = true;
   };
 }

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -42,9 +42,9 @@ let
     owner = "DataDog";
     repo = "integrations-core";
     rev = version;
-    sha256 = "sha256-tgY8Jh7N9ot3Xp+JfsA9vEzj62H2OPTEh6b1YzyNGRU=";
+    sha256 = "sha256-p5eoNNHQQl314mfUk2t3qQaerPu02GKA+tKkAY7bojk=";
   };
-  version = "7.50.2";
+  version = "7.56.2";
 
   # Build helper to build a single datadog integration package.
   buildIntegration = { pname, ... }@args:

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -33,7 +33,7 @@
 #
 # [1]: https://github.com/DataDog/integrations-core
 
-{ pkgs, python, extraIntegrations ? {} }:
+{ pkgs, python, extraIntegrations ? { }, }:
 
 let
   inherit (pkgs.lib) attrValues mapAttrs;
@@ -42,18 +42,21 @@ let
     owner = "DataDog";
     repo = "integrations-core";
     rev = version;
-    sha256 = "sha256-CIzuJ97KwsG1k65Y+8IUSka/3JX1pmQKN3hPHzZnGhQ=";
+    sha256 = "sha256-tgY8Jh7N9ot3Xp+JfsA9vEzj62H2OPTEh6b1YzyNGRU=";
   };
-  version = "7.38.0";
+  version = "7.50.2";
 
   # Build helper to build a single datadog integration package.
-  buildIntegration = { pname, ... }@args: python.pkgs.buildPythonPackage (args // {
-    inherit src version;
-    name = "datadog-integration-${pname}-${version}";
+  buildIntegration = { pname, ... }@args:
+    python.pkgs.buildPythonPackage (args // {
+      inherit src version;
+      name = "datadog-integration-${pname}-${version}";
+      pyproject = true;
 
-    sourceRoot = "${src.name}/${args.sourceRoot or pname}";
-    doCheck = false;
-  });
+      sourceRoot = "${src.name}/${args.sourceRoot or pname}";
+      buildInputs = with python.pkgs; [ hatchling setuptools ];
+      doCheck = false;
+    });
 
   # Base package depended on by all other integrations.
   datadog_checks_base = buildIntegration {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13544,7 +13544,6 @@ with pkgs;
   };
   datadog-process-agent = callPackage ../tools/networking/dd-agent/datadog-process-agent.nix { };
   datadog-integrations-core = extras: callPackage ../tools/networking/dd-agent/integrations-core.nix {
-    python = python3;
     extraIntegrations = extras;
   };
 


### PR DESCRIPTION
Updates datadog-related packages for Go 1.22 compatibility, and fixes a few issues. This should be backported to 24.11, where datadog-agent is currently marked as broken.

- Updated packages to the minimum version that supports Go 1.22
- Stripped out windows-only integration that showed up as broken in datadog UI (agentcrashdetect)
- Stripped out random test integration whose config is somehow included in the default configs
- Compiled packages with docker support by default. This will save a somewhat heavy build step for users who need docker support, while only adding 2.5% to the bin folder size (4MB).
- Update deprecated options for the process agent
- Set `dd_agent_bin` argument for the process agent to communicate with the main agent.

Superset of #356308

Resolves #351119 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
