### PR TITLE
chromium: resolve ref to rev for blink version string

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -379,7 +379,7 @@ let
     postPatch =  lib.optionalString (!isElectron) ''
       ln -s ${./files/gclient_args.gni} build/config/gclient_args.gni
 
-      echo 'LASTCHANGE=${upstream-info.DEPS."src".rev}-refs/heads/master@{#0}' > build/util/LASTCHANGE
+      echo 'LASTCHANGE=${upstream-info.DEPS."src".rev}-refs/tags/${version}@{#0}' > build/util/LASTCHANGE
       echo "$SOURCE_DATE_EPOCH" > build/util/LASTCHANGE.committime
 
       cat << EOF > gpu/config/gpu_lists_version.h

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -19,7 +19,7 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "131.0.6778.85",
+        "rev": "3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d",
         "hash": "sha256-fREToEHVbTD0IVGx/sn7csSju4BYajWZ+LDCiKWV4cI=",
         "recompress": true
       },
@@ -785,7 +785,7 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "131.0.6778.85",
+        "rev": "3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d",
         "hash": "sha256-fREToEHVbTD0IVGx/sn7csSju4BYajWZ+LDCiKWV4cI=",
         "recompress": true
       },


### PR DESCRIPTION
Ref: https://github.com/NixOS/nixpkgs/pull/357925#issuecomment-2496024939

This allows us to match the version the binaries use more closely.

For example, chromedriver darwin (binary) reports the following:

~~~bash
chromedriver --version
ChromeDriver 131.0.6778.85 (3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d-refs/branch-heads/6778@{#2285})
~~~

while on Linux, where we build chromedriver based on the chromium derivation from source and control the string ourselves:

~~~bash
chromedriver --version
ChromeDriver 131.0.6778.85 (131.0.6778.85-refs/heads/master@{#0})
~~~

With this commit, the version string now reports:

~~~bash
chromedriver --version
ChromeDriver 131.0.6778.85 (3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d-refs/tags/131.0.6778.85@{#0})
~~~

This may seem like a small and unimportant detail, but turns out an internal function within chromedriver depends on the git hash.

See https://chromium.googlesource.com/chromium/src/+/131.0.6778.85/chrome/test/chromedriver/chrome/browser_info.cc#172

This caused the tests of one package (single-file-cli) that use selenium with chromium and chromedriver to fail in 24.05.

Only in 24.05, because 24.11 and unstable removed their test dependency on chromedriver because it wasn't available for aarch64-linux at that time.

~~~
Running phase: checkPhase
Serving HTTP on 127.0.0.1 port 8000 (http://127.0.0.1:8000/) ... session not created
from unknown error: unrecognized Blink revision: 131.0.6778.85 URL: http://127.0.0.1:8000 Stack: SessionNotCreatedError: session not created from unknown error: unrecognized Blink revision: 131.0.6778.85
    at Object.throwDecodedError (/build/source/node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (/build/source/node_modules/selenium-webdriver/lib/http.js:601:13)
    at Executor.execute (/build/source/node_modules/selenium-webdriver/lib/http.js:529:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
~~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
