### PR TITLE
python3Packages.llm-cmd: init at 0.2a0

### DIFF
--- a/pkgs/development/python-modules/llm-cmd/default.nix
+++ b/pkgs/development/python-modules/llm-cmd/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  llm,
+  # dependencies
+  prompt-toolkit,
+  pygments,
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "llm-cmd";
+  version = "0.2a0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "llm-cmd";
+    tag = version;
+    hash = "sha256-RhwQEllpee/XP1p0nrgL4m+KjSZzf61J8l1jJGlg94E=";
+  };
+
+  # Only needed until https://github.com/simonw/llm-cmd/pull/18 is merged and released
+  patches = [ ./fix-test.patch ];
+  build-system = [
+    setuptools
+    # Follows the reasoning from https://github.com/NixOS/nixpkgs/pull/327800#discussion_r1681586659 about including llm in build-system
+    llm
+  ];
+
+  dependencies = [
+    prompt-toolkit
+    pygments
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportCheck = [
+    "llm_cmd"
+  ];
+
+  meta = {
+    description = "Use LLM to generate and execute commands in your shell";
+    homepage = "https://github.com/simonw/llm-cmd";
+    changelog = "https://github.com/simonw/llm-cmd/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ erethon ];
+  };
+}

--- a/pkgs/development/python-modules/llm-cmd/fix-test.patch
+++ b/pkgs/development/python-modules/llm-cmd/fix-test.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_cmd.py b/tests/test_cmd.py
+index 02b5db8..578ebaa 100644
+--- a/tests/test_cmd.py
++++ b/tests/test_cmd.py
+@@ -1,6 +1,7 @@
+-from llm.plugins import pm
++from llm.plugins import load_plugins, pm
+
+
+ def test_plugin_is_installed():
++    load_plugins()
+     names = [mod.__name__ for mod in pm.get_plugins()]
+     assert "llm_cmd" in names

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7619,6 +7619,8 @@ self: super: with self; {
 
   llm = callPackage ../development/python-modules/llm { };
 
+  llm-cmd = callPackage ../development/python-modules/llm-cmd { };
+
   llm-gguf = callPackage ../development/python-modules/llm-gguf { };
 
   llmx = callPackage ../development/python-modules/llmx { };


### PR DESCRIPTION
This is a plugin for the already packaged `llm` software. [Homepage](https://github.com/simonw/llm-cmd) of the project.

#268955, #327800, #344746 are PRs that add similar plugins.

Output of running `llm plugins` after building this package:
```
llm plugins                         
[                                                                   
  {                                                                 
    "name": "llm-cmd",                                              
    "hooks": [
      "register_commands"                                           
    ],                                                              
    "version": "0.2a0"                                      
  }                                                
]  
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
