### PR TITLE
hdf5_1_10: enable cpp support

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1809,7 +1809,7 @@ let
     });
 
     Rhdf5lib = let
-      hdf5 = pkgs.hdf5_1_10.overrideAttrs (attrs: {configureFlags = attrs.configureFlags ++ [ "--enable-cxx" ];});
+      hdf5 = pkgs.hdf5_1_10;
     in old.Rhdf5lib.overrideAttrs (attrs: {
       propagatedBuildInputs = attrs.propagatedBuildInputs ++ [ hdf5.dev pkgs.libaec ];
       patches = [ ./patches/Rhdf5lib.patch ];

--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
       applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
     '';
     license = lib.licenses.bsd3; # Lawrence Berkeley National Labs BSD 3-Clause variant
+    maintainers = with lib.maintainers; [ stephen-huan ];
     homepage = "https://www.hdfgroup.org/HDF5/";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , removeReferencesTo
+, cppSupport ? true
 , zlibSupport ? true
 , zlib
 , enableShared ? !stdenv.hostPlatform.isStatic
@@ -28,7 +29,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = optional zlibSupport zlib;
 
   configureFlags = optional enableShared "--enable-shared"
-    ++ optional javaSupport "--enable-java";
+    ++ optional javaSupport "--enable-java"
+    ++ optional cppSupport "--enable-cxx";
 
   patches = [ ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Stumbled upon this while packaging [HLIBpro](https://www.hlibpro.com/). As far as I can tell, only `rPackages.Rhdf5lib` and `python3Packages.fenics` depend on `hdf5_1_10`. `Rhdf5lib` already overrides to add `--enable-cxx` so there is no rebuild, and `fenics` seems to work fine after the change (ran `nix build .#nixosTests.fenics`).

Ambivalent whether this package should be kept at all (e.g. https://github.com/NixOS/nixpkgs/pull/298462), for what it's worth

```nix
pkgs.hdf5.overrideAttrs rec {
  version = "1.10.11";
  src = pkgs.fetchFromGitHub {
    owner = "HDFGroup";
    repo = "hdf5";
    rev = "hdf5-${builtins.replaceStrings ["."] ["_"] version}";
    hash = "sha256-hOhdOHmnY6K9xLp70jSRkN27H5BZWGiacM0UaI57vAg=";
  };
}
```

works for me and builds faster too. Of course, there's no guarantee this will continue working as the builds diverge.

cc @jiegec @jbedo @LeSuisse

<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>hdf5_1_10</li>
    <li>hdf5_1_10.dev</li>
    <li>python311Packages.fenics</li>
    <li>python311Packages.fenics.dist</li>
    <li>python312Packages.fenics</li>
    <li>python312Packages.fenics.dist</li>
  </ul>
</details>

https://github.com/NixOS/nixpkgs/blob/6665c7402996c8ee043f7604cc96b27bed698baf/pkgs/development/r-modules/default.nix#L1811-L1817

https://github.com/NixOS/nixpkgs/blob/4633a7c72337ea8fd23a4f2ba3972865e3ec685d/pkgs/top-level/python-packages.nix#L4484-L4486

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
