### PR TITLE
bash-env-json: fix path issue

### DIFF
--- a/pkgs/by-name/ba/bash-env-json/package.nix
+++ b/pkgs/by-name/ba/bash-env-json/package.nix
@@ -1,7 +1,6 @@
 {
   stdenvNoCC,
   lib,
-  makeWrapper,
   fetchFromGitHub,
   coreutils,
   gnused,
@@ -11,18 +10,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "bash-env-json";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "tesujimath";
     repo = "bash-env-json";
     rev = finalAttrs.version;
-    hash = "sha256-cZEkYOr9z6yLPA4PSo6+hogaqb1vhWaYi/rp4asfsbM=";
+    hash = "sha256-EYro4pMILnQFpXpFjdzSDuudhqC2EvysYMUmIOvesgo=";
   };
-
-  nativeBuildInputs = [
-    makeWrapper
-  ];
 
   installPhase = ''
     runHook preInstall
@@ -33,13 +28,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    wrapProgram $out/bin/bash-env-json --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        gnused
-        jq
-      ]
-    }
+    substituteInPlace $out/bin/bash-env-json --replace-fail " env " " ${lib.getExe' coreutils "env"} "
+    substituteInPlace $out/bin/bash-env-json --replace-fail " jq " " ${lib.getExe jq} "
+    substituteInPlace $out/bin/bash-env-json --replace-fail " mktemp " " ${lib.getExe' coreutils "mktemp"} "
+    substituteInPlace $out/bin/bash-env-json --replace-fail " rm " " ${lib.getExe' coreutils "rm"} "
+    substituteInPlace $out/bin/bash-env-json --replace-fail " sed " " ${lib.getExe gnused} "
+    substituteInPlace $out/bin/bash-env-json --replace-fail " touch " " ${lib.getExe' coreutils "touch"} "
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixed bash-env-json breaking if it tries to process a file that sets PATH.
This program cannot rely on PATH, therefore full paths must be used in this program all the time.
Upstream flake currently uses the same principle to build the package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
