### PR TITLE
python3Packages.scikit-survival: fix and update

### DIFF
--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -2,9 +2,10 @@
   stdenv,
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   cython,
   ecos,
+  eigen,
   joblib,
   numexpr,
   numpy,
@@ -21,9 +22,11 @@ buildPythonPackage rec {
   version = "0.23.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-JFI3SDOK74vQdoUOStYlc4e0VHps97KjV3a1NQSN6E0=";
+  src = fetchFromGitHub {
+    owner = "sebp";
+    repo = "scikit-survival";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/gHfCZH9VjE5UQ8LWoBNd8xCMln4r9Etq/eCx/F8w7A=";
   };
 
   nativeBuildInputs = [
@@ -46,9 +49,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  # treat numpy versions as lower bounds, same as setuptools build
+  # can remove scikit-learn after 0.23.1
   postPatch = ''
-    sed -i 's/numpy==/numpy>=/' pyproject.toml
+    ln -s ${lib.getInclude eigen}/include/eigen3/Eigen \
+      sksurv/linear_model/src/eigen
+    sed -i -e 's/numpy>=2.0.0/numpy/' \
+       -e 's/scikit-learn~=1.4.0/scikit-learn/' pyproject.toml
   '';
 
   # Hack needed to make pytest + cython work

--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "scikit-survival";
-  version = "0.23.0";
+  version = "0.23.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sebp";
     repo = "scikit-survival";
     rev = "refs/tags/v${version}";
-    hash = "sha256-/gHfCZH9VjE5UQ8LWoBNd8xCMln4r9Etq/eCx/F8w7A=";
+    hash = "sha256-6902chXALa73/kTJ5UwV4CrB7/7wn+QXKpp2ej/Dnk8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
*needs backport release-24.11 label*
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Pypi source https://pypi.org/project/scikit-survival/) fails to download tho (scikit_survival) works. Switch to github source.    
- Build wants an eigen submodule but just needs the include files so create a symlink to the package
- relax deps for scikit-learn and numpy
- https://github.com/sebp/scikit-survival/releases/tag/v0.23.1

https://hydra.nixos.org/build/279513496
ZHF: https://github.com/NixOS/nixpkgs/issues/352882
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
