### PR TITLE
bindiff: init at 8

### DIFF
--- a/pkgs/by-name/bi/bindiff/package.nix
+++ b/pkgs/by-name/bi/bindiff/package.nix
@@ -1,0 +1,79 @@
+{
+  buildFHSEnv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  lib,
+  stdenv,
+  jdk17,
+  fontconfig,
+  makeDesktopItem,
+}:
+let
+  version = "8";
+  meta = {
+    description = "Quickly find differences and similarities in disassembled code";
+    homepage = "https://zynamics.com/bindiff.html";
+    changelog = "https://github.com/google/bindiff/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ lib.maintainers.BonusPlay ];
+  };
+  desktopItem = makeDesktopItem {
+    name = "bindiff";
+    exec = "bindiff";
+    comment = meta.description;
+    desktopName = "BinDiff";
+    genericName = "BinDiff";
+    categories = [ "Development" ];
+    icon = "com-google-security-zynamics-bindiff";
+  };
+  pkg = stdenv.mkDerivation {
+    src = fetchurl {
+      url = "https://github.com/google/bindiff/releases/download/v${version}/bindiff_${version}_amd64.deb";
+      sha256 = "sha256-ghmQ45dKnfZzN5Q3DkhUhqwna6XXd6BrTr5XXwkvTdo=";
+    };
+    inherit version;
+    pname = "bindiff";
+
+    nativeBuildInputs = [
+      makeWrapper
+      dpkg
+    ];
+
+    dontBuild = true;
+
+    unpackPhase = ''
+      dpkg-deb -x "$src" ./
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/usr" "$out/opt"
+      cp -a usr/* "$out/usr"
+      cp -a opt/* "$out/opt"
+      cp -a etc/* "$out/etc"
+    '';
+
+    postFixup = ''
+      wrapProgram $out/opt/bindiff/bin/bindiff \
+        --set JAVA_HOME ${jdk17.home} \
+        --chdir /opt/bindiff
+
+      wrapProgram $out/opt/bindiff/bin/bindiff_ui \
+        --set JAVA_HOME ${jdk17.home} \
+        --set FONTCONFIG_FILE ${fontconfig.out}/etc/fonts/fonts.conf \
+        --chdir /opt/bindiff
+    '';
+
+    inherit desktopItem;
+    inherit meta;
+  };
+in
+buildFHSEnv {
+  name = "bindiff";
+  targetPkgs = pkgs: [ pkg ];
+  runScript = "${pkg}/opt/bindiff/bin/bindiff";
+}
+// {
+  inherit (pkg) meta name;
+}


### PR DESCRIPTION
BinDiff is an open-source comparison tool for binary files to quickly find differences and similarities in disassembled code.
While BinDiff is open-source, we can't really build it, as that requires commercial version of [YFiles](https://www.yworks.com/products/yfiles).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>bindiff</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
