### PR TITLE
image/images: Adapt remaining images to system.build.image & normalized filenames, 

### DIFF
--- a/nixos/maintainers/scripts/openstack/openstack-image.nix
+++ b/nixos/maintainers/scripts/openstack/openstack-image.nix
@@ -3,19 +3,24 @@
 { config, lib, pkgs, ... }:
 let
   copyChannel = true;
+    format = "qcow2";
 in
 {
   imports = [
     ../../../modules/virtualisation/openstack-config.nix
+    ../../../modules/image/file-options.nix
   ] ++ (lib.optional copyChannel ../../../modules/installer/cd-dvd/channel.nix);
 
   documentation.enable = copyChannel;
 
+  image.extension = format;
+  system.nixos.tags = [ "openstack" ];
+  system.build.image = config.system.build.openstackImage;
   system.build.openstackImage = import ../../../lib/make-disk-image.nix {
-    inherit lib config copyChannel;
+    inherit lib config copyChannel format;
+    inherit (config.image) baseName;
     additionalSpace = "1024M";
     pkgs = import ../../../.. { inherit (pkgs) system; }; # ensure we use the regular qemu-kvm package
-    format = "qcow2";
     configFile = pkgs.writeText "configuration.nix"
       ''
         {

--- a/nixos/modules/image/images.nix
+++ b/nixos/modules/image/images.nix
@@ -9,6 +9,7 @@ let
   inherit (lib) types;
 
   imageModules = {
+    amazon = [ ../../maintainers/scripts/ec2/amazon-image.nix ];
     azure = [ ../virtualisation/azure-image.nix ];
     digital-ocean = [ ../virtualisation/digital-ocean-image.nix ];
     google-compute = [ ../virtualisation/google-compute-image.nix ];
@@ -17,11 +18,45 @@ let
     lxc = [ ../virtualisation/lxc-container.nix ];
     lxc-metadata = [ ../virtualisation/lxc-image-metadata.nix ];
     oci = [ ../virtualisation/oci-image.nix ];
+    openstack = [ ../../maintainers/scripts/openstack/openstack-image.nix ];
+    openstack-zfs = [ ../../maintainers/scripts/openstack/openstack-image-zfs.nix ];
     proxmox = [ ../virtualisation/proxmox-image.nix ];
+    proxmox-lxc = [ ../virtualisation/proxmox-lxc.nix ];
+    qemu-efi = [ ../virtualisation/disk-image.nix ];
+    qemu = [
+      ../virtualisation/disk-image.nix
+      {
+        image.efiSupport = false;
+      }
+    ];
+    raw-efi = [
+      ../virtualisation/disk-image.nix
+      {
+        image.format = "raw";
+      }
+    ];
+    raw = [
+      ../virtualisation/disk-image.nix
+      {
+        image.format = "raw";
+        image.efiSupport = false;
+      }
+    ];
     kubevirt = [ ../virtualisation/kubevirt.nix ];
     vagrant-virtualbox = [ ../virtualisation/vagrant-virtualbox-image.nix ];
     virtualbox = [ ../virtualisation/virtualbox-image.nix ];
     vmware = [ ../virtualisation/vmware-image.nix ];
+    iso = [ ../installer/cd-dvd/iso-image.nix ];
+    iso-installer = [ ../installer/cd-dvd/installation-cd-base.nix ];
+    sd-card = [
+      (
+        let
+          module = ../. + "/installer/sd-card/sd-image-${pkgs.targetPlatform.linuxArch}.nix";
+        in
+        if builtins.pathExists module then module else throw "The module ${module} does not exist."
+      )
+    ];
+    kexec = [ ../installer/netboot/netboot-minimal.nix ];
   };
   imageConfigs = lib.mapAttrs (
     name: modules:

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -15,9 +15,6 @@
   # Adds terminus_font for people with HiDPI displays
   console.packages = options.console.packages.default ++ [ pkgs.terminus_font ];
 
-  # ISO naming.
-  isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.iso";
-
   # EFI booting
   isoImage.makeEfiBootable = true;
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -476,23 +476,33 @@ let
 in
 
 {
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      sinceRelease = 2505;
+      from = [
+        "isoImage"
+        "isoBaseName"
+      ];
+      to = [
+        "image"
+        "baseName"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      sinceRelease = 2505;
+      from = [
+        "isoImage"
+        "isoName"
+      ];
+      to = [
+        "image"
+        "fileName"
+      ];
+    })
+    ../../image/file-options.nix
+  ];
+
   options = {
-
-    isoImage.isoName = lib.mkOption {
-      default = "${config.isoImage.isoBaseName}.iso";
-      type = lib.types.str;
-      description = ''
-        Name of the generated ISO image file.
-      '';
-    };
-
-    isoImage.isoBaseName = lib.mkOption {
-      default = config.system.nixos.distroId;
-      type = lib.types.str;
-      description = ''
-        Prefix of the name of the generated ISO image file.
-      '';
-    };
 
     isoImage.compressImage = lib.mkOption {
       default = false;
@@ -858,8 +868,12 @@ in
     boot.loader.timeout = 10;
 
     # Create the ISO image.
+    image.extension = if config.isoImage.compressImage then "iso.zst" else "iso";
+    image.filePath = "iso/${config.image.fileName}";
+    system.build.image = config.system.build.isoImage;
     system.build.isoImage = pkgs.callPackage ../../../lib/make-iso9660-image.nix ({
-      inherit (config.isoImage) isoName compressImage volumeID contents;
+      inherit (config.isoImage) compressImage volumeID contents;
+      isoName = "${config.image.baseName}.iso";
       bootable = config.isoImage.makeBiosBootable;
       bootImage = "/isolinux/isolinux.bin";
       syslinux = if config.isoImage.makeBiosBootable then pkgs.syslinux else null;

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -1,11 +1,15 @@
 # This module creates netboot media containing the given NixOS
 # configuration.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, modulesPath, ... }:
 
 with lib;
 
 {
+  imports = [
+    ../../image/file-options.nix
+  ];
+
   options = {
 
     netboot.squashfsCompression = mkOption {
@@ -128,6 +132,21 @@ with lib;
         path = config.system.build.kexecScript;
       }
     ];
+
+    image.extension = "tar.xz";
+    image.filePath = "tarball/${config.image.fileName}";
+    system.nixos.tags = [ "kexec" ];
+    system.build.image = config.system.build.kexecTarball;
+    system.build.kexecTarball = pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
+      fileName = config.image.baseName;
+      storeContents = [
+        {
+          object = config.system.build.kexecScript;
+          symlink = "/kexec_nixos";
+        }
+      ];
+      contents = [];
+    };
 
     boot.loader.timeout = 10;
 

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -29,23 +29,33 @@ in
   imports = [
     (mkRemovedOptionModule [ "sdImage" "bootPartitionID" ] "The FAT partition for SD image now only holds the Raspberry Pi firmware files. Use firmwarePartitionID to configure that partition's ID.")
     (mkRemovedOptionModule [ "sdImage" "bootSize" ] "The boot files for SD image have been moved to the main ext4 partition. The FAT partition now only holds the Raspberry Pi firmware files. Changing its size may not be required.")
+    (lib.mkRenamedOptionModuleWith {
+      sinceRelease = 2505;
+      from = [
+        "sdImage"
+        "imageBaseName"
+      ];
+      to = [
+        "image"
+        "baseName"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      sinceRelease = 2505;
+      from = [
+        "sdImage"
+        "imageName"
+      ];
+      to = [
+        "image"
+        "fileName"
+      ];
+    })
+    ../../profiles/all-hardware.nix
+    ../../image/file-options.nix
   ];
 
   options.sdImage = {
-    imageName = mkOption {
-      default = "${config.sdImage.imageBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img";
-      description = ''
-        Name of the generated image file.
-      '';
-    };
-
-    imageBaseName = mkOption {
-      default = "nixos-sd-image";
-      description = ''
-        Prefix of the name of the generated image file.
-      '';
-    };
-
     storePaths = mkOption {
       type = with types; listOf package;
       example = literalExpression "[ pkgs.stdenv ]";
@@ -180,18 +190,22 @@ in
 
     sdImage.storePaths = [ config.system.build.toplevel ];
 
+    image.extension = if config.sdImage.compressImage then "img.zst" else "img";
+    image.filePath = "sd-card/${config.image.fileName}";
+    system.nixos.tags = [ "sd-card" ];
+    system.build.image = config.system.build.sdImage;
     system.build.sdImage = pkgs.callPackage ({ stdenv, dosfstools, e2fsprogs,
     mtools, libfaketime, util-linux, zstd }: stdenv.mkDerivation {
-      name = config.sdImage.imageName;
+      name = config.image.fileName;
 
       nativeBuildInputs = [ dosfstools e2fsprogs libfaketime mtools util-linux ]
       ++ lib.optional config.sdImage.compressImage zstd;
 
-      inherit (config.sdImage) imageName compressImage;
+      inherit (config.sdImage) compressImage;
 
       buildCommand = ''
         mkdir -p $out/nix-support $out/sd-image
-        export img=$out/sd-image/${config.sdImage.imageName}
+        export img=$out/sd-image/${config.image.baseName}.img
 
         echo "${pkgs.stdenv.buildPlatform.system}" > $out/nix-support/system
         if test -n "$compressImage"; then

--- a/nixos/modules/virtualisation/disk-image.nix
+++ b/nixos/modules/virtualisation/disk-image.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.image;
+in
+{
+  imports = [
+    ./disk-size-option.nix
+    ../image/file-options.nix
+  ];
+
+  options.image = {
+    format = lib.mkOption {
+      description = "Format of the disk image to generate: raw or qcow2";
+      type = lib.types.enum [
+        "raw"
+        "qcow2"
+      ];
+      default = "qcow2";
+    };
+    efiSupport = lib.mkOption {
+      description = "Whether the disk image should support EFI boot or legacy boot";
+      type = lib.types.bool;
+      default = true;
+    };
+  };
+
+  config = {
+    boot.loader.grub = lib.mkIf (!cfg.efiSupport) {
+      enable = lib.mkOptionDefault true;
+      devices = lib.mkDefault [ "/dev/vda" ];
+    };
+    boot.loader.systemd-boot.enable = lib.mkDefault cfg.efiSupport;
+    boot.growPartition = lib.mkDefault true;
+
+    fileSystems = {
+      "/" = {
+        device = "/dev/disk/by-label/nixos";
+        autoResize = true;
+        fsType = "ext4";
+      };
+      "/boot" = lib.mkIf (cfg.efiSupport) {
+        device = "/dev/disk/by-label/ESP";
+        fsType = "vfat";
+      };
+    };
+
+    system.nixos.tags = [ cfg.format ] ++ lib.optionals cfg.efiSupport [ "efi" ];
+    image.extension = cfg.format;
+    system.build.image = import ../../lib/make-disk-image.nix {
+      inherit lib config pkgs;
+      inherit (config.virtualisation) diskSize;
+      inherit (cfg) baseName format;
+      partitionTableType = if cfg.efiSupport then "efi" else "legacy";
+    };
+  };
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -62,7 +62,7 @@ let
     hydraJob ((import lib/eval-config.nix {
       inherit system;
       modules = makeModules module {
-        isoImage.isoBaseName = "nixos-${type}";
+        image.baseName = "nixos-${type}";
       };
     }).config.system.build.isoImage);
 

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -55,7 +55,7 @@ let
       }
     ];
   }).config;
-  image = "${imageCfg.system.build.amazonImage}/${imageCfg.amazonImage.name}.qcow2";
+  image = "${imageCfg.system.build.amazonImage}/${imageCfg.image.imageFile}";
 
   sshKeys = import ./ssh-keys.nix pkgs;
   snakeOilPrivateKey = sshKeys.snakeOilPrivateKey.text;

--- a/pkgs/desktops/gnome/installer.nix
+++ b/pkgs/desktops/gnome/installer.nix
@@ -7,7 +7,7 @@ let
 
   config = (import ../../../../nixos/lib/eval-config.nix {
     inherit system;
-    modules = [ module { isoImage.isoBaseName = isoBaseName; } ] ++ extraModules;
+    modules = [ module { image.baseName = isoBaseName; } ] ++ extraModules;
   }).config;
 
 in


### PR DESCRIPTION
This builds on changes in https://github.com/NixOS/nixpkgs/pull/359339 and adapts remaining images to declare system.build.image and normalize file names.
It also adds a generic disk-image.nix in order to be able to build plain qcow/raw images, similar to how nixos generators does.

It was split off https://github.com/NixOS/nixpkgs/pull/347275 in order to upstream that one in smaller chunks, easier to review, test and (hopefully not) revert.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
