### PR TITLE
python312Packages.[tf-]keras: update; enable tests

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -18,6 +19,16 @@
   tensorflow,
   pythonAtLeast,
   distutils,
+
+  # tests
+  dm-tree,
+  jax,
+  jaxlib,
+  pandas,
+  pydot,
+  pytestCheckHook,
+  tf-keras,
+  torch,
 }:
 
 buildPythonPackage rec {
@@ -53,8 +64,62 @@ buildPythonPackage rec {
     "keras._tf_keras"
   ];
 
-  # Couldn't get tests working
-  doCheck = false;
+  nativeCheckInputs = [
+    dm-tree
+    jaxlib
+    jax
+    pandas
+    pydot
+    pytestCheckHook
+    tf-keras
+    torch
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTests =
+    [
+      # Tries to install the package in the sandbox
+      "test_keras_imports"
+
+      # TypeError: this __dict__ descriptor does not support '_DictWrapper' objects
+      "test_reloading_default_saved_model"
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # AttributeError: module 'numpy' has no attribute 'float128'. Did you mean: 'float16'?
+      "test_spectrogram_error"
+    ];
+
+  disabledTestPaths = [
+    # Datasets are downloaded from the internet
+    "integration_tests/dataset_tests"
+
+    # TypeError: test_custom_fit.<locals>.CustomModel.train_step() missing 1 required positional argument: 'data'
+    "integration_tests/jax_custom_fit_test.py"
+
+    # RuntimeError: Virtual devices cannot be modified after being initialized
+    "integration_tests/tf_distribute_training_test.py"
+
+    # AttributeError: 'CustomModel' object has no attribute 'zero_grad'
+    "integration_tests/torch_custom_fit_test.py"
+
+    # Fails for an unclear reason:
+    # self.assertLen(list(net.parameters()), 2
+    # AssertionError: 0 != 2
+    "integration_tests/torch_workflow_test.py"
+
+    # Most tests require internet access
+    "keras/src/applications/applications_test.py"
+
+    # TypeError: this __dict__ descriptor does not support '_DictWrapper' objects
+    "keras/src/backend/tensorflow/saved_model_test.py"
+    "keras/src/export/export_lib_test.py"
+
+    # KeyError: 'Unable to synchronously open object (bad object header version number)'
+    "keras/src/saving/file_editor_test.py"
+  ];
 
   meta = {
     description = "Multi-backend implementation of the Keras API, with support for TensorFlow, JAX, and PyTorch";

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -61,6 +61,6 @@ buildPythonPackage rec {
     homepage = "https://keras.io";
     changelog = "https://github.com/keras-team/keras/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
   };
 }

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -8,9 +8,7 @@
 
   # dependencies
   absl-py,
-  dm-tree,
   h5py,
-  markdown-it-py,
   ml-dtypes,
   namex,
   numpy,
@@ -24,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.6.0";
+  version = "3.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     rev = "refs/tags/v${version}";
-    hash = "sha256-zbeGa4g2psAofYAVuM7BNWI2gI21e739N5ZtxVfnVUg=";
+    hash = "sha256-qidY1OmlOYPKVoxryx1bEukA7IS6rPV4jqlnuf3y39w=";
   };
 
   build-system = [
@@ -40,9 +38,7 @@ buildPythonPackage rec {
 
   dependencies = [
     absl-py
-    dm-tree
     h5py
-    markdown-it-py
     ml-dtypes
     namex
     numpy

--- a/pkgs/development/python-modules/mhcflurry/default.nix
+++ b/pkgs/development/python-modules/mhcflurry/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # dependencies
   appdirs,
@@ -29,6 +30,15 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-dxCGCPnk1IFKg8ZVqMJsojQL0KlNirKlHJoaaOYIzMU=";
   };
+
+  patches = [
+    # TODO: this has been merged in master and will thus be included in the next release.
+    (fetchpatch {
+      name = "migrate-from-nose-to-pytest";
+      url = "https://github.com/openvax/mhcflurry/commit/8e9f35381a476362ca41cb71eb0a90f6573fe4b3.patch";
+      hash = "sha256-PyyxGrjE3OZR8dKHEQBQGiRG9A8kcz/e14PRyrVvqrE=";
+    })
+  ];
 
   # keras and tensorflow are not in the official setup.py requirements but are required for the CLI utilities to run.
   dependencies = [
@@ -94,7 +104,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/openvax/mhcflurry/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];
-    # Requires a recent version of tensorflow
-    broken = lib.versionOlder tensorflow.version "2.15.0";
   };
 }

--- a/pkgs/development/python-modules/tf-keras/default.nix
+++ b/pkgs/development/python-modules/tf-keras/default.nix
@@ -9,6 +9,8 @@
   # dependencies
   numpy,
   tensorflow,
+  pythonAtLeast,
+  distutils,
 
   # tests
   pytestCheckHook,
@@ -16,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "tf-keras";
-  version = "2.17.0";
+  version = "2.18.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "tf_keras";
     inherit version;
-    hash = "sha256-/al8GNow2g9ypafoDz7uNDsJ9MIG2tbFfJRPss0YVg4=";
+    hash = "sha256-6/dEUZsyKv6tMwhqKrqHIkVHMpSv/UCXNpTz63x6130=";
   };
 
   build-system = [
@@ -32,7 +34,7 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     tensorflow
-  ];
+  ] ++ lib.optionals (pythonAtLeast "3.12") [ distutils ];
 
   pythonImportsCheck = [ "tf_keras" ];
 


### PR DESCRIPTION
## Things done

Points worth noting:
1. There is a strange issue with the `tensorflow` wheel. Ours ends-up at `tensorflow_cpu-2.18.0.dist-info` while upstream is `tensorflow tensorflow-2.18.0.dist-info`.
    Hence, as `tf-keras` requires `tensorflow` as a runtime dependency, our `pythonRuntimeDepsCheck` which tries to `importlib.metadata.distribution("tensorflow")` fails with `importlib.metadata.PackageNotFoundError: No package metadata was found for tensorflow`.
    ~~For now, I have added `tensorflow` to `pythonRelaxDeps`. It would be nice to understand the core of the issue though.~~
    -> **This has been fixed _properly_ in #359605**
3. I was able to get most `keras` tests working but had to skip a few.
    In the end, it is surely worth-it: `12054 passed, 252 skipped, 1 xpassed`.
    By the way, I used `disabledTestPaths` when I could (i.e. when all the tests of the file were failing).
    Indeed, some tests have very generic names (`test_basic` or similar) which would surely lead to false positives when added to `disabledTests`.

Fixes #316759

---

- **python312Packages.keras: 3.6.0 -> 3.7.0**
- **python312Packages.keras: add GaetanLepage as maintainer**
- **python312Packages.tf-keras: 2.17.0 -> 2.18.0**
- **python312Packages.keras: enable tests**

---

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
