### PR TITLE
virtualisation: Use system.build.image, normalize file names

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -206,3 +206,6 @@ ce21e97a1f20dee15da85c084f9d1148d84f853b
 
 # treewide: migrate packages to pkgs/by-name, take 1
 571c71e6f73af34a229414f51585738894211408
+
+# format files with nixfmt (#347275)
+adb9714bd909df283c66bbd641bd631ff50a4260

--- a/nixos/modules/image/images.nix
+++ b/nixos/modules/image/images.nix
@@ -8,7 +8,21 @@
 let
   inherit (lib) types;
 
-  imageModules = { };
+  imageModules = {
+    azure = [ ../virtualisation/azure-image.nix ];
+    digital-ocean = [ ../virtualisation/digital-ocean-image.nix ];
+    google-compute = [ ../virtualisation/google-compute-image.nix ];
+    hyperv = [ ../virtualisation/hyperv-image.nix ];
+    linode = [ ../virtualisation/linode-image.nix ];
+    lxc = [ ../virtualisation/lxc-container.nix ];
+    lxc-metadata = [ ../virtualisation/lxc-image-metadata.nix ];
+    oci = [ ../virtualisation/oci-image.nix ];
+    proxmox = [ ../virtualisation/proxmox-image.nix ];
+    kubevirt = [ ../virtualisation/kubevirt.nix ];
+    vagrant-virtualbox = [ ../virtualisation/vagrant-virtualbox-image.nix ];
+    virtualbox = [ ../virtualisation/virtualbox-image.nix ];
+    vmware = [ ../virtualisation/vmware-image.nix ];
+  };
   imageConfigs = lib.mapAttrs (
     name: modules:
     extendModules {

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -13,6 +13,7 @@ in
   imports = [
     ./azure-common.nix
     ./disk-size-option.nix
+    ../image/file-options.nix
     (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2411;
       from = [
@@ -61,10 +62,14 @@ in
   };
 
   config = {
+    image.extension = "vhd";
+    system.nixos.tags = [ "azure" ];
+    system.build.image = config.system.build.azureImage;
     system.build.azureImage = import ../../lib/make-disk-image.nix {
       name = "azure-image";
+      inherit (config.image) baseName;
       postVM = ''
-        ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o subformat=fixed,force_size -O vpc $diskImage $out/disk.vhd
+        ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o subformat=fixed,force_size -O vpc $diskImage $out/${config.image.fileName}
         rm $diskImage
       '';
       configFile = ./azure-config-user.nix;

--- a/nixos/modules/virtualisation/digital-ocean-image.nix
+++ b/nixos/modules/virtualisation/digital-ocean-image.nix
@@ -14,6 +14,7 @@ in
   imports = [
     ./digital-ocean-config.nix
     ./disk-size-option.nix
+    ../image/file-options.nix
     (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2411;
       from = [
@@ -57,32 +58,53 @@ in
   };
 
   #### implementation
-  config = {
-    system.build.digitalOceanImage = import ../../lib/make-disk-image.nix {
-      name = "digital-ocean-image";
+  config =
+    let
       format = "qcow2";
-      postVM =
-        let
-          compress =
-            {
-              "gzip" = "${pkgs.gzip}/bin/gzip";
-              "bzip2" = "${pkgs.bzip2}/bin/bzip2";
-            }
-            .${cfg.compressionMethod};
-        in
-        ''
-          ${compress} $diskImage
-        '';
-      configFile =
-        if cfg.configFile == null then
-          config.virtualisation.digitalOcean.defaultConfigFile
-        else
-          cfg.configFile;
-      inherit (config.virtualisation) diskSize;
-      inherit config lib pkgs;
-    };
+    in
+    {
+      image.extension = lib.concatStringsSep "." [
+        format
+        (
+          {
+            "gzip" = "gz";
+            "bzip2" = "bz2";
+          }
+          .${cfg.compressionMethod}
+        )
+      ];
+      system.nixos.tags = [ "digital-ocean" ];
+      system.build.image = config.system.build.digitalOceanImage;
+      system.build.digitalOceanImage = import ../../lib/make-disk-image.nix {
+        name = "digital-ocean-image";
+        inherit (config.image) baseName;
+        inherit (config.virtualisation) diskSize;
+        inherit
+          config
+          lib
+          pkgs
+          format
+          ;
+        postVM =
+          let
+            compress =
+              {
+                "gzip" = "${pkgs.gzip}/bin/gzip";
+                "bzip2" = "${pkgs.bzip2}/bin/bzip2";
+              }
+              .${cfg.compressionMethod};
+          in
+          ''
+            ${compress} $diskImage
+          '';
+        configFile =
+          if cfg.configFile == null then
+            config.virtualisation.digitalOcean.defaultConfigFile
+          else
+            cfg.configFile;
+      };
 
-  };
+    };
 
   meta.maintainers = with maintainers; [
     arianvp

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -22,6 +22,7 @@ in
   imports = [
     ./google-compute-config.nix
     ./disk-size-option.nix
+    ../image/file-options.nix
     (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2411;
       from = [
@@ -72,8 +73,12 @@ in
       fsType = "vfat";
     };
 
+    system.nixos.tags = [ "google-compute" ];
+    image.extension = "raw.tar.gz";
+    system.build.image = config.system.build.googleComputeImage;
     system.build.googleComputeImage = import ../../lib/make-disk-image.nix {
       name = "google-compute-image";
+      inherit (config.image) baseName;
       postVM = ''
         PATH=$PATH:${
           with pkgs;
@@ -83,10 +88,9 @@ in
           ]
         }
         pushd $out
-        mv $diskImage disk.raw
-        tar -Sc disk.raw | gzip -${toString cfg.compressionLevel} > \
-          nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.raw.tar.gz
-        rm $out/disk.raw
+        tar -Sc $diskImage | gzip -${toString cfg.compressionLevel} > \
+          ${config.image.fileName}
+        rm $diskImage
         popd
       '';
       format = "raw";

--- a/nixos/modules/virtualisation/kubevirt.nix
+++ b/nixos/modules/virtualisation/kubevirt.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   imports = [

--- a/nixos/modules/virtualisation/kubevirt.nix
+++ b/nixos/modules/virtualisation/kubevirt.nix
@@ -8,6 +8,7 @@
 {
   imports = [
     ../profiles/qemu-guest.nix
+    ../image/file-options.nix
   ];
 
   config = {
@@ -27,8 +28,12 @@
     services.cloud-init.enable = true;
     systemd.services."serial-getty@ttyS0".enable = true;
 
+    system.nixos.tags = [ "kubevirt" ];
+    image.extension = "qcow2";
+    system.build.image = config.system.build.kubevirtImage;
     system.build.kubevirtImage = import ../../lib/make-disk-image.nix {
       inherit lib config pkgs;
+      inherit (config.image) baseName;
       format = "qcow2";
     };
   };

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -20,6 +20,7 @@ in
   imports = [
     ./linode-config.nix
     ./disk-size-option.nix
+    ../image/file-options.nix
     (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2411;
       from = [
@@ -57,13 +58,17 @@ in
   };
 
   config = {
+    system.nixos.tags = [ "linode" ];
+    image.extension = "img.gz";
+    system.build.image = config.system.build.linodeImage;
     system.build.linodeImage = import ../../lib/make-disk-image.nix {
       name = "linode-image";
+      baseName = config.image.baseName;
       # NOTE: Linode specifically requires images to be `gzip`-ed prior to upload
       # See: https://www.linode.com/docs/products/tools/images/guides/upload-an-image/#requirements-and-considerations
       postVM = ''
         ${pkgs.gzip}/bin/gzip -${toString cfg.compressionLevel} -c -- $diskImage > \
-        $out/nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img.gz
+        $out/${config.image.fileName}
         rm $diskImage
       '';
       format = "raw";

--- a/nixos/modules/virtualisation/lxc-container.nix
+++ b/nixos/modules/virtualisation/lxc-container.nix
@@ -1,4 +1,9 @@
-{ lib, config, pkgs, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 
 {
   meta = {
@@ -8,18 +13,27 @@
   imports = [
     ./lxc-instance-common.nix
 
-    (lib.mkRemovedOptionModule [ "virtualisation" "lxc" "nestedContainer" ] "")
-    (lib.mkRemovedOptionModule [ "virtualisation" "lxc" "privilegedContainer" ] "")
+    (lib.mkRemovedOptionModule [
+      "virtualisation"
+      "lxc"
+      "nestedContainer"
+    ] "")
+    (lib.mkRemovedOptionModule [
+      "virtualisation"
+      "lxc"
+      "privilegedContainer"
+    ] "")
   ];
 
   options = { };
 
-  config = let
-    initScript = if config.boot.initrd.systemd.enable then "prepare-root" else "init";
-  in {
-    boot.isContainer = true;
-    boot.postBootCommands =
-      ''
+  config =
+    let
+      initScript = if config.boot.initrd.systemd.enable then "prepare-root" else "init";
+    in
+    {
+      boot.isContainer = true;
+      boot.postBootCommands = ''
         # After booting, register the contents of the Nix store in the Nix
         # database.
         if [ -f /nix-path-registration ]; then
@@ -31,78 +45,84 @@
         ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
       '';
 
-    # supplement 99-ethernet-default-dhcp which excludes veth
-    systemd.network = lib.mkIf config.networking.useDHCP {
-      networks."99-lxc-veth-default-dhcp" = {
-        matchConfig = {
-          Type = "ether";
-          Kind = "veth";
-          Name = [
-            "en*"
-            "eth*"
-          ];
+      # supplement 99-ethernet-default-dhcp which excludes veth
+      systemd.network = lib.mkIf config.networking.useDHCP {
+        networks."99-lxc-veth-default-dhcp" = {
+          matchConfig = {
+            Type = "ether";
+            Kind = "veth";
+            Name = [
+              "en*"
+              "eth*"
+            ];
+          };
+          DHCP = "yes";
+          networkConfig.IPv6PrivacyExtensions = "kernel";
         };
-        DHCP = "yes";
-        networkConfig.IPv6PrivacyExtensions = "kernel";
       };
+
+      system.nixos.tags = lib.mkOverride 99 [ "lxc" ];
+      image.extension = "tar.xz";
+      image.filePath = "tarball/${config.image.fileName}";
+      system.build.image = lib.mkOverride 99 config.system.build.tarball;
+
+      system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
+        fileName = config.image.baseName;
+        extraArgs = "--owner=0";
+
+        storeContents = [
+          {
+            object = config.system.build.toplevel;
+            symlink = "none";
+          }
+        ];
+
+        contents = [
+          {
+            source = config.system.build.toplevel + "/${initScript}";
+            target = "/sbin/init";
+          }
+          # Technically this is not required for lxc, but having also make this configuration work with systemd-nspawn.
+          # Nixos will setup the same symlink after start.
+          {
+            source = config.system.build.toplevel + "/etc/os-release";
+            target = "/etc/os-release";
+          }
+        ];
+
+        extraCommands = "mkdir -p proc sys dev";
+      };
+
+      system.build.squashfs = pkgs.callPackage ../../lib/make-squashfs.nix {
+        fileName = "nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}";
+
+        hydraBuildProduct = true;
+        noStrip = true; # keep directory structure
+        comp = "zstd -Xcompression-level 6";
+
+        storeContents = [ config.system.build.toplevel ];
+
+        pseudoFiles = [
+          "/sbin d 0755 0 0"
+          "/sbin/init s 0555 0 0 ${config.system.build.toplevel}/${initScript}"
+          "/dev d 0755 0 0"
+          "/proc d 0555 0 0"
+          "/sys d 0555 0 0"
+        ];
+      };
+
+      system.build.installBootLoader = pkgs.writeScript "install-lxc-sbin-init.sh" ''
+        #!${pkgs.runtimeShell}
+        ${pkgs.coreutils}/bin/ln -fs "$1/${initScript}" /sbin/init
+      '';
+
+      # networkd depends on this, but systemd module disables this for containers
+      systemd.additionalUpstreamSystemUnits = [ "systemd-udev-trigger.service" ];
+
+      systemd.packages = [ pkgs.distrobuilder.generator ];
+
+      system.activationScripts.installInitScript = lib.mkForce ''
+        ln -fs $systemConfig/${initScript} /sbin/init
+      '';
     };
-
-    system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
-      extraArgs = "--owner=0";
-
-      storeContents = [
-        {
-          object = config.system.build.toplevel;
-          symlink = "none";
-        }
-      ];
-
-      contents = [
-        {
-          source = config.system.build.toplevel + "/${initScript}";
-          target = "/sbin/init";
-        }
-        # Technically this is not required for lxc, but having also make this configuration work with systemd-nspawn.
-        # Nixos will setup the same symlink after start.
-        {
-          source = config.system.build.toplevel + "/etc/os-release";
-          target = "/etc/os-release";
-        }
-      ];
-
-      extraCommands = "mkdir -p proc sys dev";
-    };
-
-    system.build.squashfs = pkgs.callPackage ../../lib/make-squashfs.nix {
-      fileName = "nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}";
-
-      hydraBuildProduct = true;
-      noStrip = true; # keep directory structure
-      comp = "zstd -Xcompression-level 6";
-
-      storeContents = [config.system.build.toplevel];
-
-      pseudoFiles = [
-        "/sbin d 0755 0 0"
-        "/sbin/init s 0555 0 0 ${config.system.build.toplevel}/${initScript}"
-        "/dev d 0755 0 0"
-        "/proc d 0555 0 0"
-        "/sys d 0555 0 0"
-      ];
-    };
-
-    system.build.installBootLoader = pkgs.writeScript "install-lxc-sbin-init.sh" ''
-      #!${pkgs.runtimeShell}
-      ${pkgs.coreutils}/bin/ln -fs "$1/${initScript}" /sbin/init
-    '';
-
-    # networkd depends on this, but systemd module disables this for containers
-    systemd.additionalUpstreamSystemUnits = ["systemd-udev-trigger.service"];
-
-    systemd.packages = [ pkgs.distrobuilder.generator ];
-
-    system.activationScripts.installInitScript = lib.mkForce ''
-      ln -fs $systemConfig/${initScript} /sbin/init
-    '';
-  };
 }

--- a/nixos/modules/virtualisation/lxc-image-metadata.nix
+++ b/nixos/modules/virtualisation/lxc-image-metadata.nix
@@ -46,6 +46,10 @@ let
   else { files = []; properties = {}; };
 
 in {
+  imports = [
+    ../image/file-options.nix
+  ];
+
   meta = {
     maintainers = lib.teams.lxc.members;
   };
@@ -87,7 +91,12 @@ in {
   };
 
   config = {
+    system.nixos.tags = [ "lxc" "metadata" ];
+    image.extension = "tar.xz";
+    image.filePath = "tarball/${config.image.fileName}";
+    system.build.image = config.system.build.metadata;
     system.build.metadata = pkgs.callPackage ../../lib/make-system-tarball.nix {
+      fileName = config.image.baseName;
       contents = [
         {
           source = toYAML "metadata.yaml" {

--- a/nixos/modules/virtualisation/oci-image.nix
+++ b/nixos/modules/virtualisation/oci-image.nix
@@ -9,7 +9,10 @@ let
   cfg = config.oci;
 in
 {
-  imports = [ ./oci-common.nix ];
+  imports = [
+    ./oci-common.nix
+    ../image/file-options.nix
+  ];
 
   config = {
     # Use a priority just below mkOptionDefault (1500) instead of lib.mkDefault
@@ -17,10 +20,14 @@ in
     virtualisation.diskSize = lib.mkOverride 1490 (8 * 1024);
     virtualisation.diskSizeAutoSupported = false;
 
+    system.nixos.tags = [ "oci" ];
+    image.extension = "qcow2";
+    system.build.image = config.system.build.OCIImage;
     system.build.OCIImage = import ../../lib/make-disk-image.nix {
       inherit config lib pkgs;
       inherit (config.virtualisation) diskSize;
       name = "oci-image";
+      baseName = config.image.baseName;
       configFile = ./oci-config-user.nix;
       format = "qcow2";
       partitionTableType = if cfg.efi then "efi" else "legacy";

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -9,6 +9,7 @@ with lib;
 {
   imports = [
     ./disk-size-option.nix
+    ../image/file-options.nix
     (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2411;
       from = [
@@ -250,8 +251,12 @@ with lib;
           message = "'legacy+gpt' disk partitioning requires 'seabios' bios";
         }
       ];
+      image.baseName = lib.mkDefault "vzdump-qemu-${cfg.filenameSuffix}";
+      image.extension = "vma.zst";
+      system.build.image = config.system.build.VMA;
       system.build.VMA = import ../../lib/make-disk-image.nix {
         name = "proxmox-${cfg.filenameSuffix}";
+        baseName = config.image.baseName;
         inherit (cfg) partitionTableType;
         postVM =
           let
@@ -299,16 +304,16 @@ with lib;
                 });
           in
           ''
-            ${vma}/bin/vma create "vzdump-qemu-${cfg.filenameSuffix}.vma" \
+            ${vma}/bin/vma create "${config.image.baseName}.vma" \
               -c ${
                 cfgFile "qemu-server.conf" (cfg.qemuConf // cfg.qemuExtraConf)
               }/qemu-server.conf drive-virtio0=$diskImage
             rm $diskImage
-            ${pkgs.zstd}/bin/zstd "vzdump-qemu-${cfg.filenameSuffix}.vma"
-            mv "vzdump-qemu-${cfg.filenameSuffix}.vma.zst" $out/
+            ${pkgs.zstd}/bin/zstd "${config.image.baseName}.vma"
+            mv "${config.image.fileName}" $out/
 
             mkdir -p $out/nix-support
-            echo "file vma $out/vzdump-qemu-${cfg.filenameSuffix}.vma.zst" > $out/nix-support/hydra-build-products
+            echo "file vma $out/${config.image.fileName}" > $out/nix-support/hydra-build-products
           '';
         inherit (cfg.qemuConf) additionalSpace bootSize;
         inherit (config.virtualisation) diskSize;

--- a/nixos/modules/virtualisation/proxmox-lxc.nix
+++ b/nixos/modules/virtualisation/proxmox-lxc.nix
@@ -8,6 +8,10 @@
 with lib;
 
 {
+  imports = [
+    ../image/file-options.nix
+  ];
+
   options.proxmoxLXC = {
     enable = mkOption {
       default = true;
@@ -46,7 +50,15 @@ with lib;
       cfg = config.proxmoxLXC;
     in
     mkIf cfg.enable {
+      system.nixos.tags = [
+        "proxmox"
+        "lxc"
+      ];
+      image.extension = "tar.xz";
+      image.filePath = "tarball/${config.image.fileName}";
+      system.build.image = config.system.build.tarball;
       system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
+        fileName = config.image.baseName;
         storeContents = [
           {
             object = config.system.build.toplevel;

--- a/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
+++ b/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
@@ -29,31 +29,31 @@
       mkdir workdir
       cd workdir
 
-      # 1. create that metadata.json file
-      echo '{"provider":"virtualbox"}' > metadata.json
+    # 1. create that metadata.json file
+    echo '{"provider":"virtualbox"}' > metadata.json
 
-      # 2. create a default Vagrantfile config
-      cat <<VAGRANTFILE > Vagrantfile
-      Vagrant.configure("2") do |config|
-        config.vm.base_mac = "0800275F0936"
-      end
-      VAGRANTFILE
+    # 2. create a default Vagrantfile config
+    cat <<VAGRANTFILE > Vagrantfile
+    Vagrant.configure("2") do |config|
+      config.vm.base_mac = "0800275F0936"
+    end
+    VAGRANTFILE
 
-      # 3. add the exported VM files
-      tar xvf ${config.system.build.virtualBoxOVA}/*.ova
+    # 3. add the exported VM files
+    tar xvf ${config.system.build.virtualBoxOVA}/*.ova
 
-      # 4. move the ovf to the fixed location
-      mv *.ovf box.ovf
+    # 4. move the ovf to the fixed location
+    mv *.ovf box.ovf
 
-      # 5. generate OVF manifest file
-      rm *.mf
-      touch box.mf
-      for fname in *; do
-        checksum=$(sha256sum $fname | cut -d' ' -f 1)
-        echo "SHA256($fname)= $checksum" >> box.mf
-      done
+    # 5. generate OVF manifest file
+    rm *.mf
+    touch box.mf
+    for fname in *; do
+      checksum=$(sha256sum $fname | cut -d' ' -f 1)
+      echo "SHA256($fname)= $checksum" >> box.mf
+    done
 
-      # 6. compress everything back together
-      tar --owner=0 --group=0 --sort=name --numeric-owner -czf $out .
-    '';
+    # 6. compress everything back together
+    tar --owner=0 --group=0 --sort=name --numeric-owner -czf $out .
+  '';
 }

--- a/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
+++ b/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
@@ -1,6 +1,6 @@
 # Vagrant + VirtualBox
 
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   imports = [
@@ -22,8 +22,11 @@
 
   # generate the box v1 format which is much easier to generate
   # https://www.vagrantup.com/docs/boxes/format.html
+  image.extension = lib.mkOverride 999 "${config.image.baseName}.box";
+  system.nixos.tags = [ "vagrant"];
+  system.build.image = lib.mkOverride 999 config.system.build.vagrantVirtualbox;
   system.build.vagrantVirtualbox = pkgs.runCommand
-    "virtualbox-vagrant.box"
+    config.image.fileName
     {}
     ''
       mkdir workdir

--- a/nixos/modules/virtualisation/vmware-image.nix
+++ b/nixos/modules/virtualisation/vmware-image.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   boolToStr = value: if value then "on" else "off";
   cfg = config.vmware;

--- a/nixos/modules/virtualisation/vmware-image.nix
+++ b/nixos/modules/virtualisation/vmware-image.nix
@@ -17,6 +17,23 @@ let
   ];
 
 in {
+  imports = [
+    ../image/file-options.nix
+    (lib.mkRenamedOptionModuleWith {
+      sinceRelease = 2505;
+      from = [
+        "virtualisation"
+        "vmware"
+        "vmFileName"
+      ];
+      to = [
+        "image"
+        "fileName"
+      ];
+    })
+
+  ];
+
   options = {
     vmware = {
       baseImageSize = lib.mkOption {
@@ -34,13 +51,6 @@ in {
           The name of the derivation for the VMWare appliance.
         '';
       };
-      vmFileName = lib.mkOption {
-        type = lib.types.str;
-        default = "nixos-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.vmdk";
-        description = ''
-          The file name of the VMWare appliance.
-        '';
-      };
       vmSubformat = lib.mkOption {
         type = lib.types.enum subformats;
         default = "monolithicSparse";
@@ -56,10 +66,14 @@ in {
   };
 
   config = {
+    system.nixos.tags = [ "vmware" ];
+    image.extension = "vmdk";
+    system.build.image = config.system.build.vmwareImage;
     system.build.vmwareImage = import ../../lib/make-disk-image.nix {
       name = cfg.vmDerivationName;
+      baseName = config.image.baseName;
       postVM = ''
-        ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o compat6=${boolToStr cfg.vmCompat6},subformat=${cfg.vmSubformat} -O vmdk $diskImage $out/${cfg.vmFileName}
+        ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o compat6=${boolToStr cfg.vmCompat6},subformat=${cfg.vmSubformat} -O vmdk $diskImage $out/${config.image.fileName}
         rm $diskImage
       '';
       format = "raw";


### PR DESCRIPTION
This uses changes in https://github.com/NixOS/nixpkgs/pull/359326 and https://github.com/NixOS/nixpkgs/pull/359328 to normalize file names of disk images generated by modules in virtualisation. Please see the PR linked below for a table listing all changed filenames

It was split off https://github.com/NixOS/nixpkgs/pull/347275 in order to upstream that one in smaller chunks, easier to review, test and (hopefully not) revert.





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
