### PR TITLE
sbcl: Disable failing doCheck on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -202,7 +202,7 @@ stdenv.mkDerivation (self: {
   # will fail every other run. There’s a deeper problem here; we might as well
   # disable them entirely so at least the other platforms get to benefit from
   # testing.
-  doCheck = stdenv.hostPlatform.system != "x86_64-darwin";
+  doCheck = !builtins.elem stdenv.hostPlatform.system [ "x86_64-darwin" "aarch64-darwin" ];
 
   # From the INSTALL docs
   checkPhase = ''


### PR DESCRIPTION
sbcl is failing its test phase on aarch64-darwin.

It was already failing on x86_64-darwin it seems since it had this mention:

```nix
  # Tests on ofBorg’s x86_64-darwin platforms are so unstable that a random one
  # will fail every other run. There’s a deeper problem here; we might as well
  # disable them entirely so at least the other platforms get to benefit from
  # testing.
  doCheck = stdenv.hostPlatform.system != "x86_64-darwin"; 
```

The tests fail on aarch64-darwin with:

```
error: builder for '/nix/store/kgd0bni68zzrya0r87kn3qfdl074sgjn-sbcl-2.4.4.drv' failed with exit code 1;
       last 25 log lines:
       >  Expected failure:   debug.impure.lisp / (TRACE COMPILER-MACRO REDEFINED)
       >  Expected failure:   debug.impure.lisp / (TRACE WHEREIN ENCAPSULATE NIL)
       >  Expected failure:   debug.impure.lisp / (TRACE WHEREIN RECURSIVE ENCAPSULATE NIL)
       >  Expected failure:   debug.impure.lisp / (TRACE MACRO)
       >  Expected failure:   debug.impure.lisp / (TRACE LABELS WITHIN-MACRO)
       >  Expected failure:   debug.impure.lisp / (TRACE MACRO REDEFINED)
       
>  Expected failure:   debug.impure.lisp / (TRACE CAS)
       >  Expected failure:   debug.impure.lisp / (TRACE CAS GENERIC)
       >  Expected failure:   debug.impure.lisp / (TRACE SETF)
       >  Expected failure:   full-eval.impure.lisp / INLINE-FUN-CAPTURES-DECL
       >  Expected failure:   gc.impure.lisp / M-A-O-THREADLOCALLY-PRECISE
       >  Expected failure:   gc.impure.lisp / PIN-ALL-CODE-WITH-GC-ENABLED
       >  Skipped (broken):   gc.impure.lisp / CODE-ITERATION-FAST
       >  Unexpected success: gc.impure.lisp / PAGE-PROTECTED-P
       >  Expected failure:   gc.impure.lisp / ROSPACE-STRINGS
       >  Expected failure:   packages.impure.lisp / USE-PACKAGE-CONFLICT-SET
       >  Expected failure:   packages.impure.lisp / IMPORT-SINGLE-CONFLICT
       >  Skipped (broken):   run-program.impure.lisp / (RUN-PROGRAM AUTOCLOSE-STREAMS)
       >  Expected failure:   traceroot.impure.lisp / (SEARCH-ROOTS STACK-INDIRECT)
       >  Expected failure:   traceroot.impure.lisp / TRACEROOT-COLLAPSE-LISTS
       >  Expected failure:   traceroot.impure.lisp / (SEARCH-ROOTS SIMPLE-FUN)
       >  Expected failure:   traceroot.impure.lisp / SEARCH-FOR-SYMBOL-NAME
       >  Invalid exit status: run-program.test.sh
       >  (70 tests skipped for this combination of platform and features)
       > test failed, expected 104 return code, got 1
       For full logs, run 'nix log /nix/store/kgd0bni68zzrya0r87kn3qfdl074sgjn-sbcl-2.4.4.drv'.
```

Running `nix-shell -p 'sbcl.overrideAttrs { doCheck = false; }` on that aarch64 machine worked.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).