### PR TITLE
python312Packages.libtmux: 0.37.0 -> 0.39.0

### DIFF
--- a/pkgs/by-name/tm/tmuxp/package.nix
+++ b/pkgs/by-name/tm/tmuxp/package.nix
@@ -1,25 +1,28 @@
-{ lib, python3Packages, fetchPypi, installShellFiles }:
+{
+  lib,
+  fetchPypi,
+  installShellFiles,
+  python3Packages,
+}:
 
-let
+python3Packages.buildPythonApplication rec {
   pname = "tmuxp";
-  version = "1.47.0";
-  hash = "sha256-HYY6CEUPpZVvVK9kV4Ehw4wGk5YfIVSkZ0+qqf6Nz4c=";
-in
-python3Packages.buildPythonApplication {
-  inherit pname version;
+  version = "1.49.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version hash;
+    inherit pname version;
+    hash = "sha256-Fip2HnwIa03khiYlL5FkhVo84oS0OSD9f79bEFLBoNc=";
   };
 
-  nativeBuildInputs = [
-    python3Packages.poetry-core
-    python3Packages.shtab
-    installShellFiles
+  build-system = with python3Packages; [
+    hatchling
+    shtab
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  nativeBuildInputs = [ installShellFiles ];
+
+  dependencies = with python3Packages; [
     colorama
     libtmux
     pyyaml

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -3,8 +3,8 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
   ncurses,
-  poetry-core,
   procps,
   pytest-rerunfailures,
   pytestCheckHook,
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "libtmux";
-  version = "0.37.0";
+  version = "0.39.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     rev = "refs/tags/v${version}";
-    hash = "sha256-I0E6zkfQ6mx2svCaXEgKPhrrog3iLgXZ4E3CMMxPkIA=";
+    hash = "sha256-JqOxJD34DL5Iku3Ov8JzwSVThqDg41PQ/v1Dz6ex4ro=";
   };
 
   postPatch = ''
@@ -28,7 +28,7 @@ buildPythonPackage rec {
       --replace-fail '"--doctest-docutils-modules",' ""
   '';
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [
     procps


### PR DESCRIPTION
Diff: https://github.com/tmux-python/libtmux/compare/refs/tags/v0.37.0...v0.39.0

Changelog: https://github.com/tmux-python/libtmux/raw/v0.39.0/CHANGES


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
