### PR TITLE
llvmPackages.bintuils: Hack ranlib to ignore `-t`

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -383,6 +383,18 @@ stdenvNoCC.mkDerivation {
     ''
 
     ##
+    ## LLVM ranlab lacks -t option that libtool expects. We can just
+    ## skip it
+    ##
+
+    + optionalString (isLLVM && targetPlatform.isOpenBSD) ''
+      rm $out/bin/${targetPrefix}ranlib
+      wrap \
+        ${targetPrefix}ranlib ${./llvm-ranlib-wrapper.sh} \
+        "${bintools_bin}/bin/${targetPrefix}ranlib"
+    ''
+
+    ##
     ## Extra custom steps
     ##
     + extraBuildCommands;

--- a/pkgs/build-support/bintools-wrapper/llvm-ranlib-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/llvm-ranlib-wrapper.sh
@@ -1,0 +1,16 @@
+#! @shell@
+# shellcheck shell=bash
+
+args=()
+for p in "$@"; do
+    case "$p" in
+        -t)
+            # Skip, LLVM ranlib doesn't support
+            ;;
+        *)
+            args+=("$p")
+            ;;
+    esac
+done
+
+@prog@ "${args[@]}"


### PR DESCRIPTION
Old versions of libtool for OpenBSD insist on adding the `-t` flag to ranlib, which updates the timestamp. llvm-ranlib does not support `-t` and as no plans to do so [1], since it makes builds less reproducable. OpenBSD upstream deals with this by patching ranlib to ignore the `-t` flag [2].

Instead of writing patches for all LLVM versions or re-running `autoreconf` on all packages that use libtool, we can wrap ranlib to ignore the flag.

[1]: https://github.com/llvm/llvm-project/issues/57129
[2]: https://github.com/openbsd/src/commit/d00990cc11fce25520b9dde416bb8cf50990e992

An example package that requires this change is `libxcrypt`, which you can build with `pkgsCross.x86_64-openbsd.libxcrypt`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross from Linux)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
