### PR TITLE
parca: init at 0.22.0

### DIFF
--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -1,0 +1,80 @@
+{
+  buildGoModule,
+  faketty,
+  fetchFromGitHub,
+  lib,
+  nodejs,
+  pnpm,
+  stdenv,
+}:
+let
+  version = "0.22.0";
+
+  parca-src = fetchFromGitHub {
+    owner = "parca-dev";
+    repo = "parca";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-iuTlKUmugRum0qZRhuw0FR13iE2qrQegTgwpAvgJSXk=";
+  };
+
+  ui = stdenv.mkDerivation (finalAttrs: {
+    inherit version;
+    pname = "parca-ui";
+    src = "${parca-src}/ui";
+
+    pnpmDeps = pnpm.fetchDeps {
+      inherit (finalAttrs) pname src version;
+      hash = "sha256-MVNO24Oksy/qRUmEUoWoviQEo6Eimb18ZnDj5Z1vJkY=";
+    };
+
+    nativeBuildInputs = [
+      faketty
+      nodejs
+      pnpm.configHook
+    ];
+
+    # faketty is required to work around a bug in nx.
+    # See: https://github.com/nrwl/nx/issues/22445
+    buildPhase = ''
+      runHook preBuild
+      faketty pnpm build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/parca
+      mv packages/app/web/build $out/share/parca/ui
+      runHook postInstall
+    '';
+  });
+in
+
+buildGoModule rec {
+  inherit version;
+
+  pname = "parca";
+  src = parca-src;
+
+  vendorHash = "sha256-fErrbi3iSJlkguqzL6nH+fzmjxhoYVl1qH7tqRR1F1A=";
+
+  ldflags = [
+    "-X=main.version=${version}"
+    "-X=main.commit=${src.rev}"
+  ];
+
+  preBuild = ''
+    # Copy the built UI into the right place for the Go build to embed it.
+    cp -r ${ui}/share/parca/ui/* ui/packages/app/web/build
+  '';
+
+  meta = {
+    mainProgram = "parca";
+    description = "Continuous profiling for analysis of CPU and memory usage";
+    homepage = "https://github.com/parca-dev/parca";
+    changelog = "https://github.com/parca-dev/parca/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}


### PR DESCRIPTION
## Things done

This PR introduces the `parca` package. Parca, according to their own description, provides:

> Continuous profiling for analysis of CPU and memory usage, down to the line number and throughout time. Saving infrastructure cost, improving performance, and increasing reliability.

The package comprises a NodeJS frontend, and a Go backend. Note that this is the open-source server implementation, not the agent (which I may package later, but is significantly more complex).


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
