### PR TITLE
various: unpin Boost (round 2)

### DIFF
--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config
-, alsa-lib, asio, avahi, boost179, flac, libogg, libvorbis, libopus, soxr
+, alsa-lib, asio, avahi, boost, flac, libogg, libvorbis, libopus, soxr
 , IOKit, AudioToolbox
 , aixlog, popl
 , pulseaudioSupport ? false, libpulseaudio
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   # snapcast also supports building against tremor but as we have libogg, that's
   # not needed
   buildInputs = [
-    boost179
+    boost
     asio avahi flac libogg libvorbis libopus
     aixlog popl soxr
   ] ++ lib.optional pulseaudioSupport libpulseaudio

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,4 +1,4 @@
-{ autoreconfHook, boost180, cargo, coreutils, curl, cxx-rs, db62, fetchFromGitHub
+{ autoreconfHook, boost, cargo, coreutils, curl, cxx-rs, db62, fetchFromGitHub
 , git, hexdump, lib, libevent, libsodium, makeWrapper, rustPlatform
 , pkg-config, Security, stdenv, testers, tl-expected, utf8cpp, util-linux, zcash, zeromq
 }:
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
   nativeBuildInputs = [ autoreconfHook cargo cxx-rs git hexdump makeWrapper pkg-config ];
 
   buildInputs = [
-    boost180
+    boost
     db62
     libevent
     libsodium
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
 
   configureFlags = [
     "--disable-tests"
-    "--with-boost-libdir=${lib.getLib boost180}/lib"
+    "--with-boost-libdir=${lib.getLib boost}/lib"
     "RUST_TARGET=${stdenv.hostPlatform.rust.rustcTargetSpec}"
   ];
 

--- a/pkgs/by-name/lo/localproxy/package.nix
+++ b/pkgs/by-name/lo/localproxy/package.nix
@@ -6,11 +6,11 @@
 , openssl
 , protobuf_21
 , catch2
-, boost181
+, boost
 , icu
 }:
 let
-  boost = boost181.override { enableStatic = true; };
+  boost' = boost.override { enableStatic = true; };
   protobuf = protobuf_21.override { enableShared = false; };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ openssl protobuf catch2 boost icu ];
+  buildInputs = [ openssl protobuf catch2 boost' icu ];
 
   postPatch = ''
     sed -i '/set(OPENSSL_USE_STATIC_LIBS TRUE)/d' CMakeLists.txt

--- a/pkgs/by-name/nh/nheko/package.nix
+++ b/pkgs/by-name/nh/nheko/package.nix
@@ -5,7 +5,7 @@
   cmake,
   asciidoc,
   pkg-config,
-  boost179,
+  boost,
   cmark,
   coeurl,
   curl,
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      boost179
+      boost
       cmark
       coeurl
       curl

--- a/pkgs/by-name/qu/quantlib/package.nix
+++ b/pkgs/by-name/qu/quantlib/package.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, boost186 # (boost181) breaks on darwin
+, boost
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost186 ];
+  buildInputs = [ boost ];
 
   # Required by RQuantLib, may be beneficial for others too
   cmakeFlags = [ "-DQL_HIGH_RESOLUTION_DATE=ON" ];

--- a/pkgs/by-name/sv/sv-lang/package.nix
+++ b/pkgs/by-name/sv/sv-lang/package.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, boost182
+, boost
 , catch2_3
 , cmake
 , ninja
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     unordered_dense
-    boost182
+    boost
     fmt_9
     # though only used in tests, cmake will complain its absence when configuring
     catch2_3

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -9,7 +9,7 @@
   gperf,
   gawk,
   pkg-config,
-  boost182,
+  boost,
   fmt,
   luajit_openresty,
   ncurses,
@@ -47,8 +47,6 @@ let
       EOF
     '';
   };
-
-  boost = boost182;
 in
 
 stdenv.mkDerivation (self: {

--- a/pkgs/development/libraries/libpulsar/default.nix
+++ b/pkgs/development/libraries/libpulsar/default.nix
@@ -1,7 +1,7 @@
 { lib
 , asioSupport ? true
 , asio
-, boost180
+, boost
 , log4cxxSupport ? false
 , log4cxx
 , snappySupport ? false
@@ -41,7 +41,7 @@ let
     ++ lib.optional zstdSupport zstd
     ++ lib.optional log4cxxSupport log4cxx
     ++ lib.optional asioSupport asio
-    ++ lib.optional (!asioSupport) boost180;
+    ++ lib.optional (!asioSupport) boost;
 
 in
 stdenv.mkDerivation (finalAttrs: rec {

--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  boost182,
+  boost,
   gtest,
   llvmPackages,
   meson,
@@ -72,7 +72,7 @@ in
 
       buildInputs = [
         gtest
-        boost182
+        boost
         nlohmann_json
       ];
 
@@ -103,7 +103,7 @@ in
       buildInputs = [
         nix
         gtest
-        boost182
+        boost
       ];
 
       env.CXXFLAGS = "-include ${nix.dev}/include/nix/config.h";
@@ -132,7 +132,7 @@ in
         nixt
         llvmPackages.llvm
         gtest
-        boost182
+        boost
       ];
 
       nativeBuildInputs = common.nativeBuildInputs ++ [ cmake ];

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, postgresql, boost182, postgresqlTestExtension, buildPostgresqlExtension }:
+{ stdenv, lib, fetchFromGitHub, postgresql, boost, postgresqlTestExtension, buildPostgresqlExtension }:
 
 let
   version = "1.7.0";
@@ -28,7 +28,7 @@ buildPostgresqlExtension (finalAttrs: {
 
   sourceRoot = main_src.name;
 
-  buildInputs = [ boost182 ];
+  buildInputs = [ boost ];
 
   patchPhase = ''
     runHook prePatch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9569,10 +9569,7 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
-  hpx = callPackage ../development/libraries/hpx {
-    boost = boost179;
-    asio = asio.override { boost = boost179; };
-  };
+  hpx = callPackage ../development/libraries/hpx { };
 
   hspell = callPackage ../development/libraries/hspell { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4769,7 +4769,6 @@ with pkgs;
   };
 
   osl = libsForQt5.callPackage ../development/compilers/osl {
-    boost = boost179;
     libclang = llvmPackages_15.libclang;
     clang = clang_15;
     llvm = llvm_15;


### PR DESCRIPTION
More things that pin an old Boost but don’t need to, this time without leading to a Boost version getting GC’d (yet). Everything here builds.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`hpx`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (everything else)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
