### PR TITLE
nixos/buffyboard: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -16,6 +16,8 @@
 
 - [Amazon CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent), the official telemetry collector for AWS CloudWatch and AWS X-Ray. Available as [services.amazon-cloudwatch-agent](#opt-services.amazon-cloudwatch-agent.enable).
 
+- [Buffyboard](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/tree/master/buffyboard), a framebuffer on-screen keyboard. Available as [services.buffyboard](option.html#opt-services.buffyboard).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -588,6 +588,7 @@
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix
+  ./services/hardware/buffyboard.nix
   ./services/hardware/ddccontrol.nix
   ./services/hardware/display.nix
   ./services/hardware/fancontrol.nix

--- a/nixos/modules/services/hardware/buffyboard.nix
+++ b/nixos/modules/services/hardware/buffyboard.nix
@@ -1,0 +1,138 @@
+# INTEGRATION NOTES:
+# Buffyboard integrates as a virtual device in /dev/input
+# which reads touch or pointer events from other input devices
+# and generates events based on where those map to the keys it renders to the framebuffer.
+#
+# Buffyboard generates these events whether or not its onscreen keyboard is actually visible.
+# Hence special care is needed if running anything which claims ownership of the display (such as a desktop environment),
+# to avoid unwanted input events being triggered during normal desktop operation.
+#
+# Desktop users are recommended to either:
+# 1. Stop buffyboard once your DE is started.
+#   e.g. `services.buffyboard.unitConfig.Conflicts = [ "my-de.service" ];`
+# 2. Configure your DE to ignore input events from buffyboard (product-id=25209; vendor-id=26214; name=rd)
+#   e.g. `echo 'input "26214:25209:rd" events disabled' > ~/.config/sway/config`
+
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.buffyboard;
+  ini = pkgs.formats.ini { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ colinsane ];
+
+  options = {
+    services.buffyboard = with lib; {
+      enable = mkEnableOption "buffyboard framebuffer keyboard (on-screen keyboard)";
+      package = mkPackageOption pkgs "buffybox" { };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra CLI arguments to pass to buffyboard.
+        '';
+        example = [
+          "--geometry=1920x1080@640,0"
+          "--dpi=192"
+          "--rotate=2"
+          "--verbose"
+        ];
+      };
+
+      configFile = mkOption {
+        type = lib.types.path;
+        default = ini.generate "buffyboard.conf" (lib.filterAttrsRecursive (_: v: v != null) cfg.settings);
+        defaultText = lib.literalExpression ''ini.generate "buffyboard.conf" cfg.settings'';
+        description = ''
+          Path to an INI format configuration file to provide Buffyboard.
+          By default, this is generated from whatever you've set in `settings`.
+          If specified manually, then `settings` is ignored.
+
+          For an example config file see [here](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/blob/master/buffyboard/buffyboard.conf)
+        '';
+      };
+
+      settings = mkOption {
+        description = ''
+          Settings to include in /etc/buffyboard.conf.
+          Every option here is strictly optional:
+          Buffyboard will use its own baked-in defaults for those options left unset.
+        '';
+        type = types.submodule {
+          freeformType = ini.type;
+
+          options.input.pointer = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Enable or disable the use of a hardware mouse or other pointing device.
+            '';
+          };
+          options.input.touchscreen = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Enable or disable the use of the touchscreen.
+            '';
+          };
+
+          options.theme.default = mkOption {
+            type = types.either types.str (
+              types.enum [
+                null
+                "adwaita-dark"
+                "breezy-dark"
+                "breezy-light"
+                "nord-dark"
+                "nord-light"
+                "pmos-dark"
+                "pmos-light"
+              ]
+            );
+            default = null;
+            description = ''
+              Selects the default theme on boot. Can be changed at runtime to the alternative theme.
+            '';
+          };
+          options.quirks.fbdev_force_refresh = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              If true and using the framebuffer backend, this triggers a display refresh after every draw operation.
+              This has a negative performance impact.
+            '';
+          };
+        };
+        default = { };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    systemd.services.buffyboard = {
+      # upstream provides the service (including systemd hardening): we just configure it to start by default
+      # and override ExecStart so as to optionally pass extra arguments
+      serviceConfig.ExecStart = [
+        "" # clear default ExecStart
+        (utils.escapeSystemdExecArgs (
+          [
+            (lib.getExe' cfg.package "buffyboard")
+            "--config-override"
+            cfg.configFile
+          ]
+          ++ cfg.extraFlags
+        ))
+      ];
+      wantedBy = [ "getty.target" ];
+      before = [ "getty.target" ];
+    };
+  };
+}

--- a/pkgs/by-name/bu/buffybox/package.nix
+++ b/pkgs/by-name/bu/buffybox/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitLab,
+  inih,
+  lib,
+  libdrm,
+  libinput,
+  libxkbcommon,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  stdenv,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "buffybox";
+  version = "3.2.0-unstable-2024-11-10";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
+    repo = "buffybox";
+    fetchSubmodules = true; # to use its vendored lvgl
+    rev = "07e324c17564cb9aab573259a8e0824a6806a751";
+    hash = "sha256-JY9WqtRjDsQf1UVFnM6oTwyAuhlJvrhcSNJdEZ0zIus=";
+  };
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    inih
+    libdrm
+    libinput
+    libxkbcommon
+  ];
+
+  env.PKG_CONFIG_SYSTEMD_SYSTEMD_SYSTEM_UNIT_DIR = "${placeholder "out"}/lib/systemd/system";
+
+  strictDeps = true;
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "A suite of graphical applications for the terminal";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/buffybox";
+    license = licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ colinsane ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
[buffyboard](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/tree/master/buffyboard) is the On-Screen Keyboard (OSK) provided by postmarketOS's buffybox project. unlike X- or Wayland-based OSKs, buffyboard renders directly to the framebuffer and injects events via libinput: this allows it to run _without_ any Desktop Environment. the primary use-case is to make the native TTY system accessible to keyboard-less devices such as Linux tablets and mobile phones.

---

- the package can be tested with `nix-build -A buffybox && sudo ./result/bin/buffyboard`; then tab to an unused TTY (e.g. Ctrl+Alt+F2) and use the mouse/touchpad/touchscreen to use the virtual keyboard. if no on-screen keyboard is visible, click the bottom of the TTY to force a redraw.
- the service can be tested in the same manner after setting `services.buffyboard.enable = true`. a reboot or `systemctl start buffyboard.service` may be required.

pleases see the note in `nixos/modules/services/hardware/buffyboard.nix` for tips to make the experience more enjoyable if deploying to a device that also runs a desktop environment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
