### PR TITLE
nixos-rebuild-ng: implement `--target-host`

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -119,7 +119,7 @@ ruff format .
 ## TODO
 
 - [ ] Remote host/builders (via SSH)
-- [ ] Improve nix arguments handling (e.g.: `nixFlags` vs `copyFlags` in the
+- [x] Improve nix arguments handling (e.g.: `nixFlags` vs `copyFlags` in the
   old `nixos-rebuild`)
 - [ ] `_NIXOS_REBUILD_EXEC`
 - [ ] Port `nixos-rebuild.passthru.tests`

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -76,7 +76,7 @@ can run:
 # run program
 python -m nixos_rebuild
 # run tests
-python -m pytest
+pytest
 # check types
 mypy .
 # fix lint issues

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -112,7 +112,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
     # TODO: use deprecated=True in Python >=3.13
     if args.no_ssh_tty:
-        parser_warn("--no-ssh-tty deprecated, SSH's pseudo-TTY is never used anymore")
+        parser_warn("--no-ssh-tty deprecated, SSH's TTY is never used anymore")
 
     if args.action == Action.EDIT.value and (args.file or args.attr):
         parser.error("--file and --attr are not supported with 'edit'")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -7,7 +7,7 @@ from subprocess import run
 from tempfile import TemporaryDirectory
 from typing import assert_never
 
-from .models import Action, Flake, NRError, Profile, Ssh
+from .models import Action, Flake, NRError, Profile
 from .nix import (
     copy_closure,
     edit,
@@ -22,6 +22,7 @@ from .nix import (
     switch_to_configuration,
     upgrade_channels,
 )
+from .process import Remote
 from .utils import flags_to_dict, info
 
 VERBOSE = 0
@@ -177,7 +178,7 @@ def execute(argv: list[str]) -> None:
     tmpdir_path = Path(tmpdir.name)
 
     profile = Profile.from_name(args.profile_name)
-    target_host = Ssh.from_arg(args.target_host, not args.no_ssh_tty, tmpdir_path)
+    target_host = Remote.from_arg(args.target_host, not args.no_ssh_tty, tmpdir_path)
     flake = Flake.from_arg(args.flake, target_host)
 
     if args.upgrade or args.upgrade_all:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -230,7 +230,9 @@ def execute(argv: list[str]) -> None:
         case Action.TEST | Action.BUILD | Action.DRY_BUILD | Action.DRY_ACTIVATE:
             info("building the system configuration...")
             dry_run = action == Action.DRY_BUILD
-            if args.rollback and action in (Action.TEST, Action.BUILD):
+            if args.rollback:
+                if action not in (Action.TEST, Action.BUILD):
+                    raise NRError(f"--rollback is incompatible with '{action}'")
                 maybe_path_to_config = rollback_temporary_profile(profile)
                 if maybe_path_to_config:  # kinda silly but this makes mypy happy
                     path_to_config = maybe_path_to_config

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import atexit
 import json
 import os
 import sys
@@ -22,7 +23,7 @@ from .nix import (
     switch_to_configuration,
     upgrade_channels,
 )
-from .process import Remote
+from .process import Remote, cleanup_ssh
 from .utils import flags_to_dict, info
 
 VERBOSE = 0
@@ -176,6 +177,7 @@ def execute(argv: list[str]) -> None:
     # Will be cleaned up on exit automatically.
     tmpdir = TemporaryDirectory(prefix="nixos-rebuild.")
     tmpdir_path = Path(tmpdir.name)
+    atexit.register(cleanup_ssh, tmpdir_path)
 
     profile = Profile.from_name(args.profile_name)
     target_host = Remote.from_arg(args.target_host, not args.no_ssh_tty, tmpdir_path)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import json
 import os

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -29,7 +29,7 @@ from .utils import flags_to_dict, info
 VERBOSE = 0
 
 
-def parse_args(argv: list[str]) -> argparse.Namespace:
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="nixos-rebuild",
         description="Reconfigure a NixOS machine",
@@ -92,7 +92,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     copy_group = parser.add_argument_group("nix-copy-closure flags")
     copy_group.add_argument("--use-substitutes", "-s", action="store_true")
 
+    return parser
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = get_parser()
     args = parser.parse_args(argv[1:])
+
+    def parser_warn(msg):
+        info(f"{parser.prog}: warning: {msg}")
 
     global VERBOSE
     # This flag affects both nix and this script
@@ -107,23 +115,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
     # TODO: use deprecated=True in Python >=3.13
     if args.install_grub:
-        info(
-            f"{parser.prog}: warning: --install-grub deprecated, use --install-bootloader instead"
-        )
+        parser_warn("--install-grub deprecated, use --install-bootloader instead")
         args.install_bootloader = True
 
     # TODO: use deprecated=True in Python >=3.13
     if args.use_remote_sudo:
-        info(
-            f"{parser.prog}: warning: --use-remote-sudo deprecated, use --sudo instead"
-        )
+        parser_warn("--use-remote-sudo deprecated, use --sudo instead")
         args.sudo = True
 
     # TODO: use deprecated=True in Python >=3.13
     if args.no_ssh_tty:
-        info(
-            f"{parser.prog}: warning: --no-ssh-tty deprecated, SSH's pseudo-TTY is never used anymore"
-        )
+        parser_warn("--no-ssh-tty deprecated, SSH's pseudo-TTY is never used anymore")
 
     if args.action == Action.EDIT.value and (args.file or args.attr):
         parser.error("--file and --attr are not supported with 'edit'")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -47,6 +47,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--upgrade", action="store_true")
     parser.add_argument("--upgrade-all", action="store_true")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument("--sudo", action="store_true")
+    # TODO: add deprecated=True in Python >=3.13
+    parser.add_argument("--use-remote-sudo", dest="sudo", action="store_true")
     parser.add_argument("action", choices=Action.values(), nargs="?")
     parser.add_argument("--verbose", "-v", action="count", default=0)
 
@@ -181,7 +184,7 @@ def execute(argv: list[str]) -> None:
                     no_link=True,
                     **flake_flags,
                 )
-                set_profile(profile, path_to_config)
+                set_profile(profile, path_to_config, sudo=args.sudo)
             else:
                 path_to_config = nixos_build(
                     "system",
@@ -190,10 +193,11 @@ def execute(argv: list[str]) -> None:
                     no_out_link=True,
                     **nix_flags,
                 )
-                set_profile(profile, path_to_config)
+                set_profile(profile, path_to_config, sudo=args.sudo)
             switch_to_configuration(
                 path_to_config,
                 action,
+                sudo=args.sudo,
                 specialisation=args.specialisation,
                 install_bootloader=args.install_bootloader,
             )
@@ -227,6 +231,7 @@ def execute(argv: list[str]) -> None:
                 switch_to_configuration(
                     path_to_config,
                     action,
+                    sudo=args.sudo,
                     specialisation=args.specialisation,
                 )
         case Action.BUILD_VM | Action.BUILD_VM_WITH_BOOTLOADER:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -177,8 +177,8 @@ def execute(argv: list[str]) -> None:
     tmpdir_path = Path(tmpdir.name)
 
     profile = Profile.from_name(args.profile_name)
-    flake = Flake.from_arg(args.flake)
     target_host = Ssh.from_arg(args.target_host, not args.no_ssh_tty, tmpdir_path)
+    flake = Flake.from_arg(args.flake, target_host)
 
     if args.upgrade or args.upgrade_all:
         upgrade_channels(bool(args.upgrade_all))

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import os
 import platform
 import re
+import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, Self, TypedDict, override
+from typing import Any, Callable, ClassVar, Self, TypedDict, override
 
 
 class NRError(Exception):
@@ -52,21 +55,41 @@ class Flake:
         return f"{self.path}#{self.attr}"
 
     @classmethod
-    def parse(cls, flake_str: str, hostname: str | None = None) -> Self:
+    def parse(
+        cls,
+        flake_str: str,
+        hostname_fn: Callable[[], str | None] = lambda: None,
+    ) -> Self:
         m = cls._re.match(flake_str)
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
-        nixos_attr = f"nixosConfigurations.{attr or hostname or "default"}"
+        nixos_attr = f"nixosConfigurations.{attr or hostname_fn() or "default"}"
         return cls(Path(m.group("path")), nixos_attr)
 
     @classmethod
-    def from_arg(cls, flake_arg: Any) -> Self | None:
-        hostname = platform.node()
+    def from_arg(cls, flake_arg: Any, target_host: Ssh | None) -> Self | None:
+        def get_hostname() -> str | None:
+            if target_host:
+                from .process import run_wrapper  # circumvent circular import
+
+                try:
+                    return run_wrapper(
+                        ["uname", "-n"],
+                        check=True,
+                        capture_output=True,
+                        allow_tty=False,
+                        remote=target_host,
+                    ).stdout.strip()
+                except (AttributeError, subprocess.CalledProcessError):
+                    return None
+            else:
+                return platform.node()
+
         match flake_arg:
             case str(s):
-                return cls.parse(s, hostname)
+                return cls.parse(s, get_hostname)
             case True:
-                return cls.parse(".", hostname)
+                return cls.parse(".", get_hostname)
             case False:
                 return None
             case _:
@@ -76,7 +99,7 @@ class Flake:
                     # It can be a symlink to the actual flake.
                     if default_path.is_symlink():
                         default_path = default_path.readlink()
-                    return cls.parse(str(default_path.parent), hostname)
+                    return cls.parse(str(default_path.parent), get_hostname)
                 else:
                     return None
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -122,9 +122,16 @@ class SSH:
     tty: bool
 
     @classmethod
-    def from_arg(cls, host: str | None, tty: bool | None) -> Self | None:
+    def from_arg(cls, host: str | None, tty: bool | None, tmp_dir: Path) -> Self | None:
         if host:
-            opts = os.getenv("SSH_OPTS", "").split()
+            opts = os.getenv("NIX_SSHOPTS", "").split() + [
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                f"ControlPath={tmp_dir / "ssh-%n"}",
+                "-o",
+                "ControlPersist=60",
+            ]
             return cls(host, opts, bool(tty))
         else:
             return None

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -1,12 +1,10 @@
-from __future__ import annotations
-
 import os
 import platform
 import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, TypedDict, override
+from typing import Any, ClassVar, Self, TypedDict, override
 
 
 class NRError(Exception):
@@ -54,15 +52,15 @@ class Flake:
         return f"{self.path}#{self.attr}"
 
     @classmethod
-    def parse(cls, flake_str: str, hostname: str | None = None) -> Flake:
+    def parse(cls, flake_str: str, hostname: str | None = None) -> Self:
         m = cls._re.match(flake_str)
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
         nixos_attr = f"nixosConfigurations.{attr or hostname or "default"}"
-        return Flake(Path(m.group("path")), nixos_attr)
+        return cls(Path(m.group("path")), nixos_attr)
 
     @classmethod
-    def from_arg(cls, flake_arg: Any) -> Flake | None:
+    def from_arg(cls, flake_arg: Any) -> Self | None:
         hostname = platform.node()
         match flake_arg:
             case str(s):
@@ -106,15 +104,15 @@ class Profile:
     name: str
     path: Path
 
-    @staticmethod
-    def from_name(name: str = "system") -> Profile:
+    @classmethod
+    def from_name(cls, name: str = "system") -> Self:
         match name:
             case "system":
-                return Profile(name, Path("/nix/var/nix/profiles/system"))
+                return cls(name, Path("/nix/var/nix/profiles/system"))
             case _:
                 path = Path("/nix/var/nix/profiles/system-profiles") / name
                 path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
-                return Profile(name, path)
+                return cls(name, path)
 
 
 @dataclass(frozen=True)
@@ -122,10 +120,10 @@ class SSH:
     host: str
     opts: list[str]
 
-    @staticmethod
-    def from_arg(host: str | None) -> SSH | None:
+    @classmethod
+    def from_arg(cls, host: str | None) -> Self | None:
         if host:
             opts = os.getenv("SSH_OPTS", "").split()
-            return SSH(host, opts)
+            return cls(host, opts)
         else:
             return None

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -76,7 +76,6 @@ class Flake:
                         ["uname", "-n"],
                         check=True,
                         capture_output=True,
-                        allow_tty=False,
                         remote=target_host,
                     ).stdout.strip()
                 except (AttributeError, subprocess.CalledProcessError):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -119,11 +119,12 @@ class Profile:
 class SSH:
     host: str
     opts: list[str]
+    tty: bool
 
     @classmethod
-    def from_arg(cls, host: str | None) -> Self | None:
+    def from_arg(cls, host: str | None, tty: bool | None) -> Self | None:
         if host:
             opts = os.getenv("SSH_OPTS", "").split()
-            return cls(host, opts)
+            return cls(host, opts, bool(tty))
         else:
             return None

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import re
 from dataclasses import dataclass
@@ -114,3 +115,17 @@ class Profile:
                 path = Path("/nix/var/nix/profiles/system-profiles") / name
                 path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
                 return Profile(name, path)
+
+
+@dataclass(frozen=True)
+class SSH:
+    host: str
+    opts: list[str]
+
+    @staticmethod
+    def from_arg(host: str | None) -> SSH | None:
+        if host:
+            opts = os.getenv("SSH_OPTS", "").split()
+            return SSH(host, opts)
+        else:
+            return None

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -116,7 +116,7 @@ class Profile:
 
 
 @dataclass(frozen=True)
-class SSH:
+class Ssh:
     host: str
     opts: list[str]
     tty: bool

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -74,7 +74,6 @@ class Flake:
                 try:
                     return run_wrapper(
                         ["uname", "-n"],
-                        check=True,
                         capture_output=True,
                         remote=target_host,
                     ).stdout.strip()

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -12,7 +12,7 @@ from .models import (
     GenerationJson,
     NRError,
     Profile,
-    Ssh,
+    Remote,
 )
 from .process import run_wrapper
 from .utils import Args, dict_to_flags, info
@@ -22,7 +22,7 @@ FLAKE_FLAGS: Final = ["--extra-experimental-features", "nix-command flakes"]
 
 def copy_closure(
     closure: Path,
-    target_host: Ssh | None,
+    target_host: Remote | None,
     **copy_flags: Args,
 ) -> None:
     host = target_host
@@ -303,7 +303,7 @@ def rollback_temporary_profile(profile: Profile) -> Path | None:
 def set_profile(
     profile: Profile,
     path_to_config: Path,
-    target_host: Ssh | None,
+    target_host: Remote | None,
     sudo: bool,
 ) -> None:
     "Set a path as the current active Nix profile."
@@ -318,7 +318,7 @@ def set_profile(
 def switch_to_configuration(
     path_to_config: Path,
     action: Action,
-    target_host: Ssh | None,
+    target_host: Remote | None,
     sudo: bool,
     install_bootloader: bool = False,
     specialisation: str | None = None,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import shutil
 from datetime import datetime

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -32,7 +32,7 @@ def copy_closure(
     run_wrapper(
         [
             "nix-copy-closure",
-            *(dict_to_flags(copy_flags)),
+            *dict_to_flags(copy_flags),
             "--to",
             host.host,
             closure,
@@ -50,7 +50,7 @@ def edit(flake: Flake | None, **flake_flags: Args) -> None:
                 "nix",
                 *FLAKE_FLAGS,
                 "edit",
-                *(dict_to_flags(flake_flags)),
+                *dict_to_flags(flake_flags),
                 "--",
                 str(flake),
             ],
@@ -281,8 +281,8 @@ def nixos_build_flake(
         "build",
         "--print-out-paths",
         f"{flake}.config.system.build.{attr}",
+        *dict_to_flags(flake_flags),
     ]
-    run_args += dict_to_flags(flake_flags)
     r = run_wrapper(run_args, check=True, stdout=PIPE)
     return Path(r.stdout.strip())
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from subprocess import PIPE, CalledProcessError, run
+from subprocess import PIPE, CalledProcessError
 from typing import Final
 
 from .models import (
@@ -15,6 +15,7 @@ from .models import (
     NRError,
     Profile,
 )
+from .process import run
 from .utils import Args, dict_to_flags, info
 
 FLAKE_FLAGS: Final = ["--extra-experimental-features", "nix-command flakes"]
@@ -280,14 +281,15 @@ def rollback_temporary_profile(profile: Profile) -> Path | None:
         return None
 
 
-def set_profile(profile: Profile, path_to_config: Path) -> None:
+def set_profile(profile: Profile, path_to_config: Path, sudo: bool) -> None:
     "Set a path as the current active Nix profile."
-    run(["nix-env", "-p", profile.path, "--set", path_to_config], check=True)
+    run(["nix-env", "-p", profile.path, "--set", path_to_config], check=True, sudo=sudo)
 
 
 def switch_to_configuration(
     path_to_config: Path,
     action: Action,
+    sudo: bool,
     install_bootloader: bool = False,
     specialisation: str | None = None,
 ) -> None:
@@ -313,6 +315,7 @@ def switch_to_configuration(
             "LOCALE_ARCHIVE": os.getenv("LOCALE_ARCHIVE", ""),
         },
         check=True,
+        sudo=sudo,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -36,7 +36,6 @@ def copy_closure(
             host.host,
             closure,
         ],
-        check=True,
         extra_env={"NIX_SSHOPTS": " ".join(host.opts)},
     )
 
@@ -171,7 +170,6 @@ def get_generations(
         r = run_wrapper(
             ["nix-env", "-p", profile.path, "--list-generations"],
             stdout=PIPE,
-            check=True,
             remote=target_host,
             sudo=sudo,
         )
@@ -216,7 +214,6 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
             configuration_revision = run_wrapper(
                 [generation_path / "sw/bin/nixos-version", "--configuration-revision"],
                 capture_output=True,
-                check=True,
             ).stdout.strip()
         except (CalledProcessError, IOError):
             configuration_revision = "Unknown"
@@ -260,7 +257,7 @@ def nixos_build(
     else:
         run_args = ["nix-build", "<nixpkgs/nixos>", "--attr", attr]
     run_args += dict_to_flags(nix_flags)
-    r = run_wrapper(run_args, check=True, stdout=PIPE)
+    r = run_wrapper(run_args, stdout=PIPE)
     return Path(r.stdout.strip())
 
 
@@ -281,7 +278,7 @@ def nixos_build_flake(
         f"{flake}.config.system.build.{attr}",
         *dict_to_flags(flake_flags),
     ]
-    r = run_wrapper(run_args, check=True, stdout=PIPE)
+    r = run_wrapper(run_args, stdout=PIPE)
     return Path(r.stdout.strip())
 
 
@@ -289,7 +286,6 @@ def rollback(profile: Profile, target_host: Remote | None, sudo: bool) -> Path:
     "Rollback Nix profile, like one created by `nixos-rebuild switch`."
     run_wrapper(
         ["nix-env", "--rollback", "-p", profile.path],
-        check=True,
         remote=target_host,
         sudo=sudo,
     )
@@ -329,7 +325,6 @@ def set_profile(
     "Set a path as the current active Nix profile."
     run_wrapper(
         ["nix-env", "-p", profile.path, "--set", path_to_config],
-        check=True,
         remote=target_host,
         sudo=sudo,
     )
@@ -361,7 +356,6 @@ def switch_to_configuration(
     run_wrapper(
         [path_to_config / "bin/switch-to-configuration", str(action)],
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "1" if install_bootloader else "0"},
-        check=True,
         remote=target_host,
         sudo=sudo,
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -8,13 +8,6 @@ from pathlib import Path
 from typing import Self, Sequence, TypedDict, Unpack
 
 
-# Not exhaustive, but we can always extend it later.
-class RunKwargs(TypedDict, total=False):
-    capture_output: bool
-    stderr: int | None
-    stdout: int | None
-
-
 @dataclass(frozen=True)
 class Remote:
     host: str
@@ -46,6 +39,13 @@ class Remote:
             return None
 
 
+# Not exhaustive, but we can always extend it later.
+class RunKwargs(TypedDict, total=False):
+    capture_output: bool
+    stderr: int | None
+    stdout: int | None
+
+
 def cleanup_ssh(tmp_dir: Path) -> None:
     "Close SSH ControlMaster connection."
     for ctrl in tmp_dir.glob("ssh-*"):
@@ -55,7 +55,7 @@ def cleanup_ssh(tmp_dir: Path) -> None:
 def run_wrapper(
     args: Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes]],
     *,
-    check: bool,  # make it explicit so we always know if the code is handling errors
+    check: bool = True,
     extra_env: dict[str, str] | None = None,
     remote: Remote | None = None,
     sudo: bool = False,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -10,6 +10,7 @@ from .models import SSH
 # Not exhaustive, but we can always extend it later.
 class RunKwargs(TypedDict, total=False):
     capture_output: bool
+    input: str | None
     stderr: int | None
     stdin: int | None
     stdout: int | None
@@ -33,7 +34,10 @@ def run_wrapper(
             args = ["env", *extra_env_args, *args]
         if sudo:
             args = ["sudo", *args]
-        args = ["ssh", *remote.opts, remote.host, "--", *args]
+        if remote.tty:
+            args = ["ssh", "-t", *remote.opts, remote.host, "--", *args]
+        else:
+            args = ["ssh", *remote.opts, remote.host, "--", *args]
     else:
         if extra_env:
             env = (env or os.environ) | extra_env

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import subprocess
 from typing import Any, Sequence

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from typing import Sequence, TypedDict, Unpack
 
-from .models import SSH
+from .models import Ssh
 
 
 # Not exhaustive, but we can always extend it later.
@@ -22,7 +22,7 @@ def run_wrapper(
     check: bool,  # make it explicit so we always know if the code is handling errors
     env: dict[str, str] | None = None,  # replaces the current environment
     extra_env: dict[str, str] | None = None,  # appends to the current environment
-    remote: SSH | None = None,
+    remote: Ssh | None = None,
     sudo: bool = False,
     **kwargs: Unpack[RunKwargs],
 ) -> subprocess.CompletedProcess[str]:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -42,36 +42,35 @@ def run_wrapper(
     args: Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes]],
     *,
     check: bool,  # make it explicit so we always know if the code is handling errors
-    env: dict[str, str] | None = None,  # replaces the current environment
-    extra_env: dict[str, str] | None = None,  # appends to the current environment
+    extra_env: dict[str, str] | None = None,
     allow_tty: bool = True,
     remote: Remote | None = None,
     sudo: bool = False,
     **kwargs: Unpack[RunKwargs],
 ) -> subprocess.CompletedProcess[str]:
     "Wrapper around `subprocess.run` that supports extra functionality."
+    if remote and allow_tty:
+        # SSH's TTY will redirect all output to stdout, that may cause
+        # unwanted effects when used
+        assert not kwargs.get(
+            "capture_output"
+        ), "SSH's TTY is incompatible with capture_output"
+        assert not kwargs.get("stderr"), "SSH's TTY is incompatible with stderr"
+        assert not kwargs.get("stdout"), "SSH's TTY is incompatible with stdout"
+    env = None
     if remote:
-        assert env is None, "'env' can't be used with 'remote'"
         if extra_env:
             extra_env_args = [f"{env}={value}" for env, value in extra_env.items()]
             args = ["env", *extra_env_args, *args]
         if sudo:
             args = ["sudo", *args]
-        if allow_tty:
-            # SSH's TTY will redirect all output to stdout, that may cause
-            # unwanted effects when used
-            assert not kwargs.get(
-                "capture_output"
-            ), "SSH's TTY is incompatible with capture_output"
-            assert not kwargs.get("stderr"), "SSH's TTY is incompatible with stderr"
-            assert not kwargs.get("stdout"), "SSH's TTY is incompatible with stdout"
         if allow_tty and remote.tty:
             args = ["ssh", "-t", *remote.opts, remote.host, "--", *args]
         else:
             args = ["ssh", *remote.opts, remote.host, "--", *args]
     else:
         if extra_env:
-            env = (env or os.environ) | extra_env
+            env = os.environ | extra_env
         if sudo:
             args = ["sudo", *args]
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any, Sequence
+
+from .models import SSH
+
+
+def run(
+    args: Sequence[str | bytes | os.PathLike[Any]],
+    # make `check` explicit so we always know if the code is aborting on errors
+    check: bool,
+    remote: SSH | None = None,
+    sudo: bool = False,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[Any]:
+    if sudo:
+        args = ["sudo"] + list(args)
+    if remote:
+        args = ["ssh", *remote.opts, remote.host, "--"] + list(args)
+    return subprocess.run(args, check=check, **kwargs)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -26,6 +26,7 @@ class Remote:
     def from_arg(cls, host: str | None, tty: bool | None, tmp_dir: Path) -> Self | None:
         if host:
             opts = os.getenv("NIX_SSHOPTS", "").split() + [
+                # SSH ControlMaster flags, allow for faster re-connection
                 "-o",
                 "ControlMaster=auto",
                 "-o",
@@ -36,6 +37,12 @@ class Remote:
             return cls(host, opts, bool(tty))
         else:
             return None
+
+
+def cleanup_ssh(tmp_dir: Path) -> None:
+    "Close SSH ControlMaster connection."
+    for ctrl in tmp_dir.glob("ssh-*"):
+        subprocess.run(["ssh", "-o", f"ControlPath={ctrl}", "exit"], check=False)
 
 
 def run_wrapper(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,20 +1,52 @@
+from __future__ import annotations
+
 import os
 import subprocess
-from typing import Any, Sequence
+from typing import Sequence, TypedDict, Unpack
 
 from .models import SSH
 
 
-def run(
-    args: Sequence[str | bytes | os.PathLike[Any]],
-    # make `check` explicit so we always know if the code is aborting on errors
-    check: bool,
+# Not exhaustive, but we can always extend it later.
+class RunKwargs(TypedDict, total=False):
+    capture_output: bool
+    stderr: int | None
+    stdin: int | None
+    stdout: int | None
+
+
+def run_wrapper(
+    args: Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes]],
+    *,
+    check: bool,  # make it explicit so we always know if the code is handling errors
+    env: dict[str, str] | None = None,  # replaces the current environment
+    extra_env: dict[str, str] | None = None,  # appends to the current environment
     remote: SSH | None = None,
     sudo: bool = False,
-    **kwargs: Any,
-) -> subprocess.CompletedProcess[Any]:
-    if sudo:
-        args = ["sudo"] + list(args)
+    **kwargs: Unpack[RunKwargs],
+) -> subprocess.CompletedProcess[str]:
+    "Wrapper around `subprocess.run` that supports extra functionality."
     if remote:
-        args = ["ssh", *remote.opts, remote.host, "--"] + list(args)
-    return subprocess.run(args, check=check, **kwargs)
+        assert env is None, "'env' can't be used with 'remote'"
+        if extra_env:
+            extra_env_args = [f"{env}={value}" for env, value in extra_env.items()]
+            args = ["env", *extra_env_args, *args]
+        if sudo:
+            args = ["sudo", *args]
+        args = ["ssh", *remote.opts, remote.host, "--", *args]
+    else:
+        if extra_env:
+            env = (env or os.environ) | extra_env
+        if sudo:
+            args = ["sudo", *args]
+
+    return subprocess.run(
+        args,
+        check=check,
+        env=env,
+        # Hope nobody is using NixOS with non-UTF8 encodings, but "surrogateescape"
+        # should still work in those systems.
+        text=True,
+        errors="surrogateescape",
+        **kwargs,
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+import argparse
 import sys
 from functools import partial
-from typing import Any
+from typing import TypeAlias
 
 info = partial(print, file=sys.stderr)
+Args: TypeAlias = bool | str | list[str] | int | None
 
 
-def dict_to_flags(d: dict[str, Any]) -> list[str]:
+def dict_to_flags(d: dict[str, Args]) -> list[str]:
     flags = []
     for key, value in d.items():
         flag = f"--{'-'.join(key.split('_'))}"
         match value:
-            case None | False:
+            case None | False | 0 | []:
                 pass
             case True:
                 flags.append(flag)
@@ -26,3 +28,8 @@ def dict_to_flags(d: dict[str, Any]) -> list[str]:
                 for v in value:
                     flags.append(v)
     return flags
+
+
+def flags_to_dict(args: argparse.Namespace, keys: list[str]) -> dict[str, Args]:
+    d = vars(args)
+    return {k: d[k] for k in keys}

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -1,4 +1,3 @@
-import argparse
 import sys
 from functools import partial
 from typing import TypeAlias
@@ -26,8 +25,3 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
                 for v in value:
                     flags.append(v)
     return flags
-
-
-def flags_to_dict(args: argparse.Namespace, keys: list[str]) -> dict[str, Args]:
-    d = vars(args)
-    return {k: d[k] for k in keys}

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import sys
 from functools import partial

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -13,7 +13,7 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
         flag = f"--{'-'.join(key.split('_'))}"
         match value:
             case None | False | 0 | []:
-                pass
+                continue
             case True:
                 flags.append(flag)
             case int():

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
@@ -46,4 +46,5 @@ extend-select = [
 "tests/" = ["FA102"]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 addopts = ["--import-mode=importlib"]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
@@ -38,8 +38,6 @@ ignore_missing_imports = true
 extend-select = [
     # ensure imports are sorted
     "I",
-    # require 'from __future__ import annotations'
-    "FA102",
     # require `check` argument for `subprocess.run`
     "PLW1510",
 ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -74,8 +74,7 @@ def test_parse_args() -> None:
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-@patch(get_qualified_name(nr.nix.shutil.which), autospec=True, return_value="/bin/git")
-def test_execute_nix_boot(mock_which: Any, mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
     config_path = tmp_path / "test"

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -70,7 +70,7 @@ def test_parse_args() -> None:
     assert r2.attr == "bar"
 
 
-@patch(get_qualified_name(nr.nix.run, nr.nix), autospec=True)
+@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.nix.shutil.which), autospec=True, return_value="/bin/git")
 def test_execute_nix_boot(mock_which: Any, mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
@@ -143,7 +143,7 @@ def test_execute_nix_boot(mock_which: Any, mock_run: Any, tmp_path: Path) -> Non
     )
 
 
-@patch(get_qualified_name(nr.nix.run, nr.nix), autospec=True)
+@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -163,6 +163,7 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
             "--flake",
             "/path/to/config#hostname",
             "--install-bootloader",
+            "--sudo",
             "--verbose",
         ]
     )
@@ -187,6 +188,7 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
             ),
             call(
                 [
+                    "sudo",
                     "nix-env",
                     "-p",
                     Path("/nix/var/nix/profiles/system"),
@@ -196,7 +198,7 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
                 check=True,
             ),
             call(
-                [config_path / "bin/switch-to-configuration", "switch"],
+                ["sudo", config_path / "bin/switch-to-configuration", "switch"],
                 env={"NIXOS_INSTALL_BOOTLOADER": "1", "LOCALE_ARCHIVE": "/locale"},
                 check=True,
             ),
@@ -204,7 +206,7 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
     )
 
 
-@patch(get_qualified_name(nr.nix.run, nr.nix), autospec=True)
+@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.touch()
@@ -236,7 +238,7 @@ def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
     )
 
 
-@patch(get_qualified_name(nr.nix.run, nr.nix), autospec=True)
+@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
 @patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
 def test_execute_test_rollback(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -31,7 +31,7 @@ def test_parse_args() -> None:
         nr.parse_args(["nixos-rebuild", "edit", "--attr", "attr"])
     assert e.value.code == 2
 
-    r1 = nr.parse_args(
+    r1, g1 = nr.parse_args(
         [
             "nixos-rebuild",
             "switch",
@@ -50,8 +50,9 @@ def test_parse_args() -> None:
     assert r1.profile_name == "system"
     assert r1.action == "switch"
     assert r1.option == ["foo", "bar"]
+    assert g1["common_flags"].option == ["foo", "bar"]
 
-    r2 = nr.parse_args(
+    r2, g2 = nr.parse_args(
         [
             "nixos-rebuild",
             "dry-run",
@@ -70,6 +71,7 @@ def test_parse_args() -> None:
     assert r2.action == "dry-build"
     assert r2.file == "foo"
     assert r2.attr == "bar"
+    assert g2["common_flags"].verbose == 3
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -10,7 +10,12 @@ import nixos_rebuild as nr
 
 from .helpers import get_qualified_name
 
-DEFAULT_RUN_KWARGS = {"text": True, "errors": "surrogateescape", "env": ANY}
+DEFAULT_RUN_KWARGS = {
+    "env": ANY,
+    "input": None,
+    "text": True,
+    "errors": "surrogateescape",
+}
 
 
 def test_parse_args() -> None:
@@ -267,7 +272,6 @@ def test_execute_nix_switch_flake_remote(
             call(
                 [
                     "ssh",
-                    "-t",
                     "-o",
                     "ControlMaster=auto",
                     "-o",
@@ -289,7 +293,6 @@ def test_execute_nix_switch_flake_remote(
             call(
                 [
                     "ssh",
-                    "-t",
                     "-o",
                     "ControlMaster=auto",
                     "-o",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -1,4 +1,5 @@
 import platform
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -12,16 +13,15 @@ def test_flake_parse() -> None:
     assert m.Flake.parse("/path/to/flake#attr") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.attr"
     )
-    assert m.Flake.parse("/path/ to /flake", "hostname") == m.Flake(
+    assert m.Flake.parse("/path/ to /flake", lambda: "hostname") == m.Flake(
         Path("/path/ to /flake"), "nixosConfigurations.hostname"
     )
-    assert m.Flake.parse("/path/to/flake", "hostname") == m.Flake(
+    assert m.Flake.parse("/path/to/flake", lambda: "hostname") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.hostname"
     )
     assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
     assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
-    assert m.Flake.parse(".", None) == m.Flake(Path("."), "nixosConfigurations.default")
-    assert m.Flake.parse("", "") == m.Flake(Path("."), "nixosConfigurations.default")
+    assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
 
 
 @patch(get_qualified_name(platform.node), autospec=True)
@@ -29,15 +29,17 @@ def test_flake_from_arg(mock_node: Any) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
-    assert m.Flake.from_arg("/path/to/flake#attr") == m.Flake(
+    assert m.Flake.from_arg("/path/to/flake#attr", None) == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.attr"
     )
 
     # False
-    assert m.Flake.from_arg(False) is None
+    assert m.Flake.from_arg(False, None) is None
 
     # True
-    assert m.Flake.from_arg(True) == m.Flake(Path("."), "nixosConfigurations.hostname")
+    assert m.Flake.from_arg(True, None) == m.Flake(
+        Path("."), "nixosConfigurations.hostname"
+    )
 
     # None when we do not have /etc/nixos/flake.nix
     with patch(
@@ -45,7 +47,7 @@ def test_flake_from_arg(mock_node: Any) -> None:
         autospec=True,
         return_value=False,
     ):
-        assert m.Flake.from_arg(None) is None
+        assert m.Flake.from_arg(None, None) is None
 
     # None when we have a file in /etc/nixos/flake.nix
     with (
@@ -60,7 +62,7 @@ def test_flake_from_arg(mock_node: Any) -> None:
             return_value=False,
         ),
     ):
-        assert m.Flake.from_arg(None) == m.Flake(
+        assert m.Flake.from_arg(None, None) == m.Flake(
             Path("/etc/nixos"), "nixosConfigurations.hostname"
         )
 
@@ -81,8 +83,19 @@ def test_flake_from_arg(mock_node: Any) -> None:
             return_value=Path("/path/to/flake.nix"),
         ),
     ):
-        assert m.Flake.from_arg(None) == m.Flake(
+        assert m.Flake.from_arg(None, None) == m.Flake(
             Path("/path/to"), "nixosConfigurations.hostname"
+        )
+
+    with (
+        patch(
+            get_qualified_name(m.subprocess.run),
+            autospec=True,
+            return_value=subprocess.CompletedProcess([], 0, "remote-hostname\n"),
+        ),
+    ):
+        assert m.Flake.from_arg("/path/to", m.Ssh("user@host", [], False)) == m.Flake(
+            Path("/path/to"), "nixosConfigurations.remote-hostname"
         )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -94,9 +94,9 @@ def test_flake_from_arg(mock_node: Any) -> None:
             return_value=subprocess.CompletedProcess([], 0, "remote-hostname\n"),
         ),
     ):
-        assert m.Flake.from_arg(
-            "/path/to", m.Remote("user@host", [], False)
-        ) == m.Flake(Path("/path/to"), "nixosConfigurations.remote-hostname")
+        assert m.Flake.from_arg("/path/to", m.Remote("user@host", [], None)) == m.Flake(
+            Path("/path/to"), "nixosConfigurations.remote-hostname"
+        )
 
 
 @patch(get_qualified_name(m.Path.mkdir, m), autospec=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -111,37 +111,3 @@ def test_profile_from_name(mock_mkdir: Any) -> None:
         Path("/nix/var/nix/profiles/system-profiles/something"),
     )
     mock_mkdir.assert_called_once()
-
-
-def test_remote_from_name(monkeypatch: Any, tmpdir: Path) -> None:
-    monkeypatch.setenv("NIX_SSHOPTS", "")
-    assert m.Remote.from_arg("user@localhost", None, tmpdir) == m.Remote(
-        "user@localhost",
-        [
-            "-o",
-            "ControlMaster=auto",
-            "-o",
-            f"ControlPath={tmpdir / "ssh-%n"}",
-            "-o",
-            "ControlPersist=60",
-        ],
-        False,
-    )
-
-    monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar")
-    assert m.Remote.from_arg("user@localhost", True, tmpdir) == m.Remote(
-        "user@localhost",
-        [
-            "-f",
-            "foo",
-            "-b",
-            "bar",
-            "-o",
-            "ControlMaster=auto",
-            "-o",
-            f"ControlPath={tmpdir / "ssh-%n"}",
-            "-o",
-            "ControlPersist=60",
-        ],
-        True,
-    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-from nixos_rebuild import models as m
+import nixos_rebuild.models as m
 
 from .helpers import get_qualified_name
 
@@ -98,3 +98,12 @@ def test_profile_from_name(mock_mkdir: Any) -> None:
         Path("/nix/var/nix/profiles/system-profiles/something"),
     )
     mock_mkdir.assert_called_once()
+
+
+def test_ssh_from_name(monkeypatch: Any) -> None:
+    assert m.SSH.from_arg("user@localhost") == m.SSH("user@localhost", [])
+
+    monkeypatch.setenv("SSH_OPTS", "-f foo -b bar")
+    assert m.SSH.from_arg("user@localhost") == m.SSH(
+        "user@localhost", ["-f", "foo", "-b", "bar"]
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -101,9 +101,11 @@ def test_profile_from_name(mock_mkdir: Any) -> None:
 
 
 def test_ssh_from_name(monkeypatch: Any) -> None:
-    assert m.SSH.from_arg("user@localhost") == m.SSH("user@localhost", [])
+    assert m.SSH.from_arg("user@localhost", None) == m.SSH("user@localhost", [], False)
 
     monkeypatch.setenv("SSH_OPTS", "-f foo -b bar")
-    assert m.SSH.from_arg("user@localhost") == m.SSH(
-        "user@localhost", ["-f", "foo", "-b", "bar"]
+    assert m.SSH.from_arg("user@localhost", True) == m.SSH(
+        "user@localhost",
+        ["-f", "foo", "-b", "bar"],
+        True,
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -94,9 +94,9 @@ def test_flake_from_arg(mock_node: Any) -> None:
             return_value=subprocess.CompletedProcess([], 0, "remote-hostname\n"),
         ),
     ):
-        assert m.Flake.from_arg("/path/to", m.Ssh("user@host", [], False)) == m.Flake(
-            Path("/path/to"), "nixosConfigurations.remote-hostname"
-        )
+        assert m.Flake.from_arg(
+            "/path/to", m.Remote("user@host", [], False)
+        ) == m.Flake(Path("/path/to"), "nixosConfigurations.remote-hostname")
 
 
 @patch(get_qualified_name(m.Path.mkdir, m), autospec=True)
@@ -113,9 +113,9 @@ def test_profile_from_name(mock_mkdir: Any) -> None:
     mock_mkdir.assert_called_once()
 
 
-def test_ssh_from_name(monkeypatch: Any, tmpdir: Path) -> None:
+def test_remote_from_name(monkeypatch: Any, tmpdir: Path) -> None:
     monkeypatch.setenv("NIX_SSHOPTS", "")
-    assert m.Ssh.from_arg("user@localhost", None, tmpdir) == m.Ssh(
+    assert m.Remote.from_arg("user@localhost", None, tmpdir) == m.Remote(
         "user@localhost",
         [
             "-o",
@@ -129,7 +129,7 @@ def test_ssh_from_name(monkeypatch: Any, tmpdir: Path) -> None:
     )
 
     monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar")
-    assert m.Ssh.from_arg("user@localhost", True, tmpdir) == m.Ssh(
+    assert m.Remote.from_arg("user@localhost", True, tmpdir) == m.Remote(
         "user@localhost",
         [
             "-f",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -101,7 +101,8 @@ def test_profile_from_name(mock_mkdir: Any) -> None:
 
 
 def test_ssh_from_name(monkeypatch: Any, tmpdir: Path) -> None:
-    assert m.SSH.from_arg("user@localhost", None, tmpdir) == m.SSH(
+    monkeypatch.setenv("NIX_SSHOPTS", "")
+    assert m.Ssh.from_arg("user@localhost", None, tmpdir) == m.Ssh(
         "user@localhost",
         [
             "-o",
@@ -114,8 +115,8 @@ def test_ssh_from_name(monkeypatch: Any, tmpdir: Path) -> None:
         False,
     )
 
-    monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar", tmpdir)
-    assert m.SSH.from_arg("user@localhost", True, tmpdir) == m.SSH(
+    monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar")
+    assert m.Ssh.from_arg("user@localhost", True, tmpdir) == m.Ssh(
         "user@localhost",
         [
             "-f",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -6,8 +6,8 @@ from unittest.mock import ANY, call, patch
 
 import pytest
 
+import nixos_rebuild.models as m
 import nixos_rebuild.nix as n
-from nixos_rebuild import models as m
 
 from .helpers import get_qualified_name
 
@@ -297,10 +297,12 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
 def test_set_profile(mock_run: Any) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
-    n.set_profile(m.Profile("system", profile_path), config_path)
+    n.set_profile(m.Profile("system", profile_path), config_path, sudo=False)
 
     mock_run.assert_called_with(
-        ["nix-env", "-p", profile_path, "--set", config_path], check=True
+        ["nix-env", "-p", profile_path, "--set", config_path],
+        check=True,
+        sudo=False,
     )
 
 
@@ -315,6 +317,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         n.switch_to_configuration(
             profile_path,
             m.Action.SWITCH,
+            sudo=False,
             specialisation=None,
             install_bootloader=False,
         )
@@ -322,12 +325,14 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         [profile_path / "bin/switch-to-configuration", "switch"],
         env={"NIXOS_INSTALL_BOOTLOADER": "0", "LOCALE_ARCHIVE": ""},
         check=True,
+        sudo=False,
     )
 
     with pytest.raises(m.NRError) as e:
         n.switch_to_configuration(
             config_path,
             m.Action.BOOT,
+            sudo=False,
             specialisation="special",
         )
     assert (
@@ -342,6 +347,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         n.switch_to_configuration(
             Path("/path/to/config"),
             m.Action.TEST,
+            sudo=True,
             install_bootloader=True,
             specialisation="special",
         )
@@ -352,6 +358,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         ],
         env={"NIXOS_INSTALL_BOOTLOADER": "1", "LOCALE_ARCHIVE": "/path/to/locale"},
         check=True,
+        sudo=True,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -18,7 +18,7 @@ def test_copy_closure(mock_run: Any) -> None:
     n.copy_closure(closure, None)
     mock_run.assert_not_called()
 
-    target_host = m.Ssh("user@host", ["--ssh", "opt"], False)
+    target_host = m.Remote("user@host", ["--ssh", "opt"], False)
     n.copy_closure(closure, target_host)
     mock_run.assert_called_with(
         ["nix-copy-closure", "--to", "user@host", closure],
@@ -366,7 +366,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
             Path("/path/to/config"),
             m.Action.TEST,
             sudo=True,
-            target_host=m.Ssh("user@localhost", [], False),
+            target_host=m.Remote("user@localhost", [], False),
             install_bootloader=True,
             specialisation="special",
         )
@@ -378,7 +378,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "1"},
         check=True,
         sudo=True,
-        remote=m.Ssh("user@localhost", [], False),
+        remote=m.Remote("user@localhost", [], False),
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -12,7 +12,7 @@ import nixos_rebuild.nix as n
 from .helpers import get_qualified_name
 
 
-@patch(get_qualified_name(n.run, n), autospec=True)
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
     # Flake
     flake = m.Flake.parse(".#attr")
@@ -49,7 +49,7 @@ def test_get_nixpkgs_rev(mock_which: Any) -> None:
     path = Path("/path/to/nix")
 
     with patch(
-        get_qualified_name(n.run, n),
+        get_qualified_name(n.run_wrapper, n),
         autospec=True,
         side_effect=[CompletedProcess([], 0, "")],
     ) as mock_run:
@@ -58,7 +58,6 @@ def test_get_nixpkgs_rev(mock_which: Any) -> None:
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
             stdout=PIPE,
-            text=True,
         )
 
     expected_calls = [
@@ -66,7 +65,6 @@ def test_get_nixpkgs_rev(mock_which: Any) -> None:
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
             stdout=PIPE,
-            text=True,
         ),
         call(
             ["git", "-C", path, "diff", "--quiet"],
@@ -75,7 +73,7 @@ def test_get_nixpkgs_rev(mock_which: Any) -> None:
     ]
 
     with patch(
-        get_qualified_name(n.run, n),
+        get_qualified_name(n.run_wrapper, n),
         autospec=True,
         side_effect=[
             CompletedProcess([], 0, "0f7c82403fd6"),
@@ -86,7 +84,7 @@ def test_get_nixpkgs_rev(mock_which: Any) -> None:
         mock_run.assert_has_calls(expected_calls)
 
     with patch(
-        get_qualified_name(n.run, n),
+        get_qualified_name(n.run_wrapper, n),
         autospec=True,
         side_effect=[
             CompletedProcess([], 0, "0f7c82403fd6"),
@@ -118,7 +116,7 @@ def test_get_generations_from_nix_store(tmp_path: Path) -> None:
 
 
 @patch(
-    get_qualified_name(n.run, n),
+    get_qualified_name(n.run_wrapper, n),
     autospec=True,
     return_value=CompletedProcess(
         [],
@@ -183,7 +181,7 @@ def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
 
 
 @patch(
-    get_qualified_name(n.run, n),
+    get_qualified_name(n.run_wrapper, n),
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
@@ -209,13 +207,12 @@ def test_nixos_build_flake(mock_run: Any) -> None:
             "foo",
         ],
         check=True,
-        text=True,
         stdout=PIPE,
     )
 
 
 @patch(
-    get_qualified_name(n.run, n),
+    get_qualified_name(n.run_wrapper, n),
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
@@ -224,7 +221,6 @@ def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
     mock_run.assert_called_with(
         ["nix-build", "<nixpkgs/nixos>", "--attr", "attr", "--nix-flag", "foo"],
         check=True,
-        text=True,
         stdout=PIPE,
     )
 
@@ -232,7 +228,6 @@ def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
     mock_run.assert_called_with(
         ["nix-build", "file", "--attr", "preAttr.attr"],
         check=True,
-        text=True,
         stdout=PIPE,
     )
 
@@ -240,7 +235,6 @@ def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
     mock_run.assert_called_with(
         ["nix-build", "file", "--attr", "attr", "--no-out-link"],
         check=True,
-        text=True,
         stdout=PIPE,
     )
 
@@ -248,12 +242,11 @@ def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
     mock_run.assert_called_with(
         ["nix-build", "default.nix", "--attr", "preAttr.attr", "--keep-going"],
         check=True,
-        text=True,
         stdout=PIPE,
     )
 
 
-@patch(get_qualified_name(n.run, n), autospec=True)
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_rollback(mock_run: Any, tmp_path: Path) -> None:
     path = tmp_path / "test"
     path.touch()
@@ -269,7 +262,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
     path.touch()
     profile = m.Profile("system", path)
 
-    with patch(get_qualified_name(n.run, n), autospec=True) as mock_run:
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         mock_run.return_value = CompletedProcess(
             [],
             0,
@@ -288,12 +281,12 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             == path.parent / "foo-2083-link"
         )
 
-    with patch(get_qualified_name(n.run, n), autospec=True) as mock_run:
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         mock_run.return_value = CompletedProcess([], 0, stdout="")
         assert n.rollback_temporary_profile(profile) is None
 
 
-@patch(get_qualified_name(n.run, n), autospec=True)
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_set_profile(mock_run: Any) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
@@ -306,7 +299,7 @@ def test_set_profile(mock_run: Any) -> None:
     )
 
 
-@patch(get_qualified_name(n.run, n), autospec=True)
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
@@ -323,7 +316,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
         )
     mock_run.assert_called_with(
         [profile_path / "bin/switch-to-configuration", "switch"],
-        env={"NIXOS_INSTALL_BOOTLOADER": "0", "LOCALE_ARCHIVE": ""},
+        extra_env={"NIXOS_INSTALL_BOOTLOADER": "0"},
         check=True,
         sudo=False,
     )
@@ -342,6 +335,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
 
     with monkeypatch.context() as mp:
         mp.setenv("LOCALE_ARCHIVE", "/path/to/locale")
+        mp.setenv("PATH", "/path/to/bin")
         mp.setattr(Path, Path.exists.__name__, lambda self: True)
 
         n.switch_to_configuration(
@@ -356,7 +350,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
             config_path / "specialisation/special/bin/switch-to-configuration",
             "test",
         ],
-        env={"NIXOS_INSTALL_BOOTLOADER": "1", "LOCALE_ARCHIVE": "/path/to/locale"},
+        extra_env={"NIXOS_INSTALL_BOOTLOADER": "1"},
         check=True,
         sudo=True,
     )
@@ -372,11 +366,11 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
     ],
 )
 def test_upgrade_channels(mock_glob: Any) -> None:
-    with patch(get_qualified_name(n.run, n), autospec=True) as mock_run:
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)
     mock_run.assert_called_with(["nix-channel", "--update", "nixos"], check=False)
 
-    with patch(get_qualified_name(n.run, n), autospec=True) as mock_run:
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(True)
     mock_run.assert_has_calls(
         [

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -57,8 +57,7 @@ def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
         mock_run.assert_called_with(["editor", default_nix], check=False)
 
 
-@patch(get_qualified_name(n.shutil.which), autospec=True, return_value="/bin/git")
-def test_get_nixpkgs_rev(mock_which: Any) -> None:
+def test_get_nixpkgs_rev() -> None:
     assert n.get_nixpkgs_rev(None) is None
 
     path = Path("/path/to/nix")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -22,7 +22,6 @@ def test_copy_closure(mock_run: Any) -> None:
     n.copy_closure(closure, target_host)
     mock_run.assert_called_with(
         ["nix-copy-closure", "--to", "user@host", closure],
-        check=True,
         extra_env={"NIX_SSHOPTS": "--ssh opt"},
     )
 
@@ -220,7 +219,6 @@ def test_nixos_build_flake(mock_run: Any) -> None:
             "--nix-flag",
             "foo",
         ],
-        check=True,
         stdout=PIPE,
     )
 
@@ -234,28 +232,24 @@ def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
     assert n.nixos_build("attr", None, None, nix_flag="foo") == Path("/path/to/file")
     mock_run.assert_called_with(
         ["nix-build", "<nixpkgs/nixos>", "--attr", "attr", "--nix-flag", "foo"],
-        check=True,
         stdout=PIPE,
     )
 
     n.nixos_build("attr", "preAttr", "file")
     mock_run.assert_called_with(
         ["nix-build", "file", "--attr", "preAttr.attr"],
-        check=True,
         stdout=PIPE,
     )
 
     n.nixos_build("attr", None, "file", no_out_link=True)
     mock_run.assert_called_with(
         ["nix-build", "file", "--attr", "attr", "--no-out-link"],
-        check=True,
         stdout=PIPE,
     )
 
     n.nixos_build("attr", "preAttr", None, no_out_link=False, keep_going=True)
     mock_run.assert_called_with(
         ["nix-build", "default.nix", "--attr", "preAttr.attr", "--keep-going"],
-        check=True,
         stdout=PIPE,
     )
 
@@ -270,7 +264,6 @@ def test_rollback(mock_run: Any, tmp_path: Path) -> None:
     assert n.rollback(profile, None, False) == profile.path
     mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
-        check=True,
         remote=None,
         sudo=False,
     )
@@ -279,7 +272,6 @@ def test_rollback(mock_run: Any, tmp_path: Path) -> None:
     assert n.rollback(profile, target_host, True) == profile.path
     mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
-        check=True,
         remote=target_host,
         sudo=True,
     )
@@ -312,7 +304,6 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
                 "--list-generations",
             ],
             stdout=PIPE,
-            check=True,
             remote=None,
             sudo=False,
         )
@@ -330,7 +321,6 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
                 "--list-generations",
             ],
             stdout=PIPE,
-            check=True,
             remote=target_host,
             sudo=True,
         )
@@ -353,7 +343,6 @@ def test_set_profile(mock_run: Any) -> None:
 
     mock_run.assert_called_with(
         ["nix-env", "-p", profile_path, "--set", config_path],
-        check=True,
         remote=None,
         sudo=False,
     )
@@ -378,7 +367,6 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
     mock_run.assert_called_with(
         [profile_path / "bin/switch-to-configuration", "switch"],
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "0"},
-        check=True,
         sudo=False,
         remote=None,
     )
@@ -416,7 +404,6 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
             "test",
         ],
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "1"},
-        check=True,
         sudo=True,
         remote=target_host,
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -16,7 +16,7 @@ from .helpers import get_qualified_name
 def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
     # Flake
     flake = m.Flake.parse(".#attr")
-    n.edit(flake, ["--commit-lock-file"])
+    n.edit(flake, commit_lock_file=True)
     mock_run.assert_called_with(
         [
             "nix",
@@ -193,8 +193,8 @@ def test_nixos_build_flake(mock_run: Any) -> None:
     assert n.nixos_build_flake(
         "toplevel",
         flake,
-        ["--nix-flag", "foo"],
         no_link=True,
+        nix_flag="foo",
     ) == Path("/path/to/file")
     mock_run.assert_called_with(
         [
@@ -220,9 +220,7 @@ def test_nixos_build_flake(mock_run: Any) -> None:
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
 def test_nixos_build(mock_run: Any, monkeypatch: Any) -> None:
-    assert n.nixos_build("attr", None, None, ["--nix-flag", "foo"]) == Path(
-        "/path/to/file"
-    )
+    assert n.nixos_build("attr", None, None, nix_flag="foo") == Path("/path/to/file")
     mock_run.assert_called_with(
         ["nix-build", "<nixpkgs/nixos>", "--attr", "attr", "--nix-flag", "foo"],
         check=True,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -41,7 +41,7 @@ def test_run(mock_run: Any) -> None:
     p.run_wrapper(
         ["test", "--with", "flags"],
         check=True,
-        remote=m.Ssh("user@localhost", ["--ssh", "opt"], False),
+        remote=m.Remote("user@localhost", ["--ssh", "opt"], False),
     )
     mock_run.assert_called_with(
         ["ssh", "--ssh", "opt", "user@localhost", "--", "test", "--with", "flags"],
@@ -69,7 +69,7 @@ def test_run(mock_run: Any) -> None:
         check=True,
         sudo=True,
         extra_env={"FOO": "bar"},
-        remote=m.Ssh("user@localhost", ["--ssh", "opt"], True),
+        remote=m.Remote("user@localhost", ["--ssh", "opt"], True),
     )
     mock_run.assert_called_with(
         [
@@ -97,5 +97,5 @@ def test_run(mock_run: Any) -> None:
             ["test", "--with", "flags"],
             check=False,
             env={"foo": "bar"},
-            remote=m.Ssh("user@localhost", [], False),
+            remote=m.Remote("user@localhost", [], False),
         )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -41,7 +41,7 @@ def test_run(mock_run: Any) -> None:
     p.run_wrapper(
         ["test", "--with", "flags"],
         check=True,
-        remote=m.SSH("user@localhost", ["--ssh", "opt"], False),
+        remote=m.Ssh("user@localhost", ["--ssh", "opt"], False),
     )
     mock_run.assert_called_with(
         ["ssh", "--ssh", "opt", "user@localhost", "--", "test", "--with", "flags"],
@@ -69,7 +69,7 @@ def test_run(mock_run: Any) -> None:
         check=True,
         sudo=True,
         extra_env={"FOO": "bar"},
-        remote=m.SSH("user@localhost", ["--ssh", "opt"], True),
+        remote=m.Ssh("user@localhost", ["--ssh", "opt"], True),
     )
     mock_run.assert_called_with(
         [
@@ -97,5 +97,5 @@ def test_run(mock_run: Any) -> None:
             ["test", "--with", "flags"],
             check=False,
             env={"foo": "bar"},
-            remote=m.SSH("user@localhost", [], False),
+            remote=m.Ssh("user@localhost", [], False),
         )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -41,7 +41,7 @@ def test_run(mock_run: Any) -> None:
     p.run_wrapper(
         ["test", "--with", "flags"],
         check=True,
-        remote=m.SSH("user@localhost", ["--ssh", "opt"]),
+        remote=m.SSH("user@localhost", ["--ssh", "opt"], False),
     )
     mock_run.assert_called_with(
         ["ssh", "--ssh", "opt", "user@localhost", "--", "test", "--with", "flags"],
@@ -69,11 +69,12 @@ def test_run(mock_run: Any) -> None:
         check=True,
         sudo=True,
         extra_env={"FOO": "bar"},
-        remote=m.SSH("user@localhost", ["--ssh", "opt"]),
+        remote=m.SSH("user@localhost", ["--ssh", "opt"], True),
     )
     mock_run.assert_called_with(
         [
             "ssh",
+            "-t",
             "--ssh",
             "opt",
             "user@localhost",
@@ -96,5 +97,5 @@ def test_run(mock_run: Any) -> None:
             ["test", "--with", "flags"],
             check=False,
             env={"foo": "bar"},
-            remote=m.SSH("user@localhost", []),
+            remote=m.SSH("user@localhost", [], False),
         )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -53,19 +53,6 @@ def test_run(mock_run: Any) -> None:
 
     p.run_wrapper(
         ["test", "--with", "flags"],
-        check=False,
-        env={"FOO": "bar"},
-    )
-    mock_run.assert_called_with(
-        ["test", "--with", "flags"],
-        check=False,
-        env={"FOO": "bar"},
-        text=True,
-        errors="surrogateescape",
-    )
-
-    p.run_wrapper(
-        ["test", "--with", "flags"],
         check=True,
         sudo=True,
         extra_env={"FOO": "bar"},
@@ -96,6 +83,7 @@ def test_run(mock_run: Any) -> None:
         p.run_wrapper(
             ["test", "--with", "flags"],
             check=False,
-            env={"foo": "bar"},
+            allow_tty=True,
             remote=m.Remote("user@localhost", [], False),
+            capture_output=True,
         )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -1,0 +1,47 @@
+from typing import Any
+from unittest.mock import patch
+
+import nixos_rebuild.models as m
+import nixos_rebuild.process as p
+
+from .helpers import get_qualified_name
+
+
+@patch(get_qualified_name(p.subprocess.run))
+def test_run(mock_run: Any) -> None:
+    p.run(["test", "--with", "flags"], check=True)
+    mock_run.assert_called_with(["test", "--with", "flags"], check=True)
+
+    p.run(["test", "--with", "flags"], check=False, sudo=True)
+    mock_run.assert_called_with(["sudo", "test", "--with", "flags"], check=False)
+
+    p.run(
+        ["test", "--with", "flags"],
+        check=True,
+        remote=m.SSH("user@localhost", ["--ssh", "opt"]),
+    )
+    mock_run.assert_called_with(
+        ["ssh", "--ssh", "opt", "user@localhost", "--", "test", "--with", "flags"],
+        check=True,
+    )
+
+    p.run(
+        ["test", "--with", "flags"],
+        check=True,
+        sudo=True,
+        remote=m.SSH("user@localhost", ["--ssh", "opt"]),
+    )
+    mock_run.assert_called_with(
+        [
+            "ssh",
+            "--ssh",
+            "opt",
+            "user@localhost",
+            "--",
+            "sudo",
+            "test",
+            "--with",
+            "flags",
+        ],
+        check=True,
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -87,3 +88,37 @@ def test_run(mock_run: Any) -> None:
             remote=m.Remote("user@localhost", [], False),
             capture_output=True,
         )
+
+
+def test_remote_from_name(monkeypatch: Any, tmpdir: Path) -> None:
+    monkeypatch.setenv("NIX_SSHOPTS", "")
+    assert m.Remote.from_arg("user@localhost", None, tmpdir) == m.Remote(
+        "user@localhost",
+        opts=[
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={tmpdir / "ssh-%n"}",
+            "-o",
+            "ControlPersist=60",
+        ],
+        tty=False,
+    )
+
+    monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar")
+    assert m.Remote.from_arg("user@localhost", True, tmpdir) == m.Remote(
+        "user@localhost",
+        opts=[
+            "-f",
+            "foo",
+            "-b",
+            "bar",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={tmpdir / "ssh-%n"}",
+            "-o",
+            "ControlPersist=60",
+        ],
+        tty=True,
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -1,5 +1,3 @@
-import argparse
-
 import nixos_rebuild.utils as u
 
 
@@ -25,23 +23,3 @@ def test_dict_to_flags() -> None:
     ]
     r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})
     assert r2 == []
-
-
-def test_flags_to_dict() -> None:
-    r = u.flags_to_dict(
-        argparse.Namespace(
-            test_flag_1=True,
-            test_flag_2=False,
-            test_flag_3="value",
-            test_flag_4=["v1", "v2"],
-            test_flag_5=None,
-            verbose=5,
-        ),
-        ["test_flag_1", "test_flag_3", "test_flag_4", "verbose"],
-    )
-    assert r == {
-        "test_flag_1": True,
-        "test_flag_3": "value",
-        "test_flag_4": ["v1", "v2"],
-        "verbose": 5,
-    }

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -1,8 +1,10 @@
+import argparse
+
 from nixos_rebuild import utils as u
 
 
 def test_dict_to_flags() -> None:
-    r = u.dict_to_flags(
+    r1 = u.dict_to_flags(
         {
             "test_flag_1": True,
             "test_flag_2": False,
@@ -12,7 +14,7 @@ def test_dict_to_flags() -> None:
             "verbose": 5,
         }
     )
-    assert r == [
+    assert r1 == [
         "--test-flag-1",
         "--test-flag-3",
         "value",
@@ -21,3 +23,25 @@ def test_dict_to_flags() -> None:
         "v2",
         "-vvvvv",
     ]
+    r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})
+    assert r2 == []
+
+
+def test_flags_to_dict() -> None:
+    r = u.flags_to_dict(
+        argparse.Namespace(
+            test_flag_1=True,
+            test_flag_2=False,
+            test_flag_3="value",
+            test_flag_4=["v1", "v2"],
+            test_flag_5=None,
+            verbose=5,
+        ),
+        ["test_flag_1", "test_flag_3", "test_flag_4", "verbose"],
+    )
+    assert r == {
+        "test_flag_1": True,
+        "test_flag_3": "value",
+        "test_flag_4": ["v1", "v2"],
+        "verbose": 5,
+    }

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -1,6 +1,6 @@
 import argparse
 
-from nixos_rebuild import utils as u
+import nixos_rebuild.utils as u
 
 
 def test_dict_to_flags() -> None:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR ended up bigger than I expected because it needed lots of changes to support remote builders. Why this took so much code? Well:
- Need to differentiate between the multiple possible Nix flags, e.g.: `--use-substitutes` is only for `nix-copy-closure` while `--include` is only for `nix-build`
- Need an abstraction to run command remotely, so now we have `process.run_wrapper`
- We need some things done completely different remotely, e.g.: get hostname

However since everything is here now, it should be easy to add `--build-host` next. But `--build-host` is sufficiently different that I want to do this in a separate PR, e.g.: we can't use `nix-build` and need to use `nix-copy-closure` and `nix-store -r` to  realise the store path.

~~This is basically a bug to bug implementation of the original. There is an issue with `--use-remote-sudo` asking for password twice that is also reproducible in the original. It can be fixed, however I don't think it is worth it considering that we eventually we will have `activate` script once it gets back into the tree, and once we have `activate` this issue goes away.~~

I changed the implementation of remote to not depend in `ssh -t` (pseudo TTY) anymore. This is a headache since it changes lots of behaviors inside SSH (for example, it redirects all the output to stdout), and it is also unreliable.

However, `sudo` depends in the TTY to ask for password, so now we have a flag `--ask-sudo-password` that will ask the password before running the tasks remotely. For local this doesn't change anything.

I am not sure if there is some concerns about security here: we are storing the password in memory and there is no good way in Python to remove it (like `memset` that I assume `sudo` uses here), so technically it will stay there until some program overwrites it. I don't think it is a huge concern though, people store secrets in environment variables all the time and this is probably easier to dump than memory. Also, if someone wants to grab your sudo password and have access to your computer to do so, they could run a keylogger and it would be much easier than dumping your memory. But if you are a reviewer and have some concerns here, please say so. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
