### PR TITLE
python312Packages.noisereduce: init at 3.0.2

### DIFF
--- a/pkgs/development/python-modules/noisereduce/default.nix
+++ b/pkgs/development/python-modules/noisereduce/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  matplotlib,
+  numpy,
+  scipy,
+  librosa,
+  tqdm,
+  torch,
+}:
+buildPythonPackage rec {
+  pname = "noisereduce";
+  version = "3.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "timsainb";
+    repo = "noisereduce";
+    rev = "v${version}";
+    hash = "sha256-+49vVD242hjOr05z8FNvwHhcUJHWglqKrEkwDX7OMXU=";
+  };
+
+  postPatch = ''
+    # fix import check
+    # fix: cannot cache function 'x': no locator available
+    export NUMBA_CACHE_DIR=$TMP
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    scipy
+    librosa
+    tqdm
+    matplotlib
+  ];
+
+  optional-dependencies = {
+    PyTorch = [ torch ];
+  };
+
+  pythonImportsCheck = [ "noisereduce" ];
+
+  meta = {
+    description = "Noise reduction in python using spectral gating";
+    homepage = "https://github.com/timsainb/noisereduce";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hakan-demirli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9196,6 +9196,8 @@ self: super: with self; {
 
   noise = callPackage ../development/python-modules/noise { };
 
+  noisereduce = callPackage ../development/python-modules/noisereduce { };
+
   noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
 
   norfair = callPackage ../development/python-modules/norfair { };


### PR DESCRIPTION
Adds the [noisereduce](https://pypi.org/project/noisereduce/)
I have tested that the library works using [rvc-cli](https://github.com/blaisewf/rvc-cli)

Closes https://github.com/NixOS/nixpkgs/issues/351989

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
