### PR TITLE
nixfmt-classic: Stop using the hackage package

### DIFF
--- a/pkgs/by-name/ni/nixfmt-classic/generated-package.nix
+++ b/pkgs/by-name/ni/nixfmt-classic/generated-package.nix
@@ -1,0 +1,50 @@
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh
+{
+  mkDerivation,
+  base,
+  cmdargs,
+  directory,
+  fetchgit,
+  filepath,
+  lib,
+  megaparsec,
+  parser-combinators,
+  safe-exceptions,
+  scientific,
+  text,
+  unix,
+}:
+mkDerivation {
+  pname = "nixfmt";
+  version = "0.6.0";
+  src = fetchgit {
+    url = "https://github.com/NixOS/nixfmt.git";
+    sha256 = "0yh1baanifnv5fl3d7ixkgaki7ka1big0kxkiv4h5rik6zkqfyqz";
+    rev = "7e9e06eefed52d6d698b828ee83b83ea5c163f3b";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base
+    megaparsec
+    parser-combinators
+    scientific
+    text
+  ];
+  executableHaskellDepends = [
+    base
+    cmdargs
+    directory
+    filepath
+    safe-exceptions
+    text
+    unix
+  ];
+  jailbreak = true;
+  homepage = "https://github.com/serokell/nixfmt";
+  description = "An opinionated formatter for Nix";
+  license = lib.licenses.mpl20;
+  mainProgram = "nixfmt";
+}

--- a/pkgs/by-name/ni/nixfmt-classic/package.nix
+++ b/pkgs/by-name/ni/nixfmt-classic/package.nix
@@ -1,0 +1,15 @@
+{
+  haskell,
+  haskellPackages,
+  lib,
+}:
+let
+  inherit (haskell.lib.compose) overrideCabal justStaticExecutables;
+
+  overrides.passthru.updateScript = ./update.sh;
+  raw-pkg = haskellPackages.callPackage ./generated-package.nix { };
+in
+lib.pipe raw-pkg [
+  (overrideCabal overrides)
+  justStaticExecutables
+]

--- a/pkgs/by-name/ni/nixfmt-classic/update.sh
+++ b/pkgs/by-name/ni/nixfmt-classic/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix curl jq
+#
+# This script will update the nixfmt-classic derivation to the latest version using
+# cabal2nix.
+
+set -eo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+derivation_file="${script_dir}/generated-package.nix"
+latest_version="$(curl --silent 'https://api.github.com/repos/NixOS/nixfmt/releases/latest' | jq --raw-output '.tag_name')"
+
+echo "Updating nixfmt-classic to version $new_date."
+echo "Running cabal2nix and outputting to ${derivation_file}..."
+
+cat > "$derivation_file" << EOF
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh
+EOF
+
+cabal2nix 'https://github.com/NixOS/nixfmt.git' --revision "${latest_version}" --jailbreak >> "${derivation_file}"
+nixfmt "${derivation_file}"
+
+echo "Finished."

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -435,7 +435,7 @@ self: super: {
     postPatch = "sed -i s/home/tmp/ test/Spec.hs";
   }) super.shell-conduit;
 
-  # https://github.com/serokell/nixfmt/issues/130
+  # https://github.com/NixOS/nixfmt/issues/130
   nixfmt = doJailbreak super.nixfmt;
 
   # Too strict upper bounds on turtle and text

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18497,8 +18497,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration IOKit;
   };
 
-  nixfmt-classic = haskellPackages.nixfmt.bin;
-
   nixpkgs-manual = callPackage ../../doc/doc-support/package.nix { };
 
   nixos-artwork = callPackage ../data/misc/nixos-artwork { };


### PR DESCRIPTION
Removes dependency on the hackage package so we can finally fix https://github.com/NixOS/nixfmt/issues/161 and also moves the entire package to pkgs/by-name.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @NixOS/nix-formatting 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
