### PR TITLE
nixos/frr: make runtime directory world-readable

### DIFF
--- a/nixos/modules/services/networking/frr.nix
+++ b/nixos/modules/services/networking/frr.nix
@@ -220,7 +220,7 @@ in
         '';
       };
 
-      systemd.tmpfiles.rules = [ "d /run/frr 0750 frr frr -" ];
+      systemd.tmpfiles.rules = [ "d /run/frr 0755 frr frr -" ];
 
       systemd.services.frr = {
         description = "FRRouting";


### PR DESCRIPTION
FRR creates a number of sockets within its runtime directory, some of which are used for internal IPC, but also those used by the vtysh interface. The internal sockets are created with appropriately restrictive permissions (`frr:frr 0660`), however the VTY sockets have group `frrvty` (e.g. `frr:frrvty 0660`). This is intended to provide access control for allowing selected non-root users to access the VTY interface without requiring root access.

However, the NixOS module for FRR creates the runtime directory with permissions `frr:frr 0750`, which means that non-root/non-frr users cannot read this directory. This change changes the permissions of `/run/frr` from 0750 to 0755 to allow unprivileged users to read the directory, so those who are members of the `frrvty` group can connect to the VTY sockets.

This change also brings the NixOS module in line with how this is handled in other FRR distributions (e.g. Cumulus Linux or SONiC), as they also create `/run/frr` with world-readability.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

