### PR TITLE
typespec: init at 0.64.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17521,6 +17521,12 @@
     githubId = 25278658;
     name = "Patrick Widmer";
   };
+  paukaifler = {
+    email = "pau@kaifler.me";
+    github = "PauKaifler";
+    githubId = 81905706;
+    name = "Pau Kaifler";
+  };
   paulsmith = {
     email = "paulsmith@pobox.com";
     github = "paulsmith";

--- a/pkgs/by-name/ty/typespec/package.nix
+++ b/pkgs/by-name/ty/typespec/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  nodejs,
+  pnpm_9,
+  testers,
+}:
+
+let
+  workspace = "compiler...";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "typespec";
+  version = "0.64.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "typespec";
+    tag = "typespec@${finalAttrs.version}";
+    hash = "sha256-zZTZdnmRTjhnoz/5JHnn4h/YlMpXF/I7o1mDeiRVPUA=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm_9.configHook
+  ];
+
+  pnpmWorkspaces = [ workspace ];
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    hash = "sha256-W8m6ibiy9Okga0qWpZWDYklXAwpHwk85Q6UTaFJhDrU=";
+  };
+
+  postPatch = ''
+    # `fetchFromGitHub` doesn't clone via git and thus installing would otherwise fail.
+    substituteInPlace packages/compiler/scripts/generate-manifest.js \
+      --replace-fail 'execSync("git rev-parse HEAD").toString().trim()' '"${finalAttrs.src.rev}"'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm -r --filter ${workspace} build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib/typespec/packages/compiler"
+    cp -r --parents \
+      node_modules \
+      package.json \
+      packages/compiler/cmd \
+      packages/compiler/dist \
+      packages/compiler/entrypoints \
+      packages/compiler/lib \
+      packages/compiler/node_modules \
+      packages/compiler/templates \
+      packages/compiler/package.json \
+      "$out/lib/typespec"
+
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/tsp" \
+      --add-flags "$out/lib/typespec/packages/compiler/cmd/tsp.js"
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/tsp-server" \
+      --add-flags "$out/lib/typespec/packages/compiler/cmd/tsp-server.js"
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ ''--version-regex=typespec@(\d+\.\d+\.\d+)'' ];
+  };
+
+  meta = {
+    description = "Language for defining cloud service APIs and shapes";
+    longDescription = ''
+      TypeSpec is a highly extensible language with primitives that can describe
+      API shapes common among REST, OpenAPI, gRPC, and other protocols.
+
+      TypeSpec is excellent for generating many different API description
+      formats, client and service code, documentation, and many other assets.
+      All this while keeping your TypeSpec definition as a single source of truth.
+    '';
+    homepage = "https://typespec.io/";
+    changelog = "https://github.com/microsoft/typespec/releases/tag/typespec@${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ paukaifler ];
+    mainProgram = "tsp";
+  };
+})


### PR DESCRIPTION
This PR adds [typespec](https://github.com/microsoft/typespec), a compiler with included language server for defining API shapes for REST, OpenAPI, gRPC and others.
We have been using this derivation at work for some time and it worked well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
