### PR TITLE
nixos/azure: move image-specific configs from azure-common to azure-image, fix console output

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -151,6 +151,8 @@
 
 - Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
 
+- `virtualisation/azure-common.nix`'s filesystem and grub configurations have been moved to `virtualisation/azure-image.nix`. This makes `azure-common.nix` more generic so it could be used for users who generate Azure image using other methods (e.g. nixos-generators and disko). For existing users depending on these configurations, please also import `azure-image.nix`.
+
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
 
 - The `earlyoom` service is now using upstream systemd service, which enables

--- a/nixos/modules/virtualisation/azure-common.nix
+++ b/nixos/modules/virtualisation/azure-common.nix
@@ -31,6 +31,9 @@ in
     services.cloud-init.network.enable = true;
     systemd.services.cloud-config.serviceConfig.Restart = "on-failure";
 
+    # cloud-init.network.enable also enables systemd-networkd
+    networking.useNetworkd = true;
+
     # Ensure kernel outputs to ttyS0 (Azure Serial Console),
     # and reboot machine upon fatal boot issues
     boot.kernelParams = [

--- a/nixos/modules/virtualisation/azure-common.nix
+++ b/nixos/modules/virtualisation/azure-common.nix
@@ -1,9 +1,18 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let
   cfg = config.virtualisation.azure;
-  mlxDrivers = [ "mlx4_en" "mlx4_core" "mlx5_core" ];
+  mlxDrivers = [
+    "mlx4_en"
+    "mlx4_core"
+    "mlx5_core"
+  ];
 in
 {
   options.virtualisation.azure = {
@@ -13,16 +22,25 @@ in
     };
   };
 
-  imports = [
-    ../profiles/headless.nix
-    ./azure-agent.nix
-  ];
-
   config = {
-    virtualisation.azure.agent.enable = true;
+    services.waagent.enable = true;
+    services.cloud-init.enable = true;
+    services.cloud-init.network.enable = true;
+    systemd.services.cloud-config.serviceConfig.Restart = "on-failure";
 
-    boot.kernelParams = [ "console=ttyS0" "earlyprintk=ttyS0" "rootdelay=300" "panic=1" "boot.panic_on_fail" ];
-    boot.initrd.kernelModules = [ "hv_vmbus" "hv_netvsc" "hv_utils" "hv_storvsc" ];
+    boot.kernelParams = [
+      "console=ttyS0"
+      "earlyprintk=ttyS0"
+      "rootdelay=300"
+      "panic=1"
+      "boot.panic_on_fail"
+    ];
+    boot.initrd.kernelModules = [
+      "hv_vmbus"
+      "hv_netvsc"
+      "hv_utils"
+      "hv_storvsc"
+    ];
     boot.initrd.availableKernelModules = lib.optionals cfg.acceleratedNetworking mlxDrivers;
 
     # Accelerated networking
@@ -30,19 +48,9 @@ in
       matchConfig.Driver = mlxDrivers;
       linkConfig.Unmanaged = "yes";
     };
-    networking.networkmanager.unmanaged = lib.mkIf cfg.acceleratedNetworking
-      (builtins.map (drv: "driver:${drv}") mlxDrivers);
-
-    # Generate a GRUB menu.
-    boot.loader.grub.device = "/dev/sda";
-
-    boot.growPartition = true;
-
-    fileSystems."/" = {
-      device = "/dev/disk/by-label/nixos";
-      fsType = "ext4";
-      autoResize = true;
-    };
+    networking.networkmanager.unmanaged = lib.mkIf cfg.acceleratedNetworking (
+      builtins.map (drv: "driver:${drv}") mlxDrivers
+    );
 
     # Allow root logins only using the SSH key that the user specified
     # at instance creation time, ping client connections to avoid timeouts
@@ -55,31 +63,19 @@ in
 
     # Always include cryptsetup so that NixOps can use it.
     # sg_scan is needed to finalize disk removal on older kernels
-    environment.systemPackages = [ pkgs.cryptsetup pkgs.sg3_utils ];
+    environment.systemPackages = [
+      pkgs.cryptsetup
+      pkgs.sg3_utils
+    ];
 
     networking.usePredictableInterfaceNames = false;
 
-    services.udev.extraRules = ''
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:0", ATTR{removable}=="0", SYMLINK+="disk/by-lun/0",
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:1", ATTR{removable}=="0", SYMLINK+="disk/by-lun/1",
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:2", ATTR{removable}=="0", SYMLINK+="disk/by-lun/2"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:3", ATTR{removable}=="0", SYMLINK+="disk/by-lun/3"
-
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:4", ATTR{removable}=="0", SYMLINK+="disk/by-lun/4"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:5", ATTR{removable}=="0", SYMLINK+="disk/by-lun/5"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:6", ATTR{removable}=="0", SYMLINK+="disk/by-lun/6"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:7", ATTR{removable}=="0", SYMLINK+="disk/by-lun/7"
-
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:8", ATTR{removable}=="0", SYMLINK+="disk/by-lun/8"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:9", ATTR{removable}=="0", SYMLINK+="disk/by-lun/9"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:10", ATTR{removable}=="0", SYMLINK+="disk/by-lun/10"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:11", ATTR{removable}=="0", SYMLINK+="disk/by-lun/11"
-
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:12", ATTR{removable}=="0", SYMLINK+="disk/by-lun/12"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:13", ATTR{removable}=="0", SYMLINK+="disk/by-lun/13"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:14", ATTR{removable}=="0", SYMLINK+="disk/by-lun/14"
-      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:15", ATTR{removable}=="0", SYMLINK+="disk/by-lun/15"
-
-    '';
+    services.udev.extraRules =
+      with builtins;
+      concatStringsSep "\n" (
+        map (i: ''
+          ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:${toString i}", ATTR{removable}=="0", SYMLINK+="disk/by-lun/${toString i}"
+        '') (lib.range 1 15)
+      );
   };
 }

--- a/nixos/modules/virtualisation/azure-common.nix
+++ b/nixos/modules/virtualisation/azure-common.nix
@@ -5,7 +5,6 @@
   ...
 }:
 
-with lib;
 let
   cfg = config.virtualisation.azure;
   mlxDrivers = [
@@ -16,7 +15,7 @@ let
 in
 {
   options.virtualisation.azure = {
-    acceleratedNetworking = mkOption {
+    acceleratedNetworking = lib.mkOption {
       default = false;
       description = "Whether the machine's network interface has enabled accelerated networking.";
     };
@@ -68,7 +67,7 @@ in
     services.openssh.settings.ClientAliveInterval = 180;
 
     # Force getting the hostname from Azure
-    networking.hostName = mkDefault "";
+    networking.hostName = lib.mkDefault "";
 
     # Always include cryptsetup so that NixOps can use it.
     # sg_scan is needed to finalize disk removal on older kernels
@@ -79,12 +78,8 @@ in
 
     networking.usePredictableInterfaceNames = false;
 
-    services.udev.extraRules =
-      with builtins;
-      concatStringsSep "\n" (
-        map (i: ''
-          ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:${toString i}", ATTR{removable}=="0", SYMLINK+="disk/by-lun/${toString i}"
-        '') (lib.range 1 15)
-      );
+    services.udev.extraRules = lib.concatMapStrings (i: ''
+      ENV{DEVTYPE}=="disk", KERNEL!="sda" SUBSYSTEM=="block", SUBSYSTEMS=="scsi", KERNELS=="?:0:0:${toString i}", ATTR{removable}=="0", SYMLINK+="disk/by-lun/${toString i}"
+    '') (lib.range 1 15);
   };
 }

--- a/nixos/modules/virtualisation/azure-config-user.nix
+++ b/nixos/modules/virtualisation/azure-config-user.nix
@@ -8,5 +8,11 @@
   # This configures everything but bootstrap services,
   # which only need to be run once and have already finished
   # if you are able to see this comment.
-  imports = [ "${modulesPath}/virtualisation/azure-common.nix" ];
+  imports = [
+    "${modulesPath}/virtualisation/azure-common.nix"
+    "${modulesPath}/virtualisation/azure-image.nix"
+  ];
+
+  # Please update the VM Generation to the actual value
+  virtualisation.azureImage.vmGeneration = "v1";
 }

--- a/nixos/modules/virtualisation/azure-config-user.nix
+++ b/nixos/modules/virtualisation/azure-config-user.nix
@@ -13,6 +13,6 @@
     "${modulesPath}/virtualisation/azure-image.nix"
   ];
 
-  # Please update the VM Generation to the actual value
-  virtualisation.azureImage.vmGeneration = "v1";
+  # Please set the VM Generation to the actual value
+  # virtualisation.azureImage.vmGeneration = "v1";
 }

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -76,12 +76,15 @@ in
     system.build.azureImage = import ../../lib/make-disk-image.nix {
       name = "azure-image";
       inherit (config.image) baseName;
+
+      # Azure expects vhd format with fixed size,
+      # generating raw format and convert with subformat args afterwards
+      format = "raw";
       postVM = ''
         ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o subformat=fixed,force_size -O vpc $diskImage $out/${config.image.fileName}
         rm $diskImage
       '';
       configFile = ./azure-config-user.nix;
-      format = "raw";
 
       bootSize = "${toString cfg.bootSize}M";
       partitionTableType = if (cfg.vmGeneration == "v2") then "efi" else "legacy";
@@ -96,8 +99,13 @@ in
       efiSupport = (cfg.vmGeneration == "v2");
       device = if efiSupport then "nodev" else "/dev/sda";
       efiInstallAsRemovable = efiSupport;
+      # Force grub to run in text mode and output to console
+      # by disabling font and splash image
       font = null;
       splashImage = null;
+      # For Gen 1 VM, configurate grub output to serial_com0.
+      # Not needed for Gen 2 VM wbere serial_com0 does not exist,
+      # and outputing to console is enough to make Azure Serial Console working
       extraConfig = lib.mkIf (!efiSupport) ''
         serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
         terminal_input --append serial
@@ -108,6 +116,7 @@ in
     fileSystems = {
       "/" = {
         device = "/dev/disk/by-label/${cfg.label}";
+        inherit (cfg) label;
         fsType = "ext4";
         autoResize = true;
       };

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -96,7 +96,9 @@ in
       efiSupport = (cfg.vmGeneration == "v2");
       device = if efiSupport then "nodev" else "/dev/sda";
       efiInstallAsRemovable = efiSupport;
-      extraConfig = ''
+      font = null;
+      splashImage = null;
+      extraConfig = lib.mkIf (!efiSupport) ''
         serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
         terminal_input --append serial
         terminal_output --append serial

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -110,14 +110,18 @@ let
       };
 
       ResourceDisk = {
-        Format = mkEnableOption ''
-          If set to `true`, waagent formats and mounts the resource disk that the platform provides,
-          unless the file system type in `ResourceDisk.FileSystem` is set to `ntfs`.
-          The agent makes a single Linux partition (ID 83) available on the disk.
-          This partition isn't formatted if it can be successfully mounted.
+        Format = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If set to `true`, waagent formats and mounts the resource disk that the platform provides,
+            unless the file system type in `ResourceDisk.FileSystem` is set to `ntfs`.
+            The agent makes a single Linux partition (ID 83) available on the disk.
+            This partition isn't formatted if it can be successfully mounted.
 
-          This configuration has no effect if resource disk is managed by cloud-init.
-        '';
+            This configuration has no effect if resource disk is managed by cloud-init.
+          '';
+        };
 
         FileSystem = mkOption {
           type = types.str;
@@ -155,12 +159,16 @@ let
           '';
         };
 
-        EnableSwap = mkEnableOption ''
-          If enabled, the agent creates a swap file (`/swapfile`) on the resource disk
-          and adds it to the system swap space.
+        EnableSwap = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If enabled, the agent creates a swap file (`/swapfile`) on the resource disk
+            and adds it to the system swap space.
 
-          This configuration has no effect if resource disk is managed by cloud-init.
-        '';
+            This configuration has no effect if resource disk is managed by cloud-init.
+          '';
+        };
 
         SwapSizeMB = mkOption {
           type = types.int;
@@ -173,16 +181,24 @@ let
         };
       };
 
-      Logs.Verbose = lib.mkEnableOption ''
-        If you set this option, log verbosity is boosted.
-        Waagent logs to `/var/log/waagent.log` and uses the system logrotate functionality to rotate logs.
-      '';
+      Logs.Verbose = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If you set this option, log verbosity is boosted.
+          Waagent logs to `/var/log/waagent.log` and uses the system logrotate functionality to rotate logs.
+        '';
+      };
 
       OS = {
-        EnableRDMA = lib.mkEnableOption ''
-          If enabled, the agent attempts to install and then load an RDMA kernel driver
-          that matches the version of the firmware on the underlying hardware.
-        '';
+        EnableRDMA = lib.mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If enabled, the agent attempts to install and then load an RDMA kernel driver
+            that matches the version of the firmware on the underlying hardware.
+          '';
+        };
 
         RootDeviceScsiTimeout = lib.mkOption {
           type = types.nullOr types.int;
@@ -212,17 +228,19 @@ let
         };
       };
 
-      AutoUpdate.Enable = lib.mkEnableOption ''
-        Enable or disable autoupdate for goal state processing.
-      '';
+      AutoUpdate.Enable = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether or not to enable autoupdate for goal state processing.
+        '';
+      };
     };
   };
 in
 {
   options.services.waagent = {
-    enable = lib.mkEnableOption ''
-      Whether to enable the Windows Azure Linux Agent.
-    '';
+    enable = lib.mkEnableOption "Windows Azure Linux Agent";
 
     package = lib.mkPackageOption pkgs "waagent" { };
 

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -192,15 +192,6 @@ let
             If set to `null`, the system defaults are used.
           '';
         };
-
-        OpensslPath = lib.mkOption {
-          type = types.nullOr types.path;
-          default = lib.getExe pkgs.openssl;
-          defaultText = literalExpression "lib.getExe pkgs.openssl";
-          description = ''
-            Specify a path for the openssl binary to use for cryptographic operations.
-          '';
-        };
       };
 
       HttpProxy = {

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -192,6 +192,15 @@ let
             If set to `null`, the system defaults are used.
           '';
         };
+
+        OpensslPath = lib.mkOption {
+          type = types.nullOr types.path;
+          default = lib.getExe pkgs.openssl;
+          defaultText = literalExpression "lib.getExe pkgs.openssl";
+          description = ''
+            Specify a path for the openssl binary to use for cryptographic operations.
+          '';
+        };
       };
 
       HttpProxy = {

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -31,7 +31,7 @@ let
       attrsOf (
         either atom (attrsOf atom)
         // {
-          description = atom.description + "or an attribute set of them";
+          description = atom.description + " or an attribute set of them";
         }
       );
     generate =

--- a/pkgs/by-name/wa/waagent/package.nix
+++ b/pkgs/by-name/wa/waagent/package.nix
@@ -4,6 +4,7 @@
   lib,
   python3,
   bash,
+  openssl,
   nixosTests,
 }:
 
@@ -30,11 +31,13 @@ python.pkgs.buildPythonApplication rec {
   # Replace tools used in udev rules with their full path and ensure they are present.
   postPatch = ''
     substituteInPlace config/66-azure-storage.rules \
-      --replace-fail readlink ${coreutils}/bin/readlink \
-      --replace-fail cut ${coreutils}/bin/cut \
-      --replace-fail /bin/sh ${bash}/bin/sh
+      --replace-fail readlink '${coreutils}/bin/readlink' \
+      --replace-fail cut '${coreutils}/bin/cut' \
+      --replace-fail '/bin/sh' '${bash}/bin/sh'
     substituteInPlace config/99-azure-product-uuid.rules \
-      --replace-fail "/bin/chmod" "${coreutils}/bin/chmod"
+      --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
+    substituteInPlace azurelinuxagent/common/conf.py \
+      --replace-fail '/usr/bin/openssl' '${openssl}/bin/openssl'
   '';
 
   propagatedBuildInputs = [ python.pkgs.distro ];

--- a/pkgs/by-name/wa/waagent/package.nix
+++ b/pkgs/by-name/wa/waagent/package.nix
@@ -4,7 +4,6 @@
   lib,
   python3,
   bash,
-  gitUpdater,
   nixosTests,
 }:
 
@@ -65,13 +64,8 @@ python.pkgs.buildPythonApplication rec {
 
   dontWrapPythonPrograms = false;
 
-  passthru = {
-    tests = {
-      inherit (nixosTests) waagent;
-    };
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-    };
+  passthru.tests = {
+    inherit (nixosTests) waagent;
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**[azure-common.nix]**

- Moved image specific configs (namely file system configs and grub configs) out of `azure-common.nix`, because these settings are only intended for images generated using `azure-image.nix`. This will make `azure-common.nix` more generic so folks generating azure image using other methods (e.g. disko) can leverage it.
- Removed reference of `headless.nix` to make the console work (which was left out by mistake from #333508). Thanks @nh2 for the great finding.
- Enabled cloud-init by default. Otherwise, the current waagent would try ifupdown for networking management, which is not available in NixOS ecosystem.


**[azure-image.nix]**

- Included image specific configs (mentioned as above).
- Fixed grub console output for Gen 2 VM by forcing grub to run in text mode.
- Added option for customizing root partition label.
- Updated the default configuration.nix copied into the image (`azure-config-user.nix`), prompting user to set the correct vmGeneration before rebuilding. Doing this instead of dynamically generating to remain compatibility, as I found some open-source configurations on GitHub are referencing this file directly.

**[azure-agent.nix]**

- Removed assertion of Network Manager, because the current version of waagent works well with Network Manager.
- Removed reference of `python39` because the current version of waagent is depending on a newer Python version which already exist in the environment given how it is [packaged](https://github.com/NixOS/nixpkgs/blob/3ecd1bade7a69909de83709fbdec4d3af5a5d251/pkgs/by-name/wa/waagent/package.nix).

Changes in this PR is testable via flake [codgician/azure-aarch64-nixos](https://github.com/codgician/azure-aarch64-nixos) (instructions for generating images provided in README.md). Tested for both Gen 2 grub and Gen 2 systemd-boot on aarch64.

![image](https://github.com/user-attachments/assets/c5925afd-e58b-46dc-9f67-8b5df258e359)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
