### PR TITLE
moneydance: fix GTK crash

### DIFF
--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -1,9 +1,11 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchzip,
   makeWrapper,
   openjdk23,
+  wrapGAppsHook3,
   jvmFlags ? [ ],
 }:
 let
@@ -20,8 +22,25 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wwSb3CuhuXB4I9jq+TpLPbd1k9UzqQbAaZkGKgi+nns=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  # We must use wrapGAppsHook (since Java GUIs on Linux use GTK), but by
+  # default that uses makeBinaryWrapper which doesn't support flags that need
+  # quoting: <https://github.com/NixOS/nixpkgs/issues/330471>. Thanks to
+  # @Artturin for the tip to override the wrapper generator.
+  nativeBuildInputs = [
+    makeWrapper
+    (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
+  ];
   buildInputs = [ jdk ];
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec $out/bin
+    cp -p $src/lib/* $out/libexec/
+
+    runHook postInstall
+  '';
 
   # Note the double escaping in the call to makeWrapper. The escapeShellArgs
   # call quotes each element of the flags list as a word[1] and returns a
@@ -31,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # 1. https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html
   # 2. https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
-  installPhase =
+  postFixup =
     let
       finalJvmFlags = [
         "-client"
@@ -42,14 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
       ] ++ jvmFlags ++ [ "Moneydance" ];
     in
     ''
-      runHook preInstall
-
-      mkdir -p $out/libexec $out/bin
-      cp -p $src/lib/* $out/libexec/
+      # This is in postFixup because gappsWrapperArgs is generated in preFixup
       makeWrapper ${jdk}/bin/java $out/bin/moneydance \
+        "''${gappsWrapperArgs[@]}" \
         --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)}
-
-      runHook postInstall
     '';
 
   passthru = {

--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchzip, makeWrapper, openjdk23, jvmFlags ? [ ] }:
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  openjdk23,
+  jvmFlags ? [ ],
+}:
 let
   jdk = openjdk23.override {
     enableJavaFX = true;
@@ -24,26 +31,30 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # 1. https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html
   # 2. https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
-  installPhase = let
-    finalJvmFlags = [
-      "-client"
-      "--add-modules"
-      "javafx.swing,javafx.controls,javafx.graphics"
-      "-classpath"
-      "${placeholder "out"}/libexec/*"
-    ] ++ jvmFlags ++ [ "Moneydance" ];
-  in ''
-    runHook preInstall
+  installPhase =
+    let
+      finalJvmFlags = [
+        "-client"
+        "--add-modules"
+        "javafx.swing,javafx.controls,javafx.graphics"
+        "-classpath"
+        "${placeholder "out"}/libexec/*"
+      ] ++ jvmFlags ++ [ "Moneydance" ];
+    in
+    ''
+      runHook preInstall
 
-    mkdir -p $out/libexec $out/bin
-    cp -p $src/lib/* $out/libexec/
-    makeWrapper ${jdk}/bin/java $out/bin/moneydance \
-      --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)}
+      mkdir -p $out/libexec $out/bin
+      cp -p $src/lib/* $out/libexec/
+      makeWrapper ${jdk}/bin/java $out/bin/moneydance \
+        --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)}
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
-  passthru = { inherit jdk; };
+  passthru = {
+    inherit jdk;
+  };
 
   meta = {
     homepage = "https://infinitekind.com/moneydance";


### PR DESCRIPTION
Fixes a GTK crash on Linux due to ["No GSettings schemas are installed on the system"](https://nixos.wiki/wiki/Packaging/Quirks_and_Caveats#GLib-GIO-Message:_Using_the_.27memory.27_GSettings_backend._Your_settings_will_not_be_saved_or_shared_with) by adding `wrapGAppsHook`. While we're at it, get ahead of the formatting RFC and apply the new `nixfmt`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
