### PR TITLE
hdf4: 4.2.15 -> 4.3.0

### DIFF
--- a/pkgs/by-name/hd/hdf4/package.nix
+++ b/pkgs/by-name/hd/hdf4/package.nix
@@ -5,6 +5,7 @@
   fetchurl,
   fixDarwinDylibNames,
   cmake,
+  ninja,
   libjpeg,
   uselibtirpc ? stdenv.hostPlatform.isLinux,
   libtirpc,
@@ -30,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     [
       cmake
+      ninja
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       fixDarwinDylibNames

--- a/pkgs/by-name/hd/hdf4/package.nix
+++ b/pkgs/by-name/hd/hdf4/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
   stdenv,
-  fetchpatch,
-  fetchurl,
-  fixDarwinDylibNames,
+  fetchFromGitHub,
   cmake,
   ninja,
   libjpeg,
@@ -21,22 +19,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hdf";
-  version = "4.2.16-2";
+  version = "4.3.0";
 
-  src = fetchurl {
-    url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${finalAttrs.version}/src/hdf-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-xcMjS1ASJYrvLkQy9kmzHCGyYBWvuhhXrYNkDD8raSw=";
+  src = fetchFromGitHub {
+    owner = "HDFGroup";
+    repo = "hdf4";
+    rev = "refs/tags/hdf${finalAttrs.version}";
+    hash = "sha256-Q2VKwkp/iroStrOnwHI8d/dtMWkMoJesBVBVChwNa30=";
   };
 
-  nativeBuildInputs =
-    [
-      cmake
-      ninja
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      fixDarwinDylibNames
-    ]
-    ++ lib.optional fortranSupport gfortran;
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ] ++ lib.optional fortranSupport gfortran;
 
   buildInputs =
     [
@@ -47,23 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional szipSupport szip
     ++ lib.optional uselibtirpc libtirpc;
 
-  preConfigure =
-    lib.optionalString uselibtirpc ''
-      # Make tirpc discovery work with CMAKE_PREFIX_PATH
-      substituteInPlace config/cmake/FindXDR.cmake \
-        --replace-fail 'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATHS "/usr/include" "/usr/include/tirpc")' \
-                       'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATH_SUFFIXES include/tirpc)'
-    ''
-    + lib.optionalString szipSupport ''
-      export SZIP_INSTALL=${szip}
-    '';
-
   cmakeFlags =
     [
       (lib.cmakeBool "BUILD_SHARED_LIBS" true)
       (lib.cmakeBool "HDF4_BUILD_TOOLS" true)
       (lib.cmakeBool "HDF4_BUILD_UTILS" true)
-      (lib.cmakeBool "HDF4_BUILD_WITH_INSTALL_NAME" false)
+      (lib.cmakeBool "HDF4_BUILD_WITH_INSTALL_NAME" true)
       (lib.cmakeBool "HDF4_ENABLE_JPEG_LIB_SUPPORT" true)
       (lib.cmakeBool "HDF4_ENABLE_Z_LIB_SUPPORT" true)
       (lib.cmakeBool "HDF4_ENABLE_NETCDF" netcdfSupport)
@@ -87,33 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeFeature "H4_PRINTF_LL_TEST_RUN__TRYRUN_OUTPUT" "")
     ];
 
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=implicit-function-declaration"
-      "-Wno-error=implicit-int"
-    ];
-  };
-
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
-  excludedTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    "MFHDF_TEST-hdftest"
-    "MFHDF_TEST-hdftest-shared"
-    "HDP-dumpsds-18"
-    "NC_TEST-nctest"
-  ];
-
-  checkPhase =
-    let
-      excludedTestsRegex = lib.optionalString (
-        finalAttrs.excludedTests != [ ]
-      ) "(${lib.concatStringsSep "|" finalAttrs.excludedTests})";
-    in
-    ''
-      runHook preCheck
-      ctest -E "${excludedTestsRegex}" --output-on-failure
-      runHook postCheck
-    '';
+  doCheck = true;
 
   outputs = [
     "bin"


### PR DESCRIPTION
Includes fixes for GCC 14.

I love it when an update simplifies things. I’ve checked the build with all the feature flags enabled and on GCC 14 and LLVM 19. Not sure if the cross stuff is still necessary, but I didn’t test it so I’ve left it alone.

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages marked as broken and skipped:</summary>
  <ul>
    <li>hdfview</li>
    <li>python311Packages.python-mapnik</li>
    <li>python311Packages.python-mapnik.dist</li>
    <li>python311Packages.worldengine</li>
    <li>python311Packages.worldengine.dist</li>
    <li>python312Packages.python-mapnik</li>
    <li>python312Packages.python-mapnik.dist</li>
    <li>python312Packages.shimmy</li>
    <li>python312Packages.shimmy.dist</li>
    <li>python312Packages.worldengine</li>
    <li>python312Packages.worldengine.dist</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>t-rex</li>
  </ul>
</details>
<details>
  <summary>145 packages built:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>cloudcompare</li>
    <li>entwine</li>
    <li>gdal (python312Packages.gdal)</li>
    <li>gmt</li>
    <li>gnudatalanguage</li>
    <li>gplates</li>
    <li>grass</li>
    <li>h5utils</li>
    <li>hdf4</li>
    <li>hdf4.bin</li>
    <li>hdf4.dev</li>
    <li>mapcache</li>
    <li>mapnik</li>
    <li>mapproxy</li>
    <li>mapproxy.dist</li>
    <li>mapserver</li>
    <li>merkaartor</li>
    <li>mysql-workbench</li>
    <li>octavePackages.mapping</li>
    <li>openorienteering-mapper</li>
    <li>paraview</li>
    <li>pdal</li>
    <li>perl538Packages.Tirex</li>
    <li>perl538Packages.Tirex.devdoc</li>
    <li>perl540Packages.Tirex</li>
    <li>perl540Packages.Tirex.devdoc</li>
    <li>python311Packages.bsuite</li>
    <li>python311Packages.bsuite.dist</li>
    <li>python311Packages.cartopy</li>
    <li>python311Packages.cartopy.dist</li>
    <li>python311Packages.django-bootstrap4</li>
    <li>python311Packages.django-bootstrap4.dist</li>
    <li>python311Packages.django-bootstrap5</li>
    <li>python311Packages.django-bootstrap5.dist</li>
    <li>python311Packages.drf-extra-fields</li>
    <li>python311Packages.drf-extra-fields.dist</li>
    <li>python311Packages.fiona</li>
    <li>python311Packages.fiona.dist</li>
    <li>python311Packages.folium</li>
    <li>python311Packages.folium.dist</li>
    <li>python311Packages.gdal</li>
    <li>python311Packages.geoarrow-pandas</li>
    <li>python311Packages.geoarrow-pandas.dist</li>
    <li>python311Packages.geoarrow-pyarrow</li>
    <li>python311Packages.geoarrow-pyarrow.dist</li>
    <li>python311Packages.geodatasets</li>
    <li>python311Packages.geodatasets.dist</li>
    <li>python311Packages.geopandas</li>
    <li>python311Packages.geopandas.dist</li>
    <li>python311Packages.geoparquet</li>
    <li>python311Packages.geoparquet.dist</li>
    <li>python311Packages.inequality</li>
    <li>python311Packages.inequality.dist</li>
    <li>python311Packages.libpysal</li>
    <li>python311Packages.libpysal.dist</li>
    <li>python311Packages.mapclassify</li>
    <li>python311Packages.mapclassify.dist</li>
    <li>python311Packages.momepy</li>
    <li>py
    <li>py
    <li>python311Packages.morecantile.dist</li>
    <li>python311Packages.netbox-documents</li>
    <li>python311Packages.netbox-documents.dist</li>
    <li>python311Packages.osmnx</li>
    <li>python311Packages.osmnx.dist</li>
    <li>python311Packages.plotnine</li>
    <li>python311Packages.plotnine.dist</li>
    <li>python311Packages.pygmt</li>
    <li>python311Packages.pygmt.dist</li>
    <li>python311Packages.pyogrio</li>
    <li>python311Packages.pyogrio.dist</li>
    <li>python311Packages.rasterio</li>
    <li>python311Packages.rasterio.dist</li>
    <li>python311Packages.rio-tiler</li>
    <li>python311Packages.rio-tiler.dist</li>
    <li>python311Packages.rioxarray</li>
    <li>python311Packages.rioxarray.dist</li>
    <li>python311Packages.shimmy</li>
    <li>python311Packages.shimmy.dist</li>
    <li>python311Packages.wktutils</li>
    <li>python311Packages.wktutils.dist</li>
    <li>python312Packages.bsuite</li>
    <li>python312Packages.bsuite.dist</li>
    <li>python312Packages.cartopy</li>
    <li>python312Packages.cartopy.dist</li>
    <li>python312Packages.django-bootstrap4</li>
    <li>python312Packages.django-bootstrap4.dist</li>
    <li>python312Packages.django-bootstrap5</li>
    <li>python312Packages.django-bootstrap5.dist</li>
    <li>python312Packages.drf-extra-fields</li>
    <li>python312Packages.drf-extra-fields.dist</li>
    <li>python312Packages.fiona</li>
    <li>python312Packages.fiona.dist</li>
    <li>python312Packages.folium</li>
    <li>python312Packages.folium.dist</li>
    <li>python312Packages.geoarrow-pandas</li>
    <li>python312Packages.geoarrow-pandas.dist</li>
    <li>python312Packages.geoarrow-pyarrow</li>
    <li>python312Packages.geoarrow-pyarrow.dist</li>
    <li>python312Packages.geodatasets</li>
    <li>python312Packages.geodatasets.dist</li>
    <li>python312Packages.geopandas</li>
    <li>python312Packages.geopandas.dist</li>
    <li>python312Packages.geoparquet</li>
    <li>python312Packages.geoparquet.dist</li>
    <li>python312Packages.inequality</li>
    <li>python312Packages.inequality.dist</li>
    <li>python312Packages.libpysal</li>
    <li>python312Packages.libpysal.dist</li>
    <li>python312Packages.mapclassify</li>
    <li>python312Packages.mapclassify.dist</li>
    <li>python312Packages.momepy</li>
    <li>python312Packages.momepy.dist</li>
    <li>python312Packages.morecantile</li>
    <li>python312Packages.morecantile.dist</li>
    <li>python312Packages.netbox-documents</li>
    <li>python312Packages.netbox-documents.dist</li>
    <li>python312Packages.osmnx</li>
    <li>python312Packages.osmnx.dist</li>
    <li>python312Packages.plotnine</li>
    <li>python312Packages.plotnine.dist</li>
    <li>python312Packages.pygmt</li>
    <li>python312Packages.pygmt.dist</li>
    <li>python312Packages.pyogrio</li>
    <li>python312Packages.pyogrio.dist</li>
    <li>python312Packages.rasterio</li>
    <li>python312Packages.rasterio.dist</li>
    <li>python312Packages.rio-tiler</li>
    <li>python312Packages.rio-tiler.dist</li>
    <li>python312Packages.rioxarray</li>
    <li>python312Packages.rioxarray.dist</li>
    <li>python312Packages.wktutils</li>
    <li>python312Packages.wktutils.dist</li>
    <li>pytrainer</li>
    <li>pytrainer.dist</li>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>qmapshack</li>
    <li>saga</li>
    <li>sumo</li>
    <li>survex</li>
    <li>therion</li>
    <li>tunnelx</li>
    <li>vpv</li>
  </ul>
</details>

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `aarch64-darwin`
<details>
  <summary>:fast_forward: 16 packages marked as broken and skipped:</summary>
  <ul>
    <li>gplates</li>
    <li>hdfview</li>
    <li>python311Packages.python-mapnik</li>
    <li>python311Packages.python-mapnik.dist</li>
    <li>python311Packages.shimmy</li>
    <li>python311Packages.shimmy.dist</li>
    <li>python311Packages.worldengine</li>
    <li>python311Packages.worldengine.dist</li>
    <li>python312Packages.python-mapnik</li>
    <li>python312Packages.python-mapnik.dist</li>
    <li>python312Packages.shimmy</li>
    <li>python312Packages.shimmy.dist</li>
    <li>python312Packages.worldengine</li>
    <li>python312Packages.worldengine.dist</li>
    <li>sumo</li>
    <li>vpv</li>
  </ul>
</details>
<details>
  <summary>:x: 6 packages failed to build:</summary>
  <ul>
    <li>mapcache</li>
    <li>merkaartor</li>
    <li>octavePackages.mapping</li>
    <li>saga</li>
    <li>t-rex</li>
    <li>therion</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 124 packages built:</summary>
  <ul>
    <li>gdal (python312Packages.gdal)</li>
    <li>gmt</li>
    <li>gnudatalanguage</li>
    <li>grass</li>
    <li>h5utils</li>
    <li>hdf4</li>
    <li>hdf4.bin</li>
    <li>hdf4.dev</li>
    <li>mapnik</li>
    <li>mapproxy</li>
    <li>mapproxy.dist</li>
    <li>mapserver</li>
    <li>openorienteering-mapper</li>
    <li>pdal</li>
    <li>perl538Packages.Tirex</li>
    <li>perl538Packages.Tirex.devdoc</li>
    <li>perl540Packages.Tirex</li>
    <li>perl540Packages.Tirex.devdoc</li>
    <li>python311Packages.bsuite</li>
    <li>python311Packages.bsuite.dist</li>
    <li>python311Packages.cartopy</li>
    <li>python311Packages.cartopy.dist</li>
    <li>python311Packages.django-bootstrap4</li>
    <li>python311Packages.django-bootstrap4.dist</li>
    <li>python311Packages.django-bootstrap5</li>
    <li>python311Packages.django-bootstrap5.dist</li>
    <li>python311Packages.drf-extra-fields</li>
    <li>python311Packages.drf-extra-fields.dist</li>
    <li>python311Packages.fiona</li>
    <li>python311Packages.fiona.dist</li>
    <li>python311Packages.folium</li>
    <li>python311Packages.folium.dist</li>
    <li>python311Packages.gdal</li>
    <li>python311Packages.geoarrow-pandas</li>
    <li>python311Packages.geoarrow-pandas.dist</li>
    <li>python311Packages.geoarrow-pyarrow</li>
    <li>python311Packages.geoarrow-pyarrow.dist</li>
    <li>python311Packages.geodatasets</li>
    <li>python311Packages.geodatasets.dist</li>
    <li>python311Packages.geopandas</li>
    <li>python311Packages.geopandas.dist</li>
    <li>python311Packages.geoparquet</li>
    <li>python311Packages.geoparquet.dist</li>
    <li>python311Packages.inequality</li>
    <li>python311Packages.inequality.dist</li>
    <li>python311Packages.libpysal</li>
    <li>python311Packages.libpysal.dist</li>
    <li>python311Packages.mapclassify</li>
    <li>python311Packages.mapclassify.dist</li>
    <li>python311Packages.momepy</li>
    <li>python311Packages.momepy.dist</li>
    <li>python311Packages.morecantile</li>
    <li>python311Packages.morecantile.dist</li>
    <li>python311Packages.netbox-documents</li>
    <li>python311Packages.netbox-documents.dist</li>
    <li>python311Packages.osmnx</li>
    <li>python311Packages.osmnx.dist</li>
    <li>python311Packages.plotnine</li>
    <li>python311Packages.plotnine.dist</li>
    <li>py
    <li>python311Packages.pygmt.dist</li>
    <li>python311Packages.pyogrio</li>
    <li>python311Packages.pyogrio.dist</li>
    <li>python311Packages.rasterio</li>
    <li>python311Packages.rasterio.dist</li>
    <li>python311Packages.rio-tiler</li>
    <li>python311Packages.rio-tiler.dist</li>
    <li>python311Packages.rioxarray</li>
    <li>python311Packages.rioxarray.dist</li>
    <li>python311Packages.wktutils</li>
    <li>python311Packages.wktutils.dist</li>
    <li>python312Packages.bsuite</li>
    <li>python312Packages.bsuite.dist</li>
    <li>python312Packages.cartopy</li>
    <li>python312Packages.cartopy.dist</li>
    <li>python312Packages.django-bootstrap4</li>
    <li>python312Packages.django-bootstrap4.dist</li>
    <li>python312Packages.django-bootstrap5</li>
    <li>python312Packages.django-bootstrap5.dist</li>
    <li>python312Packages.drf-extra-fields</li>
    <li>python312Packages.drf-extra-fields.dist</li>
    <li>python312Packages.fiona</li>
    <li>python312Packages.fiona.dist</li>
    <li>python312Packages.folium</li>
    <li>python312Packages.folium.dist</li>
    <li>python312Packages.geoarrow-pandas</li>
    <li>python312Packages.geoarrow-pandas.dist</li>
    <li>python312Packages.geoarrow-pyarrow</li>
    <li>python312Packages.geoarrow-pyarrow.dist</li>
    <li>python312Packages.geodatasets</li>
    <li>python312Packages.geodatasets.dist</li>
    <li>python312Packages.geopandas</li>
    <li>python312Packages.geopandas.dist</li>
    <li>python312Packages.geoparquet</li>
    <li>python312Packages.geoparquet.dist</li>
    <li>python312Packages.inequality</li>
    <li>python312Packages.inequality.dist</li>
    <li>python312Packages.libpysal</li>
    <li>python312Packages.libpysal.dist</li>
    <li>python312Packages.mapclassify</li>
    <li>python312Packages.mapclassify.dist</li>
    <li>python312Packages.momepy</li>
    <li>python312Packages.momepy.dist</li>
    <li>python312Packages.morecantile</li>
    <li>python312Packages.morecantile.dist</li>
    <li>python312Packages.netbox-documents</li>
    <li>python312Packages.netbox-documents.dist</li>
    <li>python312Packages.osmnx</li>
    <li>python312Packages.osmnx.dist</li>
    <li>python312Packages.plotnine</li>
    <li>python312Packages.plotnine.dist</li>
    <li>python312Packages.pygmt</li>
    <li>python312Packages.pygmt.dist</li>
    <li>python312Packages.pyogrio</li>
    <li>python312Packages.pyogrio.dist</li>
    <li>python312Packages.rasterio</li>
    <li>python312Packages.rasterio.dist</li>
    <li>python312Packages.rio-tiler</li>
    <li>python312Packages.rio-tiler.dist</li>
    <li>python312Packages.rioxarray</li>
    <li>python312Packages.rioxarray.dist</li>
    <li>python312Packages.wktutils</li>
    <li>python312Packages.wktutils.dist</li>
    <li>survex</li>
  </ul>
</details>

No regressions, as far as I can tell.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
