### PR TITLE
cloudflare-warp: 2024.9.346 -> 2024.11.309

### DIFF
--- a/pkgs/by-name/cl/cloudflare-warp/package.nix
+++ b/pkgs/by-name/cl/cloudflare-warp/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation rec {
   pname = "cloudflare-warp";
-  version = "2024.9.346";
+  version = "2024.11.309";
 
   suffix = {
     aarch64-linux = "arm64";
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}.0_${suffix}.deb";
     hash = {
-      aarch64-linux = "sha256-dgu/OiQPT7bkPnhrDArQg2lDAcOyhzZ5nJrjS2dqpFo=";
-      x86_64-linux = "sha256-KwxLF7LWB49M+kZPJ9M4OcDSF1f3MX4S0dTtTkzQVRQ=";
+      aarch64-linux = "sha256-pdCPN4NxaQqWNRPZY1CN03KnTdzl62vJ3JNfxGozI4k=";
+      x86_64-linux = "sha256-THxXETyy08rBmvghrc8HIQ2cBSLeNVl8SkD43CVY/tE=";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Release Note: https://github.com/cloudflare/cloudflare-docs/blob/c38928bdfca9f7d0e2afa10d2b1ac992558abdb5/src/content/changelogs/warp.yaml#L50-L63
* NixOS Module: https://github.com/NixOS/nixpkgs/pull/321142 # cc: @treyfortmuller
* Previous updating: https://github.com/NixOS/nixpkgs/pull/346926

<details>
<summary>Logs in Ubuntu when getting the version</summary>

Including several noisy error logs because of I ran this on zsh.

```console
> # Add cloudflare gpg key
> curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg


> # Add this repo to your apt repositories
> echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list


> # Install
> sudo apt-get update && sudo apt-get install cloudflare-warp
deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ noble main
Get:1 https://pkg.cloudflareclient.com noble InRelease [2567 B]                                                   
Hit:2 http://security.ubuntu.com/ubuntu noble-security InRelease                                                  
Hit:3 http://archive.ubuntu.com/ubuntu noble InRelease
Get:4 https://pkg.cloudflareclient.com noble/main amd64 Packages [458 B]
Hit:5 http://archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu noble-backports InRelease
Fetched 3025 B in 2s (1494 B/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  desktop-file-utils gnupg2 libnss3-tools
Suggested packages:
  traceroute
The following NEW packages will be installed:
  cloudflare-warp desktop-file-utils gnupg2 libnss3-tools
0 upgraded, 4 newly installed, 0 to remove and 146 not upgraded.
Need to get 37.8 MB of archives.
After this operation, 105 MB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 https://pkg.cloudflareclient.com noble/main amd64 cloudflare-warp amd64 2024.11.309.0 [37.1 MB]
Get:2 http://archive.ubuntu.com/ubuntu noble/universe amd64 gnupg2 all 2.4.4-2ubuntu17 [4748 B]
Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 desktop-file-utils amd64 0.27-2build1 [53.8 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble/main amd64 libnss3-tools amd64 2:3.98-1build1 [615 kB]
Fetched 37.8 MB in 3s (13.2 MB/s)                                          
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_TIME = "en_DK.UTF-8",
	LANG = "ja_JP.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package gnupg2.
(Reading database ... 103525 files and directories currently installed.)
Preparing to unpack .../gnupg2_2.4.4-2ubuntu17_all.deb ...
Unpacking gnupg2 (2.4.4-2ubuntu17) ...
Selecting previously unselected package desktop-file-utils.
Preparing to unpack .../desktop-file-utils_0.27-2build1_amd64.deb ...
Unpacking desktop-file-utils (0.27-2build1) ...
Selecting previously unselected package libnss3-tools.
Preparing to unpack .../libnss3-tools_2%3a3.98-1build1_amd64.deb ...
Unpacking libnss3-tools (2:3.98-1build1) ...
Selecting previously unselected package cloudflare-warp.
Preparing to unpack .../cloudflare-warp_2024.11.309.0_amd64.deb ...
Unpacking cloudflare-warp (2024.11.309.0) ...
Setting up gnupg2 (2.4.4-2ubuntu17) ...
Setting up desktop-file-utils (0.27-2build1) ...
Setting up libnss3-tools (2:3.98-1build1) ...
Setting up cloudflare-warp (2024.11.309.0) ...
-sh: 56: /home/kachick.linux/.nix-profile/etc/profile.d/hm-session-vars.sh: [[: not found
-sh: 7: [[: not found
-sh: 56: /home/kachick.linux/.nix-profile/etc/profile.d/hm-session-vars.sh: [[: not found
-sh: 7: [[: not found
Created symlink /etc/systemd/system/multi-user.target.wants/warp-svc.service → /usr/lib/systemd/system/warp-svc.service.
Processing triggers for man-db (2.12.0-4build2) ...
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_TIME = "en_DK.UTF-8",
	LANG = "ja_JP.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Scanning processes...                                                                                                                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.

> bash
> # Install
> sudo apt-get update && sudo apt-get install cloudflare-warp
                
Hit:1 https://pkg.cloudflareclient.com noble InRelease                                                            
Hit:2 http://archive.ubuntu.com/ubuntu noble InRelease                                                            
Hit:3 http://security.ubuntu.com/ubuntu noble-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu noble-backports InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
cloudflare-warp is already the newest version (2024.11.309.0).
0 upgraded, 0 newly installed, 0 to remove and 146 not upgraded.
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) - Extracted to https://github.com/NixOS/nixpkgs/pull/358956
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - `connect`, `disconnect`, `status`, `version`
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
