### PR TITLE
python312Packages.tensorflow: rename generated wheel from tensorflow_cpu to tensorflow

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -54,7 +54,7 @@ let
   isCudaJetson = cudaSupport && cudaPackages.cudaFlags.isJetsonBuild;
   isCudaX64 = cudaSupport && stdenv.hostPlatform.isx86_64;
 in
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "tensorflow" + lib.optionalString cudaSupport "-gpu";
   version = packages."${"version" + lib.optionalString isCudaJetson "_jetson"}";
   format = "wheel";
@@ -141,73 +141,97 @@ buildPythonPackage {
     popd
   '';
 
-  # Note that we need to run *after* the fixup phase because the
-  # libraries are loaded at runtime. If we run in preFixup then
-  # patchelf --shrink-rpath will remove the cuda libraries.
   postFixup =
-    let
-      # rpaths we only need to add if CUDA is enabled.
-      cudapaths = lib.optionals cudaSupport [
-        cudatoolkit.out
-        cudatoolkit.lib
-        cudnn
-      ];
+    # When using the cpu-only wheel, the final package will be named `tensorflow_cpu`.
+    # Then, in each package requiring `tensorflow`, our pythonRuntimeDepsCheck will fail with:
+    # importlib.metadata.PackageNotFoundError: No package metadata was found for tensorflow
+    # Hence, we manually rename the package to `tensorflow`.
+    lib.optionalString ((builtins.match ".*tensorflow_cpu.*" src.url) != null) ''
+      (
+        cd $out/${python.sitePackages}
 
-      libpaths = [
-        (lib.getLib stdenv.cc.cc)
-        zlib
-      ];
+        dest="tensorflow-${version}.dist-info"
 
-      rpath = lib.makeLibraryPath (libpaths ++ cudapaths);
-    in
-    lib.optionalString stdenv.hostPlatform.isLinux ''
-      # This is an array containing all the directories in the tensorflow2
-      # package that contain .so files.
-      #
-      # TODO: Create this list programmatically, and remove paths that aren't
-      # actually needed.
-      rrPathArr=(
-        "$out/${python.sitePackages}/tensorflow/"
-        "$out/${python.sitePackages}/tensorflow/core/kernels"
-        "$out/${python.sitePackages}/tensorflow/compiler/mlir/stablehlo/"
-        "$out/${python.sitePackages}/tensorflow/compiler/tf2tensorrt/"
-        "$out/${python.sitePackages}/tensorflow/compiler/tf2xla/ops/"
-        "$out/${python.sitePackages}/tensorflow/include/external/ml_dtypes/"
-        "$out/${python.sitePackages}/tensorflow/lite/experimental/microfrontend/python/ops/"
-        "$out/${python.sitePackages}/tensorflow/lite/python/analyzer_wrapper/"
-        "$out/${python.sitePackages}/tensorflow/lite/python/interpreter_wrapper/"
-        "$out/${python.sitePackages}/tensorflow/lite/python/metrics/"
-        "$out/${python.sitePackages}/tensorflow/lite/python/optimize/"
-        "$out/${python.sitePackages}/tensorflow/python/"
-        "$out/${python.sitePackages}/tensorflow/python/autograph/impl/testing"
-        "$out/${python.sitePackages}/tensorflow/python/client"
-        "$out/${python.sitePackages}/tensorflow/python/data/experimental/service"
-        "$out/${python.sitePackages}/tensorflow/python/framework"
-        "$out/${python.sitePackages}/tensorflow/python/grappler"
-        "$out/${python.sitePackages}/tensorflow/python/lib/core"
-        "$out/${python.sitePackages}/tensorflow/python/lib/io"
-        "$out/${python.sitePackages}/tensorflow/python/platform"
-        "$out/${python.sitePackages}/tensorflow/python/profiler/internal"
-        "$out/${python.sitePackages}/tensorflow/python/saved_model"
-        "$out/${python.sitePackages}/tensorflow/python/util"
-        "$out/${python.sitePackages}/tensorflow/tsl/python/lib/core"
-        "$out/${python.sitePackages}/tensorflow.libs/"
-        "${rpath}"
+        mv tensorflow_cpu-${version}.dist-info "$dest"
+
+        (
+          cd "$dest"
+
+          substituteInPlace METADATA \
+            --replace-fail "tensorflow_cpu" "tensorflow"
+          substituteInPlace RECORD \
+            --replace-fail "tensorflow_cpu" "tensorflow"
+        )
       )
+    ''
+    # Note that we need to run *after* the fixup phase because the
+    # libraries are loaded at runtime. If we run in preFixup then
+    # patchelf --shrink-rpath will remove the cuda libraries.
+    + (
+      let
+        # rpaths we only need to add if CUDA is enabled.
+        cudapaths = lib.optionals cudaSupport [
+          cudatoolkit.out
+          cudatoolkit.lib
+          cudnn
+        ];
 
-      # The the bash array into a colon-separated list of RPATHs.
-      rrPath=$(IFS=$':'; echo "''${rrPathArr[*]}")
-      echo "about to run patchelf with the following rpath: $rrPath"
+        libpaths = [
+          (lib.getLib stdenv.cc.cc)
+          zlib
+        ];
 
-      find $out -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
-        echo "about to patchelf $lib..."
-        chmod a+rx "$lib"
-        patchelf --set-rpath "$rrPath" "$lib"
-        ${lib.optionalString cudaSupport ''
-          addDriverRunpath "$lib"
-        ''}
-      done
-    '';
+        rpath = lib.makeLibraryPath (libpaths ++ cudapaths);
+      in
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        # This is an array containing all the directories in the tensorflow2
+        # package that contain .so files.
+        #
+        # TODO: Create this list programmatically, and remove paths that aren't
+        # actually needed.
+        rrPathArr=(
+          "$out/${python.sitePackages}/tensorflow/"
+          "$out/${python.sitePackages}/tensorflow/core/kernels"
+          "$out/${python.sitePackages}/tensorflow/compiler/mlir/stablehlo/"
+          "$out/${python.sitePackages}/tensorflow/compiler/tf2tensorrt/"
+          "$out/${python.sitePackages}/tensorflow/compiler/tf2xla/ops/"
+          "$out/${python.sitePackages}/tensorflow/include/external/ml_dtypes/"
+          "$out/${python.sitePackages}/tensorflow/lite/experimental/microfrontend/python/ops/"
+          "$out/${python.sitePackages}/tensorflow/lite/python/analyzer_wrapper/"
+          "$out/${python.sitePackages}/tensorflow/lite/python/interpreter_wrapper/"
+          "$out/${python.sitePackages}/tensorflow/lite/python/metrics/"
+          "$out/${python.sitePackages}/tensorflow/lite/python/optimize/"
+          "$out/${python.sitePackages}/tensorflow/python/"
+          "$out/${python.sitePackages}/tensorflow/python/autograph/impl/testing"
+          "$out/${python.sitePackages}/tensorflow/python/client"
+          "$out/${python.sitePackages}/tensorflow/python/data/experimental/service"
+          "$out/${python.sitePackages}/tensorflow/python/framework"
+          "$out/${python.sitePackages}/tensorflow/python/grappler"
+          "$out/${python.sitePackages}/tensorflow/python/lib/core"
+          "$out/${python.sitePackages}/tensorflow/python/lib/io"
+          "$out/${python.sitePackages}/tensorflow/python/platform"
+          "$out/${python.sitePackages}/tensorflow/python/profiler/internal"
+          "$out/${python.sitePackages}/tensorflow/python/saved_model"
+          "$out/${python.sitePackages}/tensorflow/python/util"
+          "$out/${python.sitePackages}/tensorflow/tsl/python/lib/core"
+          "$out/${python.sitePackages}/tensorflow.libs/"
+          "${rpath}"
+        )
+
+        # The the bash array into a colon-separated list of RPATHs.
+        rrPath=$(IFS=$':'; echo "''${rrPathArr[*]}")
+        echo "about to run patchelf with the following rpath: $rrPath"
+
+        find $out -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
+          echo "about to patchelf $lib..."
+          chmod a+rx "$lib"
+          patchelf --set-rpath "$rrPath" "$lib"
+          ${lib.optionalString cudaSupport ''
+            addDriverRunpath "$lib"
+          ''}
+        done
+      ''
+    );
 
   # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow
   # and the propagated input tensorboard, which causes environment collisions.


### PR DESCRIPTION
## Things done

As we fetch the "cpu-only" tensorflow wheel, we get a package named `tensorflow_cpu`.
While `import tensorflow` works fine, our `pythonRuntimeDepsCheck` calls `importlib.metadata.distribution('tensorflow')` which fails with:
```
importlib.metadata.PackageNotFoundError: No package metadata was found for tensorflow
```

This PR introduces a (dirty) patch that renames the generated artifacts from `tensorflow_cpu` to `tensorflow`.

**Note:** This only affects `x86_64-linux`.

cc @mweinelt @SomeoneSerge

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
