### PR TITLE
kodiPackages.{twitch, python-twitch}: init at 3.0.2

### DIFF
--- a/pkgs/applications/video/kodi/addons/python-twitch/default.nix
+++ b/pkgs/applications/video/kodi/addons/python-twitch/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rel,
+  buildKodiAddon,
+  fetchzip,
+  addonUpdateScript,
+  requests,
+  six,
+}:
+buildKodiAddon rec {
+  pname = "python-twitch";
+  namespace = "script.module.python.twitch";
+  version = "3.0.2";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/${lib.toLower rel}/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-9MzGrBlMz8nZKTgCJrMAWDxKiZuzlhnTOxbja+XTxCI=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    six
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.twitch-module";
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/anxdpanic/script.module.python.twitch";
+    description = "Python twitch library packed for Kodi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ itepastra ];
+  };
+}

--- a/pkgs/applications/video/kodi/addons/twitch/default.nix
+++ b/pkgs/applications/video/kodi/addons/twitch/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rel,
+  buildKodiAddon,
+  fetchzip,
+  addonUpdateScript,
+  requests,
+  python-twitch,
+}:
+buildKodiAddon rec {
+  pname = "twitch";
+  namespace = "plugin.video.twitch";
+  version = "3.0.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/${lib.toLower rel}/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-EQj4/yejzUVzLfiYHw38ip1DIqfShnEVrxcfLYjbBaI=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    python-twitch
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.trakt";
+    };
+  };
+
+  meta = {
+    homepage = "https://kodi.wiki/view/Add-on:Twitch";
+    description = "Twitch.tv livestream integration";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ itepastra ];
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -213,6 +213,8 @@ let
 
     typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
 
+    twitch = callPackage ../applications/video/kodi/addons/twitch { };
+
     arrow = callPackage ../applications/video/kodi/addons/arrow { };
 
     trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -185,6 +185,8 @@ let
 
     plugin-cache = callPackage ../applications/video/kodi/addons/plugin-cache { };
 
+    python-twitch = callPackage ../applications/video/kodi/addons/python-twitch { };
+
     requests = callPackage ../applications/video/kodi/addons/requests { };
 
     requests-cache = callPackage ../applications/video/kodi/addons/requests-cache { };


### PR DESCRIPTION
- **kodiPackages.python-twitch: init at 3.0.2**
- **kodiPackages.twitch: init at 3.0.2**

fixes #274154

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
