### PR TITLE
wikiman: init at 2.13.2

### DIFF
--- a/pkgs/by-name/wi/wikiman/fix-paths.patch
+++ b/pkgs/by-name/wi/wikiman/fix-paths.patch
@@ -1,0 +1,44 @@
+diff --git a/wikiman.sh b/wikiman.sh
+index 89a436e..adc6510 100755
+--- a/wikiman.sh
++++ b/wikiman.sh
+@@ -46,38 +46,7 @@ if printenv WIKIMAN_TUI_PREVIEW >/dev/null; then
+ fi
+ 
+ init() {
+-
+-	# BSD compatibility: Installation prefix
+-
+-	case "$(dirname "$0")" in
+-		"$HOME/bin"|"$HOME/.local/bin")
+-			conf_sys_usr="$HOME/.local/share";
+-			conf_sys_etc="${XDG_CONFIG_HOME:-"$HOME/.config"}/wikiman";;
+-		'/bin'|'/sbin'|'/usr/bin'|'/usr/sbin')
+-			conf_sys_usr='/usr';
+-			conf_sys_etc='/etc';;
+-		'/usr/local/bin'|'/usr/local/sbin')
+-			conf_sys_usr='/usr/local';
+-			conf_sys_etc='/usr/local/etc';;
+-		*)
+-			case "$(dirname "$(command -v wikiman)")" in
+-				"$HOME/bin"|"$HOME/.local/bin")
+-					echo 'warning: unsupported installation path, using fallback for user install' 1>&2;
+-					conf_sys_usr="$HOME/.local/share";
+-					conf_sys_etc="${XDG_CONFIG_HOME:-"$HOME/.config"}/wikiman";;
+-				'/bin'|'/sbin'|'/usr/bin'|'/usr/sbin')
+-					echo 'warning: unsupported installation path, using fallback for Linux' 1>&2;
+-					conf_sys_usr='/usr';
+-					conf_sys_etc='/etc';;
+-				'/usr/local/bin'|'/usr/local/sbin')
+-					echo 'warning: unsupported installation path, using fallback for BSD' 1>&2;
+-					conf_sys_usr='/usr/local';
+-					conf_sys_etc='/usr/local/etc';;
+-				*)
+-					echo 'error: unsupported installation path - failed to establish fallback' 1>&2;
+-					exit 5;;
+-			esac;;
+-	esac
++	conf_sys_etc="/etc/xdg/wikiman/wikiman.conf"
+ 
+ 	export conf_sys_usr
+ 	export conf_sys_etc

--- a/pkgs/by-name/wi/wikiman/package.nix
+++ b/pkgs/by-name/wi/wikiman/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+
+  fzf,
+  ripgrep,
+  gawk,
+  w3m,
+  coreutils,
+  parallel,
+
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "wikiman";
+  version = "2.13.2";
+
+  src = fetchFromGitHub {
+    owner = "filiparag";
+    repo = "wikiman";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-gk/9PVIRw9OQrdCSS+LcniXDYNcHUQUxZ2XGQCwpHaI=";
+  };
+
+  patches = [ ./fix-paths.patch ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  postInstall = ''
+    mv $out/usr/* $out
+    rmdir $out/usr
+  '';
+
+  postFixup =
+    let
+      runtimeDependencies = [
+        fzf
+        ripgrep
+        gawk
+        w3m
+        coreutils
+        parallel
+      ];
+    in
+    ''
+      wrapProgram $out/bin/wikiman \
+        --prefix PATH : "${lib.makeBinPath runtimeDependencies}":$out/bin \
+        --set "conf_sys_usr" "$out"
+    '';
+
+  # Couldn't do a versionCheckHook since the script fails when no sources are found.
+  # Even when just printing the version. Yeah.
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offline search engine for manual pages, Arch Wiki, Gentoo Wiki and other documentation";
+    homepage = "https://github.com/filiparag/wikiman";
+    license = with lib.licenses; [ mit ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "wikiman";
+  };
+})


### PR DESCRIPTION
Closes #359330

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
