### PR TITLE
openbsd.mkDerivation: Set proper MACHINE variables

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -27,6 +27,25 @@ lib.makeOverridable (
         stdenvLibcMinimal
       else
         stdenv;
+
+    machineMap = {
+      aarch64 = "arm64";
+      armv7l = "armv7";
+      i486 = "i386";
+      i586 = "i386";
+      i686 = "i386";
+      x86_64 = "amd64";
+    };
+
+    archMap = {
+      aarch64 = "aarch64";
+      armv7l = "arm";
+      i486 = "i386";
+      i586 = "i386";
+      i686 = "i386";
+      x86_64 = "amd64";
+    };
+
   in
   stdenv'.mkDerivation (
     rec {
@@ -57,22 +76,12 @@ lib.makeOverridable (
 
       HOST_SH = stdenv'.shell;
 
-      MACHINE_ARCH =
-        {
-          # amd64 not x86_64 for this on unlike NetBSD
-          x86_64 = "amd64";
-          aarch64 = "arm64";
-          i486 = "i386";
-          i586 = "i386";
-          i686 = "i386";
-        }
-        .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
-
-      MACHINE = MACHINE_ARCH;
-
+      MACHINE = machineMap.${stdenv'.hostPlatform.parsed.cpu.name};
+      MACHINE_ARCH = archMap.${stdenv'.hostPlatform.parsed.cpu.name};
       MACHINE_CPU = MACHINE_ARCH;
 
-      MACHINE_CPUARCH = MACHINE_ARCH;
+      TARGET_MACHINE_ARCH = archMap.${stdenv'.targetPlatform.parsed.cpu.name};
+      TARGET_MACHINE_CPU = TARGET_MACHINE_ARCH;
 
       COMPONENT_PATH = attrs.path or null;
 


### PR DESCRIPTION
OpenBSD values for MACHINE/MACHINE_ARCH/MACHINE_CPU are slightly different than other BSDs. While fixing these, also set TARGET_ARCH/TARGET_CPU, needed by a small number of yet-to-be-packaged programs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
