### PR TITLE
sequoia-chameleon-gnupg: set meta.mainProgram

### DIFF
--- a/pkgs/by-name/se/sequoia-chameleon-gnupg/package.nix
+++ b/pkgs/by-name/se/sequoia-chameleon-gnupg/package.nix
@@ -44,5 +44,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://gitlab.com/sequoia-pgp/sequoia-chameleon-gnupg";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ nickcao ];
+    mainProgram = "gpg-sq";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As I understand the purpose of the package, sequoia-chameleon-gnupg will have a subset of features of gnupg.
So, gnupg includes many programs but clarifies that `gpg` is the main one.
Can we also specify `gpg-sq` by default?

* https://github.com/NixOS/nixpkgs/blob/9ec2da8299b47037735287ad70509d6b8ac74459/pkgs/tools/security/gnupg/1.nix#L38
* https://github.com/NixOS/nixpkgs/blob/9ec2da8299b47037735287ad70509d6b8ac74459/pkgs/tools/security/gnupg/24.nix#L104
* init: https://github.com/NixOS/nixpkgs/pull/206997

```console
> ls -alh /nix/store/4zisizdxx9liz7vr8w29zjf8d66g1bdn-gnupg-2.4.5/bin
total 5.6M
dr-xr-xr-x  2 root root 4.0K Jan  1  1970 .
dr-xr-xr-x  5 root root 4.0K Jan  1  1970 ..
-r-xr-xr-x  2 root root 3.1K Jan  1  1970 addgnupghome
-r-xr-xr-x  2 root root 2.3K Jan  1  1970 applygnupgdefaults
-r-xr-xr-x  2 root root 670K Jan  1  1970 dirmngr
-r-xr-xr-x  2 root root 124K Jan  1  1970 dirmngr-client
-r-xr-xr-x  2 root root 1.3M Jan  1  1970 gpg
-r-xr-xr-x  2 root root 484K Jan  1  1970 gpg-agent
-r-xr-xr-x  2 root root 287K Jan  1  1970 gpg-card
-r-xr-xr-x  2 root root 162K Jan  1  1970 gpg-connect-agent
-r-xr-xr-x  2 root root 243K Jan  1  1970 gpg-wks-client
-r-xr-xr-x  2 root root 210K Jan  1  1970 gpg-wks-server
lrwxrwxrwx 16 root root    3 Jan  1  1970 gpg2 -> gpg
-r-xr-xr-x  2 root root 182K Jan  1  1970 gpgconf
-r-xr-xr-x  2 root root  39K Jan  1  1970 gpgparsemail
-r-xr-xr-x  2 root root 265K Jan  1  1970 gpgscm
-r-xr-xr-x  2 root root 656K Jan  1  1970 gpgsm
-r-xr-xr-x  2 root root  87K Jan  1  1970 gpgsplit
-r-xr-xr-x  2 root root 144K Jan  1  1970 gpgtar
-r-xr-xr-x  2 root root 604K Jan  1  1970 gpgv
-r-xr-xr-x  2 root root 200K Jan  1  1970 kbxutil
lrwxrwxrwx 16 root root   10 Jan  1  1970 libexec -> ../libexec
-r-xr-xr-x  2 root root  26K Jan  1  1970 watchgnupg

> ls -alh /nix/store/nlgxgzh3ybwfvmn10q6ah6wzap3p7jzf-sequoia-chameleon-gnupg-0.11.2/bin
total 30M
dr-xr-xr-x 2 root root 4.0K Jan  1  1970 .
dr-xr-xr-x 3 root root 4.0K Jan  1  1970 ..
-r-xr-xr-x 2 root root  19M Jan  1  1970 gpg-sq
-r-xr-xr-x 2 root root  11M Jan  1  1970 gpgv-sq
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
