### PR TITLE
maven.buildMavenPackage: support finalAttrs and overrideAttrs

### DIFF
--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -1,105 +1,118 @@
-{ lib
-, stdenv
-, jdk
-, maven
-}:
-
-{ src
-, sourceRoot ? null
-, buildOffline ? false
-, doCheck ? true
-, patches ? [ ]
-, pname
-, version
-, mvnJdk ? jdk
-, mvnHash ? ""
-, mvnFetchExtraArgs ? { }
-, mvnDepsParameters ? ""
-, manualMvnArtifacts ? [ ]
-, manualMvnSources ? [ ]
-, mvnParameters ? ""
-, ...
-} @args:
-
 # originally extracted from dbeaver
 # created to allow using maven packages in the same style as rust
+{
+  lib,
+  stdenv,
+  jdk,
+  maven,
+}:
 
 let
-  mvnSkipTests = lib.optionalString (!doCheck) "-DskipTests";
-  fetchedMavenDeps = stdenv.mkDerivation ({
-    name = "${pname}-${version}-maven-deps";
-    inherit src sourceRoot patches;
-
-    nativeBuildInputs = [
-      maven
-    ] ++ args.nativeBuildInputs or [ ];
-
-    JAVA_HOME = mvnJdk;
-
-    buildPhase = ''
-      runHook preBuild
-    '' + lib.optionalString buildOffline ''
-      mvn de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}
-
-      for artifactId in ${builtins.toString manualMvnArtifacts}
-      do
-        echo "downloading manual $artifactId"
-        mvn dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2
-      done
-
-      for artifactId in ${builtins.toString manualMvnSources}
-      do
-        group=$(echo $artifactId | cut -d':' -f1)
-        artifact=$(echo $artifactId | cut -d':' -f2)
-        echo "downloading manual sources $artifactId"
-        mvn dependency:sources -DincludeGroupIds="$group" -DincludeArtifactIds="$artifact" -Dmaven.repo.local=$out/.m2
-      done
-    '' + lib.optionalString (!buildOffline) ''
-      mvn package -Dmaven.repo.local=$out/.m2 ${mvnSkipTests} ${mvnParameters}
-    '' + ''
-      runHook postBuild
-    '';
-
-    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''
-      runHook preInstall
-
-      find $out -type f \( \
-        -name \*.lastUpdated \
-        -o -name resolver-status.properties \
-        -o -name _remote.repositories \) \
-        -delete
-
-      runHook postInstall
-    '';
-
-    # don't do any fixup
-    dontFixup = true;
-    outputHashAlgo = if mvnHash != "" then null else "sha256";
-    outputHashMode = "recursive";
-    outputHash = mvnHash;
-  } // mvnFetchExtraArgs);
+  # almost the some as lib.extends, but it doesn't do `prev //`
+  transforms =
+    transformation: rattrs: # <--- inputs
+    final:
+    transformation final (rattrs final);
 in
-stdenv.mkDerivation (builtins.removeAttrs args [ "mvnFetchExtraArgs" ] // {
-  inherit fetchedMavenDeps;
 
-  nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
-    maven
-  ];
+let
+  transformAttrs =
+    finalAttrs: inputAttrs:
+    let
+      mvnSkipTests = lib.optionalString (!finalAttrs.doCheck) "-DskipTests";
+    in
+    {
+      buildOffline = false;
+      doCheck = true;
+      mvnJdk = jdk;
+      mvnHash = "";
+      mvnParameters = "";
+      mvnDepsParameters = "";
+      manualMvnArtifacts = [ ];
+      manualMvnSources = [ ];
 
-  JAVA_HOME = mvnJdk;
+      fetchedMavenDeps = stdenv.mkDerivation (
+        {
+          name = "${finalAttrs.pname}-${finalAttrs.version}-maven-deps";
+          src = finalAttrs.src or null;
+          sourceRoot = finalAttrs.sourceRoot or null;
+          patches = finalAttrs.patches or [ ];
 
-  buildPhase = ''
-    runHook preBuild
+          nativeBuildInputs = [ maven ] ++ inputAttrs.nativeBuildInputs or [ ];
 
-    mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
-    runHook afterDepsSetup
-    mvn package -o -nsu "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnSkipTests} ${mvnParameters}
+          JAVA_HOME = finalAttrs.mvnJdk;
 
-    runHook postBuild
-  '';
+          buildPhase =
+            ''
+              runHook preBuild
+            ''
+            + lib.optionalString finalAttrs.buildOffline ''
+              mvn de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -Dmaven.repo.local=$out/.m2 ${finalAttrs.mvnDepsParameters}
 
-  meta = args.meta or { } // {
-    platforms = args.meta.platforms or maven.meta.platforms;
-  };
-})
+              for artifactId in ${builtins.toString finalAttrs.manualMvnArtifacts}
+              do
+                echo "downloading manual $artifactId"
+                mvn dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2
+              done
+
+              for artifactId in ${builtins.toString finalAttrs.manualMvnSources}
+              do
+                group=$(echo $artifactId | cut -d':' -f1)
+                artifact=$(echo $artifactId | cut -d':' -f2)
+                echo "downloading manual sources $artifactId"
+                mvn dependency:sources -DincludeGroupIds="$group" -DincludeArtifactIds="$artifact" -Dmaven.repo.local=$out/.m2
+              done
+            ''
+            + lib.optionalString (!finalAttrs.buildOffline) ''
+              mvn package -Dmaven.repo.local=$out/.m2 ${mvnSkipTests} ${finalAttrs.mvnParameters}
+            ''
+            + ''
+              runHook postBuild
+            '';
+
+          # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+          installPhase = ''
+            runHook preInstall
+
+            find $out -type f \( \
+              -name \*.lastUpdated \
+              -o -name resolver-status.properties \
+              -o -name _remote.repositories \) \
+              -delete
+
+            runHook postInstall
+          '';
+
+          # don't do any fixup
+          dontFixup = true;
+          outputHashAlgo = if finalAttrs.mvnHash != "" then null else "sha256";
+          outputHashMode = "recursive";
+          outputHash = finalAttrs.mvnHash;
+        }
+        // inputAttrs.mvnFetchExtraArgs or { }
+      );
+
+      JAVA_HOME = finalAttrs.mvnJdk;
+
+      buildPhase = ''
+        runHook preBuild
+
+        mvnDeps=$(cp -dpR ${finalAttrs.fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
+        runHook afterDepsSetup
+        mvn package -o -nsu "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnSkipTests} ${finalAttrs.mvnParameters}
+
+        runHook postBuild
+      '';
+
+    }
+    // builtins.removeAttrs inputAttrs [ "mvnFetchExtraArgs" ]
+    // {
+      nativeBuildInputs = [ maven ] ++ inputAttrs.nativeBuildInputs or [ ];
+
+      meta = {
+        platforms = maven.meta.platforms;
+      } // inputAttrs.meta or { };
+    };
+in
+
+argsOrFn: stdenv.mkDerivation (transforms transformAttrs (lib.toFunction argsOrFn))

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -33,31 +33,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru =
-    let
-      makeOverridableMavenPackage =
-        mavenRecipe: mavenArgs:
-        let
-          drv = mavenRecipe mavenArgs;
-          overrideWith =
-            newArgs: mavenArgs // (if lib.isFunction newArgs then newArgs mavenArgs else newArgs);
-        in
-        drv
-        // {
-          overrideMavenAttrs = newArgs: makeOverridableMavenPackage mavenRecipe (overrideWith newArgs);
-        };
-    in
-    {
-      buildMaven = callPackage ./build-maven.nix {
-        maven = finalAttrs.finalPackage;
-      };
-
-      buildMavenPackage = makeOverridableMavenPackage (
-        callPackage ./build-maven-package.nix {
-          maven = finalAttrs.finalPackage;
-        }
-      );
+  passthru = {
+    buildMaven = callPackage ./build-maven.nix {
+      maven = finalAttrs.finalPackage;
     };
+
+    buildMavenPackage = callPackage ./build-maven-package.nix {
+      maven = finalAttrs.finalPackage;
+    };
+  };
 
   meta = {
     homepage = "https://maven.apache.org/";

--- a/pkgs/by-name/qu/quark-goldleaf/package.nix
+++ b/pkgs/by-name/qu/quark-goldleaf/package.nix
@@ -1,30 +1,31 @@
-{ lib
-, jdk
-, maven
-, fetchFromGitHub
-, fetchpatch
-, makeDesktopItem
-, copyDesktopItems
-, imagemagick
-, wrapGAppsHook3
-, gtk3
+{
+  lib,
+  jdk,
+  maven,
+  fetchFromGitHub,
+  fetchpatch,
+  makeDesktopItem,
+  copyDesktopItems,
+  imagemagick,
+  wrapGAppsHook3,
+  gtk3,
 }:
 
 let
   jdk' = jdk.override { enableJavaFX = true; };
 in
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "quark-goldleaf";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "XorTroll";
     repo = "Goldleaf";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-gagIQGOiygJ0Onm0SrkbFWaovqWX2WJNx7LpSRheCLM=";
   };
 
-  sourceRoot = "${src.name}/Quark";
+  sourceRoot = "${finalAttrs.src.name}/Quark";
 
   patches = [
     ./fix-maven-plugin-versions.patch
@@ -81,19 +82,26 @@ maven.buildMavenPackage rec {
       exec = "quark-goldleaf";
       icon = "quark-goldleaf";
       desktopName = "Quark";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       terminal = false;
-      categories = [ "Utility" "FileTransfer" ];
-      keywords = [ "nintendo" "switch" "goldleaf" ];
+      categories = [
+        "Utility"
+        "FileTransfer"
+      ];
+      keywords = [
+        "nintendo"
+        "switch"
+        "goldleaf"
+      ];
     })
   ];
 
   meta = {
-    changelog = "https://github.com/XorTroll/Goldleaf/releases/tag/${src.rev}";
+    changelog = "https://github.com/XorTroll/Goldleaf/releases/tag/${finalAttrs.version}";
     description = "A GUI tool for transfering files between a computer and a Nintendo Switch running Goldleaf";
     homepage = "https://github.com/XorTroll/Goldleaf#quark-and-remote-browsing";
     longDescription = ''
-      ${meta.description}
+      ${finalAttrs.meta.description}
 
       For the program to work properly, you will have to install Nintendo Switch udev rules.
 
@@ -110,5 +118,4 @@ maven.buildMavenPackage rec {
     maintainers = with lib.maintainers; [ tomasajt ];
     platforms = with lib.platforms; linux ++ darwin;
   };
-}
-
+})


### PR DESCRIPTION
This is a POC for an alternative to the changes introduced in https://github.com/NixOS/nixpkgs/pull/313152, which I only noticed when it got merged.

This would not only allow plain `drv.overrideAttrs ...` for `buildMavenPackage`-based packages, but also allow doing `buildMavenPackage (finalAttrs: ...)`

Very similar to https://github.com/NixOS/nixpkgs/pull/354999 and https://github.com/NixOS/nixpkgs/pull/353526 (it uses the same logic)

The only thing this doesn't currently allow overriding is `mvnFetchExtraArgs`, since it isn't part of `finalAttrs`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
