### PR TITLE
 home-assistant-custom-components.philips_airpurifier_coap: init at 0.28.0, python3Packages.aioairctrl: init at 0.2.5 

### DIFF
--- a/pkgs/development/python-modules/aioairctrl/default.nix
+++ b/pkgs/development/python-modules/aioairctrl/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  wheel,
+  aiocoap,
+  pycryptodomex,
+}:
+
+buildPythonPackage rec {
+  pname = "aioairctrl";
+  version = "0.2.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-BPUV79S2A0F6vZA2pd3XNLpmRHTp6RSoNXPcI+OJRbk=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    aiocoap
+    pycryptodomex
+  ];
+
+  pythonImportsCheck = [ "aioairctrl" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Library for controlling Philips air purifiers (using encrypted CoAP)";
+    homepage = "https://github.com/kongo09/aioairctrl";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ justinas ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/philips_airpurifier_coap/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/philips_airpurifier_coap/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+
+  aioairctrl,
+  getmac,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "kongo09";
+  domain = "philips_airpurifier_coap";
+  version = "0.28.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "philips-airpurifier-coap";
+    rev = "v${version}";
+    hash = "sha256-yoaph/R3c4j+sXEC02Hv+ixtuif70/y6Gag5NBpKFLs=";
+  };
+
+  postPatch = ''
+    substituteInPlace custom_components/philips_airpurifier_coap/manifest.json --replace-fail 'getmac==0.9.4' 'getmac>=0.9.4'
+  '';
+
+  dependencies = [
+    aioairctrl
+    getmac
+  ];
+
+  meta = {
+    description = "Philips AirPurifier custom component for Home Assistant";
+    homepage = "https://github.com/kongo09/philips-airpurifier-coap";
+    license = lib.licenses.unfree; # See https://github.com/kongo09/philips-airpurifier-coap/issues/209
+    maintainers = with lib.maintainers; [ justinas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -153,6 +153,8 @@ self: super: with self; {
 
   aio-pika = callPackage ../development/python-modules/aio-pika { };
 
+  aioairctrl = callPackage ../development/python-modules/aioairctrl { };
+
   aioacaia = callPackage ../development/python-modules/aioacaia { };
 
   aioairzone = callPackage ../development/python-modules/aioairzone { };


### PR DESCRIPTION
Adds the [philips-airpurifier-coap](https://github.com/kongo09/philips-airpurifier-coap) Home Assistant custom component.

Manually confirmed that the integration works on my Home Assistant instance.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
