### PR TITLE
Cinnamon updates 2024-11-26

### DIFF
--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -7,14 +7,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "folder-color-switcher";
-  version = "1.6.4";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # They don't really do tags, this is just a named commit.
-    rev = "c9d1a2b9c7f40ff7bb77ee74a277988bb8a4adf2";
-    hash = "sha256-5k0YybA40MefqQixNFyQFMuy7t4aSGsI3BK0RbZDu28=";
+    rev = "ba8ea15a48a1a31f318676f4079789af20bdf099";
+    hash = "sha256-jbfc831wTA3NMa905ZzMnV0dyzzqZxOzrRPdgS7E2ZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.0.6";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-Q6V4axKlGhX1/uaugNkjoynHSL5jWA/eqzAsbJYcRSo=";
+    sha256 = "sha256-ZsbX4xB6sLpZH6vaVFlkC7hAhPLZa1T+FlPANqBQTOg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-l-icons/package.nix
+++ b/pkgs/by-name/mi/mint-l-icons/package.nix
@@ -9,14 +9,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-l-icons";
-  version = "1.7.2";
+  version = "1.7.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # https://github.com/linuxmint/mint-l-icons/issues/11
-    rev = "ee03e6dad0b1f9e25847977eae42766e2ddd4877";
-    hash = "sha256-OKlkqDp9mZOeM4M9QN9H0WH4k+5eMEUshvadaV6qhBA=";
+    # They don't really do tags, this is just a named commit.
+    rev = "f1900facf915715623ef0ca2874ae4dd04039e81";
+    hash = "sha256-UpVuhzZdw0Ri6X20N/yGFMmwEymMvLr78DwYaHD+CNY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-themes/package.nix
+++ b/pkgs/by-name/mi/mint-themes/package.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.1.8";
+  version = "2.1.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-mkcIhZRaOUom1Rurz/IO646FSF50efLN6xfesPdyVHc=";
+    hash = "sha256-+RuhpM4Qk5iU+Mxi8adneUL8fpC896FGKR2HNTnc1+U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-x-icons/package.nix
+++ b/pkgs/by-name/mi/mint-x-icons/package.nix
@@ -11,13 +11,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-x-icons";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-OiMQpVT5cydhw6Lb+vW+LiB/4gRuRhKXe93ocFj6qa4=";
+    hash = "sha256-9oXMMLVjirzRVJ0Pmd/1LjeeNUgYMKaGeih3eQA7k5U=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.7.7";
+  version = "1.7.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-SJ6h1All5bub+Yue8zUrAYdlNf005MAdnl+pkOelods=";
+    hash = "sha256-30Mv6ixNgXK2CbLoX7Dw9i57QCkG8U3RA48WB4e3e8o=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/xa/xapp/package.nix
+++ b/pkgs/by-name/xa/xapp/package.nix
@@ -14,6 +14,7 @@
 , stdenv
 , vala
 , wrapGAppsHook3
+, file
 , inxi
 , mate
 , dbus
@@ -22,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.8.5";
+  version = "2.8.6";
 
   outputs = [ "out" "dev" ];
 
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-HGWaa1S+maphP9colWdWSzGyoA0f4vJkF889X5/rzvs=";
+    hash = "sha256-OQfP0XPBQrxJDrKb5PEqpBtinkQ35NMUbsYnxhbuehU=";
   };
 
   # Recommended by upstream, which enables the build of xapp-debug.
@@ -76,13 +77,18 @@ stdenv.mkDerivation rec {
     chmod +x schemas/meson_install_schemas.py # patchShebangs requires executable file
     patchShebangs schemas/meson_install_schemas.py
 
-    # Patch pastebin & inxi location
-    sed "s|/usr/bin/pastebin|$out/bin/pastebin|" -i scripts/upload-system-info
-    sed "s|'inxi'|'${inxi}/bin/inxi'|" -i scripts/upload-system-info
+    # Used in cinnamon-settings
+    substituteInPlace scripts/upload-system-info \
+      --replace-fail "'/usr/bin/pastebin'" "'$out/bin/pastebin'" \
+      --replace-fail "'inxi'" "'${inxi}/bin/inxi'"
+
+    # Used in x-d-p-xapp
+    substituteInPlace scripts/xfce4-set-wallpaper \
+      --replace-fail "file --mime-type" "${file}/bin/file --mime-type"
   '';
 
   # Fix gtk3 module target dir. Proper upstream solution should be using define_variable.
-  PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
+  env.PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
 
   meta = with lib; {
     homepage = "https://github.com/linuxmint/xapp";

--- a/pkgs/by-name/xd/xdg-desktop-portal-xapp/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-xapp/package.nix
@@ -10,17 +10,18 @@
 , gsettings-desktop-schemas
 , mate
 , xdg-desktop-portal
+, xapp
 }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-xapp";
-  version = "1.0.9";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xdg-desktop-portal-xapp";
     rev = version;
-    hash = "sha256-4U8d9lQxMHQ2XYXnNCQjrNup8z14Q8Ke1Bkf09AVM6k=";
+    hash = "sha256-9v0faB5HhUUPXOWDDyTUPaPwzMjhqdiAyuv9kM4mm2Q=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +42,11 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
   ];
+
+  preFixup = ''
+    # For xfce4-set-wallpaper
+    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ xapp ]}")
+  '';
 
   meta = with lib; {
     description = "Backend implementation for xdg-desktop-portal for Cinnamon, MATE, Xfce";

--- a/pkgs/by-name/xe/xed-editor/package.nix
+++ b/pkgs/by-name/xe/xed-editor/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.6.6";
+  version = "3.6.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    hash = "sha256-Lpdv8mX3GDzXH1FGGdmgK9b8P3EY7ETuEhGfSwc6IIE=";
+    hash = "sha256-hQy06+/8rJIvHK7uKyMsIMH0qAZgza/2l/hOHDMOgo4=";
   };
 
   patches = [


### PR DESCRIPTION
Note that the "Linux Mint" Cinnamon theme is removed in mint-themes 2.1.9, if you are choosing the "Mint-X" style in cinnamon-settings, it will now use "Mint-X" as the Cinnamon theme (instead of  "Linux Mint").

<!--

nemo: 6.2.8 -> 6.4.0
cinnamon-settings-daemon: 6.2.0 -> 6.4.0
cinnamon-session: 6.2.1 -> 6.4.0
cinnamon-control-center: 6.2.0 -> 6.4.0
cinnamon-desktop: 6.2.0 -> 6.4.0
cinnamon-translations: 6.2.2 -> 6.4.0
cinnamon-screensaver: 6.2.1 -> 6.4.0
muffin: 6.2.0 -> 6.4.0
nemo-fileroller: 6.2.0 -> 6.4.0
nemo-python: 6.2.0 -> 6.4.0

folder-color-switcher: 1.6.4 -> 1.6.5
mint-themes: 2.1.8 -> 2.1.9
mint-x-icons: 1.7.1 -> 1.7.2
mint-y-icons: 1.7.7 -> 1.7.8
mint-l-icons: 1.7.2 -> 1.7.3
xed-editor: 3.6.6 -> 3.6.7
xapp: 2.8.5 -> 2.8.6
lightdm-slick-greeter: 2.0.6 -> 2.0.7
xdg-desktop-portal-xapp: 1.0.9 -> 1.1.0

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

