### PR TITLE
mktxp: init at 1.2.9

### DIFF
--- a/pkgs/by-name/mk/mktxp/package.nix
+++ b/pkgs/by-name/mk/mktxp/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+let
+  version = "1.2.9";
+in
+python3Packages.buildPythonApplication {
+  pname = "mktxp";
+  inherit version;
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "akpw";
+    repo = "mktxp";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-LPCx5UJuL22aRbRYD+GkDAQ/0RCi+WJwvsF86ZQ01JY=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    pypaInstallHook
+    setuptoolsBuildHook
+  ];
+
+  dependencies = with python3Packages; [
+    prometheus-client
+    routeros-api
+    configobj
+    humanize
+    texttable
+    speedtest-cli
+    waitress
+    packaging
+  ];
+
+  meta = {
+    homepage = "https://github.com/akpw/mktxp";
+    changelog = "https://github.com/akpw/mktxp/releases/tag/v${version}";
+    description = "Prometheus Exporter for Mikrotik RouterOS devices";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.BonusPlay ];
+    mainProgram = "mktxp";
+  };
+}


### PR DESCRIPTION
mktxp is a Prometheus exporter for Mikrotik RouterOS devices.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>mktxp</li>
    <li>mktxp.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
