### PR TITLE
treewide: fix unstable Gentoo patch URLs

### DIFF
--- a/pkgs/by-name/au/autopanosiftc/package.nix
+++ b/pkgs/by-name/au/autopanosiftc/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchurl {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/autopano-sift-C/files/autopano-sift-C-2.5.1-lm.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/autopano-sift-C/files/autopano-sift-C-2.5.1-lm.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "1bfcr5sps0ip9gl4jprji5jgf9wkczz6d2clsjjlbsy8r3ixi3lv";
     })
   ];

--- a/pkgs/by-name/bf/bfr/package.nix
+++ b/pkgs/by-name/bf/bfr/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [ (fetchurl {
-        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-misc/bfr/files/bfr-1.6-perl.patch";
+        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-misc/bfr/files/bfr-1.6-perl.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
         sha256 = "1pk9jm3c1qzs727lh0bw61w3qbykaqg4jblywf9pvq5bypk88qfj";
       })
     ];

--- a/pkgs/by-name/bi/bitmeter/package.nix
+++ b/pkgs/by-name/bi/bitmeter/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchurl {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/bitmeter/files/bitmeter-1.2-fix-build-system.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/bitmeter/files/bitmeter-1.2-fix-build-system.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "021mz6933iw7mpk6b9cbjr8naj6smbq1hwqjszlyx72qbwrrid7k";
     })
   ];

--- a/pkgs/by-name/cu/cuneiform/package.nix
+++ b/pkgs/by-name/cu/cuneiform/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "19cmrlx4khn30qqrpyayn7bicg8yi0wpz1x1bvqqrbvr3kwldxyj";
   })
   (fetchurl {
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/cuneiform/files/cuneiform-1.1.0-gcc11.patch";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/cuneiform/files/cuneiform-1.1.0-gcc11.patch?id=fd8e596c6a5eab634656e265c3da5241f5ceee8c";
     sha256 = "14bp2f4dvlgxnpdza1rgszhkbxhp6p7lhgnb1s7c1x7vwdrx0ri7";
   })
   ];

--- a/pkgs/by-name/db/dbus_cplusplus/package.nix
+++ b/pkgs/by-name/db/dbus_cplusplus/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     (fetchurl {
       name = "gcc-4.7.patch";
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/"
-          + "dbus-c++/files/dbus-c++-0.9.0-gcc-4.7.patch";
+          + "dbus-c++/files/dbus-c++-0.9.0-gcc-4.7.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "0rwcz9pvc13b3yfr0lkifnfz0vb5q6dg240bzgf37ni4s8rpc72g";
     })
     (fetchpatch {

--- a/pkgs/by-name/li/libieee1284/package.nix
+++ b/pkgs/by-name/li/libieee1284/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchurl {
       name = "musl.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/libieee1284/files/libieee1284-0.2.11-don-t-blindly-assume-outb_p-to-be-available.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/libieee1284/files/libieee1284-0.2.11-don-t-blindly-assume-outb_p-to-be-available.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       hash = "sha256-sNu0OPBMa9GIwSu754noateF4FZC14f+8YRgYUl13KQ=";
     })
   ];

--- a/pkgs/by-name/pn/pngtoico/package.nix
+++ b/pkgs/by-name/pn/pngtoico/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/pngtoico/files/pngtoico-1.0.1-libpng15.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/pngtoico/files/pngtoico-1.0.1-libpng15.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       hash = "sha256-MeRV4FL37Wq7aFRnjbxPokcBKmPM+h94cnFJmdvHAt0=";
     })
   ];

--- a/pkgs/by-name/tk/tkman/package.nix
+++ b/pkgs/by-name/tk/tkman/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [(fetchpatch {
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/tkman/files/tkman-CVE-2008-5137.diff";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/tkman/files/tkman-CVE-2008-5137.diff?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
     hash = "sha256-l97SY2/YnMgzHYKnVYCVJKV7oGLN1hXNpeHFlLVzTMA=";
   })];
 

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch2 {
       name = "parameterized-docstring-3.13-compat.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-python/parameterized/files/parameterized-0.9.0-py313-test.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-python/parameterized/files/parameterized-0.9.0-py313-test.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       hash = "sha256-tWcN0eRC0oRHrOaa/cctXLhi1WapDKvxO36e6gU6UIk=";
     })
   ];

--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
       sha256 = "sha256-W8R1l7ZPcsfiIy1QBJvh0M8du0w1cnTg3PyAz65v4rE=";
     })
     (fetchpatch {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.65.0-sane-backends-1.1.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.65.0-sane-backends-1.1.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "sha256-AmMZ+/lrUMR7IU+S8MEn0Ji5pqOiD6izFJBsJ0tCCCw=";
     })
   ];


### PR DESCRIPTION
Without `?id=commitSha` these point to the main branch. One of the patches in this PR had in fact already disappeared! (I found the commit where it was added, so the URL works again)

I checked that all patches still resolve to the same contents.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: 0 rebuilds... (it targets staging since one of these URLs was introduced in staging)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc