### PR TITLE
buildGoModule: Use the `env` attribute to pass environment variables 

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -176,31 +176,6 @@ Following example could be used to only build the example-cli and example-server
 
 Specified as a string or list of strings. Causes the builder to skip building child packages that match any of the provided values.
 
-### `CGO_ENABLED` {#var-go-CGO_ENABLED}
-
-When set to `0`, the [cgo](https://pkg.go.dev/cmd/cgo) command is disabled. As consequence, the build
-program can't link against C libraries anymore, and the resulting binary is statically linked.
-
-When building with CGO enabled, Go will likely link some packages from the Go standard library against C libraries,
-even when the target code does not explicitly call into C dependencies. With `env.CGO_ENABLED = 0;`, Go
-will always use the Go native implementation of these internal packages. For reference see
-[net](https://pkg.go.dev/net#hdr-Name_Resolution) and [os/user](https://pkg.go.dev/os/user#pkg-overview) packages.
-Notice that the decision whether these packages should use native Go implementation or not can also be controlled
-on a per package level using build tags (`tags`). In case CGO is disabled, these tags have no additional effect.
-
-When a Go program depends on C libraries, place those dependencies in `buildInputs`:
-
-```nix
-{
-  buildInputs = [
-    libvirt
-    libxml2
-  ];
-}
-```
-
-`CGO_ENABLED` defaults to `1`.
-
 ### `enableParallelBuilding` {#var-go-enableParallelBuilding}
 
 Whether builds and tests should run in parallel.
@@ -247,7 +222,34 @@ Alternatively, the primary derivation provides an overridable `passthru.override
 
 ## Controlling the Go environment {#ssec-go-environment}
 
-The Go build can be further tweaked by setting environment variables. In most cases, this isn't needed. Possible values can be found in the [Go documentation of accepted environment variables](https://pkg.go.dev/cmd/go#hdr-Environment_variables). Notice that some of these flags are set by the builder itself and should not be set explicitly. If in doubt, grep the implementation of the builder.
+The Go build can be further tweaked by setting environment variables via the `env` attribute. In most cases, this isn't needed. Possible values can be found in the [Go documentation of accepted environment variables](https://pkg.go.dev/cmd/go#hdr-Environment_variables). Notice that some of these flags are set by the build helper itself and should not be set explicitly. If in doubt, grep the implementation of the build helper.
+
+`buildGoModule` officially supports the following environment variables:
+
+### `env.CGO_ENABLED` {#var-go-CGO_ENABLED}
+
+When set to `0`, the [cgo](https://pkg.go.dev/cmd/cgo) command is disabled. As consequence, the build
+program can't link against C libraries anymore, and the resulting binary is statically linked.
+
+When building with CGO enabled, Go will likely link some packages from the Go standard library against C libraries,
+even when the target code does not explicitly call into C dependencies. With `env.CGO_ENABLED = 0;`, Go
+will always use the Go native implementation of these internal packages. For reference see
+[net](https://pkg.go.dev/net#hdr-Name_Resolution) and [os/user](https://pkg.go.dev/os/user#pkg-overview) packages.
+Notice that the decision whether these packages should use native Go implementation or not can also be controlled
+on a per package level using build tags (`tags`). In case CGO is disabled, these tags have no additional effect.
+
+When a Go program depends on C libraries, place those dependencies in `buildInputs`:
+
+```nix
+{
+  buildInputs = [
+    libvirt
+    libxml2
+  ];
+}
+```
+
+`env.CGO_ENABLED` defaults to `1`.
 
 ## Skipping tests {#ssec-skip-go-tests}
 

--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -182,7 +182,7 @@ When set to `0`, the [cgo](https://pkg.go.dev/cmd/cgo) command is disabled. As c
 program can't link against C libraries anymore, and the resulting binary is statically linked.
 
 When building with CGO enabled, Go will likely link some packages from the Go standard library against C libraries,
-even when the target code does not explicitly call into C dependencies. With `CGO_ENABLED = 0;`, Go
+even when the target code does not explicitly call into C dependencies. With `env.CGO_ENABLED = 0;`, Go
 will always use the Go native implementation of these internal packages. For reference see
 [net](https://pkg.go.dev/net#hdr-Name_Resolution) and [os/user](https://pkg.go.dev/os/user#pkg-overview) packages.
 Notice that the decision whether these packages should use native Go implementation or not can also be controlled

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -63,6 +63,12 @@
 - `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
   See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
 
+- `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
+
+  Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.
+
+  Third-party projects supporting both stable and unstable channels could detect this change through the absence of the `CGO_ENABLED` function argument in `buildGoModule` (`!((lib.functionArgs buildGoModule) ? CGO_ENABLED)`).
+
 - `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
 
 - `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-cm-push.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-cm-push.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     sed -e '/^hooks:/,+2 d' -i plugin.yaml
   '';
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-dt.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-dt.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
 
   # require network/login
   doCheck = false;
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   postInstall = ''
     install -dm755 $out/helm-dt/bin

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -39,7 +39,7 @@ let
         doCheck = false;
         # https://github.com/hashicorp/terraform-provider-scaffolding/blob/a8ac8375a7082befe55b71c8cbb048493dd220c2/.goreleaser.yml
         # goreleaser (used for builds distributed via terraform registry) requires that CGO is disabled
-        CGO_ENABLED = 0;
+        env.CGO_ENABLED = 0;
         ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${rev}" ];
         src = mkProviderFetcher {
           name = "source-${rev}";

--- a/pkgs/applications/networking/discordo/default.nix
+++ b/pkgs/applications/networking/discordo/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-UTZIx4zXIMdQBQXfzk3+j43yx7vlitw4Mwmon8oYjd8=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -120,7 +120,7 @@ buildPythonApplication rec {
     "fortify3"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   GOFLAGS = "-trimpath";
 
   configurePhase = ''

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -59,11 +59,12 @@
 }@args':
 
 let
-  args = removeAttrs args' [ "overrideModAttrs" ];
-
-  GO111MODULE = "on";
-  GOTOOLCHAIN = "local";
-
+  args = removeAttrs args' [
+    "overrideModAttrs"
+    # Compatibility layer to the directly-specified CGO_ENABLED.
+    # TODO(@ShamrockLee): Remove after Nixpkgs 25.05 branch-off
+    "CGO_ENABLED"
+  ];
 in
 (stdenv.mkDerivation (finalAttrs:
   args
@@ -77,8 +78,6 @@ in
     nativeBuildInputs = (finalAttrs.nativeBuildInputs or [ ]) ++ [ go git cacert ];
 
     inherit (finalAttrs) src modRoot;
-    inherit (go) GOOS GOARCH;
-    inherit GO111MODULE GOTOOLCHAIN;
 
     # The following inheritance behavior is not trivial to expect, and some may
     # argue it's not ideal. Changing it may break vendor hashes in Nixpkgs and
@@ -169,14 +168,33 @@ in
 
     nativeBuildInputs = [ go ] ++ nativeBuildInputs;
 
+  env = args.env or { } // {
     inherit (go) GOOS GOARCH;
+
+    GO111MODULE = "on";
+    GOTOOLCHAIN = "local";
+
+    CGO_ENABLED = args.env.CGO_ENABLED or (
+      if args'?CGO_ENABLED then
+        # Compatibility layer to the CGO_ENABLED attribute not specified as env.CGO_ENABLED
+        # TODO(@ShamrockLee): Remove and convert to
+        # CGO_ENABLED = args.env.CGO_ENABLED or go.CGO_ENABLED
+        # after the Nixpkgs 25.05 branch-off.
+        lib.warn
+          "${finalAttrs.finalPackage.meta.position}: buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead."
+          args'.CGO_ENABLED
+      else
+        go.CGO_ENABLED
+    );
+  };
 
     GOFLAGS = GOFLAGS
       ++ lib.warnIf (lib.any (lib.hasPrefix "-mod=") GOFLAGS) "use `proxyVendor` to control Go module/vendor behavior instead of setting `-mod=` in GOFLAGS"
         (lib.optional (!finalAttrs.proxyVendor) "-mod=vendor")
       ++ lib.warnIf (builtins.elem "-trimpath" GOFLAGS) "`-trimpath` is added by default to GOFLAGS by buildGoModule when allowGoReference isn't set to true"
         (lib.optional (!allowGoReference) "-trimpath");
-    inherit CGO_ENABLED enableParallelBuilding GO111MODULE GOTOOLCHAIN;
+
+  inherit enableParallelBuilding;
 
     # If not set to an explicit value, set the buildid empty for reproducibility.
     ldflags = ldflags ++ lib.optional (!lib.any (lib.hasPrefix "-buildid=") ldflags) "-buildid=";

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -40,9 +40,6 @@
   # IE: programs coupled with the compiler.
 , allowGoReference ? false
 
-  # Go env. variable to enable CGO.
-, CGO_ENABLED ? go.CGO_ENABLED
-
   # Meta data for the final derivation.
 , meta ? { }
 

--- a/pkgs/by-name/ar/arkade/package.nix
+++ b/pkgs/by-name/ar/arkade/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     hash = "sha256-MFce+stC+OzUL0H0ahZZAfMwr9Y+EVJIMmhhRl4JYaU=";
   };
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/at/athens/package.nix
+++ b/pkgs/by-name/at/athens/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-W65lQYGrRg8LwFERj5MBOPFAn2j+FE7ep4ANuAGmfgM=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
   ldflags = [
     "-s"
     "-X github.com/gomods/athens/pkg/build.version=${version}"

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -6,7 +6,7 @@ buildGoModule {
 
   vendorHash = "sha256-BcL9QAc2jJqoPaQImJIFtCiu176nxmVcCLPjXjNBwqI=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "cmd/ldap" ];
 

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -285,7 +285,7 @@ let
         --replace-fail './web' "${authentik-django}/web"
     '';
 
-    CGO_ENABLED = 0;
+    env.CGO_ENABLED = 0;
 
     vendorHash = "sha256-BcL9QAc2jJqoPaQImJIFtCiu176nxmVcCLPjXjNBwqI=";
 

--- a/pkgs/by-name/au/authentik/radius.nix
+++ b/pkgs/by-name/au/authentik/radius.nix
@@ -6,7 +6,7 @@ buildGoModule {
 
   vendorHash = "sha256-BcL9QAc2jJqoPaQImJIFtCiu176nxmVcCLPjXjNBwqI=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "cmd/radius" ];
 

--- a/pkgs/by-name/ba/bazel-watcher/package.nix
+++ b/pkgs/by-name/ba/bazel-watcher/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   vendorHash = "sha256-0I/bvuyosN55oNSMuom4C8rVjxneUaqV19l9OMiwWhU=";
 
   # The dependency github.com/fsnotify/fsevents requires CGO
-  CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
+  env.CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
   ldflags = [
     "-s"
     "-X main.Version=${version}"

--- a/pkgs/by-name/be/bee/package.nix
+++ b/pkgs/by-name/be/bee/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
     "-X github.com/ethersphere/bee/v2/pkg/postage/listener.batchFactorOverridePublic=5"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   postInstall = ''
     mkdir -p $out/lib/systemd/system

--- a/pkgs/by-name/be/betula/package.nix
+++ b/pkgs/by-name/be/betula/package.nix
@@ -13,7 +13,7 @@
   };
   vendorHash = "sha256-SWcQYF8LP6lw5kWlAVFt3qiwDnvpSOXenmdm6TSfJSc=";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
   # These tests use internet, so are failing in Nix build.
   # See also: https://todo.sr.ht/~bouncepaw/betula/91
   checkFlags = "-skip=TestTitles|TestHEntries";

--- a/pkgs/by-name/bi/bingo/package.nix
+++ b/pkgs/by-name/bi/bingo/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
     rm get_e2e_test.go get_e2e_utils_test.go
   '';
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/bi/bitrise/package.nix
+++ b/pkgs/by-name/bi/bitrise/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     "-X github.com/bitrise-io/bitrise/version.Commit=${src.rev}"
     "-X github.com/bitrise-io/bitrise/version.BuildNumber=0"
   ];
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/bl/bluetuith/package.nix
+++ b/pkgs/by-name/bl/bluetuith/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-tEVzuhE0Di7edGa5eJHLLqOecCuoj02h91TsZiZU1PM=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/br/brev-cli/package.nix
+++ b/pkgs/by-name/br/brev-cli/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-g+LjubG1s3z47I69mEfkSaAmi1+eNSp4M5Wic6h0+Xc=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   subPackages = [ "." ];
 
   ldflags = [

--- a/pkgs/by-name/bu/buildkit-nix/package.nix
+++ b/pkgs/by-name/bu/buildkit-nix/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-SFsf2QOIuUQY5Zzshb2190pQtOBGEsELBRihOvHYVGA=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/ca/capslock/package.nix
+++ b/pkgs/by-name/ca/capslock/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/capslock" ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/ch/chamber/package.nix
+++ b/pkgs/by-name/ch/chamber/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-1ySOlP0sFk3+IRt/zstZK6lEE2pzoVSiZz3wFxdesgc=";
   };
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   vendorHash = "sha256-KlouLjW9hVKFi9uz34XHd4CzNOiyO245QNygkB338YQ=";
 

--- a/pkgs/by-name/ci/civo/package.nix
+++ b/pkgs/by-name/ci/civo/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # Some lint checks fail
   doCheck = false;

--- a/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
+++ b/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
     "-X=main.date=1970-01-01"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   passthru.tests.version = testers.testVersion { package = cloudflare-dynamic-dns; };
 

--- a/pkgs/by-name/co/colima/package.nix
+++ b/pkgs/by-name/co/colima/package.nix
@@ -41,7 +41,7 @@ buildGoModule rec {
   # https://hydra.nixos.org/build/212378003/log
   excludedPackages = "gvproxy";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   preConfigure = ''
     ldflags="-s -w -X github.com/abiosoft/colima/config.appVersion=${version} \

--- a/pkgs/by-name/co/commitizen-go/package.nix
+++ b/pkgs/by-name/co/commitizen-go/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-X 'github.com/lintingzhen/commitizen-go/cmd.revision=${commit_revision}'"

--- a/pkgs/by-name/co/copacetic/package.nix
+++ b/pkgs/by-name/co/copacetic/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     versionCheckHook
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # These packages contain networking dependent tests which fail in the sandbox
   excludedPackages = [

--- a/pkgs/by-name/de/deck/package.nix
+++ b/pkgs/by-name/de/deck/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s -w -X github.com/kong/deck/cmd.VERSION=${version}"

--- a/pkgs/by-name/do/docker-credential-gcr/package.nix
+++ b/pkgs/by-name/do/docker-credential-gcr/package.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-YcBDurQjGhjds3CB63gTjsPbsvlHJnGxWbsFrx3vCy4=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ea/earthly/package.nix
+++ b/pkgs/by-name/ea/earthly/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   vendorHash = "sha256-bwNuQPGjAQ9Afa2GuPWrW8ytfIvhsOYFKPt0zyfdZhU=";
   subPackages = [ "cmd/earthly" "cmd/debugger" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ea/easeprobe/package.nix
+++ b/pkgs/by-name/ea/easeprobe/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/easeprobe" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/en/endlessh-go/package.nix
+++ b/pkgs/by-name/en/endlessh-go/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-unIyU60IrbiKDIjUf9F2pqqGNIA4gFp5XyQlvx6+xxQ=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -29,7 +29,7 @@ buildGoModule {
 
   vendorHash = "sha256-Gg1mifMVt6Ma8yQ/t0R5nf6NXbzLZBpuZrYsW48p0mw=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fa/faas-cli/package.nix
+++ b/pkgs/by-name/fa/faas-cli/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/fe/ferretdb/package.nix
+++ b/pkgs/by-name/fe/ferretdb/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-GT6e9yd6LF6GFlGBWVAmcM6ysB/6cIGLbnM0hxfX5TE=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "cmd/ferretdb" ];
 

--- a/pkgs/by-name/fl/flclash/package.nix
+++ b/pkgs/by-name/fl/flclash/package.nix
@@ -33,7 +33,7 @@ let
 
     vendorHash = "sha256-yam3DgY/dfwIRc7OvFltwX29x6xGlrrsK4Oj6oaGYRw=";
 
-    CGO_ENABLED = 0;
+    env.CGO_ENABLED = 0;
 
     buildPhase = ''
       runHook preBuild

--- a/pkgs/by-name/fz/fzf/package.nix
+++ b/pkgs/by-name/fz/fzf/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-utHQzXjtdnshUsYDQEQY2qoQGZsnfXXPj3A9VsDj0vQ=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/by-name/ga/gat/package.nix
+++ b/pkgs/by-name/ga/gat/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-ns1jFmBvIfclb3SBtdg05qNBy18p6VjtEKrahtxJUM4=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -43,7 +43,7 @@ in buildGo123Module rec {
 
   vendorHash = "sha256-oly6SLgXVyvKQQuPrb76LYngoDPNLjTAs4gWCT3/kew=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/gl/globalping-cli/package.nix
+++ b/pkgs/by-name/gl/globalping-cli/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   preCheck = ''

--- a/pkgs/by-name/go/go-chromecast/package.nix
+++ b/pkgs/by-name/go/go-chromecast/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-EI37KPdNxPXdgmxvawTiRQ516dLxt5o0iYvGcAHXdUw=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/go/go-graft/package.nix
+++ b/pkgs/by-name/go/go-graft/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-DXW0NtFYvcCX4CgMs5/5HPaO9f9eFtw401wmJdCbHPU=";
   };
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-X github.com/mzz2017/gg/cmd.Version=${version}" "-s" "-w" ];
   vendorHash = "sha256-fnM4ycqDyruCdCA1Cr4Ki48xeQiTG4l5dLVuAafEm14=";

--- a/pkgs/by-name/go/go-judge/package.nix
+++ b/pkgs/by-name/go/go-judge/package.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
     echo v${version} > ./cmd/go-judge/version/version.txt
   '';
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = with lib; {
     description = "High performance sandbox service based on container technologies";

--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     "-X" "github.com/vektra/mockery/v2/pkg/logging.SemVer=v${version}"
   ];
 
-  CGO_ENABLED = false;
+  env.CGO_ENABLED = false;
 
   proxyVendor = true;
   vendorHash = "sha256-z1ceS+LO6d7T264pw2BLadw804aGRISyrKW/dr4fZHA=";

--- a/pkgs/by-name/go/go-task/package.nix
+++ b/pkgs/by-name/go/go-task/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     "-X=github.com/go-task/task/v3/internal/version.version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   postInstall = ''
     ln -s $out/bin/task $out/bin/go-task

--- a/pkgs/by-name/go/go2rtc/package.nix
+++ b/pkgs/by-name/go/go2rtc/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-N8aJmxNQ/p2ddJG9DuIVVjcgzEC6TzD0sz992h3q0RU=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/go/gobusybox/package.nix
+++ b/pkgs/by-name/go/gobusybox/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
     "cmd/rewritepkg"
   ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   vendorHash = "sha256-s4bQLXNFhyAk+UNI1xJXQABjBXtPFXiWvmdttV/6Bm8=";
 

--- a/pkgs/by-name/go/gofumpt/package.nix
+++ b/pkgs/by-name/go/gofumpt/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-kJysyxROvB0eMAHbvNF+VXatEicn4ln2Vqkzp7GDWAQ=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/go/goimports-reviser/package.nix
+++ b/pkgs/by-name/go/goimports-reviser/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   };
   vendorHash = "sha256-z+FeAXPXKi653im2X2WOP1R9gRl/x7UBnndoEXoxdwA=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/go/gose/package.nix
+++ b/pkgs/by-name/go/gose/package.nix
@@ -39,7 +39,7 @@ buildGoModule {
 
   vendorHash = "sha256-U/umJ6McCuD0HARVMj1JXHOpVxcph16z7Y7i47Nf3cg=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/gose

--- a/pkgs/by-name/go/goss/package.nix
+++ b/pkgs/by-name/go/goss/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-Rf6Xt54y1BN2o90rDW0WvEm4H5pPfsZ786MXFjsAFaM=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/gr/grmon/package.nix
+++ b/pkgs/by-name/gr/grmon/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-ySgWEGHlEJpfB/BZuRs1bELBspEaiaX/UnJai2V/hx0=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/gt/gtrash/package.nix
+++ b/pkgs/by-name/gt/gtrash/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
   # disabled because it is required to run on docker.
   doCheck = false;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/gv/gvisor/package.nix
+++ b/pkgs/by-name/gv/gvisor/package.nix
@@ -34,7 +34,7 @@ buildGoModule {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/he/hello-go/package.nix
+++ b/pkgs/by-name/he/hello-go/package.nix
@@ -28,10 +28,12 @@ buildGoModule {
       Specify target platform by setting GOOS and GOARCH:
 
       ```nix
-      hello-go.overrideAttrs {
-        GOOS = "linux";
-        GOARCH = "arm64";
-      }
+      hello-go.overrideAttrs (previousAttrs: {
+        env = previousAttrs.env or { } // {
+          GOOS = "linux";
+          GOARCH = "arm64";
+        };
+      })
       ```
 
       See https://pkg.go.dev/internal/platform#pkg-variables for a list

--- a/pkgs/by-name/he/hello-go/package.nix
+++ b/pkgs/by-name/he/hello-go/package.nix
@@ -10,7 +10,7 @@ buildGoModule {
 
   vendorHash = null;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # go installs binary into $out/bin/$GOOS_$GOARCH/hello-go in cross compilation
   postInstall = ''

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -62,7 +62,6 @@ buildGo123Module {
   ];
 
   CGO_ENABLED = 0;
-  GOOS = "linux";
   doCheck = false;
 
   ldflags = [

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -61,7 +61,7 @@ buildGo123Module {
     nodejs
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   doCheck = false;
 
   ldflags = [

--- a/pkgs/by-name/hy/hyprspace/package.nix
+++ b/pkgs/by-name/hy/hyprspace/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
     hash = "sha256-zWajCfHFqPa3Z72DHcxBUq4bmcCu1lpEKUbZZewpYOE=";
   };
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   vendorHash = "sha256-LJpgGeD47Bs+Cq9Z7WWFa49F8/n3exOyxRcd6EkkL2g=";
 

--- a/pkgs/by-name/im/imgpkg/package.nix
+++ b/pkgs/by-name/im/imgpkg/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/imgpkg" ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
   ldflags = [ "-X=carvel.dev/imgpkg/pkg/imgpkg/cmd.Version=${version}" ];
 
   meta = {

--- a/pkgs/by-name/in/incus/client.nix
+++ b/pkgs/by-name/in/incus/client.nix
@@ -23,7 +23,7 @@ buildGoModule {
     version
     ;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/in/infrastructure-agent/package.nix
+++ b/pkgs/by-name/in/infrastructure-agent/package.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
     "-X main.gitCommit=${src.rev}"
   ];
 
-  CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
+  env.CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
 
   subPackages = [
     "cmd/newrelic-infra"

--- a/pkgs/by-name/jj/jj/package.nix
+++ b/pkgs/by-name/jj/jj/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/jj" ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/jq/jq-lsp/package.nix
+++ b/pkgs/by-name/jq/jq-lsp/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = "sha256-8sZGnoP7l09ZzLJqq8TUCquTOPF0qiwZcFhojUnnEIY=";
 
   # based on https://github.com/wader/jq-lsp/blob/master/.goreleaser.yml
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/jx/jx/package.nix
+++ b/pkgs/by-name/jx/jx/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/k3/k3sup/package.nix
+++ b/pkgs/by-name/k3/k3sup/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
       --replace "/bin/bash" "${bash}/bin/bash"
   '';
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s" "-w"

--- a/pkgs/by-name/k8/k8sgpt/package.nix
+++ b/pkgs/by-name/k8/k8sgpt/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   vendorHash = "sha256-K9do7u13w2a/9jI7LRtbRvjKJcFU9AnDp2u+ZWSVxw0=";
 
   # https://nixos.org/manual/nixpkgs/stable/#var-go-CGO_ENABLED
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # https://nixos.org/manual/nixpkgs/stable/#ssec-skip-go-tests
   checkFlags = [

--- a/pkgs/by-name/ka/kapp/package.nix
+++ b/pkgs/by-name/ka/kapp/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/kapp" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-X carvel.dev/kapp/pkg/kapp/version.Version=${version}"

--- a/pkgs/by-name/kb/kbld/package.nix
+++ b/pkgs/by-name/kb/kbld/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/kbld" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-X=carvel.dev/kbld/pkg/kbld/version.Version=${version}"

--- a/pkgs/by-name/kd/kdigger/package.nix
+++ b/pkgs/by-name/kd/kdigger/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
 
   # static to be easily copied into containers since it's an in-pod pen-testing tool
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ke/keep-sorted/package.nix
+++ b/pkgs/by-name/ke/keep-sorted/package.nix
@@ -18,7 +18,7 @@ buildGo123Module rec {
 
   vendorHash = "sha256-HTE9vfjRmi5GpMue7lUfd0jmssPgSOljbfPbya4uGsc=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/ki/kind/package.nix
+++ b/pkgs/by-name/ki/kind/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ku/kube-router/package.nix
+++ b/pkgs/by-name/ku/kube-router/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-KmAMGKm+cFGRMD1Nyn9/CHv9vUvflAiLJcro08GIGtw=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ku/kubeclarity/package.nix
+++ b/pkgs/by-name/ku/kubeclarity/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/cli";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ku/kubectl-gadget/package.nix
+++ b/pkgs/by-name/ku/kubectl-gadget/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-V2bgMFJGo1t1MiJyACdB9mjM2xtHwgH6bNEbEeZC2XM=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s" "-w"

--- a/pkgs/by-name/ku/kubedock/package.nix
+++ b/pkgs/by-name/ku/kubedock/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
     "-X github.com/joyrex2001/kubedock/internal/config.Version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = with lib; {
     description = "Minimal implementation of the Docker API that will orchestrate containers on a Kubernetes cluster";

--- a/pkgs/by-name/ku/kubemq-community/package.nix
+++ b/pkgs/by-name/ku/kubemq-community/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
     sha256 = "sha256-oAo/O3T3wtfCumT2kjoyXKfCFHijVzSmxhslaKaeF3Y=";
   };
 
-  CGO_ENABLED=0;
+  env.CGO_ENABLED = 0;
 
   ldflags=[ "-w" "-s" "-X main.version=${version}" ];
 

--- a/pkgs/by-name/ku/kubevela/package.nix
+++ b/pkgs/by-name/ku/kubevela/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   subPackages = [ "references/cmd/cli" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # Workaround for permission issue in shell completion
   HOME = "$TMPDIR";

--- a/pkgs/by-name/ku/kulala-fmt/package.nix
+++ b/pkgs/by-name/ku/kulala-fmt/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-GazDEm/qv0nh8vYT+Tf0n4QDGHlcYtbMIj5rlZBvpKo=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ma/matchbox-server/package.nix
+++ b/pkgs/by-name/ma/matchbox-server/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
   ];
 
   # Disable cgo to produce a static binary
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # Don't run Go tests
   doCheck = false;

--- a/pkgs/by-name/mk/mkuimage/package.nix
+++ b/pkgs/by-name/mk/mkuimage/package.nix
@@ -25,7 +25,7 @@ buildGoModule {
     "cmd/mkuimage"
   ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/mo/mockgen/package.nix
+++ b/pkgs/by-name/mo/mockgen/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-0OnK5/e0juEYrNJuVkr+tK66btRW/oaHpJSDakB32Bc=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "mockgen" ];
 

--- a/pkgs/by-name/my/myks/package.nix
+++ b/pkgs/by-name/my/myks/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   passthru.tests.version = testers.testVersion { package = myks; };
 

--- a/pkgs/by-name/my/mynewt-newt/package.nix
+++ b/pkgs/by-name/my/mynewt-newt/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
 
   # CGO_ENABLED=0 required for mac - "error: 'TARGET_OS_MAC' is not defined, evaluates to 0"
   # https://github.com/shirou/gopsutil/issues/976
-  CGO_ENABLED = if stdenv.hostPlatform.isLinux then 1 else 0;
+  env.CGO_ENABLED = if stdenv.hostPlatform.isLinux then 1 else 0;
 
   meta = with lib; {
     homepage = "https://mynewt.apache.org/";

--- a/pkgs/by-name/na/nali/package.nix
+++ b/pkgs/by-name/na/nali/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [ "-s" "-w" "-X github.com/zu1k/nali/internal/constant.Version=${version}" ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-qDzd+aq08PN9kl1YkvNLGvWaFVh7xFXJhGdx/ELwYGY=";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   buildInputs = [
     libusb1

--- a/pkgs/by-name/no/nodeinfo/package.nix
+++ b/pkgs/by-name/no/nodeinfo/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = {
     mainProgram = "nodeinfo";

--- a/pkgs/by-name/no/nomad-driver-containerd/package.nix
+++ b/pkgs/by-name/no/nomad-driver-containerd/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     substituteInPlace containerd/driver.go --replace-warn 'PluginVersion = "v0.9.3"' 'PluginVersion = "v${version}"'
   '';
 
-  CGO_ENABLED = "1";
+  env.CGO_ENABLED = "1";
 
   vendorHash = "sha256-OO+a5AqhB0tf6lyodhYl9HUSaWvtXWwevRHYy1Q6VoU=";
   subPackages = [ "." ];

--- a/pkgs/by-name/nw/nwg-look/package.nix
+++ b/pkgs/by-name/nw/nwg-look/package.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
     gtk3
   ];
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   postInstall = ''
     mkdir -p $out/share

--- a/pkgs/by-name/op/opengfw/package.nix
+++ b/pkgs/by-name/op/opengfw/package.nix
@@ -9,7 +9,7 @@ let
 in
 buildGoModule {
   inherit pname version;
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   vendorHash = "sha256-F8jTvgxOhOGVtl6B8u0xAIvjNwVjBtvAhApzjIgykpY=";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/or/ory/package.nix
+++ b/pkgs/by-name/or/ory/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   tags = [
     "sqlite"

--- a/pkgs/by-name/pa/pathvector/package.nix
+++ b/pkgs/by-name/pa/pathvector/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-hgUuntT6jMWI14qDE3Yjm5W8UqQ6CcvoILmSDaVEZac=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}" "-X main.date=unknown" ];
 

--- a/pkgs/by-name/pi/picocrypt-cli/package.nix
+++ b/pkgs/by-name/pi/picocrypt-cli/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   meta = {
     description = "Command-line interface for Picocrypt";

--- a/pkgs/by-name/pi/picocrypt/package.nix
+++ b/pkgs/by-name/pi/picocrypt/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
     wrapGAppsHook3
   ];
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   postInstall = ''
     mv $out/bin/Picocrypt $out/bin/picocrypt-gui

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # Upstream build instructions
   ldflags = [

--- a/pkgs/by-name/po/podman-tui/package.nix
+++ b/pkgs/by-name/po/podman-tui/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   tags = [ "containers_image_openpgp" "remote" ]
     ++ lib.optional stdenv.hostPlatform.isDarwin "darwin";

--- a/pkgs/by-name/pu/pushup/package.nix
+++ b/pkgs/by-name/pu/pushup/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   vendorHash = null;
   subPackages = ".";
   # Pushup doesn't need CGO so disable it.
-  CGO_ENABLED=0;
+  env.CGO_ENABLED = 0;
   ldflags = [ "-s" "-w" ];
   nativeBuildInputs = [ makeWrapper ];
   # The Go compiler is a runtime dependency of Pushup.

--- a/pkgs/by-name/ra/ran/package.nix
+++ b/pkgs/by-name/ra/ran/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-ObroruWWNilHIclqNvbEaa7vwk+1zMzDKbjlVs7Fito=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-X" "main._version_=v${version}"

--- a/pkgs/by-name/sc/scripthaus/package.nix
+++ b/pkgs/by-name/sc/scripthaus/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-GUZNPLBgqN1zBzCcPl7TB9/4/Yk4e7K6I20nVaM6ank=";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-extldflags=-static" ];
 

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-SiQw6pq0Fyy8Ia39S/Vgp9Mlfog2drtVn43g+GXiQuI=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-extldflags=-static" ];
 

--- a/pkgs/by-name/sk/skeema/package.nix
+++ b/pkgs/by-name/sk/skeema/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/sl/slsa-verifier/package.nix
+++ b/pkgs/by-name/sl/slsa-verifier/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-HJ3/RY0Co86y1t2Mas5C+rjwRRG4ZJgxjkz9iWcKf5E=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "cli/slsa-verifier" ];
 

--- a/pkgs/by-name/sm/smtprelay/package.nix
+++ b/pkgs/by-name/sm/smtprelay/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
     "."
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   # We do not supply the build time as the build wouldn't be reproducible otherwise.
   ldflags = [

--- a/pkgs/by-name/st/stackit-cli/package.nix
+++ b/pkgs/by-name/st/stackit-cli/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   pname = "steampipe";
   version = "1.0.1";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   src = fetchFromGitHub {
     owner = "turbot";

--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -9,9 +9,12 @@ buildGo123Module {
     version
     src
     vendorHash
-    CGO_ENABLED
     ;
   pname = "tailscale-gitops-pusher";
+
+  env = {
+    inherit (tailscale) CGO_ENABLED;
+  };
 
   subPackages = [
     "cmd/gitops-pusher"

--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -9,7 +9,7 @@ buildGo123Module {
   pname = "tailscale-nginx-auth";
   inherit (tailscale) version src vendorHash;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "cmd/nginx-auth" ];
 

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -49,7 +49,7 @@ buildGo123Module {
     installShellFiles
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [
     "cmd/derper"

--- a/pkgs/by-name/te/templ/package.nix
+++ b/pkgs/by-name/te/templ/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/templ" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/te/temporal/package.nix
+++ b/pkgs/by-name/te/temporal/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   excludedPackages = [ "./build" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/by-name/te/terraform-plugin-docs/package.nix
+++ b/pkgs/by-name/te/terraform-plugin-docs/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
 
   allowGoReference = true;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/tr/trdl-client/package.nix
+++ b/pkgs/by-name/tr/trdl-client/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/trdl" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/tr/treefmt2/package.nix
+++ b/pkgs/by-name/tr/treefmt2/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ty/tygo/package.nix
+++ b/pkgs/by-name/ty/tygo/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-E73yqGhPzZA/1xTYGvTBy0/b4SE9hzx+gdhjX3ClE/Y=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/u-/u-root/package.nix
+++ b/pkgs/by-name/u-/u-root/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/up/updatecli/package.nix
+++ b/pkgs/by-name/up/updatecli/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
   # tests require network access
   doCheck = false;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/up/uplosi/package.nix
+++ b/pkgs/by-name/up/uplosi/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-2lJmPNLpI1ksFb0EtcjPjyTy7eX1DKeX0F80k9FtGno=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
   ldflags = [
     "-s"
     "-X main.version=${version}"

--- a/pkgs/by-name/va/vacuum-go/package.nix
+++ b/pkgs/by-name/va/vacuum-go/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-M9+AKgZwqnOtejIHdBF8MAWg2sJLX2cJtNdMZylp1UE=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/we/webmesh/package.nix
+++ b/pkgs/by-name/we/webmesh/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-xoc7NSdg5bn3aXgcrolJwv8jyrv2HEXFmiCtRXBVwVg=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [
     "cmd/webmesh-node"

--- a/pkgs/by-name/we/werf/package.nix
+++ b/pkgs/by-name/we/werf/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     lib.optionals stdenv.hostPlatform.isLinux [ btrfs-progs ]
     ++ lib.optionals stdenv.hostPlatform.isGnu [ stdenv.cc.libc.static ];
 
-  CGO_ENABLED = if stdenv.hostPlatform.isLinux then 1 else 0;
+  env.CGO_ENABLED = if stdenv.hostPlatform.isLinux then 1 else 0;
 
   ldflags =
     [
@@ -40,7 +40,7 @@ buildGoModule rec {
       "-w"
       "-X github.com/werf/werf/v2/pkg/werf.Version=v${version}"
     ]
-    ++ lib.optionals (CGO_ENABLED == 1) [
+    ++ lib.optionals (env.CGO_ENABLED == 1) [
       "-extldflags=-static"
       "-linkmode external"
     ];
@@ -53,7 +53,7 @@ buildGoModule rec {
       "dfrunsecurity"
       "dfssh"
     ]
-    ++ lib.optionals (CGO_ENABLED == 1) [
+    ++ lib.optionals (env.CGO_ENABLED == 1) [
       "cni"
       "exclude_graphdriver_devicemapper"
       "netgo"
@@ -73,7 +73,7 @@ buildGoModule rec {
         pkg/true_git/*test.go \
         test/e2e
     ''
-    + lib.optionalString (CGO_ENABLED == 0) ''
+    + lib.optionalString (env.CGO_ENABLED == 0) ''
       # A workaround for osusergo.
       export USER=nixbld
     '';

--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
   proxyVendor = true; # darwin/linux hash mismatch
   vendorHash = "sha256-YwFq0KxUctU3ElZBo/b68pyp4lJnFGL9ClKIwUzdngM=";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/wh/whoami/package.nix
+++ b/pkgs/by-name/wh/whoami/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   doCheck = false;
 

--- a/pkgs/by-name/wo/woodpecker-plugin-git/package.nix
+++ b/pkgs/by-name/wo/woodpecker-plugin-git/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-wB1Uv7ZSIEHzR8z96hwXScoGA31uhoql/wwAH3Olj2E=";
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/wu/wush/package.nix
+++ b/pkgs/by-name/wu/wush/package.nix
@@ -23,7 +23,7 @@ buildGoModule {
     "-s -w -X main.version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = with lib; {
     homepage = "https://github.com/coder/wush";

--- a/pkgs/by-name/zk/zk/package.nix
+++ b/pkgs/by-name/zk/zk/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   doCheck = false;
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   ldflags = [
     "-s"

--- a/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
@@ -14,7 +14,7 @@ buildGoModule {
 
   subPackages = "cmd/agent";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = common.meta // {
     description = "Woodpecker Continuous Integration agent";

--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -14,7 +14,7 @@ buildGoModule {
 
   subPackages = "cmd/cli";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = common.meta // {
     description = "Command line client for the Woodpecker Continuous Integration server";

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -14,7 +14,7 @@ buildGoModule {
 
   subPackages = "cmd/server";
 
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/development/tools/devpod/default.nix
+++ b/pkgs/development/tools/devpod/default.nix
@@ -46,7 +46,7 @@ rec {
 
     vendorHash = null;
 
-    CGO_ENABLED = 0;
+    env.CGO_ENABLED = 0;
 
     ldflags = [
       "-X github.com/loft-sh/devpod/pkg/version.version=v${version}"

--- a/pkgs/servers/etcd/3.5/default.nix
+++ b/pkgs/servers/etcd/3.5/default.nix
@@ -21,7 +21,9 @@ let
     hash = etcdSrcHash;
   };
 
-  env.CGO_ENABLED = 0;
+  env = {
+    CGO_ENABLED = 0;
+  };
 
   meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
@@ -35,7 +37,7 @@ let
     pname = "etcdserver";
 
     inherit
-      CGO_ENABLED
+      env
       meta
       src
       version
@@ -60,7 +62,7 @@ let
     pname = "etcdutl";
 
     inherit
-      CGO_ENABLED
+      env
       meta
       src
       version
@@ -75,7 +77,7 @@ let
     pname = "etcdctl";
 
     inherit
-      CGO_ENABLED
+      env
       meta
       src
       version

--- a/pkgs/servers/etcd/3.5/default.nix
+++ b/pkgs/servers/etcd/3.5/default.nix
@@ -21,7 +21,7 @@ let
     hash = etcdSrcHash;
   };
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";

--- a/pkgs/servers/mail/mailpit/default.nix
+++ b/pkgs/servers/mail/mailpit/default.nix
@@ -68,7 +68,7 @@ buildGoModule {
   pname = "mailpit";
   inherit src version vendorHash;
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -45,7 +45,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   tags = [ "kqueue" ];
 

--- a/pkgs/servers/minio/legacy_fs.nix
+++ b/pkgs/servers/minio/legacy_fs.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   tags = [ "kqueue" ];
 

--- a/pkgs/servers/monitoring/loki/promtail.nix
+++ b/pkgs/servers/monitoring/loki/promtail.nix
@@ -1,7 +1,9 @@
 { grafana-loki }:
 
-grafana-loki.overrideAttrs (o: {
+grafana-loki.overrideAttrs (previousAttrs: {
   pname = "promtail";
   subPackages = [ "clients/cmd/promtail" ];
-  env.CGO_ENABLED = 1;
+  env = previousAttrs.env or { } // {
+    CGO_ENABLED = 1;
+  };
 })

--- a/pkgs/servers/monitoring/loki/promtail.nix
+++ b/pkgs/servers/monitoring/loki/promtail.nix
@@ -3,5 +3,5 @@
 grafana-loki.overrideAttrs (o: {
   pname = "promtail";
   subPackages = [ "clients/cmd/promtail" ];
-  CGO_ENABLED = 1;
+  env.CGO_ENABLED = 1;
 })

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -41,8 +41,6 @@ import ./versions.nix (
       zlib
     ];
 
-    inherit (buildGoModule.go) GOOS GOARCH;
-
     # need to provide GO* env variables & patch for reproducibility
     postPatch = ''
       substituteInPlace src/go/Makefile.am \

--- a/pkgs/servers/tracing/honeycomb/honeymarker/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeymarker/default.nix
@@ -16,7 +16,6 @@ import ./versions.nix (
       rev = "v${version}";
       hash = sha256;
     };
-    inherit (buildGoModule.go) GOOS GOARCH;
 
     meta = with lib; {
       description = "provides a simple CRUD interface for dealing with per-dataset markers on honeycomb.io";

--- a/pkgs/servers/tracing/honeycomb/honeytail/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeytail/default.nix
@@ -16,7 +16,6 @@ import ./versions.nix (
       rev = "v${version}";
       hash = sha256;
     };
-    inherit (buildGoModule.go) GOOS GOARCH;
 
     meta = with lib; {
       description = "agent for ingesting log file data into honeycomb.io and making it available for exploration";

--- a/pkgs/servers/tracing/honeycomb/honeyvent/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeyvent/default.nix
@@ -16,7 +16,6 @@ import ./versions.nix (
       rev = "v${version}";
       hash = sha256;
     };
-    inherit (buildGoModule.go) GOOS GOARCH;
 
     meta = with lib; {
       description = "CLI for sending individual events to honeycomb.io";

--- a/pkgs/tools/misc/opentelemetry-collector/builder.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/builder.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   sourceRoot = "${src.name}/cmd/builder";
   vendorHash = "sha256-8g/92NOCj/mH1szrKR04R+Yy9GBYNnQFMi9KhqGKelU=";
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -100,7 +100,7 @@ let
         # upstream strongly recommends disabling CGO
         # additionally dependencies have had issues when GCO was enabled that weren't caught upstream
         # https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#using-cgo
-        CGO_ENABLED = 0;
+        env.CGO_ENABLED = 0;
 
         ldflags = [
           "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Pass all environment variables with `env` and instruct users to do so in the Nixpkgs Reference Manual.

This is part of the efforts to allow `buildGoModule` to take `__structuredAttrs = true`. This change would only rebuild the documentation ~and is easy to merge~ (it turns out to be a tree-wide fix, but fortunately, reviewers can reproduce the tree-wide changes by string substitution). Other significant/mass-rebuilding changes are split away to make reviewing smoother.

One may notice that the added code's indentation differs from the surrounding code. That is because the original code is out-of-formatting and indented too much.

These changes should rebuild no packages other than the documentation.

Cc:
@doronbehar @kalbasit @zowoq (people who might be interested in `buildGoModule`)
@emilazy @wolfgangwalther (people who might be interested in `__structuredAttrs`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
