### PR TITLE
prusa-slicer: fix build with GCC 14 and strictDeps

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -90,10 +90,19 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "version_${finalAttrs.version}";
   };
 
+  # required for GCC 14
+  postPatch = ''
+    substituteInPlace src/libslic3r/Arrange/Core/DataStoreTraits.hpp \
+      --replace-fail \
+      "WritableDataStoreTraits<ArrItem>::template set" \
+      "WritableDataStoreTraits<ArrItem>::set"
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config
     wrapGAppsHook3
+    wxGTK-override'
   ];
 
   buildInputs = [
@@ -131,6 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk_11_0.frameworks.CoreWLAN
   ];
+
+  strictDeps = true;
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
GCC 14 is in staging and will break the package otherwise.

Upstream: https://github.com/prusa3d/PrusaSlicer/pull/13630

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).