### PR TITLE
jxrlib: 1.1 -> 1.2~git20170615.f752187-5.2, fix warning flags for GCC 14; colmap: unpin Boost

### DIFF
--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, cmake, boost179, ceres-solver, eigen,
+{ lib, fetchFromGitHub, cmake, boost, ceres-solver, eigen,
   freeimage, glog, libGLU, glew, qtbase,
   flann,
   cgal,
@@ -17,7 +17,7 @@
 assert cudaSupport -> cudaPackages != { };
 
 let
-  boost_static = boost179.override { enableStatic = true; };
+  boost_static = boost.override { enableStatic = true; };
   stdenv' = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 
   # TODO: migrate to redist packages

--- a/pkgs/by-name/jx/jxrlib/package.nix
+++ b/pkgs/by-name/jx/jxrlib/package.nix
@@ -16,9 +16,10 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  };
+  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " (
+    [ "-Wno-error=implicit-function-declaration"]
+    ++ lib.optionals stdenv.cc.isGNU [ "-Wno-error=incompatible-pointer-types" ]
+  );
 
   postPatch = ''
     QUILT_PATCHES=debian/patches quilt push -a

--- a/pkgs/by-name/jx/jxrlib/package.nix
+++ b/pkgs/by-name/jx/jxrlib/package.nix
@@ -1,40 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
+{ lib, stdenv, fetchFromGitLab, cmake, ninja, quilt }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "jxrlib";
-  version = "1.1";
+  version = "1.2~git20170615.f752187-5.2";
 
-  # Use the source from a fork on github because CodePlex does not
-  # deliver an easily downloadable tarball.
-  src = fetchFromGitHub {
-    owner = "4creators";
-    repo = pname;
-    rev = "f7521879862b9085318e814c6157490dd9dbbdb4";
-    sha256 = "0rk3hbh00nw0wgbfbqk1szrlfg3yq7w6ar16napww3nrlm9cj65w";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian-phototools-team";
+    repo = "jxrlib";
+    rev = "56e10e601a962c2e8d178e60e52cd8cf2d50f9c0";
+    hash = "sha256-BX4kLlFk8AfouKE9KDyG1EFFYLFB/HqYQRxFdjAe2J8=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/df96f9b9c1fbe9cdc97589c337f8a948bc81c4d0/debian/patches/usecmake.patch";
-      sha256 = "sha256-BpCToLgA5856PZk5mXlwAy3Oh9aYP/2wvu2DXDTqufM=";
-    })
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/6c88037293aff8d5bc8a76ea32b36781c430ede3/debian/patches/bug803743.patch";
-      sha256 = "sha256-omIGa+ZrWjaH/IkBn4jgjufF/HEDKw69anVCX4hw+xQ=";
-    })
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/b23d49062ec6a9b2739c9dade86be525a72fc807/debian/patches/pkg-config.patch";
-      sha256 = "sha256-ZACaXEi+rbKIFBHtSBheyFfqV2HYsKKrT+SmTShyUhg=";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja quilt ];
 
   strictDeps = true;
 
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
   };
+
+  postPatch = ''
+    QUILT_PATCHES=debian/patches quilt push -a
+  '';
 
   meta = with lib; {
     description = "Implementation of the JPEG XR image codec standard";


### PR DESCRIPTION
FreeImage my nemesis. But hey, more Boost clean‐up.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
