### PR TITLE
vllm: 0.6.2 -> 0.6.4

### DIFF
--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pydantic,
+  transformers,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "compressed-tensors";
+  version = "0.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "neuralmagic";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-iTCGfufnrCT1LMz0e5MfD4XfbvYhUb/Ujbfnb5MkTUw=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pydantic
+    transformers
+    torch
+  ];
+}

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -55,14 +55,6 @@ buildPythonPackage rec {
     fetchSubmodules = true;
   };
 
-  patches = [
-    (fetchpatch {
-      url =
-        "https://github.com/cfhammill/cupy/commit/67526c756e4a0a70f0420bf0e7f081b8a35a8ee5.patch";
-      hash = "sha256-WZgexBdM9J0ep5s+9CGZriVq0ZidCRccox+g0iDDywQ=";
-    })
-  ];
-
   # See https://docs.cupy.dev/en/v10.2.0/reference/environment.html. Seting both
   # CUPY_NUM_BUILD_JOBS and CUPY_NUM_NVCC_THREADS to NIX_BUILD_CORES results in
   # a small amount of thrashing but it turns out there are a large number of

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -47,6 +47,8 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
+  stdenv = cudaPackages.backendStdenv;
+
   src = fetchFromGitHub {
     owner = "cupy";
     repo = "cupy";

--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  numpy,
+  pydantic,
+  jsonschema,
+  sentencepiece,
+  typing-extensions,
+  tiktoken,
+  pillow,
+  requests,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "mistral-common";
+  version = "1.5.1";
+  pyproject = true;
+
+  build-system = [
+    poetry-core
+  ];
+
+  disabled = pythonOlder "3.8";
+
+  dependencies = [
+    numpy
+    pydantic
+    jsonschema
+    sentencepiece
+    typing-extensions
+    tiktoken
+    pillow
+    requests
+  ];
+
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-TaFqkR/P/xoKMCsB8G98CHN0I3d80S2uLYyDg0P88VE=";
+  };
+
+  meta = with lib; {
+    description = "mistral-common is a set of tools to help you work with Mistral models.";
+    homepage = "https://github.com/mistralai/mistral-common";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bgamari ];
+  };
+}

--- a/pkgs/development/python-modules/partial-json-parser/default.nix
+++ b/pkgs/development/python-modules/partial-json-parser/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pdm-backend,
+}:
+
+buildPythonPackage rec {
+  pname = "partial-json-parser";
+  version = "0.2.1.1.post4";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "partial_json_parser";
+    inherit version;
+    hash = "sha256-o48Rzriahvv70KytQXDUF9yzF2IcbsmrXytmUvP0YL8=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+}

--- a/pkgs/development/python-modules/vllm/0003-propagate-pythonpath.patch
+++ b/pkgs/development/python-modules/vllm/0003-propagate-pythonpath.patch
@@ -1,0 +1,12 @@
+diff --git a/vllm/model_executor/models/registry.py b/vllm/model_executor/models/registry.py
+index f5a02a5b..e830f987 100644
+--- a/vllm/model_executor/models/registry.py
++++ b/vllm/model_executor/models/registry.py
+@@ -482,6 +482,7 @@ def _run_in_subprocess(fn: Callable[[], _T]) -> _T:
+         returned = subprocess.run(
+             [sys.executable, "-m", "vllm.model_executor.models.registry"],
+             input=input_bytes,
++            env={'PYTHONPATH': ':'.join(sys.path)},
+             capture_output=True)
+ 
+         # check if the subprocess is successful

--- a/pkgs/development/python-modules/vllm/0004-drop-lsmod.patch
+++ b/pkgs/development/python-modules/vllm/0004-drop-lsmod.patch
@@ -1,0 +1,28 @@
+commit bdaf607ea3cad3aa6188f4f15d9aff7132e5ef73
+Author: Ben Gamari <ben@smart-cactus.org>
+Date:   Wed Nov 27 14:56:15 2024 -0500
+
+    Drop use of lsmod
+
+diff --git a/setup.py b/setup.py
+index b9365898..20d96409 100644
+--- a/setup.py
++++ b/setup.py
+@@ -254,16 +254,7 @@ def _is_hpu() -> bool:
+     try:
+         subprocess.run(["hl-smi"], capture_output=True, check=True)
+     except (FileNotFoundError, PermissionError, subprocess.CalledProcessError):
+-        if not os.path.exists('/dev/accel/accel0') and not os.path.exists(
+-                '/dev/accel/accel_controlD0'):
+-            # last resort...
+-            try:
+-                output = subprocess.check_output(
+-                    'lsmod | grep habanalabs | wc -l', shell=True)
+-                is_hpu_available = int(output) > 0
+-            except (ValueError, FileNotFoundError, PermissionError,
+-                    subprocess.CalledProcessError):
+-                is_hpu_available = False
++        is_hpu_available = False
+     return is_hpu_available or VLLM_TARGET_DEVICE == "hpu"
+ 
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9857,6 +9857,8 @@ self: super: with self; {
 
   parts = callPackage ../development/python-modules/parts { };
 
+  partial-json-parser = callPackage ../development/python-modules/partial-json-parser { };
+
   particle = callPackage ../development/python-modules/particle { };
 
   parver = callPackage ../development/python-modules/parver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8097,6 +8097,8 @@ self: super: with self; {
 
   mistletoe = callPackage ../development/python-modules/mistletoe { };
 
+  mistral-common = callPackage ../development/python-modules/mistral-common { };
+
   mistune = callPackage ../development/python-modules/mistune { };
 
   mitmproxy = callPackage ../development/python-modules/mitmproxy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2524,6 +2524,8 @@ self: super: with self; {
 
   compressai = callPackage ../development/python-modules/compressai { };
 
+  compressed-tensors = callPackage ../development/python-modules/compressed-tensors { };
+
   compressed-rtf = callPackage ../development/python-modules/compressed-rtf { };
 
   concurrent-log-handler = callPackage ../development/python-modules/concurrent-log-handler { };


### PR DESCRIPTION
This updates the previously-broken `vllm` derivation to 0.6.4 and brings it into a functional state. Specifically I:

 * introduce needed Python dependencies (`compressed-tensors`, `mistral-common`, and `partial-json-parser`)
 * rework how target selection is handled and introduce support for the CPU backend
 * fix `vllm`'s subprocess spawn logic to ensure that `PYTHONPATH` is propagated to the child


Smoke-tested with:

```nix
let
  pkgs = import ./. {};

  cpu = pkgs.python3Packages.vllm;

  rocm = pkgs.python3Packages.vllm.override {
    torch = pkgs.python3Packages.torchWithRocm;
  };

  cuda = pkgs.python3Packages.vllm.override {
    torch = pkgs.python3Packages.torchWithCuda;
  };
in { inherit cpu rocm cuda; }
```
invoking `bin/vllm serve facebook/opt-125m --chat-template ./template.jinja` and then `bin/vllm chat`. 

Currently `rocm` is broken due to `torch` but `cpu` works. `cuda` test is still running.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (using the `cpu` target)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
