### PR TITLE
treewide: use dpkg setup hook

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook3 ];
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
-
   dontBuild = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -33,11 +33,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook3 ];
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
-
   dontBuild = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -32,16 +32,12 @@ stdenv.mkDerivation rec {
   version = "5.2.5";
 
   src = fetchurl {
+    name = "bitwig-studio-${version}.deb";
     url = "https://www.bitwig.com/dl/Bitwig%20Studio/${version}/installer_linux/";
     hash = "sha256-x6Uw6o+a3nArMm1Ev5ytGtLDGQ3r872WqlC022zT8Hk=";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook3 ];
-
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
 
   dontBuild = true;
   dontWrapGApps = true; # we only want $gappsWrapperArgs here

--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper dpkg desktop-file-utils asar ];
 
-  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
-
   installPhase = let
     libPath = lib.makeLibraryPath [
       libsecret

--- a/pkgs/applications/graphics/odafileconverter/default.nix
+++ b/pkgs/applications/graphics/odafileconverter/default.nix
@@ -18,15 +18,10 @@ in mkDerivation {
     sha256 = "10027a3ab18efd04ca75aa699ff550eca3bdfe6f7084460d3c00001bffb50070";
   };
 
-  unpackPhase = ''
-    dpkg -x $src oda_unpacked
-    sourceRoot=$PWD/oda_unpacked
-  '';
-
   installPhase = ''
     mkdir -p $out/bin $out/lib
-    cp -vr $sourceRoot/usr/bin/ODAFileConverter_${version} $out/libexec
-    cp -vr $sourceRoot/usr/share $out/share
+    cp -vr usr/bin/ODAFileConverter_${version} $out/libexec
+    cp -vr usr/share $out/share
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/applications/misc/parsec/bin.nix
+++ b/pkgs/applications/misc/parsec/bin.nix
@@ -33,14 +33,6 @@ stdenvNoCC.mkDerivation {
     sha256 = "sha256-9F56u+jYj2CClhbnGlLi65FxS1Vq00coxwu7mjVTY1w=";
   };
 
-  unpackPhase = ''
-    runHook preUnpack
-
-    dpkg-deb -x $src .
-
-    runHook postUnpack
-  '';
-
   nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper ];
 
   buildInputs = [

--- a/pkgs/applications/misc/pdfstudio/common.nix
+++ b/pkgs/applications/misc/pdfstudio/common.nix
@@ -46,7 +46,6 @@ let
       })
     ];
 
-    unpackCmd = "dpkg-deb -x $src ./${program}-${version}";
     dontBuild = true;
 
     postPatch = ''

--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -20,11 +20,7 @@ in mkDerivation rec {
   nativeBuildInputs = [ dpkg ];
   # avoid https://github.com/NixOS/patchelf/issues/99
   dontStrip = true;
-  unpackPhase = ''
-    mkdir pkg
-    dpkg-deb -x $src pkg
-    sourceRoot=pkg
-  '';
+
   installPhase = ''
     mkdir -p $out/bin
     cp usr/bin/rescuetime $out/bin

--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -24,8 +24,6 @@ let
         makeWrapper
       ];
 
-      unpackPhase = "dpkg-deb -x $src .";
-
       installPhase = ''
         mkdir -p $out/bin
         mv usr/share $out/share

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -71,8 +71,6 @@ in stdenv.mkDerivation (rec {
   ];
   runtimeDependencies = [ libglvnd (lib.getLib stdenv.cc.cc) (lib.getLib udev) libnotify libappindicator-gtk3 ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   installPhase = ''
     mkdir -p $out/bin
     cp -r opt $out

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -99,8 +99,6 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   runtimeDependencies = [ (lib.getLib systemd) libGL libnotify libappindicator wayland ];
 
   installPhase = ''

--- a/pkgs/applications/office/morgen/default.nix
+++ b/pkgs/applications/office/morgen/default.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation rec {
   version = "3.5.9";
 
   src = fetchurl {
+    name = "morgen-${version}.deb";
     url = "https://dl.todesktop.com/210203cqcj00tw1/versions/${version}/linux/deb";
     hash = "sha256-ZKlj/QuQnrqQepsJY6KCROC2fXK/4Py5tmI/FVnRi9w=";
   };
@@ -18,10 +19,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ alsa-lib gtk3 libxshmfence mesa nss ];
-
-  unpackCmd = ''
-    dpkg-deb -x ${src} ./morgen-${pname}
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/al/alfaview/package.nix
+++ b/pkgs/by-name/al/alfaview/package.nix
@@ -50,10 +50,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/bd/bdf2psf/package.nix
+++ b/pkgs/by-name/bd/bdf2psf/package.nix
@@ -14,12 +14,6 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
   dontBuild = true;
 
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x $src .
-    runHook postUnpack
-  '';
-
   installPhase = ''
     runHook preInstall
     substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl "${perl}/bin/perl"

--- a/pkgs/by-name/bl/bluemail/package.nix
+++ b/pkgs/by-name/bl/bluemail/package.nix
@@ -64,8 +64,6 @@ stdenv.mkDerivation rec {
     udev
   ];
 
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
-
   dontBuild = true;
   dontStrip = true;
   dontWrapGApps = true;

--- a/pkgs/by-name/br/brave/make-brave.nix
+++ b/pkgs/by-name/br/brave/make-brave.nix
@@ -189,12 +189,6 @@ stdenv.mkDerivation {
     adwaita-icon-theme
   ];
 
-  unpackPhase =
-    if stdenv.hostPlatform.isLinux then
-      "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner"
-    else
-      "unzip $src";
-
   installPhase =
     lib.optionalString stdenv.hostPlatform.isLinux ''
       runHook preInstall

--- a/pkgs/by-name/cu/cups-brother-hll2375dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hll2375dw/package.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-N5VCBZLFrfw29QjjzlSvQ12urvyaf7ez/RJ08UwqHdk=";
   };
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   patches = [
     # The brother lpdwrapper uses a temporary file to convey the printer settings.
     # The original settings file will be copied with "400" permissions and the "brprintconflsr3"

--- a/pkgs/by-name/ff/fflinuxprint/package.nix
+++ b/pkgs/by-name/ff/fflinuxprint/package.nix
@@ -16,9 +16,6 @@ stdenv.mkDerivation (finalAttrs: {
     curlOpts = "--user-agent Mozilla/5.0"; # HTTP 410 otherwise
   };
 
-  sourceRoot = ".";
-  unpackCmd = "dpkg-deb -x $curSrc .";
-
   nativeBuildInputs = [
     autoPatchelfHook
     dpkg

--- a/pkgs/by-name/ga/gamepad-tool/package.nix
+++ b/pkgs/by-name/ga/gamepad-tool/package.nix
@@ -11,11 +11,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ dpkg qt5.wrapQtAppsHook autoPatchelfHook ];
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $curSrc root
-  '';
-
   dontBuild = true;
 
   buildInputs = [

--- a/pkgs/by-name/he/headset/package.nix
+++ b/pkgs/by-name/he/headset/package.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper dpkg ];
 
-  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/ho/holochain-launcher/package.nix
+++ b/pkgs/by-name/ho/holochain-launcher/package.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
     glib-networking
   ];
 
-  unpackCmd = "dpkg-deb -x $curSrc source";
-
   installPhase = ''
     mv usr $out
     mv $out/bin/holochain-launcher-${prerelease} $out/bin/holochain-launcher

--- a/pkgs/by-name/hy/hyper/package.nix
+++ b/pkgs/by-name/hy/hyper/package.nix
@@ -24,12 +24,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg ];
 
-  unpackPhase = ''
-    mkdir pkg
-    dpkg-deb -x $src pkg
-    sourceRoot=pkg
-  '';
-
   installPhase = ''
     mkdir -p "$out/bin"
     mv opt "$out/"

--- a/pkgs/by-name/id/ideamaker/package.nix
+++ b/pkgs/by-name/id/ideamaker/package.nix
@@ -131,12 +131,6 @@ stdenv.mkDerivation (finalAttrs: {
       libsForQt5.quazip
     ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x $src .
-    runHook postUnpack
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/in/insync-emblem-icons/package.nix
+++ b/pkgs/by-name/in/insync-emblem-icons/package.nix
@@ -19,14 +19,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ dpkg ];
 
-  unpackPhase = ''
-    runHook preUnpack
-
-    dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-permissions --no-same-owner
-
-    runHook postUnpack
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/in/insync/package.nix
+++ b/pkgs/by-name/in/insync/package.nix
@@ -46,14 +46,6 @@ let
       libthai
     ] ++ (with libsForQt5; [ qt5.qtvirtualkeyboard ]);
 
-    unpackPhase = ''
-      runHook preUnpack
-
-      dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-permissions --no-same-owner
-
-      runHook postUnpack
-    '';
-
     installPhase = ''
       runHook preInstall
 

--- a/pkgs/by-name/ip/ipscan/package.nix
+++ b/pkgs/by-name/ip/ipscan/package.nix
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-UPkUwZV3NIeVfL3yYvqOhm4X5xW+40GOlZGy8WGhYmk=";
   };
 
-  sourceRoot = ".";
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src .";
-
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
 
   buildInputs = [ jdk ];
 

--- a/pkgs/by-name/ji/jigasi/package.nix
+++ b/pkgs/by-name/ji/jigasi/package.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
 
   dontBuild = true;
 
-  unpackCmd = "dpkg-deb -x $src debcontents";
-
   installPhase = ''
     runHook preInstall
     substituteInPlace usr/share/${pname}/${pname}.sh \

--- a/pkgs/by-name/ke/keeweb/package.nix
+++ b/pkgs/by-name/ke/keeweb/package.nix
@@ -112,13 +112,10 @@ else
     nativeBuildInputs = [
       autoPatchelfHook
       wrapGAppsHook3
+      dpkg
     ];
 
     buildInputs = libraries;
-
-    unpackPhase = ''
-      ${dpkg}/bin/dpkg-deb --fsys-tarfile $src | tar --extract
-    '';
 
     installPhase = ''
       runHook preInstall

--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gHn1xqBc7M9wkek1Ja1gry8TKIuUxQP8T45x3z2S4uc=";
   };
 
-  sourceRoot = ".";
   nativeBuildInputs = [ makeWrapper dpkg ];
   buildInputs = [
     glib
@@ -50,7 +49,6 @@ stdenv.mkDerivation rec {
     sdcv
     SDL2
   ];
-  unpackCmd = "dpkg-deb -x ${src} .";
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/by-name/li/lightworks/package.nix
+++ b/pkgs/by-name/li/lightworks/package.nix
@@ -65,10 +65,10 @@ let
       else
         throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
 
-    nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ dpkg ];
-
-    unpackPhase = "dpkg-deb -x ${src} ./";
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
 
     installPhase = ''
       mkdir -p $out/bin

--- a/pkgs/by-name/lu/lunacy/package.nix
+++ b/pkgs/by-name/lu/lunacy/package.nix
@@ -27,11 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-roD/bKv1N2sru/tZ6Zl1J2AyY1mgj2ssB2a42kwBNHM=";
   };
 
-  unpackCmd = ''
-    mkdir -p root
-    dpkg-deb -x $src root
-  '';
-
   buildInputs = [
     zlib
     libgcc

--- a/pkgs/by-name/mo/molly-guard/package.nix
+++ b/pkgs/by-name/mo/molly-guard/package.nix
@@ -9,11 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1k6b1hn8lc4rj9n036imsl7s9lqj6ny3acdhnbnamsdkkndmxrw7";
   };
 
-  buildInputs = [ dpkg ];
-
-  unpackCmd = ''
-    dpkg-deb -x "$src" source
-  '';
+  nativeBuildInputs = [ dpkg ];
 
   installPhase = ''
     sed -i "s|/lib/molly-guard|${systemd}/sbin|g" lib/molly-guard/molly-guard

--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -120,10 +120,6 @@ let
 
     dontWrapQtApps = true;
 
-    unpackPhase = ''
-      dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
-    '';
-
     installPhase = ''
       runHook preInstall
 

--- a/pkgs/by-name/op/opera/package.nix
+++ b/pkgs/by-name/op/opera/package.nix
@@ -58,8 +58,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-PBbozIdA+cfEzGIyL1P+25FZtrnd7ldctOtZYomKd/8=";
   };
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook

--- a/pkgs/by-name/pi/picoscope/package.nix
+++ b/pkgs/by-name/pi/picoscope/package.nix
@@ -29,8 +29,7 @@ let
       src = fetchurl { inherit (sources.libpicoipp) url sha256; };
       nativeBuildInputs = [ dpkg autoPatchelfHook ];
       buildInputs = [ (lib.getLib stdenv.cc.cc) ];
-      sourceRoot = ".";
-      unpackCmd = "dpkg-deb -x $src .";
+
       installPhase = ''
         runHook preInstall
         mkdir -p $out/lib
@@ -57,8 +56,6 @@ let
       src = fetchurl { inherit url sha256; };
       # picoscope does a signature check, so we can't patchelf these
       nativeBuildInputs = [ dpkg ];
-      sourceRoot = ".";
-      unpackCmd = "dpkg-deb -x $src .";
       installPhase = ''
         runHook preInstall
         mkdir -p $out/lib
@@ -82,8 +79,6 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ dpkg makeWrapper ];
   buildInputs = [ gtk-sharp-3_0 mono glib libusb1 zlib ];
 
-  unpackCmd = "dpkg-deb -x $src .";
-  sourceRoot = ".";
   scopeLibs = lib.attrVals (map (x: "lib${x}") scopes) scopePkgs;
   MONO_PATH = "${gtk-sharp-3_0}/lib/mono/gtk-sharp-3.0:" + (lib.makeLibraryPath
     ([

--- a/pkgs/by-name/pi/pixeluvo/package.nix
+++ b/pkgs/by-name/pi/pixeluvo/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/po/polar-bookshelf/package.nix
+++ b/pkgs/by-name/po/polar-bookshelf/package.nix
@@ -93,8 +93,6 @@ stdenv.mkDerivation rec {
 
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/po/polar-bookshelf1/package.nix
+++ b/pkgs/by-name/po/polar-bookshelf1/package.nix
@@ -87,10 +87,6 @@ stdenv.mkDerivation rec {
 
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
 
-  unpackPhase = ''
-    dpkg-deb -x $src .
-  '';
-
   installPhase = ''
     mkdir -p $out/share/polar-bookshelf $out/bin $out/lib
     mv opt/Polar\ Bookshelf/* $out/share/polar-bookshelf

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
     [ makeShellWrapper ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       alsa-lib
-      dpkg
       gtk3
       libglvnd
       libxkbcommon
@@ -62,6 +61,7 @@ stdenv.mkDerivation {
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
+      dpkg
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       _7zz
@@ -71,8 +71,6 @@ stdenv.mkDerivation {
     # Needed to fix the "Zygote could not fork" error.
     (lib.getLib systemd)
   ];
-
-  postUnpack = lib.optionalString stdenv.hostPlatform.isLinux ''dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-owner'';
 
   installPhase =
     if stdenv.hostPlatform.isDarwin then

--- a/pkgs/by-name/sp/spacedrive/package.nix
+++ b/pkgs/by-name/sp/spacedrive/package.nix
@@ -115,14 +115,6 @@ else
       gst_all_1.gstreamer
     ];
 
-    unpackPhase = ''
-      runHook preUnpack
-
-      dpkg-deb -x $src .
-
-      runHook postUnpack
-    '';
-
     installPhase = ''
       runHook preInstall
 

--- a/pkgs/by-name/ss/sslmate-agent/package.nix
+++ b/pkgs/by-name/ss/sslmate-agent/package.nix
@@ -14,10 +14,6 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
   ];
 
-  unpackCmd = ''
-    dpkg-deb -x ${src} ./sslmate-agent-${pname}
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/st/staruml/package.nix
+++ b/pkgs/by-name/st/staruml/package.nix
@@ -35,12 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ wrapGAppsHook3 dpkg ];
   buildInputs = [ glib hicolor-icon-theme ];
 
-  unpackPhase = ''
-    mkdir pkg
-    dpkg-deb -x $src pkg
-    sourceRoot=pkg
-  '';
-
   installPhase = ''
     mkdir -p $out/bin
     mv opt $out

--- a/pkgs/by-name/te/terra-station/package.nix
+++ b/pkgs/by-name/te/terra-station/package.nix
@@ -30,14 +30,10 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ makeWrapper asar ];
+  nativeBuildInputs = [ makeWrapper asar dpkg ];
 
   dontConfigure = true;
   dontBuild = true;
-
-  unpackPhase = ''
-    ${dpkg}/bin/dpkg-deb -x $src .
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/th/thedesk/package.nix
+++ b/pkgs/by-name/th/thedesk/package.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -92,8 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
   runtimeDependencies =
     [ (lib.getLib systemd) libnotify libdbusmenu xdg-utils ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/un/unifi/package.nix
+++ b/pkgs/by-name/un/unifi/package.nix
@@ -18,12 +18,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x $src ./
-    runHook postUnpack
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/up/upwork/package.nix
+++ b/pkgs/by-name/up/upwork/package.nix
@@ -32,10 +32,6 @@ stdenv.mkDerivation rec {
 
   dontWrapGApps = true;
 
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -109,14 +109,6 @@ let
       systemd
     ];
 
-    unpackPhase = ''
-      runHook preUnpack
-
-      dpkg-deb -x $src .
-
-      runHook postUnpack
-    '';
-
     installPhase = ''
       runHook preInstall
 

--- a/pkgs/by-name/wk/wkhtmltopdf/package.nix
+++ b/pkgs/by-name/wk/wkhtmltopdf/package.nix
@@ -56,19 +56,10 @@ let
       (lib.getLib libpng)
     ];
 
-    unpackPhase = ''
-      runHook preUnpack
-
-      mkdir pkg
-      dpkg-deb -x $src pkg
-
-      runHook postUnpack
-    '';
-
     installPhase = ''
       runHook preInstall
 
-      cp -r pkg/usr/local $out
+      cp -r usr/local $out
 
       runHook postInstall
     '';

--- a/pkgs/by-name/wo/wonderdraft/package.nix
+++ b/pkgs/by-name/wo/wonderdraft/package.nix
@@ -17,8 +17,10 @@ stdenv.mkDerivation rec {
     url = "https://wonderdraft.net/";
     hash = "sha256-3eYnEH6P94z9axFsrkJA4QMcHyg/gNRczqL3h5Sc2Tg=";
   };
-  sourceRoot = ".";
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";
+
+  nativeBuildInputs = [
+    dpkg
+  ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/by-name/ye/yesplaymusic/package.nix
+++ b/pkgs/by-name/ye/yesplaymusic/package.nix
@@ -100,6 +100,7 @@ else stdenv.mkDerivation {
     autoPatchelfHook
     wrapGAppsHook3
     makeWrapper
+    dpkg
   ];
 
   buildInputs = libraries;
@@ -107,10 +108,6 @@ else stdenv.mkDerivation {
   runtimeDependencies = [
     (lib.getLib systemd)
   ];
-
-  unpackPhase = ''
-    ${dpkg}/bin/dpkg-deb -x $src .
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/misc/jitsi-meet-prosody/default.nix
+++ b/pkgs/misc/jitsi-meet-prosody/default.nix
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "LsZItRkFvpYaj5DwEv4C6tRpmypHadzSVv8/Wto2/68=";
   };
 
-  dontBuild = true;
+  nativeBuildInputs = [ dpkg ];
 
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/jicofo/default.nix
+++ b/pkgs/servers/jicofo/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   dontBuild = true;
 
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+  nativeBuildInputs = [ dpkg ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -13,9 +13,10 @@ stdenv.mkDerivation {
 
   dontBuild = true;
 
-  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
-
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/plex/raw.nix
+++ b/pkgs/servers/plex/raw.nix
@@ -28,10 +28,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg ];
 
-  unpackPhase = ''
-    dpkg-deb -R $src .
-  '';
-
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/lib"


### PR DESCRIPTION
Make use of the setup-hook included in dpkg.

2 packages failed to build before:
- pdfstudioviewer
  - hash mismatch
- wonderdraft
  - requires pre-downloading

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
