### PR TITLE
notonoto: fix font installation issues, notonoto-hs: init at 0.0.3

### DIFF
--- a/pkgs/by-name/no/notonoto-hs/package.nix
+++ b/pkgs/by-name/no/notonoto-hs/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  fontforge,
+  python3,
+}:
+
+let
+  python3' = python3.withPackages (
+    ps: with ps; [
+      fonttools
+      ttfautohint-py
+    ]
+  );
+in
+
+stdenvNoCC.mkDerivation rec {
+  pname = "notonoto-hs";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "yuru7";
+    repo = "NOTONOTO";
+    tag = "v${version}";
+    hash = "sha256-1dbx4yC8gL41OEAE/LNDyoDb4xhAwV5h8oRmdlPULUo=";
+  };
+
+  nativeBuildInputs = [
+    fontforge
+    python3'
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    fontforge --script fontforge_script.py --hidden-zenkaku-space
+    python3 ./fonttools_script.py
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 build/*.ttf -t $out/share/fonts/truetype/notonoto-hs
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Programming font that combines Noto Sans Mono and Noto Sans JP";
+    homepage = "https://github.com/yuru7/NOTONOTO";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ genga898 ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/no/notonoto/package.nix
+++ b/pkgs/by-name/no/notonoto/package.nix
@@ -2,7 +2,19 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
+  fontforge,
+  python3,
 }:
+
+let
+  python3' = python3.withPackages (
+    ps: with ps; [
+      fonttools
+      ttfautohint-py
+    ]
+  );
+in
+
 stdenvNoCC.mkDerivation rec {
   pname = "notonoto";
   version = "0.0.3";
@@ -14,10 +26,24 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-1dbx4yC8gL41OEAE/LNDyoDb4xhAwV5h8oRmdlPULUo=";
   };
 
+  nativeBuildInputs = [
+    fontforge
+    python3'
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    fontforge --script fontforge_script.py
+    python3 ./fonttools_script.py
+
+    runHook postBuild
+  '';
+
   installPhase = ''
     runHook preInstall
 
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/notonoto {} \;
+    install -Dm444 build/*.ttf -t $out/share/fonts/truetype/notonoto
 
     runHook postInstall
   '';
@@ -27,7 +53,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/yuru7/NOTONOTO";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ genga898 ];
-    mainProgram = "notonoto";
+    platforms = lib.platforms.all;
   };
-
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #359013

Fixes issue on the wrong fonts being installed, replacing `fetchFromGitHub` with `fetchzip` to fetch the built fonts from 
the releases page. 

Add [notonoto-hs](https://github.com/yuru7/NOTONOTO) to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
