### PR TITLE
nixos: add initialHashedPasswordFile option

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -224,7 +224,10 @@ foreach my $u (@{$spec->{users}}) {
         $u->{uid} = allocUid($name, $u->{isSystemUser}) if !defined $u->{uid};
 
         if (!defined $u->{hashedPassword}) {
-            if (defined $u->{initialPassword}) {
+            if (defined $u->{initialHashedPasswordFile}) {
+                $u->{hashedPassword} = read_file($u->{initialHashedPasswordFile});
+                chomp $u->{hashedPassword}
+            } elsif (defined $u->{initialPassword}) {
                 $u->{hashedPassword} = hashPassword($u->{initialPassword});
             } elsif (defined $u->{initialHashedPassword}) {
                 $u->{hashedPassword} = $u->{initialHashedPassword};

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -86,6 +86,18 @@ let
     command).
   '';
 
+  initialHashedPasswordDescription = ''
+    Specifies the initial hashed password for the user, i.e. the
+    hashed password assigned if the user does not already
+    exist. If {option}`users.mutableUsers` is true, the
+    password can be changed subsequently using the
+    {command}`passwd` command. Otherwise, it's
+    equivalent to setting the {option}`hashedPassword` option.
+
+    Note that the {option}`hashedPassword` option will override
+    this option if both are set.
+  '';
+
   userOpts = { name, config, ... }: {
 
     options = {
@@ -322,17 +334,21 @@ let
         type = with types; nullOr (passwdEntry str);
         default = null;
         description = ''
-          Specifies the initial hashed password for the user, i.e. the
-          hashed password assigned if the user does not already
-          exist. If {option}`users.mutableUsers` is true, the
-          password can be changed subsequently using the
-          {command}`passwd` command. Otherwise, it's
-          equivalent to setting the {option}`hashedPassword` option.
-
-          Note that the {option}`hashedPassword` option will override
-          this option if both are set.
-
+          ${initialHashedPasswordDescription}
           ${hashedPasswordDescription}
+        '';
+      };
+
+      initialHashedPasswordFile = mkOption {
+        type = with types; nullOr (passwdEntry str);
+        default = null;
+        description = ''
+          The full path to a file that contains the hash of a user's
+          initial password. The file should contain exactly one line, which
+          should be the password in an encrypted form that is suitable for the
+          `chpasswd -e` command.
+
+          ${initialHashedPasswordDescription}
         '';
       };
 
@@ -413,6 +429,9 @@ let
         })
         (mkIf (!cfg.mutableUsers && config.initialHashedPassword != null) {
           hashedPassword = mkDefault config.initialHashedPassword;
+        })
+        (mkIf (!cfg.mutableUsers && config.initialHashedPasswordFile != null) {
+          hashedPasswordFile = mkDefault config.initialHashedPasswordFile;
         })
         (mkIf (config.isNormalUser && config.subUidRanges == [] && config.subGidRanges == []) {
           autoSubUidGidRange = mkDefault true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -911,6 +911,7 @@ in {
   sfxr-qt = handleTest ./sfxr-qt.nix {};
   sgt-puzzles = handleTest ./sgt-puzzles.nix {};
   shadow = handleTest ./shadow.nix {};
+  shadow-immutable = handleTest ./shadow-immutable.nix {};
   shadowsocks = handleTest ./shadowsocks {};
   shattered-pixel-dungeon = handleTest ./shattered-pixel-dungeon.nix {};
   shiori = handleTest ./shiori.nix {};

--- a/nixos/tests/shadow-immutable.nix
+++ b/nixos/tests/shadow-immutable.nix
@@ -1,0 +1,158 @@
+let
+  password1 = "foobar";
+  password2 = "helloworld";
+  password3 = "bazqux";
+  password4 = "asdf123";
+  hashed_bcrypt = "$2b$05$8xIEflrk2RxQtcVXbGIxs.Vl0x7dF1/JSv3cyX6JJt0npzkTCWvxK"; # fnord
+  hashed_yeshash = "$y$j9T$d8Z4EAf8P1SvM/aDFbxMS0$VnTXMp/Hnc7QdCBEaLTq5ZFOAFo2/PM0/xEAFuOE88."; # fnord
+  hashed_sha512crypt = "$6$ymzs8WINZ5wGwQcV$VC2S0cQiX8NVukOLymysTPn4v1zJoJp3NGyhnqyv/dAf4NWZsBWYveQcj6gEJr4ZUjRBRjM0Pj1L8TCQ8hUUp0"; # meow
+in
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "shadow-immutable";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ nequissimus ];
+    };
+
+    nodes.shadow =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.shadow ];
+
+        users = {
+          mutableUsers = false;
+          users.emma = {
+            isNormalUser = true;
+            initialPassword = password1;
+            shell = pkgs.bash;
+          };
+          users.layla = {
+            isNormalUser = true;
+            initialPassword = password2;
+            shell = pkgs.shadow;
+          };
+          users.ash = {
+            isNormalUser = true;
+            initialPassword = password4;
+            shell = pkgs.bash;
+          };
+          users.berta = {
+            isNormalUser = true;
+            initialHashedPasswordFile = (pkgs.writeText "hashed_bcrypt" hashed_bcrypt).outPath;
+            shell = pkgs.bash;
+          };
+          users.yesim = {
+            isNormalUser = true;
+            hashedPassword = hashed_yeshash;
+            shell = pkgs.bash;
+          };
+        };
+      };
+
+    testScript = ''
+      shadow.wait_for_unit("multi-user.target")
+      shadow.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
+
+      with subtest("Normal login"):
+          shadow.send_key("alt-f2")
+          shadow.wait_until_succeeds("[ $(fgconsole) = 2 ]")
+          shadow.wait_for_unit("getty@tty2.service")
+          shadow.wait_until_succeeds("pgrep -f 'agetty.*tty2'")
+          shadow.wait_until_tty_matches("2", "login: ")
+          shadow.send_chars("emma\n")
+          shadow.wait_until_tty_matches("2", "login: emma")
+          shadow.wait_until_succeeds("pgrep login")
+          shadow.sleep(2)
+          shadow.send_chars("${password1}\n")
+          shadow.send_chars("whoami > /tmp/1\n")
+          shadow.wait_for_file("/tmp/1")
+          assert "emma" in shadow.succeed("cat /tmp/1")
+
+      with subtest("Switch user"):
+          shadow.send_chars("su - ash\n")
+          shadow.sleep(2)
+          shadow.send_chars("${password4}\n")
+          shadow.sleep(2)
+          shadow.send_chars("whoami > /tmp/3\n")
+          shadow.wait_for_file("/tmp/3")
+          assert "ash" in shadow.succeed("cat /tmp/3")
+
+      with subtest("Change password"):
+          shadow.send_key("alt-f3")
+          shadow.wait_until_succeeds("[ $(fgconsole) = 3 ]")
+          shadow.wait_for_unit("getty@tty3.service")
+          shadow.wait_until_succeeds("pgrep -f 'agetty.*tty3'")
+          shadow.wait_until_tty_matches("3", "login: ")
+          shadow.send_chars("emma\n")
+          shadow.wait_until_tty_matches("3", "login: emma")
+          shadow.wait_until_succeeds("pgrep login")
+          shadow.sleep(2)
+          shadow.send_chars("${password1}\n")
+          shadow.send_chars("passwd\n")
+          shadow.sleep(2)
+          shadow.send_chars("${password1}\n")
+          shadow.sleep(2)
+          shadow.send_chars("${password3}\n")
+          shadow.sleep(2)
+          shadow.send_chars("${password3}\n")
+          shadow.sleep(2)
+          shadow.send_key("alt-f4")
+          shadow.wait_until_succeeds("[ $(fgconsole) = 4 ]")
+          shadow.wait_for_unit("getty@tty4.service")
+          shadow.wait_until_succeeds("pgrep -f 'agetty.*tty4'")
+          shadow.wait_until_tty_matches("4", "login: ")
+          shadow.send_chars("emma\n")
+          shadow.wait_until_tty_matches("4", "login: emma")
+          shadow.wait_until_succeeds("pgrep login")
+          shadow.sleep(2)
+          shadow.send_chars("${password3}\n")
+          shadow.wait_until_tty_matches("4", "Login incorrect")
+          shadow.wait_until_tty_matches("4", "login:")
+          shadow.send_chars("emma\n")
+          shadow.wait_until_tty_matches("4", "login: emma")
+          shadow.wait_until_succeeds("pgrep login")
+          shadow.sleep(2)
+          shadow.send_chars("${password1}\n")
+          shadow.send_chars("whoami > /tmp/2\n")
+          shadow.wait_for_file("/tmp/2")
+          assert "emma" in shadow.succeed("cat /tmp/2")
+
+      with subtest("Groups"):
+          assert "foobar" not in shadow.succeed("groups emma")
+          shadow.succeed("groupadd foobar")
+          shadow.succeed("usermod -a -G foobar emma")
+          assert "foobar" in shadow.succeed("groups emma")
+
+      with subtest("nologin shell"):
+          shadow.send_key("alt-f5")
+          shadow.wait_until_succeeds("[ $(fgconsole) = 5 ]")
+          shadow.wait_for_unit("getty@tty5.service")
+          shadow.wait_until_succeeds("pgrep -f 'agetty.*tty5'")
+          shadow.wait_until_tty_matches("5", "login: ")
+          shadow.send_chars("layla\n")
+          shadow.wait_until_tty_matches("5", "login: layla")
+          shadow.wait_until_succeeds("pgrep login")
+          shadow.send_chars("${password2}\n")
+          shadow.wait_until_tty_matches("5", "login:")
+
+      with subtest("check alternate password hashes"):
+          shadow.send_key("alt-f6")
+          shadow.wait_until_succeeds("[ $(fgconsole) = 6 ]")
+          for u in ["berta", "yesim"]:
+              shadow.wait_for_unit("getty@tty6.service")
+              shadow.wait_until_succeeds("pgrep -f 'agetty.*tty6'")
+              shadow.wait_until_tty_matches("6", "login: ")
+              shadow.send_chars(f"{u}\n")
+              shadow.wait_until_tty_matches("6", f"login: {u}")
+              shadow.wait_until_succeeds("pgrep login")
+              shadow.sleep(2)
+              shadow.send_chars("fnord\n")
+              shadow.send_chars(f"whoami > /tmp/{u}\n")
+              shadow.wait_for_file(f"/tmp/{u}")
+              print(shadow.succeed(f"cat /tmp/{u}"))
+              assert u in shadow.succeed(f"cat /tmp/{u}")
+              shadow.send_chars("logout\n")
+    '';
+  }
+)


### PR DESCRIPTION
It's currently not possible to use agenix for secrets with an immutable filesystem because `hashedPasswordFile` does not work with `mutableUsers = false` and the password must be specified with `initialPassword`/`initialHashedPassword`

This PR adds an `initialHashedPasswordFile` option to match the `hashedPasswordFile` option which already exists.

There is some additional work to be done around `systemd.sysusers.enable = true` and false parity.

As shown by  `nixos/tests/systemd-sysusers-immutable.nix` `hashedPasswordFile` works for immutable users whereas when not using systemd users `hashedPasswordFile` does not work and we'd need `initialHashedPasswordFile`.

I assume that's actually a bug in sysusers because it won't be possible to change the user's password in the next generation, though I don't fully understand the need for `initialHashedPassword` and `hashedPassword`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@lilyinstarlight 
@aneeshusa 
@adisbladis 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
