### PR TITLE
ledger: fix build with boost 1.86

### DIFF
--- a/pkgs/by-name/le/ledger/package.nix
+++ b/pkgs/by-name/le/ledger/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, boost, gmp, mpfr, libedit, python3, gpgme
+{ stdenv, lib, fetchFromGitHub, fetchpatch2, cmake, boost, gmp, mpfr, libedit, python3, gpgme
 , installShellFiles, texinfo, gnused, usePython ? false, gpgmeSupport ? false }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,29 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     hash   = "sha256-Uym4s8EyzXHlISZqThcb6P1H5bdgD9vmdIOLkk5ikG0=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "ledger-boost-1.85-compat.patch";
+      url = "https://github.com/ledger/ledger/commit/46207852174feb5c76c7ab894bc13b4f388bf501.patch";
+      hash = "sha256-X0NSN60sEFLvcfMmtVoxC7fidcr5tJUlFVQ/E8qfLss=";
+    })
+    (fetchpatch2 {
+      name = "ledger-boost-1.86-compat-1.patch";
+      url = "https://github.com/ledger/ledger/commit/f6750ed89b46926d1f0859f3b25d18ed62ac219e.patch";
+      hash = "sha256-pktwotuMbZcR2DpZccMqV13524avKvazDX/+Ki6h69g=";
+    })
+    (fetchpatch2 {
+      name = "ledger-boost-1.86-compat-2.patch";
+      url = "https://github.com/ledger/ledger/commit/62f626fa73bd6832028f43c204c43cf15bd5f409.patch";
+      hash = "sha256-cazhSxadNpiA6ofZxS8JALOPy88cNPM/jKHaUYk8pBw=";
+    })
+    (fetchpatch2 {
+      name = "ledger-boost-1.86-compat-3.patch";
+      url = "https://github.com/ledger/ledger/commit/124398c35be573324cf2384c08b99b4476f29e2b.patch";
+      hash = "sha256-N3dUrqNsOiVgedoYmyfYllK+4lvKdMxc8iq0+DgEbxc=";
+    })
+  ];
 
   outputs = [ "out" "dev" ] ++ lib.optionals usePython [ "py" ];
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
