### PR TITLE
openbsd.{pathDefinesHook,init,mount}: init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/init/no-reset-path.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/init/no-reset-path.patch
@@ -1,0 +1,12 @@
+diff --git a/sbin/init/init.c b/sbin/init/init.c
+index cf7ed60afe9..2decfc15d4f 100644
+--- a/sbin/init/init.c
++++ b/sbin/init/init.c
+@@ -595,7 +595,6 @@ f_single_user(void)
+ 		 */
+ 		argv[0] = name;
+ 		argv[1] = NULL;
+-		setenv("PATH", _PATH_STDPATH, 1);
+ 		execv(shell, argv);
+ 		emergency("can't exec %s for single user: %m", shell);
+ 

--- a/pkgs/os-specific/bsd/openbsd/pkgs/init/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/init/package.nix
@@ -1,0 +1,13 @@
+{
+  mkDerivation,
+  pathDefinesHook,
+  runtimeShell,
+}:
+
+mkDerivation {
+  path = "sbin/init";
+  patches = [ ./no-reset-path.patch ];
+  extraNativeBuildInputs = [ pathDefinesHook ];
+  PATH_DEFINE__PATH_BSHELL = runtimeShell;
+  meta.mainProgram = "init";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount/package.nix
@@ -1,0 +1,9 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount";
+  meta.mainProgram = "mount";
+  patches = [ ./search-path.patch ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount/search-path.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount/search-path.patch
@@ -1,0 +1,39 @@
+diff --git a/sbin/mount/mount.c b/sbin/mount/mount.c
+index eaff190b572..4bce21559f6 100644
+--- a/sbin/mount/mount.c
++++ b/sbin/mount/mount.c
+@@ -338,12 +338,6 @@ mountfs(const char *vfstype, const char *spec, const char *name,
+ {
+ 	char *cp;
+ 
+-	/* List of directories containing mount_xxx subcommands. */
+-	static const char *edirs[] = {
+-		_PATH_SBIN,
+-		_PATH_USRSBIN,
+-		NULL
+-	};
+ 	const char **argv, **edir;
+ 	struct statfs sf;
+ 	pid_t pid;
+@@ -427,15 +421,12 @@ mountfs(const char *vfstype, const char *spec, const char *name,
+ 		return (1);
+ 	case 0:					/* Child. */
+ 		/* Go find an executable. */
+-		edir = edirs;
+-		do {
+-			(void)snprintf(execname,
+-			    sizeof(execname), "%s/mount_%s", *edir, vfstype);
+-			argv[0] = execname;
+-			execv(execname, (char * const *)argv);
+-			if (errno != ENOENT)
+-				warn("exec %s for %s", execname, name);
+-		} while (*++edir != NULL);
++		(void)snprintf(execname,
++		    sizeof(execname), "mount_%s", vfstype);
++		argv[0] = execname;
++		execvp(execname, (char * const *)argv);
++		if (errno != ENOENT)
++			warn("exec %s for %s", execname, name);
+ 
+ 		if (errno == ENOENT)
+ 			warn("no mount helper program found for %s", vfstype);

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount_ffs/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount_ffs/package.nix
@@ -1,0 +1,8 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount_ffs";
+  extraPaths = [ "sbin/mount" ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount_tmpfs/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount_tmpfs/package.nix
@@ -1,0 +1,8 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount_tmpfs";
+  extraPaths = [ "sbin/mount" ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pathDefinesHook/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pathDefinesHook/package.nix
@@ -1,0 +1,3 @@
+{ makeSetupHook }:
+
+makeSetupHook { name = "openbsd-setup-hook"; } ./setup-hook.sh

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pathDefinesHook/setup-hook.sh
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pathDefinesHook/setup-hook.sh
@@ -1,0 +1,30 @@
+# include this hook to override the filepath #defines in <paths.h>
+# adding `PATH_DEFINE__PATH_BSHELL = runtimeShell` to your derivation will add
+# `#define _PATH_BSHELL ${runtimeShell}` to your include/paths.h
+
+pathDefinesIncludeFile="$TMP/pathDefinesInclude/paths.h"
+setupPathDefinesHeader() {
+    mkdir -p "$(dirname "$pathDefinesIncludeFile")"
+    (
+        echo "#ifndef _PATH_DEFINES_NIXPKGS_H"
+        echo "#define _PATH_DEFINES_NIXPKGS_H"
+        echo "#include_next <paths.h>"
+        echo
+        # enumerate environment searching for PATH_DEFINE_*
+        # https://stackoverflow.com/questions/39529648/how-to-iterate-through-all-the-env-variables-printing-key-and-value
+        while IFS='=' read -r -d '' envName envValue; do
+            if [[ "$envName" == PATH_DEFINE_* ]]; then
+                defineName="${envName#PATH_DEFINE_}"
+                echo "#ifdef ${defineName}"
+                echo "#undef ${defineName}"
+                echo "#endif"
+                echo "#define ${defineName} \"${envValue}\""
+                echo
+            fi
+        done < <(env -0)
+        echo "#endif"
+    ) >"$pathDefinesIncludeFile"
+    export NIX_CFLAGS_COMPILE_BEFORE="$NIX_CFLAGS_COMPILE_BEFORE -I$(dirname "$pathDefinesIncludeFile")"
+}
+
+preConfigureHooks+=(setupPathDefinesHeader)


### PR DESCRIPTION
Add some basic OpenBSD tools along with `pathDefinesHook`, which makes it easy to override the contents of `paths.h`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
