### PR TITLE
treewide: pin Gradle 8 where deprecation warning present in build log

### DIFF
--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -8,10 +8,13 @@
 , xdg-utils
 , gtk3
 , jdk
-, gradle
+, gradle_8
 , python3
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation rec {
   version = "5.13";
   pname = "jabref";

--- a/pkgs/by-name/ap/apksigner/package.nix
+++ b/pkgs/by-name/ap/apksigner/package.nix
@@ -2,10 +2,13 @@
 , stdenv
 , fetchgit
 , jdk_headless
-, gradle
+, gradle_8
 , makeWrapper
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation rec {
   pname = "apksigner";
   version = "34.0.5-unstable-2024-03-06";

--- a/pkgs/by-name/ar/armitage/package.nix
+++ b/pkgs/by-name/ar/armitage/package.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , fetchFromGitHub
 , jdk11
-, gradle
+, gradle_8
 , metasploit
 , makeWrapper
 , makeDesktopItem
@@ -46,6 +46,9 @@ let
     # Update for Gradle 8 (https://github.com/r00t0v3rr1d3/armitage/pull/1)
     ./gradle-8.patch
   ];
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/at/atlauncher/package.nix
+++ b/pkgs/by-name/at/atlauncher/package.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jre,
   lib,
   makeWrapper,
@@ -18,7 +18,10 @@
   udev,
   xorg,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "atlauncher";
   version = "3.4.38.0";

--- a/pkgs/by-name/ja/jadx/package.nix
+++ b/pkgs/by-name/ja/jadx/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jdk,
   quark-engine,
   makeBinaryWrapper,
@@ -11,7 +11,10 @@
   copyDesktopItems,
   desktopToDarwinBundle,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jadx";
   version = "1.5.0";

--- a/pkgs/by-name/li/libeufin/package.nix
+++ b/pkgs/by-name/li/libeufin/package.nix
@@ -4,13 +4,15 @@
   fetchgit,
   python3,
   jdk17_headless,
-  gradle,
+  gradle_8,
   makeWrapper,
   postgresql,
   postgresqlTestHook,
 }:
 let
   customPython = python3.withPackages (p: [ p.setuptools ]);
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libeufin";

--- a/pkgs/by-name/mi/mindustry/package.nix
+++ b/pkgs/by-name/mi/mindustry/package.nix
@@ -6,7 +6,7 @@
   makeDesktopItem,
   copyDesktopItems,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jdk17,
   zenity,
 
@@ -43,6 +43,8 @@ let
   buildVersion = makeBuildVersion version;
 
   jdk = jdk17;
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
   Mindustry = fetchFromGitHub {
     owner = "Anuken";

--- a/pkgs/by-name/mu/mucommander/package.nix
+++ b/pkgs/by-name/mu/mucommander/package.nix
@@ -2,12 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   makeWrapper,
   jdk,
   gsettings-desktop-schemas,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mucommander";
   version = "1.5.2-1";

--- a/pkgs/by-name/ne/nextflow/package.nix
+++ b/pkgs/by-name/ne/nextflow/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   openjdk,
-  gradle,
+  gradle_8,
   wget,
   which,
   gnused,
@@ -14,6 +14,10 @@
   testers,
   nixosTests,
 }:
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nextflow";
   # 24.08.0-edge is compatible with Java 21. The current (as of 2024-09-19)

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -7,7 +7,7 @@
 
   fetchpatch2,
 
-  gradle,
+  gradle_8,
   gradle_7,
   perl,
   pkg-config,
@@ -57,7 +57,7 @@ let
   atLeast21 = lib.versionAtLeast featureVersion "21";
   atLeast23 = lib.versionAtLeast featureVersion "23";
 
-  gradle_openjfx = if atLeast23 then gradle else gradle_7;
+  gradle_openjfx = if atLeast23 then gradle_8 else gradle_7;
 in
 
 assert lib.assertMsg (lib.pathExists sourceFile)

--- a/pkgs/by-name/pd/pdftk/package.nix
+++ b/pkgs/by-name/pd/pdftk/package.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchFromGitLab, gradle, jre, runtimeShell }:
-
+{ lib, stdenv, fetchFromGitLab, gradle_8, jre, runtimeShell }:
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation rec {
   pname = "pdftk";
   version = "3.3.3";

--- a/pkgs/by-name/si/signald/package.nix
+++ b/pkgs/by-name/si/signald/package.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitLab, jdk17_headless, coreutils, findutils, gnused,
-gradle, git, makeWrapper, jre_minimal
+gradle_8, git, makeWrapper, jre_minimal
 }:
 
 let
@@ -31,6 +31,9 @@ let
       "jdk.unsupported"
     ];
   };
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
 in stdenv.mkDerivation {
   inherit pname src version;

--- a/pkgs/games/shattered-pixel-dungeon/generic.nix
+++ b/pkgs/games/shattered-pixel-dungeon/generic.nix
@@ -10,7 +10,7 @@
 , lib
 , stdenv
 , makeWrapper
-, gradle
+, gradle_8
 , perl
 , jre
 , libGL
@@ -54,6 +54,9 @@ let
   };
 
   depsPath' = if depsPath != null then depsPath else ./. + "/${pname}/deps.json";
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
 in stdenv.mkDerivation (cleanAttrs // {
   inherit pname version src patches postPatch;

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   lib,
   callPackage,
-  gradle,
+  gradle_8,
   makeBinaryWrapper,
   openjdk21,
   unzip,
@@ -72,6 +72,9 @@ let
     }
     HERE
   '';
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
Some packages have this in their build logs:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```
Let's proactively pin these to Gradle 8 to prevent breakages when Gradle 9 is released, packaged, and set as the default version of `gradle`.

**Package maintainers: I encourage you to submit upstream patches to fix these deprecations**, unpinning Gradle 8 once the fix is released by upstream.

This should not cause any rebuilds; please leave a comment if this caused any.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
