### PR TITLE
python312Packages.spsdk: 2.2.1 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/libuuu/default.nix
+++ b/pkgs/development/python-modules/libuuu/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  setuptools-scm,
+  autoPatchelfHook,
+  pytestCheckHook,
+  udev,
+}:
+
+buildPythonPackage rec {
+  pname = "libuuu";
+  version = "1.5.182";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-k6JwGxYeFbGNl7zcuKN6SbRq8Z4yD1dXXL3ORyGqhYE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    udev
+  ];
+
+  dependencies = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [
+    "libuuu"
+  ];
+
+  # Prevent tests to load the plugin from the source files instead of the installed ones
+  preCheck = ''
+    rm -rf libuuu
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python wraper for libuuu";
+    homepage = "https://github.com/nxp-imx/mfgtools/tree/master/wrapper";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    badPlatforms = [
+      # The pypi archive does not contain the pre-built library for these platforms
+      "aarch64-linux"
+      "x86_64-darwin"
+    ];
+  };
+}

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -2,6 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
   asn1crypto,
   bincopy,
   bitstring,
@@ -13,8 +19,10 @@
   cryptography,
   deepmerge,
   fastjsonschema,
+  filelock,
   hexdump,
   libusbsio,
+  libuuu,
   oscrypto,
   packaging,
   platformdirs,
@@ -23,30 +31,41 @@
   pyserial,
   requests,
   ruamel-yaml,
-  setuptools-scm,
   sly,
-  spsdk,
-  testers,
   typing-extensions,
+
+  # tests
   ipykernel,
   pytest-notebook,
   pytestCheckHook,
   voluptuous,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "spsdk";
-  version = "2.2.1";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nxp-mcuxpresso";
     repo = "spsdk";
-    rev = "refs/tags/${version}";
-    hash = "sha256-qFgG9jdF667EtMqXGGk/oxTEi+6J2s/3gKokP+JaFVw=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WRR4YyA4HaYoyOZSt/RYivhH2E/20DKLXExWg2yOL48=";
   };
 
-  build-system = [ setuptools-scm ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=72.1,<74" "setuptools"
+
+    substituteInPlace setup.py \
+      --replace-fail "setuptools>=72.1,<74" "setuptools"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   pythonRelaxDeps = [
     "cryptography"
@@ -55,9 +74,11 @@ buildPythonPackage rec {
     "typing-extensions"
   ];
 
-  # Remove unneeded unfree package. pyocd-pemicro is only used when
-  # generating a pyinstaller package, which we don't do.
-  pythonRemoveDeps = [ "pyocd-pemicro" ];
+  pythonRemoveDeps = [
+    # Remove unneeded unfree package. pyocd-pemicro is only used when
+    # generating a pyinstaller package, which we don't do.
+    "pyocd-pemicro"
+  ];
 
   dependencies = [
     asn1crypto
@@ -71,8 +92,10 @@ buildPythonPackage rec {
     cryptography
     deepmerge
     fastjsonschema
+    filelock
     hexdump
     libusbsio
+    libuuu
     oscrypto
     packaging
     platformdirs
@@ -85,23 +108,32 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  pythonImportsCheck = [ "spsdk" ];
+
+  preInstallCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
+
   nativeCheckInputs = [
     ipykernel
     pytest-notebook
     pytestCheckHook
     voluptuous
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  disabledTests = [
+    # Missing rotk private key
+    "test_general_notebooks"
   ];
 
-  pythonImportsCheck = [ "spsdk" ];
-
-  passthru.tests.version = testers.testVersion { package = spsdk; };
-
-  meta = with lib; {
-    changelog = "https://github.com/nxp-mcuxpresso/spsdk/blob/${src.rev}/docs/release_notes.rst";
+  meta = {
+    changelog = "https://github.com/nxp-mcuxpresso/spsdk/blob/v${version}/docs/release_notes.rst";
     description = "NXP Secure Provisioning SDK";
     homepage = "https://github.com/nxp-mcuxpresso/spsdk";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       frogamic
       sbruder
     ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7348,6 +7348,8 @@ self: super: with self; {
     inherit (pkgs) libusbsio;
   };
 
+  libuuu = callPackage ../development/python-modules/libuuu { };
+
   libversion = callPackage ../development/python-modules/libversion {
     inherit (pkgs) libversion;
   };


### PR DESCRIPTION
## Things done

- **python312Packages.libuuu: init at 1.5.82**
- **python312Packages.spsdk: 2.2.1 -> 2.4.0**

Currently, `python312Packages.spsdk` is broken.
This PR updates it and adds its new required dependency `python312Packages.libuuu`.
Unfortunately, fetching the `libuuu` package from pypi does not allow to support `aarch64-linux` and `x86_64-darwin`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
