### PR TITLE
openjdk8: fix build with GCC 14

### DIFF
--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -443,6 +443,11 @@ stdenv.mkDerivation (finalAttrs: {
               "-std=gnu++98"
               "-Wno-error"
             ]
+            ++ [
+              # error by default in GCC 14
+              "-Wno-error=int-conversion"
+              "-Wno-error=incompatible-pointer-types"
+            ]
           );
 
       NIX_LDFLAGS = lib.concatStringsSep " " (


### PR DESCRIPTION
ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).