### PR TITLE
image/images: init

### DIFF
--- a/nixos/modules/image/file-options.nix
+++ b/nixos/modules/image/file-options.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+{
+  options.image = {
+    baseName = lib.mkOption {
+      type = lib.types.str;
+      default = "nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}";
+      description = ''
+        Basename of the image filename without any extension (e.g. `image_1`).
+      '';
+    };
+
+    extension = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        Extension of the image filename (e.g. `raw`).
+      '';
+    };
+
+    # FIXME: this should be marked readOnly, when there are no
+    # mkRenamedOptionModuleWith calls with `image.fileName` as
+    # as a target left anymore (i.e. 24.11). We can't do it
+    # before, as some source options where writable before.
+    # Those should use image.baseName and image.extension instead.
+    fileName = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.image.baseName}.${config.image.extension}";
+      description = ''
+        Filename of the image including all extensions (e.g `image_1.raw` or
+        `image_1.raw.zst`).
+      '';
+    };
+
+    filePath = lib.mkOption {
+      type = lib.types.str;
+      default = config.image.fileName;
+      description = ''
+        Path of the image, relative to `$out` in `system.build.image`.
+        While it defaults to `config.image.fileName`, it can be different for builders where
+        the image is in sub directory, such as `iso`, `sd-card` or `kexec` images.
+      '';
+    };
+  };
+}

--- a/nixos/modules/image/images.nix
+++ b/nixos/modules/image/images.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  extendModules,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  imageModules = { };
+  imageConfigs = lib.mapAttrs (
+    name: modules:
+    extendModules {
+      inherit modules;
+    }
+  ) config.image.modules;
+in
+{
+  options = {
+    system.build = {
+      images = lib.mkOption {
+        type = types.lazyAttrsOf types.raw;
+        readOnly = true;
+        description = ''
+          Different target images generated for this NixOS configuration.
+        '';
+      };
+    };
+    image.modules = lib.mkOption {
+      type = types.attrsOf (types.listOf types.deferredModule);
+      description = ''
+        image-specific NixOS Modules used for `system.build.images`.
+      '';
+    };
+  };
+
+  config.image.modules = lib.mkIf (!config.system.build ? image) imageModules;
+  config.system.build.images = lib.mkIf (!config.system.build ? image) (
+    lib.mapAttrs (
+      name: nixos:
+      let
+        inherit (nixos) config;
+        inherit (config.image) filePath;
+        builder =
+          config.system.build.image
+            or (throw "Module for `system.build.images.${name}` misses required `system.build.image` option.");
+      in
+      lib.recursiveUpdate builder {
+        passthru = {
+          inherit config filePath;
+        };
+      }
+    ) imageConfigs
+  );
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -125,6 +125,7 @@
   ./i18n/input-method/kime.nix
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix
+  ./image/images.nix
   ./installer/tools/tools.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix


### PR DESCRIPTION
This PR adds two new image-related modules:

- [nixos/modules/image/file-options.nix](https://github.com/NixOS/nixpkgs/compare/master...phaer:virtualisation-images-phase-one?expand=1#diff-5b0fd9b0f1bc3282bd66e1facebae1ad3a4c5f6fa5e71c858448a9d2ea643501) defines a re-usable set of options to handle image file names. It will be used in follow-up PRs to normalize the names of disk images generated in nixpkgs.

- [nixos/modules/image/images.nix](https://github.com/NixOS/nixpkgs/compare/master...phaer:virtualisation-images-phase-one?expand=1#diff-7bcccc5118447059de51ec7931f393719b565df46b4cc670167cbb7188f6bb4b) adds two new options:

  - `image.modules`: An attrset mapping image variant names to a list of nixos
    modules to use when building such images.

  - `system.build.images`: An attrset mapping image variant names to a nixos instance
    based on the current config plus variant-specific modules (see
    `image.modules` above.

It does *not* contain any actual modules in images.modules yet, they will follow in upcoming PRs such as in https://github.com/NixOS/nixpkgs/pull/359339

It was split off https://github.com/NixOS/nixpkgs/pull/347275 in order to upstream that one in smaller chunks, easier to review, test and (hopefully not) revert.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
