### PR TITLE
qtwayland: propagate wayland

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -13,9 +13,9 @@ qtModule {
   # wayland-scanner needs to be propagated as both build
   # (for the wayland-scanner binary) and host (for the
   # actual wayland.xml protocol definition)
-  propagatedBuildInputs = [ qtbase qtdeclarative wayland-scanner ];
-  propagatedNativeBuildInputs = [ wayland wayland-scanner ];
-  buildInputs = [ wayland libdrm ];
+  propagatedBuildInputs = [ qtbase qtdeclarative wayland wayland-scanner ];
+  propagatedNativeBuildInputs = [ wayland-scanner ];
+  buildInputs = [ libdrm ];
   nativeBuildInputs = [ pkg-config ];
 
   # Replace vendored wayland.xml with our matching version


### PR DESCRIPTION
Some dependencies like telegram-desktop require it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (on staging where GCC 14 is the default)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

(previously this PR contained a patch to telegram-desktop)