### PR TITLE
formats.libconfig: add support for dashes

### DIFF
--- a/pkgs/pkgs-lib/formats/libconfig/src/src/main.rs
+++ b/pkgs/pkgs-lib/formats/libconfig/src/src/main.rs
@@ -24,7 +24,7 @@ fn validate_setting_name(key: &str) -> bool {
     (first_char.is_alphabetic() || first_char == '*')
         && key[1..]
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '*')
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '*' || c == '-')
 }
 
 const SPECIAL_TYPES: [&str; 5] = ["octal", "hex", "float", "list", "array"];

--- a/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
@@ -14,6 +14,9 @@ let
     simple_top_level_attr = "1.0";
     nested.attrset.has.a.integer.value = 100;
     some_floaty = 29.95;
+    ## dashes in key names
+    top-level-dash = "pass";
+    nested.level-dash = "pass";
     ## Same syntax here on these two, but they should get serialized differently:
     # > A list may have zero or more elements, each of which can be a scalar value, an array, a group, or another list.
     list1d = libconfig.lib.mkList [ 1 "mixed!" 5 2 ];

--- a/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/expected.txt
+++ b/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/expected.txt
@@ -1,6 +1,6 @@
 array1d=[1, 5, 2];array2d=([1, 2], [2, 1]);list1d=(1, "mixed!", 5, 2);list2d=(1, (1, 1.2, "foo"), ("bar", 1.2, 1));nasty_string="\"@
 \\	^*bf
-0\";'''$";nested={attrset={has={a={integer={value=100;};};};};};simple_top_level_attr="1.0";some_floaty=29.95;weirderTypes={
+0\";'''$";nested={attrset={has={a={integer={value=100;};};};};level-dash="pass";};simple_top_level_attr="1.0";some_floaty=29.95;top-level-dash="pass";weirderTypes={
 @include "@include_file@"
 array_of_ints=[0732, 0xa3, 1234];bigint=9223372036854775807;float=0.0012;hex=0x1fc3;list_of_weird_types=(3.141592654, 9223372036854775807, 0x1fc3, 027, 1.2e-32, 1.0);octal=027;pi=3.141592654;};
 


### PR DESCRIPTION
Adding support for dashes "-" in Libconfig generator as specified in the[libconfig manual](https://hyperrealm.github.io/libconfig/libconfig_manual.html#Configuration-Files):
> All names are case-sensitive. They may consist only of alphanumeric characters, dashes (‘-’), underscores (‘_’), and asterisks (‘*’), and must begin with a letter or asterisk. No other characters are allowed.


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [-] (Package updates) Added a release notes entry if the change is major or breaking
  - [-] (Module updates) Added a release notes entry if the change is significant
  - [-] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).