### PR TITLE
patroni: 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, python3Packages
-, fetchFromGitHub
-, nixosTests
-, nix-update-script
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nixosTests,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -2,22 +2,23 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
   nixosTests,
   nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "patroni";
-  version = "4.0.3";
+  version = "4.0.4";
 
   src = fetchFromGitHub {
     owner = "zalando";
-    repo = pname;
+    repo = "patroni";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-urNTxaipM4wD+1fp7EFdT7/FGLq86O1nOfst7JyX0fc=";
+    sha256 = "sha256-if3azfBb6/OegahZYAM2RMxmWRDsCX5DNkUATTcAUrw=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     boto3
     click
     consul
@@ -36,18 +37,22 @@ python3Packages.buildPythonApplication rec {
     ydiff
   ];
 
+  pythonImportsCheck = [ "patroni" ];
+
   nativeCheckInputs = with python3Packages; [
     flake8
     mock
     pytestCheckHook
     pytest-cov
     requests
+    versionCheckHook
   ];
+  versionCheckProgramArg = [ "--version" ];
 
   # Fix tests by preventing them from writing to /homeless-shelter.
   preCheck = "export HOME=$(mktemp -d)";
 
-  pythonImportsCheck = [ "patroni" ];
+  __darwinAllowLocalNetworking = true;
 
   passthru = {
     tests.patroni = nixosTests.patroni;
@@ -55,11 +60,12 @@ python3Packages.buildPythonApplication rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://patroni.readthedocs.io/en/latest/";
     description = "Template for PostgreSQL HA with ZooKeeper, etcd or Consul";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = teams.deshaw.members;
+    changelog = "https://github.com/patroni/patroni/blob/v${version}/docs/releases.rst";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = lib.teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/python-etcd/default.nix
+++ b/pkgs/development/python-modules/python-etcd/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -9,7 +10,6 @@
   etcd_3_4,
   mock,
   pyopenssl,
-  stdenv,
 }:
 
 buildPythonPackage {
@@ -48,9 +48,20 @@ buildPythonPackage {
     done
   '';
 
-  meta = with lib; {
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Seems to be failing because of network restrictions
+    # AttributeError: Can't get local object 'TestWatch.test_watch_indexed_generator.<locals>.watch_value'
+    "test_watch"
+    "test_watch_generator"
+    "test_watch_indexed"
+    "test_watch_indexed_generator"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
     description = "Python client for Etcd";
     homepage = "https://github.com/jplana/python-etcd";
-    license = licenses.mit;
+    license = lib.licenses.mit;
   };
 }


### PR DESCRIPTION
## Things done

- **patroni: format**
- **patroni: 4.0.3 -> 4.0.4**

Changelog: https://github.com/patroni/patroni/blob/v4.0.4/docs/releases.rst

cc @de11n @invokes-su

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
