### PR TITLE
freeorion: 0.5.0.1 -> 0.5.0.1-unstable-2024-07-28

### DIFF
--- a/pkgs/by-name/fr/freeorion/package.nix
+++ b/pkgs/by-name/fr/freeorion/package.nix
@@ -5,7 +5,7 @@
 , doxygen
 , graphviz
 , makeWrapper
-, boost179
+, boost
 , SDL2
 , python3
 , freetype
@@ -24,17 +24,19 @@
 
 stdenv.mkDerivation rec {
   pname = "freeorion";
-  version = "0.5.0.1";
+  version = "0.5.0.1-unstable-2024-07-28";
 
   src = fetchFromGitHub {
     owner = "freeorion";
     repo = "freeorion";
-    rev = "v${version}";
-    sha256 = "sha256-VvTq6TcLc5BMvRTjVsZ2HA9ug3WAqFuTHIoFQ/9/zWc=";
+    # Current `release-0.5` commit to pick up Boost and GCC 14 fixes
+    # until another release is cut.
+    rev = "dc3d6a4f01aa78229c419fa17b4e383f73b024e2";
+    hash = "sha256-9yPk77YeYkGMJqrlDYRTUMDKMWpxUXhVCnHhomiUc/A=";
   };
 
   buildInputs = [
-    (boost179.override { enablePython = true; python = python3; })
+    (boost.override { enablePython = true; python = python3; })
     (python3.withPackages (p: with p; [ pycodestyle ]))
     SDL2
     freetype


### PR DESCRIPTION
Includes fixes for GCC 14 and Boost 1.86. This is the HEAD of their stable 0.5 release maintenance branch; they haven’t cut a tag from it, but it consists of six simple commits on top of the current version: <https://github.com/freeorion/freeorion/compare/v0.5.0.1...dc3d6a4f01aa78229c419fa17b4e383f73b024e2>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
