### PR TITLE
vapoursynth: fix darwin build

### DIFF
--- a/pkgs/by-name/va/vapoursynth-nnedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-nnedi3/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   pkg-config,
   vapoursynth,
@@ -18,6 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-jd/PCXhbCZGMsoXjekbeqMSRVBJAy4INdpkTbZFjVO0=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "build-fixes-for-aarch64-apple-silicon.patch";
+      url = "https://github.com/dubhater/vapoursynth-nnedi3/commit/15c15080ed4406929aa0d2d6a3f83ca3e26bc979.patch";
+      hash = "sha256-8gNj4LixfrGq0MaIYdZuwSK/2iyh1E9s/uuSBJHZwx8=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/va/vapoursynth-znedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-znedi3/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -D -t $out/lib/vapoursynth vsznedi3${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -D -t $out/lib/vapoursynth vsznedi3.so
     install -D -m644 -t $out/share/nnedi3 nnedi3_weights.bin
 
     runHook postInstall

--- a/pkgs/by-name/va/vapoursynth/package.nix
+++ b/pkgs/by-name/va/vapoursynth/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  doInstallCheck = true;
+  doInstallCheck = !stdenv.hostPlatform.isDarwin;
 
   passthru = rec {
     # If vapoursynth is added to the build inputs of mpv and then
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     };
   };
 
-  postPatch = ''
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # Export weak symbol nixPluginDir to permit override of default plugin path
     sed -E -i \
       -e 's/(VS_PATH_PLUGINDIR)/(nixPluginDir ? nixPluginDir : \1)/g' \
@@ -103,11 +103,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin; # see https://github.com/NixOS/nixpkgs/pull/189446 for partial fix
     description = "Video processing framework with the future in mind";
     homepage = "http://www.vapoursynth.com/";
     license = licenses.lgpl21;
-    platforms = platforms.x86_64;
+    platforms = platforms.all;
     maintainers = with maintainers; [
       rnhmjoj
       sbruder

--- a/pkgs/by-name/va/vapoursynth/package.nix
+++ b/pkgs/by-name/va/vapoursynth/package.nix
@@ -12,9 +12,7 @@
   zimg,
   libass,
   python3,
-  libiconv,
   testers,
-  ApplicationServices,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,21 +31,16 @@ stdenv.mkDerivation rec {
     autoreconfHook
     makeWrapper
   ];
-  buildInputs =
-    [
-      zimg
-      libass
-      (python3.withPackages (
-        ps: with ps; [
-          sphinx
-          cython
-        ]
-      ))
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libiconv
-      ApplicationServices
-    ];
+  buildInputs = [
+    zimg
+    libass
+    (python3.withPackages (
+      ps: with ps; [
+        sphinx
+        cython
+      ]
+    ))
+  ];
 
   enableParallelBuilding = true;
   doInstallCheck = true;

--- a/pkgs/by-name/va/vapoursynth/plugin-interface.nix
+++ b/pkgs/by-name/va/vapoursynth/plugin-interface.nix
@@ -51,77 +51,80 @@ let
 
   ext = stdenv.hostPlatform.extensions.sharedLibrary;
 in
-runCommand "${vapoursynth.name}-with-plugins"
-  {
-    nativeBuildInputs = [ makeWrapper ];
-    passthru = {
-      inherit python3;
-      inherit (vapoursynth) src version;
-      withPlugins = plugins': withPlugins (plugins ++ plugins');
-    };
-  }
-  ''
-    mkdir -p \
-      $out/bin \
-      $out/lib/pkgconfig \
-      $out/lib/vapoursynth \
-      $out/${python3.sitePackages}
+if false then
+  vapoursynth
+else
+  runCommand "${vapoursynth.name}-with-plugins"
+    {
+      nativeBuildInputs = [ makeWrapper ];
+      passthru = {
+        inherit python3;
+        inherit (vapoursynth) src version;
+        withPlugins = plugins': withPlugins (plugins ++ plugins');
+      };
+    }
+    ''
+      mkdir -p \
+        $out/bin \
+        $out/lib/pkgconfig \
+        $out/lib/vapoursynth \
+        $out/${python3.sitePackages}
 
-    for textFile in \
-        lib/pkgconfig/vapoursynth{,-script}.pc \
-        lib/libvapoursynth.la \
-        lib/libvapoursynth-script.la \
-        ${python3.sitePackages}/vapoursynth.la
-    do
-        substitute ${vapoursynth}/$textFile $out/$textFile \
-            --replace "${vapoursynth}" "$out"
-    done
+      for textFile in \
+          lib/pkgconfig/vapoursynth{,-script}.pc \
+          lib/libvapoursynth.la \
+          lib/libvapoursynth-script.la \
+          ${python3.sitePackages}/vapoursynth.la
+      do
+          substitute ${vapoursynth}/$textFile $out/$textFile \
+              --replace "${vapoursynth}" "$out"
+      done
 
-    for binaryPlugin in ${pluginsEnv}/lib/vapoursynth/*; do
-        ln -s $binaryPlugin $out/''${binaryPlugin#"${pluginsEnv}/"}
-    done
+      for binaryPlugin in ${pluginsEnv}/lib/vapoursynth/*; do
+          ln -s $binaryPlugin $out/''${binaryPlugin#"${pluginsEnv}/"}
+      done
 
-    for pythonPlugin in ${pythonEnvironment}/${python3.sitePackages}/*; do
-        ln -s $pythonPlugin $out/''${pythonPlugin#"${pythonEnvironment}/"}
-    done
+      for pythonPlugin in ${pythonEnvironment}/${python3.sitePackages}/*; do
+          ln -s $pythonPlugin $out/''${pythonPlugin#"${pythonEnvironment}/"}
+      done
 
-    for binaryFile in \
-        lib/libvapoursynth${ext} \
-        lib/libvapoursynth-script${ext}.0.0.0
-    do
-      old_rpath=$(patchelf --print-rpath ${vapoursynth}/$binaryFile)
-      new_rpath="$old_rpath:$out/lib"
-      patchelf \
-          --set-rpath "$new_rpath" \
-          --output $out/$binaryFile \
-          ${vapoursynth}/$binaryFile
-      patchelf \
-          --add-needed libvapoursynth-nix-plugins${ext} \
-          $out/$binaryFile
-    done
-
-    for binaryFile in \
-        ${python3.sitePackages}/vapoursynth${ext} \
-        bin/.vspipe-wrapped
-    do
+      for binaryFile in \
+          lib/libvapoursynth${ext} \
+          lib/libvapoursynth-script${ext}.0.0.0
+      do
         old_rpath=$(patchelf --print-rpath ${vapoursynth}/$binaryFile)
-        new_rpath="''${old_rpath//"${vapoursynth}"/"$out"}"
+        new_rpath="$old_rpath:$out/lib"
         patchelf \
             --set-rpath "$new_rpath" \
             --output $out/$binaryFile \
             ${vapoursynth}/$binaryFile
-    done
+        patchelf \
+            --add-needed libvapoursynth-nix-plugins${ext} \
+            $out/$binaryFile
+      done
 
-    ln -s ${nixPlugins} $out/lib/libvapoursynth-nix-plugins${ext}
-    ln -s ${vapoursynth}/include $out/include
-    ln -s ${vapoursynth}/lib/vapoursynth/* $out/lib/vapoursynth
-    ln -s \
-        libvapoursynth-script${ext}.0.0.0 \
-        $out/lib/libvapoursynth-script${ext}
-    ln -s \
-        libvapoursynth-script${ext}.0.0.0 \
-        $out/lib/libvapoursynth-script${ext}.0
+      for binaryFile in \
+          ${python3.sitePackages}/vapoursynth${ext} \
+          bin/.vspipe-wrapped
+      do
+          old_rpath=$(patchelf --print-rpath ${vapoursynth}/$binaryFile)
+          new_rpath="''${old_rpath//"${vapoursynth}"/"$out"}"
+          patchelf \
+              --set-rpath "$new_rpath" \
+              --output $out/$binaryFile \
+              ${vapoursynth}/$binaryFile
+      done
 
-    makeWrapper $out/bin/.vspipe-wrapped $out/bin/vspipe \
-        --prefix PYTHONPATH : $out/${python3.sitePackages}
-  ''
+      ln -s ${nixPlugins} $out/lib/libvapoursynth-nix-plugins${ext}
+      ln -s ${vapoursynth}/include $out/include
+      ln -s ${vapoursynth}/lib/vapoursynth/* $out/lib/vapoursynth
+      ln -s \
+          libvapoursynth-script${ext}.0.0.0 \
+          $out/lib/libvapoursynth-script${ext}
+      ln -s \
+          libvapoursynth-script${ext}.0.0.0 \
+          $out/lib/libvapoursynth-script${ext}.0
+
+      makeWrapper $out/bin/.vspipe-wrapped $out/bin/vspipe \
+          --prefix PYTHONPATH : $out/${python3.sitePackages}
+    ''

--- a/pkgs/by-name/va/vapoursynth/plugin-interface.nix
+++ b/pkgs/by-name/va/vapoursynth/plugin-interface.nix
@@ -51,8 +51,13 @@ let
 
   ext = stdenv.hostPlatform.extensions.sharedLibrary;
 in
-if false then
-  vapoursynth
+if stdenv.hostPlatform.isDarwin then
+  vapoursynth.overrideAttrs (previousAttrs: {
+    pname = "vapoursynth-with-plugins";
+    configureFlags = (previousAttrs.configureFlags or [ ]) ++ [
+      "--with-plugindir=${pluginsEnv}/lib/vapoursynth"
+    ];
+  })
 else
   runCommand "${vapoursynth.name}-with-plugins"
     {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9051,10 +9051,6 @@ with pkgs;
 
   eigen2 = callPackage ../development/libraries/eigen/2.0.nix { };
 
-  vapoursynth = callPackage ../by-name/va/vapoursynth/package.nix {
-    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
-  };
-
   vapoursynth-editor = libsForQt5.callPackage ../by-name/va/vapoursynth/editor.nix { };
 
   vmmlib = callPackage ../development/libraries/vmmlib {


### PR DESCRIPTION
For the plugin interface, as there is no equivalent to `patchelf --add-needed` on Darwin, this PR takes the easier way back to rebuilding `vapoursynth` with `--with-plugindir=${pluginsEnv}/lib/vapoursynth` instead.

Tested `vapoursynth.withPlugins [ ffms vapoursynth-mvtools ];` on aarch64-darwin following the instructions in https://gist.github.com/phiresky/4bfcfbbd05b3c2ed8645, with #359262 and the following changes applied:

- In `motioninterpolation.vpy`, replace `vapoursynth.get_core()` with `vapoursynth.core`;
- In the command, replace `--y4m` with `-c y4m`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
