### PR TITLE
osrm-backend: 5.27.1 -> 5.27.1-unstable-2024-11-03

### DIFF
--- a/pkgs/servers/osrm-backend/default.nix
+++ b/pkgs/servers/osrm-backend/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osrm-backend";
-  version = "5.27.1";
+  version = "5.27.1-unstable-2024-11-03";
 
   src = fetchFromGitHub {
     owner = "Project-OSRM";
     repo = "osrm-backend";
-    rev = "v${version}";
-    sha256 = "sha256-3oA/U5O4GLfwMF7x99JQuFK7ewDrLJLh6BBLYfnyNaM=";
+    rev = "3614af7f6429ee35c3f2e836513b784a74664ab6";
+    hash = "sha256-iix++G49cC13wZGZIpXu1SWGtVAcqpuX3GhsIaETzUU=";
   };
 
   nativeBuildInputs = [
@@ -43,37 +43,8 @@ stdenv.mkDerivation rec {
     expat
   ];
 
-  patches = [
-    # gcc-13 build fix:
-    #   https://github.com/Project-OSRM/osrm-backend/pull/6632
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/Project-OSRM/osrm-backend/commit/af59a9cfaee4d601b5c88391624a05f2a38da17b.patch";
-      hash = "sha256-dB9JP/DrJXpFGLD/paein2z64UtHIYZ17ycb91XWpEI=";
-    })
-  ];
-
-  env.NIX_CFLAGS_COMPILE = toString (
-    [
-      # Needed with GCC 12
-      "-Wno-error=stringop-overflow"
-      "-Wno-error=uninitialized"
-      # Needed for GCC 13
-      "-Wno-error=array-bounds"
-    ]
-    ++
-      # error: aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on macOS 10.13 or newer
-      (lib.optionals
-        (
-          stdenv.hostPlatform.isDarwin
-          && stdenv.hostPlatform.isx86_64
-          && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13"
-        )
-        [
-          "-faligned-allocation"
-        ]
-      )
-  );
+  # Needed with GCC 12
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=uninitialized";
 
   postInstall = ''
     mkdir -p $out/share/osrm-backend

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11859,8 +11859,6 @@ with pkgs;
   opensmtpd-filter-rspamd = callPackage ../servers/mail/opensmtpd/filter-rspamd.nix { };
   osrm-backend = callPackage ../servers/osrm-backend {
     tbb = tbb_2021_11;
-    # https://github.com/Project-OSRM/osrm-backend/issues/6503
-    boost = boost179;
   };
 
   postfix = callPackage ../servers/mail/postfix { };


### PR DESCRIPTION
Includes fixes for newer versions of GCC and Boost and obsoletes our patch and most of our flags.

Upstream has not cut a release tag in over two years. They have signalled a desire to make a new release this year, but have limited resources to do so:

* <https://github.com/Project-OSRM/osrm-backend/issues/6747>
* <https://github.com/Project-OSRM/osrm-backend/issues/6778>
* <https://github.com/Project-OSRM/osrm-backend/issues/7028>

The NixOS test passes, so I think this should be okay and leave this package in a healthier state than it is currently in.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (on top of https://github.com/NixOS/nixpkgs/pull/359060)
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
