### PR TITLE
craft-docs: init at 2.8.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13180,6 +13180,13 @@
     githubId = 7910815;
     name = "Alex McGrath";
   };
+  lylythechosenone = {
+    name = "Lysander Mealy";
+    email = "lysander.mealy@gmail.com";
+    github = "lylythechosenone";
+    githubId = 19551513;
+    matrix = "lylythechosenone@matrix.org";
+  };
   lyndeno = {
     name = "Lyndon Sanche";
     email = "lsanche@lyndeno.ca";

--- a/pkgs/by-name/cr/craft-docs/package.nix
+++ b/pkgs/by-name/cr/craft-docs/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "craft-docs";
+  version = "2.8.8";
+
+  src = fetchurl {
+    name = "Craft.dmg";
+    url = "https://res.craft.do/native/sparkle/Craft.dmg";
+    hash = "sha256-5IlzPLzUZmMFEyL2tNDXjvb86/CW4dscVzbnNipKrek=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Craft.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Craft.app
+    cp -R . $out/Applications/Craft.app
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Proprietary note-taking and document-writing software.";
+    homepage = "https://craft.do/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ lylythechosenone ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Create a package for craft-docs, as in #359033. Will break as soon as Craft updates, as there is no method of downloading a specific, stable version. I am in discussion with their team to establish such a method, but until then, it'll have to be manually updated as quickly as possible as new versions come in to prevent breakage.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Note: package only supports darwin. Should work on x86_64-darwin, but I have no way of testing currently.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
