### PR TITLE
superlu: 5.2.1 -> 7.0.0; openmolcas: unpin Boost

### DIFF
--- a/pkgs/by-name/op/openmolcas/package.nix
+++ b/pkgs/by-name/op/openmolcas/package.nix
@@ -14,7 +14,7 @@
   libxc,
   makeWrapper,
   gsl,
-  boost180,
+  boost,
   autoPatchelfHook,
   enableQcmaquis ? false,
   # Note that the CASPT2 module is broken with MPI
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
       armadillo
       libxc
       gsl.dev
-      boost180
+      boost
     ]
     ++ lib.optionals enableMpi [
       mpi

--- a/pkgs/by-name/su/superlu/package.nix
+++ b/pkgs/by-name/su/superlu/package.nix
@@ -1,44 +1,59 @@
-{ lib, stdenv, fetchurl, cmake,
+{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, ninja,
   gfortran, blas, lapack}:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
-stdenv.mkDerivation rec {
-  version = "5.2.1";
+stdenv.mkDerivation (finalAttrs: {
   pname = "superlu";
+  version = "7.0.0";
 
-  src = fetchurl {
-    url = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_${version}.tar.gz";
-    sha256 = "0qzlb7cd608q62kyppd0a8c65l03vrwqql6gsm465rky23b6dyr8";
+  src = fetchFromGitHub {
+    owner = "xiaoyeli";
+    repo = "superlu";
+    rev = "refs/tags/v${finalAttrs.version}";
+    # Remove non‐free files.
+    #
+    # See:
+    # * <https://github.com/xiaoyeli/superlu/issues/9>
+    # * <https://github.com/xiaoyeli/superlu/blob/0bbd6571bd839d866bff6a8ff1eaa812a8c31463/License.txt#L32-L65>
+    # * <https://salsa.debian.org/science-team/superlu/-/blob/0acab1b41f332f2f2e3b0b5d28ba7fc9f7539533/debian/copyright>
+    postFetch = "rm $out/SRC/mc64ad.* $out/DOC/*.pdf";
+    hash = "sha256-iJiVyY+/vr6kll8FCunvZ8rKBj+w+Rnj4F696XW9xFc=";
   };
 
-  nativeBuildInputs = [ cmake gfortran ];
+  patches = [
+    (fetchurl {
+      url = "https://salsa.debian.org/science-team/superlu/-/raw/fae141179928d1cc5a8e381503e8b1264d297c3d/debian/patches/mc64ad-stub.patch";
+      hash = "sha256-QUaNUDaRghTqr6jk1TE6a7CdXABqu7xAkYZDhL/lZBQ=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ninja gfortran ];
 
   propagatedBuildInputs = [ blas ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=true"
-    "-DUSE_XSDK_DEFAULTS=true"
-  ];
-
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=implicit-function-declaration"
-      "-Wno-error=implicit-int"
-    ];
-  };
-
-  patches = [
-    ./add-superlu-lib-as-dependency-for-the-unit-tests.patch
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "enable_fortran" true)
   ];
 
   doCheck = true;
-  checkTarget = "test";
 
   meta = {
-    homepage = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/";
-    license = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/License.txt";
+    homepage = "https://portal.nersc.gov/project/sparse/superlu/";
+    license = [
+      lib.licenses.bsd3Lbnl
+
+      # Xerox code; actually `Boehm-GC` variant.
+      lib.licenses.mit
+
+      # University of Minnesota example files.
+      lib.licenses.gpl2Plus
+
+      # University of Florida code; permissive COLAMD licence.
+      lib.licenses.free
+    ];
     description = "Library for the solution of large, sparse, nonsymmetric systems of linear equations";
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Includes fixes for GCC 14. Also addresses non‐free code already removed by Debian. If there’s demand for this functionality it could be re‐added under a flag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
