### PR TITLE
hydra: 2024-10-24 -> 2024-11-25

### DIFF
--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -21,7 +21,6 @@
 , nukeReferences
 , git
 , nlohmann_json
-, docbook_xsl
 , openssh
 , openldap
 , gnused
@@ -35,13 +34,14 @@
 , cdrkit
 , pixz
 , boost
-, autoreconfHook
 , mdbook
 , foreman
 , python3
 , libressl
 , cacert
 , glibcLocales
+, meson
+, ninja
 , fetchFromGitHub
 , nixosTests
 , unstableGitUpdater
@@ -81,6 +81,7 @@ let
         DigestSHA1
         EmailMIME
         EmailSender
+        FileCopyRecursive
         FileLibMagic
         FileSlurper
         FileWhich
@@ -124,13 +125,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hydra";
-  version = "0-unstable-2024-10-24";
+  version = "0-unstable-2024-11-25";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "f974891c76e295240017dd7f04d50ecb4b70284e";
-    hash = "sha256-xVSu4ZNdlOEh2KcloDvhVeiFSYgk22W5fDvQlwn+kbE=";
+    rev = "e75a4cbda86eed897ac853b256c8fd10829bc7e0";
+    hash = "sha256-CCiBM7jV/zLegMizyfRETiYE8XYMEqzPXFAWPwjjMFc=";
   };
 
   buildInputs = [
@@ -177,7 +178,8 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
     makeWrapper
     pkg-config
     mdbook
@@ -193,8 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
     openldap
   ];
 
-  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
-
   env = {
     NIX_CFLAGS_COMPILE = "-pthread";
     OPENLDAP_ROOT = openldap;
@@ -206,9 +206,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   enableParallelBuilding = true;
+  mesonBuildType = "release";
+
+  postPatch = ''
+    patchShebangs .
+  '';
 
   preCheck = ''
-    patchShebangs .
     export LOGNAME=''${LOGNAME:-foo}
     # set $HOME for bzr so it can create its trace file
     export HOME=$(mktemp -d)


### PR DESCRIPTION
Moves from an autotools build system to meson.

https://github.com/NixOS/hydra/commit/182a48c9fbcd6e6063bd6166c314174a8e79294c

~~(Still running the build/tests on my machine, if anything happens I'll update here and otherwise it's probably good). Build is already good but tests are currently running.~~

A test failed... Not sure what's up with that.

Continuation and adaptation of: https://github.com/NixOS/nixpkgs/pull/356391

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
