### PR TITLE
inkscape-extensions.inkstitch: init at 3.1.0

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -44,6 +44,7 @@
     mkdir -p $out/share/inkscape/extensions
     cp ${inkcut}/share/inkscape/extensions/* $out/share/inkscape/extensions
   '');
+  inkstitch = callPackage ./extensions/inkstitch { };
   silhouette = callPackage ./extensions/silhouette { };
   textext = callPackage ./extensions/textext {
     pdflatex = texlive.combined.scheme-basic;

--- a/pkgs/applications/graphics/inkscape/extensions/inkstitch/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/inkstitch/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  gettext,
+}:
+let
+  version = "3.1.0";
+in
+python3.pkgs.buildPythonApplication {
+  pname = "inkstitch";
+  inherit version;
+  pyproject = false; # Uses a Makefile (yikes)
+
+  src = fetchFromGitHub {
+    owner = "inkstitch";
+    repo = "inkstitch";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-CGhJsDRhElgemNv2BXqZr6Vi5EyBArFak7Duz545ivY=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+  ];
+
+  dependencies =
+    with python3.pkgs;
+    [
+      pyembroidery
+      inkex
+      wxpython
+      networkx
+      shapely
+      lxml
+      appdirs
+      numpy
+      jinja2
+      requests
+      # Upstream wants colormath2 yet still refers to it as colormath. Curious.
+      colormath
+      flask
+      fonttools
+      trimesh
+      scipy
+      diskcache
+      flask-cors
+    ]
+    # Inkstitch uses the builtin tomllib instead when Python >=3.11
+    ++ lib.optional (pythonOlder "3.11") tomli;
+
+  makeFlags = [ "manual" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/inkscape/extensions
+    cp -a inx $out/share/inkscape/extensions/inkstitch
+
+    runHook postInstall
+  '';
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Inkscape extension for machine embroidery design";
+    homepage = "https://inkstitch.org/";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/development/python-modules/pyembroidery/default.nix
+++ b/pkgs/development/python-modules/pyembroidery/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  pytestCheckHook,
+}:
+let
+  pname = "pyembroidery";
+
+  # Mysteriously, the latest version published on PyPI has the version of 1.5.1,
+  # but the latest GitHub version stopped at 1.2.39. Further more Ink/Stitch requires the .exceptions
+  # module which is absent from the PyPI release.
+  # I guess this is *technically* the correct version name, but... yikes.
+  version = "1.5.1-unstable-2024-06-26";
+in
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "inkstitch";
+    repo = "pyembroidery";
+    rev = "b603b8d2b2bf91b5b0823a8a619562de5fd756e7";
+    hash = "sha256-cnWQ/ZScdXTFMLHdceyCLjgEkcwv3KuZHwXWlsYCcBA=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "pyembroidery"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Failed assertions.
+  # See https://github.com/inkstitch/pyembroidery/issues/108
+  disabledTests = [
+    "test_generic_write_gcode"
+    "test_jef_trims_commands"
+  ];
+
+  meta = {
+    description = "Python library for the reading and writing of embroidery files";
+    homepage = "https://github.com/inkstitch/pyembroidery";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10170,6 +10170,8 @@ self: super: with self; {
 
   pybars3 = callPackage ../development/python-modules/pybars3 { };
 
+  pyembroidery = callPackage ../development/python-modules/pyembroidery { };
+
   pymeta3 = callPackage ../development/python-modules/pymeta3 { };
 
   pypemicro = callPackage ../development/python-modules/pypemicro { };


### PR DESCRIPTION
Closes #133180 after over 3 years (!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
