### PR TITLE
libpq: init at 17.2

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -246,6 +246,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /maintainers/scripts/kde @K900 @NickCao @SuperSandro2000 @ttuegel
 
 # PostgreSQL and related stuff
+/pkgs/by-name/ps/psqlodbc @NixOS/postgres
 /pkgs/servers/sql/postgresql @NixOS/postgres
 /pkgs/development/tools/rust/cargo-pgrx @NixOS/postgres
 /nixos/modules/services/databases/postgresql.md @NixOS/postgres

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -7,7 +7,7 @@
 , nix-update-script
 , openssl
 , pkg-config
-, postgresql
+, libpq
 , protobuf
 , rustPlatform
 , rust-jemalloc-sys
@@ -130,7 +130,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   nativeCheckInputs = [
-    postgresql
+    libpq
   ];
 
   passthru = {

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -27,7 +27,7 @@
 , netcdf
 , pdal
 , pkg-config
-, postgresql
+, libpq
 , proj
 , python3Packages
 , readline
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     netcdf
     pdal
-    postgresql
+    libpq
     proj
     readline
     sqlite
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-openmp"
     "--with-pdal"
     "--with-postgres"
-    "--with-postgres-libs=${postgresql.lib}/lib/"
+    "--with-postgres-libs=${libpq}/lib/"
     "--with-proj-includes=${proj.dev}/include"
     "--with-proj-libs=${proj}/lib"
     "--with-proj-share=${proj}/share/proj"

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -21,6 +21,7 @@
   grass,
   gsl,
   hdf5,
+  libpq,
   libspatialindex,
   libspatialite,
   libzip,
@@ -28,7 +29,6 @@
   ninja,
   openssl,
   pdal,
-  postgresql,
   proj,
   protobuf,
   python3,
@@ -116,13 +116,13 @@ mkDerivation rec {
       geos
       gsl
       hdf5
+      libpq
       libspatialindex
       libspatialite
       libzip
       netcdf
       openssl
       pdal
-      postgresql
       proj
       protobuf
       qca-qt5

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -27,7 +27,7 @@
 , ninja
 , openssl
 , pdal
-, postgresql
+, libpq
 , proj
 , protobuf
 , python3
@@ -119,7 +119,7 @@ in mkDerivation rec {
     netcdf
     openssl
     pdal
-    postgresql
+    libpq
     proj
     protobuf
     qca-qt5

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -9,7 +9,7 @@
   qmake,
   qtwayland,
   qtsvg,
-  postgresql,
+  libpq,
   cups,
   libxml2,
 }:
@@ -37,17 +37,16 @@ stdenv.mkDerivation rec {
       "CONFIG+=release"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      "PGSQL_INC=${lib.getDev postgresql}/include"
-      "PGSQL_LIB=${lib.getLib postgresql}/lib/libpq.dylib"
+      "PGSQL_INC=${lib.getDev libpq}/include"
+      "PGSQL_LIB=${lib.getLib libpq}/lib/libpq.dylib"
       "XML_INC=${libxml2.dev}/include/libxml2"
       "XML_LIB=${libxml2.out}/lib/libxml2.dylib"
       "PREFIX=${placeholder "out"}/Applications/pgModeler.app/Contents"
     ];
 
-  # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.
   buildInputs =
     [
-      postgresql
+      libpq
       qtsvg
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland ]

--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  postgresql,
+  libpq,
   autoPatchelfHook,
   writeScript,
 }:
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     stdenv.cc.cc
-    postgresql.lib
+    libpq
   ];
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -3,7 +3,7 @@
 , makeWrapper, ncurses, pkg-config, libxml2, sqlite, zlib
 , libpulseaudio, libopus, libogg, jansson, libsodium
 
-, postgresqlSupport ? true, postgresql }:
+, postgresqlSupport ? true, libpq }:
 
 stdenv.mkDerivation rec {
   pname = "gnunet";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     adns curl gmp gnutls libextractor libgcrypt libgnurl libidn
     libmicrohttpd libunistring libxml2 ncurses gettext libsodium
     sqlite zlib libpulseaudio libopus libogg jansson
-  ] ++ lib.optional postgresqlSupport postgresql;
+  ] ++ lib.optional postgresqlSupport libpq;
 
   preConfigure = ''
     # Brute force: since nix-worker chroots don't provide

--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -30,8 +30,8 @@
   kreport,
   lcms2,
   libmysqlclient,
+  libpq,
   marble,
-  postgresql,
 }:
 
 mkDerivation rec {
@@ -74,8 +74,8 @@ mkDerivation rec {
     kreport
     lcms2
     libmysqlclient
+    libpq
     marble
-    postgresql
   ];
 
   propagatedUserEnvPkgs = [ kproperty ];

--- a/pkgs/applications/office/ledger-web/default.nix
+++ b/pkgs/applications/office/ledger-web/default.nix
@@ -3,7 +3,7 @@
   bundlerApp,
   bundlerUpdateScript,
   withPostgresql ? true,
-  postgresql,
+  libpq,
   withSqlite ? false,
   sqlite,
 }:
@@ -13,7 +13,7 @@ bundlerApp {
   gemdir = ./.;
   exes = [ "ledger_web" ];
 
-  buildInputs = lib.optional withPostgresql postgresql ++ lib.optional withSqlite sqlite;
+  buildInputs = lib.optional withPostgresql libpq ++ lib.optional withSqlite sqlite;
 
   passthru.updateScript = bundlerUpdateScript "ledger-web";
 

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -113,7 +113,7 @@
 , kwindowsystem ? null
 , variant ? "fresh"
 , symlinkJoin
-, postgresql
+, libpq
 , makeFontsConf
 , amiri
 , caladea
@@ -395,7 +395,7 @@ in stdenv.mkDerivation (finalAttrs: {
     pam
     perl
     poppler
-    postgresql
+    libpq
     python311
     sane-backends
     unixODBC

--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -34,7 +34,7 @@
 , openssl
 , pango
 , pkg-config
-, postgresql
+, libpq
 , protobuf
 , python3
 , rdkafka
@@ -259,7 +259,7 @@ in
 
   pq-sys = attr: {
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ postgresql ];
+    buildInputs = [ libpq ];
   };
 
   prost-build = attr: {

--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -5,10 +5,10 @@
   curl,
   gmp,
   gsl,
+  libpq,
   mpfr,
   ncurses,
   plotutils,
-  postgresql,
   pkg-config,
   withPDFDoc ? true,
 }:
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     gmp
     gsl
     plotutils
-    postgresql
+    libpq
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/cp/cppdb/package.nix
+++ b/pkgs/by-name/cp/cppdb/package.nix
@@ -5,7 +5,7 @@
   cmake,
   sqlite,
   libmysqlclient,
-  postgresql,
+  libpq,
   unixODBC,
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     sqlite
     libmysqlclient
-    postgresql
+    libpq
     unixODBC
   ];
 

--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -27,6 +27,7 @@
   libchardet,
   libical,
   libmysqlclient,
+  libpq,
   libsrs2,
   libuuid,
   libxml2,
@@ -34,7 +35,6 @@
   openssl,
   pcre2,
   perl,
-  postgresql,
   rsync,
   shapelib,
   sqlite,
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
       xapian
     ]
     ++ lib.optionals withMySQL [ libmysqlclient ]
-    ++ lib.optionals withPgSQL [ postgresql ]
+    ++ lib.optionals withPgSQL [ libpq ]
     ++ lib.optionals withSQLite [ sqlite ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/di/diesel-cli/package.nix
+++ b/pkgs/by-name/di/diesel-cli/package.nix
@@ -6,10 +6,10 @@
   installShellFiles,
   libiconv,
   libmysqlclient,
+  libpq,
   nix-update-script,
   openssl,
   pkg-config,
-  postgresql,
   rustPlatform,
   sqlite,
   testers,
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs =
     [ openssl ]
     ++ lib.optional sqliteSupport sqlite
-    ++ lib.optional postgresqlSupport postgresql
+    ++ lib.optional postgresqlSupport libpq
     ++ lib.optionals mysqlSupport [
       libmysqlclient
       zlib

--- a/pkgs/by-name/dr/drogon/package.nix
+++ b/pkgs/by-name/dr/drogon/package.nix
@@ -14,7 +14,7 @@
   sqliteSupport ? true,
   sqlite,
   postgresSupport ? false,
-  postgresql,
+  libpq,
   redisSupport ? false,
   hiredis,
   mysqlSupport ? false,
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
       c-ares
     ]
     ++ lib.optional sqliteSupport sqlite
-    ++ lib.optional postgresSupport postgresql
+    ++ lib.optional postgresSupport libpq
     ++ lib.optional redisSupport hiredis
     # drogon uses mariadb for mysql (see https://github.com/drogonframework/drogon/wiki/ENG-02-Installation#Library-Dependencies)
     ++ lib.optionals mysqlSupport [

--- a/pkgs/by-name/ds/dspam/package.nix
+++ b/pkgs/by-name/ds/dspam/package.nix
@@ -13,7 +13,7 @@
   zlib,
   mariadb-connector-c,
   withPgSQL ? false,
-  postgresql,
+  libpq,
   withSQLite ? false,
   sqlite,
   withDB ? false,
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
       zlib
       mariadb-connector-c.out
     ]
-    ++ lib.optional withPgSQL postgresql
+    ++ lib.optional withPgSQL libpq
     ++ lib.optional withSQLite sqlite
     ++ lib.optional withDB db;
   nativeBuildInputs = [ makeWrapper ];
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
       "--with-mysql-includes=${mariadb-connector-c.dev}/include/mysql"
       "--with-mysql-libraries=${mariadb-connector-c.out}/lib/mysql"
     ]
-    ++ lib.optional withPgSQL "--with-pgsql-libraries=${postgresql.lib}/lib";
+    ++ lib.optional withPgSQL "--with-pgsql-libraries=${libpq}/lib";
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:

--- a/pkgs/by-name/ex/exim/package.nix
+++ b/pkgs/by-name/ex/exim/package.nix
@@ -17,7 +17,7 @@
   libmysqlclient,
   zlib,
   enablePgSQL ? false,
-  postgresql,
+  libpq,
   enableSqlite ? false,
   sqlite,
   enableAuthDovecot ? false,
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       libmysqlclient
       zlib
     ]
-    ++ lib.optional enablePgSQL postgresql
+    ++ lib.optional enablePgSQL libpq
     ++ lib.optionals enableSqlite [
       sqlite
       sqlite.dev
@@ -117,8 +117,8 @@ stdenv.mkDerivation rec {
       ''}
       ${lib.optionalString enablePgSQL ''
         s:^# \(LOOKUP_PGSQL=yes\)$:\1:
-        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lpq -L${postgresql.lib}/lib:
-        s:^# \(LOOKUP_LIBS\)=.*:\1=-lpq -L${postgresql.lib}/lib:
+        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lpq -L${libpq}/lib:
+        s:^# \(LOOKUP_LIBS\)=.*:\1=-lpq -L${libpq}/lib:
       ''}
       ${lib.optionalString enableSqlite ''
         s:^# \(LOOKUP_SQLITE=yes\)$:\1:

--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -6,7 +6,7 @@
   flex,
   bison,
   systemd,
-  postgresql,
+  libpq,
   openssl,
   libyaml,
   darwin,
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       openssl
       libyaml
-      postgresql
+      libpq
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ systemd ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/fr/freeradius/package.nix
+++ b/pkgs/by-name/fr/freeradius/package.nix
@@ -21,7 +21,7 @@
   withMysql ? false,
   libmysqlclient,
   withPostgresql ? false,
-  postgresql,
+  libpq,
   withPcap ? true,
   libpcap,
   withRedis ? false,
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withLdap openldap
     ++ lib.optional withMemcached libmemcached
     ++ lib.optional withMysql libmysqlclient
-    ++ lib.optional withPostgresql postgresql
+    ++ lib.optional withPostgresql libpq
     ++ lib.optional withPcap libpcap
     ++ lib.optional withRedis hiredis
     ++ lib.optional withRest curl

--- a/pkgs/by-name/ga/gammu/package.nix
+++ b/pkgs/by-name/ga/gammu/package.nix
@@ -17,7 +17,7 @@
   libdbi ? null,
   libdbiDrivers ? null,
   postgresSupport ? false,
-  postgresql ? null,
+  libpq ? null,
 }:
 
 stdenv.mkDerivation rec {
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
       libdbi
       libdbiDrivers
     ]
-    ++ lib.optionals postgresSupport [ postgresql ];
+    ++ lib.optionals postgresSupport [ libpq ];
 
   meta = with lib; {
     homepage = "https://wammu.eu/gammu/";

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -152,7 +152,6 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     pixz
     boost
-    postgresql
     nlohmann_json
     prometheus-cpp
   ];
@@ -195,6 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     libressl.nc
     openldap
+    postgresql
   ];
 
   env = {

--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -67,7 +67,7 @@ in
 , pkg-config
 , libargon2
 , openldap
-, postgresql
+, libpq
 , libmysqlclient
 , pcre
 , pcre2
@@ -97,7 +97,7 @@ let
     ];
     ldap            = [ openldap ];
     mysql           = [ libmysqlclient ];
-    pgsql           = [ postgresql ];
+    pgsql           = [ libpq ];
     regex_pcre      = [ pcre ];
     regex_pcre2     = [ pcre2 ];
     regex_re2       = [ re2 ];

--- a/pkgs/by-name/ke/kepler/package.nix
+++ b/pkgs/by-name/ke/kepler/package.nix
@@ -3,9 +3,9 @@
   stdenv,
   darwin,
   fetchFromGitHub,
+  libpq,
   openssl,
   pkg-config,
-  postgresql,
   rustPlatform,
   zstd,
 }:
@@ -29,8 +29,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =
     [
+      libpq
       openssl
-      postgresql
       zstd
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/li/libdbiDrivers/package.nix
+++ b/pkgs/by-name/li/libdbiDrivers/package.nix
@@ -6,7 +6,7 @@
   # TODO: migrate away from overriding packages to null
   libmysqlclient ? null,
   sqlite ? null,
-  postgresql ? null,
+  libpq ? null,
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libdbi
     sqlite
-    postgresql
   ] ++ lib.optional (libmysqlclient != null) libmysqlclient;
 
   patches = [
@@ -58,8 +57,10 @@ stdenv.mkDerivation rec {
       "--with-sqlite3-incdir=${sqlite.dev}/include/sqlite"
       "--with-sqlite3-libdir=${sqlite.out}/lib/sqlite"
     ]
-    ++ lib.optionals (postgresql != null) [
+    ++ lib.optionals (libpq != null) [
       "--with-pgsql"
+      "--with-pgsql-incdir=${libpq.dev}/include"
+      "--with-pgsql-libdir=${libpq}/lib/"
     ];
 
   env.NIX_CFLAGS_COMPILE = toString (

--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  postgresql,
+  libpq,
   python3,
 }:
 
@@ -23,12 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    postgresql.dev
     python3
   ];
 
   buildInputs = [
-    postgresql.lib
+    libpq
   ];
 
   postPatch = ''

--- a/pkgs/by-name/lu/luanti/package.nix
+++ b/pkgs/by-name/lu/luanti/package.nix
@@ -26,7 +26,7 @@
   gmp,
   libspatialindex,
   leveldb,
-  postgresql,
+  libpq,
   hiredis,
   libiconv,
   ninja,
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals buildServer [
       leveldb
-      postgresql
+      libpq
       hiredis
       prometheus-cpp
     ];

--- a/pkgs/by-name/ma/mapserver/package.nix
+++ b/pkgs/by-name/ma/mapserver/package.nix
@@ -17,10 +17,10 @@
   harfbuzz,
   libjpeg,
   libpng,
+  libpq,
   librsvg,
   libxml2,
   pkg-config,
-  postgresql,
   proj,
   protobufc,
   python3,
@@ -61,9 +61,9 @@ stdenv.mkDerivation rec {
     harfbuzz
     libjpeg
     libpng
+    libpq
     librsvg
     libxml2
-    postgresql
     proj
     protobufc
     zlib

--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -10,7 +10,7 @@
   xcbuild,
   libkrb5,
   libmongocrypt,
-  postgresql,
+  libpq,
   makeWrapper,
 }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     libkrb5
     libmongocrypt
-    postgresql
+    libpq
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/od/odyssey/package.nix
+++ b/pkgs/by-name/od/odyssey/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   openssl,
-  postgresql,
+  libpq,
   zstd,
   fetchpatch,
 }:
@@ -31,12 +31,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     openssl
-    postgresql
+    libpq
     zstd
   ];
   cmakeFlags = [
-    "-DPQ_LIBRARY=${postgresql.lib}/lib"
     "-DBUILD_COMPRESSION=ON"
+    "-DPOSTGRESQL_INCLUDE_DIR=${lib.getDev libpq}/include/postgresql/server"
+    "-DPOSTGRESQL_LIBRARY=${libpq}/lib"
+    "-DPOSTGRESQL_LIBPGPORT=${lib.getDev libpq}/lib"
   ];
 
   installPhase = ''

--- a/pkgs/by-name/op/opendbx/package.nix
+++ b/pkgs/by-name/op/opendbx/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   readline,
   libmysqlclient,
-  postgresql,
+  libpq,
   sqlite,
 }:
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     readline
     libmysqlclient
-    postgresql
+    libpq
     sqlite
   ];
 

--- a/pkgs/by-name/os/osm2pgsql/package.nix
+++ b/pkgs/by-name/os/osm2pgsql/package.nix
@@ -10,7 +10,7 @@
   cli11,
   zlib,
   boost,
-  postgresql,
+  libpq,
   python3,
   withLuaJIT ? false,
   lua,
@@ -49,9 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
       expat
       fmt_11
       libosmium
+      libpq
       nlohmann_json
       opencv
-      postgresql
       potrace
       proj
       protozero

--- a/pkgs/by-name/pa/pam_pgsql/package.nix
+++ b/pkgs/by-name/pa/pam_pgsql/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
-  postgresql,
+  libpq,
   libgcrypt,
   pam,
   libxcrypt,
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libgcrypt
     pam
-    postgresql
+    libpq
     libxcrypt
   ];
 

--- a/pkgs/by-name/pd/pdal/package.nix
+++ b/pkgs/by-name/pd/pdal/package.nix
@@ -18,7 +18,7 @@
 , libxml2
 , openscenegraph
 , pkg-config
-, postgresql
+, libpq
 , proj
 , sqlite
 , tiledb
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtiff
     libxml2
     openscenegraph
-    postgresql
+    libpq
     proj
     sqlite
     tiledb

--- a/pkgs/by-name/pd/pdns/package.nix
+++ b/pkgs/by-name/pd/pdns/package.nix
@@ -12,7 +12,7 @@
   openssl,
   systemd,
   mariadb-connector-c,
-  postgresql,
+  libpq,
   lua,
   openldap,
   geoip,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     boost
     mariadb-connector-c
-    postgresql
+    libpq
     lua
     openldap
     sqlite

--- a/pkgs/by-name/pg/pgbackrest/package.nix
+++ b/pkgs/by-name/pg/pgbackrest/package.nix
@@ -9,7 +9,7 @@
   libbacktrace,
   bzip2,
   lz4,
-  postgresql,
+  libpq,
   libxml2,
   libyaml,
   zlib,
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     libbacktrace
     bzip2
     lz4
-    postgresql
+    libpq
     libxml2
     libyaml
     zlib

--- a/pkgs/by-name/pg/pgmanage/package.nix
+++ b/pkgs/by-name/pg/pgmanage/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  postgresql,
+  libpq,
   openssl,
   nixosTests,
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    postgresql
+    libpq
     openssl
   ];
 

--- a/pkgs/by-name/pg/pgpool/package.nix
+++ b/pkgs/by-name/pg/pgpool/package.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, postgresql
+, libpq
 , openssl
 , libxcrypt
 , withPam ? stdenv.hostPlatform.isLinux
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    postgresql
+    libpq
     openssl
     libxcrypt
   ] ++ lib.optional withPam pam;

--- a/pkgs/by-name/pm/pmacct/package.nix
+++ b/pkgs/by-name/pm/pmacct/package.nix
@@ -15,7 +15,7 @@
   withSQLite ? true,
   sqlite,
   withPgSQL ? true,
-  postgresql,
+  libpq,
   withMysql ? true,
   libmysqlclient,
   zlib,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withJansson jansson
     ++ lib.optional withNflog libnetfilter_log
     ++ lib.optional withSQLite sqlite
-    ++ lib.optional withPgSQL postgresql
+    ++ lib.optional withPgSQL libpq
     ++ lib.optionals withMysql [
       libmysqlclient
       zlib

--- a/pkgs/by-name/ps/pspg/package.nix
+++ b/pkgs/by-name/ps/pspg/package.nix
@@ -7,7 +7,7 @@
   pkg-config,
   installShellFiles,
   readline,
-  postgresql,
+  libpq,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,9 +27,9 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     gnugrep
+    libpq
     ncurses
     readline
-    postgresql
   ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];

--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   postgresql,
   openssl,
   withLibiodbc ? false,
@@ -14,11 +15,13 @@ assert lib.xor withLibiodbc withUnixODBC;
 
 stdenv.mkDerivation rec {
   pname = "psqlodbc";
-  version = "16.00.0000";
+  version = "${builtins.replaceStrings [ "_" ] [ "." ] (lib.strings.removePrefix "REL-" src.tag)}";
 
-  src = fetchurl {
-    url = "mirror://postgresql/odbc/versions.old/src/${pname}-${version}.tar.gz";
-    hash = "sha256-r9iS+J0uzujT87IxTxvVvy0CIBhyxuNDHlwxCW7KTIs=";
+  src = fetchFromGitHub {
+    owner = "postgresql-interfaces";
+    repo = "psqlodbc";
+    tag = "REL-17_00_0002";
+    hash = "sha256-zCjoX+Ew8sS5TWkFSgoqUN5ukEF38kq+MdfgCQQGv9w=";
   };
 
   buildInputs =
@@ -28,6 +31,10 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional withLibiodbc libiodbc
     ++ lib.optional withUnixODBC unixODBC;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   passthru = lib.optionalAttrs withUnixODBC {
     fancyName = "PostgreSQL";

--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
   autoreconfHook,
   postgresql,
   openssl,
@@ -36,10 +37,14 @@ stdenv.mkDerivation rec {
     autoreconfHook
   ];
 
-  passthru = lib.optionalAttrs withUnixODBC {
-    fancyName = "PostgreSQL";
-    driver = "lib/psqlodbcw.so";
-  };
+  passthru =
+    {
+      updateScript = nix-update-script { };
+    }
+    // lib.optionalAttrs withUnixODBC {
+      fancyName = "PostgreSQL";
+      driver = "lib/psqlodbcw.so";
+    };
 
   configureFlags = [
     "--with-libpq=${lib.getDev postgresql}/bin/pg_config"

--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     description = "ODBC driver for PostgreSQL";
     license = licenses.lgpl2;
     platforms = platforms.unix;
-    maintainers = [ ];
+    maintainers = postgresql.meta.maintainers;
   };
 }

--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   autoreconfHook,
-  postgresql,
+  libpq,
   openssl,
   withLibiodbc ? false,
   libiodbc,
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      postgresql
+      libpq
       openssl
     ]
     ++ lib.optional withLibiodbc libiodbc
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     };
 
   configureFlags = [
-    "--with-libpq=${lib.getDev postgresql}/bin/pg_config"
+    "--with-libpq=${lib.getDev libpq}"
   ] ++ lib.optional withLibiodbc "--with-iodbc=${libiodbc}";
 
   meta = with lib; {
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     description = "ODBC driver for PostgreSQL";
     license = licenses.lgpl2;
     platforms = platforms.unix;
-    maintainers = postgresql.meta.maintainers;
+    maintainers = libpq.meta.maintainers;
   };
 }

--- a/pkgs/by-name/sa/saga/package.nix
+++ b/pkgs/by-name/sa/saga/package.nix
@@ -19,7 +19,7 @@
   opencv,
   vigra,
   pdal,
-  postgresql,
+  libpq,
   darwin,
   unixODBC,
   poppler,
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       libharu
       opencv
       vigra
-      postgresql
+      libpq
       libiodbc
       xz
       qhull

--- a/pkgs/by-name/so/sope/package.nix
+++ b/pkgs/by-name/so/sope/package.nix
@@ -1,5 +1,5 @@
 { gnustep, lib, fetchFromGitHub, fetchpatch, libxml2, openssl
-, openldap, mariadb, libmysqlclient, postgresql }:
+, openldap, mariadb, libmysqlclient, libpq }:
 
 gnustep.stdenv.mkDerivation rec {
   pname = "sope";
@@ -16,7 +16,7 @@ gnustep.stdenv.mkDerivation rec {
   buildInputs = [ gnustep.base libxml2 openssl ]
     ++ lib.optional (openldap != null) openldap
     ++ lib.optionals (mariadb != null) [ libmysqlclient mariadb ]
-    ++ lib.optional (postgresql != null) postgresql;
+    ++ lib.optional (libpq != null) libpq;
 
   # Configure directories where files are installed to. Everything is automatically
   # put into $out (thanks GNUstep) apart from the makefiles location which is where
@@ -33,7 +33,7 @@ gnustep.stdenv.mkDerivation rec {
   configureFlags = [ "--prefix=" "--disable-debug" "--enable-xml" "--with-ssl=ssl" ]
     ++ lib.optional (openldap != null) "--enable-openldap"
     ++ lib.optional (mariadb != null) "--enable-mysql"
-    ++ lib.optional (postgresql != null) "--enable-postgresql";
+    ++ lib.optional (libpq != null) "--enable-postgresql";
 
   env = {
     GNUSTEP_CONFIG_FILE = "/build/GNUstep.conf";

--- a/pkgs/by-name/sp/spatialite-gui/package.nix
+++ b/pkgs/by-name/sp/spatialite-gui/package.nix
@@ -7,6 +7,7 @@
   curl,
   freexl,
   geos,
+  libpq,
   librasterlite2,
   librttopo,
   libspatialite,
@@ -16,7 +17,6 @@
   lz4,
   minizip,
   openjpeg,
-  postgresql,
   proj,
   sqlite,
   virtualpg,
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     curl
     freexl
     geos
+    libpq
     librasterlite2
     librttopo
     libspatialite
@@ -51,7 +52,6 @@ stdenv.mkDerivation rec {
     lz4
     minizip
     openjpeg
-    postgresql
     proj
     sqlite
     virtualpg

--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -7,10 +7,10 @@
   flex,
   gitMinimal,
   lib,
+  libpq,
   libtool,
   libunwind,
   pkg-config,
-  postgresql,
   ripgrep,
   stdenv,
 }:
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [
     bison
     flex
-    postgresql
+    libpq
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/sy/syndicate_utils/package.nix
+++ b/pkgs/by-name/sy/syndicate_utils/package.nix
@@ -5,7 +5,7 @@
   libxml2,
   libxslt,
   openssl,
-  postgresql,
+  libpq,
   sqlite,
 }:
 
@@ -22,7 +22,7 @@ buildNimPackage (finalAttrs: {
   };
 
   buildInputs = [
-    postgresql.out
+    libpq
     sqlite
     libxml2
     libxslt

--- a/pkgs/by-name/ta/taler-challenger/package.nix
+++ b/pkgs/by-name/ta/taler-challenger/package.nix
@@ -13,7 +13,7 @@
   libmicrohttpd,
   libsodium,
   libtool,
-  postgresql,
+  libpq,
   taler-exchange,
   taler-merchant,
   runtimeShell,
@@ -59,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     libgnurl
     libmicrohttpd
+    libpq
     libsodium
     libtool
-    postgresql
     taler-exchange
     taler-merchant
   ];

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -10,7 +10,7 @@
   libsodium,
   libunistring,
   pkg-config,
-  postgresql,
+  libpq,
   autoreconfHook,
   python3,
   recutils,
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     libmicrohttpd
     jansson
     libsodium
-    postgresql
+    libpq
     curl
     recutils
     gettext

--- a/pkgs/by-name/ta/taler-sync/package.nix
+++ b/pkgs/by-name/ta/taler-sync/package.nix
@@ -9,9 +9,9 @@
   gnunet,
   jansson,
   libmicrohttpd,
+  libpq,
   libsodium,
   libtool,
-  postgresql,
   taler-exchange,
   taler-merchant,
   runtimeShell,
@@ -41,9 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     jansson
     libgcrypt
     libmicrohttpd
+    libpq
     libsodium
     libtool
-    postgresql
     taler-exchange
     taler-merchant
   ];

--- a/pkgs/by-name/th/thc-hydra/package.nix
+++ b/pkgs/by-name/th/thc-hydra/package.nix
@@ -9,7 +9,7 @@
   pcre,
   libssh,
   libmysqlclient,
-  postgresql,
+  libpq,
   samba,
   withGUI ? false,
   makeWrapper,
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     pcre
     libssh
     libmysqlclient
-    postgresql
+    libpq
     samba
   ] ++ lib.optional withGUI gtk2;
 

--- a/pkgs/by-name/tn/tntdb/package.nix
+++ b/pkgs/by-name/tn/tntdb/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   autoreconfHook,
   cxxtools,
-  postgresql,
+  libpq,
   libmysqlclient,
   sqlite,
   zlib,
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cxxtools
-    postgresql
+    libpq
     libmysqlclient
     sqlite
     zlib

--- a/pkgs/by-name/ul/ulogd/package.nix
+++ b/pkgs/by-name/ul/ulogd/package.nix
@@ -12,7 +12,7 @@
   autoconf,
   autogen,
   libtool,
-  postgresql,
+  libpq,
   libmysqlclient,
   sqlite,
   pkg-config,
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     libmnl
     libnfnetlink
     libpcap
-    postgresql
+    libpq
     libmysqlclient
     sqlite
   ];

--- a/pkgs/by-name/vi/virtualpg/package.nix
+++ b/pkgs/by-name/vi/virtualpg/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   validatePkgConfig,
-  postgresql,
+  libpq,
   sqlite,
   darwin,
 }:
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     validatePkgConfig
-    postgresql # for pg_config
+    libpq # for pg_config
   ];
 
   buildInputs = [
-    postgresql
+    libpq
     sqlite
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.Kerberos ];
 

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -10,6 +10,7 @@
   procps,
   ruby,
   postgresql,
+  libpq,
   imlib2,
   jq,
   moreutils,
@@ -59,7 +60,7 @@ let
     ];
     gemConfig = defaultGemConfig // {
       pg = attrs: {
-        buildFlags = [ "--with-pg-config=${lib.getDev postgresql}/bin/pg_config" ];
+        buildInputs = [ libpq ];
       };
       rszr = attrs: {
         buildInputs = [

--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -14,7 +14,7 @@
 , gnatcoll-iconv
 , gnatcoll-readline
 , sqlite
-, postgresql
+, libpq
 }:
 
 let
@@ -29,7 +29,7 @@ let
     ];
     postgres = [
       gnatcoll-sql
-      postgresql
+      libpq
     ];
     sqlite = [
       gnatcoll-sql

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -6,7 +6,7 @@
   openssl,
   mlton,
   libmysqlclient,
-  postgresql,
+  libpq,
   sqlite,
   gcc,
   icu,
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     openssl
     mlton
     libmysqlclient
-    postgresql
+    libpq
     sqlite
     icu
   ];
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     export CCARGS="-I$out/include \
                    -L${lib.getLib openssl}/lib \
                    -L${libmysqlclient}/lib \
-                   -L${postgresql.lib}/lib \
+                   -L${libpq}/lib \
                    -L${sqlite.out}/lib";
   '';
 

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -53,6 +53,7 @@
   libjpeg,
   libjxl,
   libmysqlclient,
+  libpq,
   libpng,
   libspatialite,
   libtiff,
@@ -66,7 +67,6 @@
   pcre2,
   pkg-config,
   poppler,
-  postgresql,
   proj,
   python3,
   qhull,
@@ -153,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
         libhwy
       ];
       mysqlDeps = lib.optionals useMysql [ libmysqlclient ];
-      postgresDeps = lib.optionals usePostgres [ postgresql ];
+      postgresDeps = lib.optionals usePostgres [ libpq ];
       popplerDeps = lib.optionals usePoppler [ poppler ];
       arrowDeps = lib.optionals useArrow [ arrow-cpp ];
       hdfDeps = lib.optionals useHDF [

--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -8,7 +8,7 @@
   kcoreaddons,
   python3,
   sqlite,
-  postgresql,
+  libpq,
   libmysqlclient,
   qttools,
 }:
@@ -44,7 +44,7 @@ mkDerivation rec {
     kcoreaddons
     python3
     sqlite
-    postgresql
+    libpq
     libmysqlclient
   ];
 

--- a/pkgs/development/libraries/libgda/6.x.nix
+++ b/pkgs/development/libraries/libgda/6.x.nix
@@ -24,11 +24,11 @@
   mysqlSupport ? false,
   libmysqlclient ? null,
   postgresSupport ? false,
-  postgresql ? null,
+  libpq ? null,
 }:
 
 assert mysqlSupport -> libmysqlclient != null;
-assert postgresSupport -> postgresql != null;
+assert postgresSupport -> libpq != null;
 
 stdenv.mkDerivation rec {
   pname = "libgda";
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
       libmysqlclient
     ]
     ++ lib.optionals postgresSupport [
-      postgresql
+      libpq
     ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -20,7 +20,7 @@
   mysqlSupport ? false,
   libmysqlclient,
   postgresSupport ? false,
-  postgresql,
+  libpq,
 }:
 
 stdenv.mkDerivation rec {
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       libmysqlclient
     ]
     ++ lib.optionals postgresSupport [
-      postgresql
+      libpq
     ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -13,7 +13,7 @@
   gmp,
   libmysqlclient,
   withMysql ? false,
-  postgresql,
+  libpq,
   withPostgresql ? false,
   sqlite,
   withSqlite ? true,
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional withMysql libmysqlclient
     ++ lib.optional withSqlite sqlite
-    ++ lib.optional withPostgresql postgresql
+    ++ lib.optional withPostgresql libpq
     ++ lib.optional withBdb db;
 
   propagatedBuildInputs = [ librdf_rasqal ];

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -22,7 +22,7 @@
   sqlite,
   zlib,
   catch2,
-  postgresql,
+  libpq,
   protozero,
   sparsehash,
 }:
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     sqlite
     zlib
     libxml2
-    postgresql
+    libpq
     protozero
     sparsehash
   ];

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -53,7 +53,7 @@
 
   # optional dependencies
   cups ? null,
-  postgresql ? null,
+  libpq ? null,
   withGtk3 ? false,
   dconf,
   gtk3,
@@ -162,7 +162,7 @@ stdenv.mkDerivation (
         ++ lib.optional developerBuild gdb
         ++ lib.optional (cups != null) cups
         ++ lib.optional (mysqlSupport) libmysqlclient
-        ++ lib.optional (postgresql != null) postgresql;
+        ++ lib.optional (libpq != null) libpq;
 
       nativeBuildInputs =
         [
@@ -360,7 +360,7 @@ stdenv.mkDerivation (
       # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
       # if dependency paths contain the string "pq", which can occur in the hash.
       # To prevent these failures, we need to override PostgreSQL detection.
-      PSQL_LIBS = lib.optionalString (postgresql != null) "-L${postgresql.lib}/lib -lpq";
+      PSQL_LIBS = lib.optionalString (libpq != null) "-L${libpq}/lib -lpq";
 
     }
     // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
@@ -453,7 +453,7 @@ stdenv.mkDerivation (
           "${openssl.dev}/include"
           "-system-sqlite"
           ''-${if mysqlSupport then "plugin" else "no"}-sql-mysql''
-          ''-${if postgresql != null then "plugin" else "no"}-sql-psql''
+          ''-${if libpq != null then "plugin" else "no"}-sql-psql''
           "-system-libpng"
 
           "-make libs"

--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -73,7 +73,7 @@
   # optional dependencies
   cups,
   libmysqlclient,
-  postgresql,
+  libpq,
   withGtk3 ? false,
   gtk3,
   withLibinput ? false,
@@ -176,9 +176,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withGtk3 gtk3
     ++ lib.optional withLibinput libinput
     ++ lib.optional (libmysqlclient != null && !stdenv.hostPlatform.isMinGW) libmysqlclient
-    ++ lib.optional (
-      postgresql != null && lib.meta.availableOn stdenv.hostPlatform postgresql
-    ) postgresql;
+    ++ lib.optional (libpq != null && lib.meta.availableOn stdenv.hostPlatform libpq) libpq;
 
   nativeBuildInputs = [
     bison

--- a/pkgs/development/libraries/soci/default.nix
+++ b/pkgs/development/libraries/soci/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fetchpatch,
   sqlite,
-  postgresql,
+  libpq,
   boost,
   darwin,
   lib,
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       sqlite
-      postgresql
+      libpq
       boost
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, boost, pkg-config, doxygen, qtbase, libharu
-, pango, fcgi, firebird, libmysqlclient, postgresql, graphicsmagick, glew, openssl
+, pango, fcgi, firebird, libmysqlclient, libpq, graphicsmagick, glew, openssl
 , pcre, harfbuzz, icu
 }:
 
@@ -20,7 +20,7 @@ let
       nativeBuildInputs = [ cmake pkg-config ];
       buildInputs = [
         boost doxygen qtbase libharu
-        pango fcgi firebird libmysqlclient postgresql graphicsmagick glew
+        pango fcgi firebird libmysqlclient libpq graphicsmagick glew
         openssl pcre harfbuzz icu
       ];
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -30,6 +30,7 @@
 , libmpack
 , libmysqlclient
 , libpsl
+, libpq
 , libuuid
 , libuv
 , libxcrypt
@@ -44,7 +45,6 @@
 , openssl
 , pcre
 , pkg-config
-, postgresql
 , readline
 , rustPlatform
 , sol2
@@ -361,7 +361,7 @@ in
 
   luadbi-postgresql = prev.luadbi-postgresql.overrideAttrs (oa: {
     buildInputs = oa.buildInputs ++ [
-      (lib.getDev postgresql)
+      (lib.getDev libpq)
     ];
   });
 

--- a/pkgs/development/ocaml-modules/postgresql/default.nix
+++ b/pkgs/development/ocaml-modules/postgresql/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, postgresql }:
+{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, libpq }:
 
 buildDunePackage rec {
   pname = "postgresql";
@@ -15,9 +15,8 @@ buildDunePackage rec {
     sha256 = "1i4pnh2v00i0s7s9pcwz1x6s4xcd77d08gjjkvy0fmda6mqq6ghn";
   };
 
-  nativeBuildInputs = [ postgresql ];
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ postgresql ];
+  propagatedBuildInputs = [ libpq ];
 
   meta = {
     description = "Bindings to the PostgreSQL library";

--- a/pkgs/development/octave-modules/database/default.nix
+++ b/pkgs/development/octave-modules/database/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchurl,
   struct,
-  postgresql,
+  libpq,
 }:
 
 buildOctavePackage rec {
@@ -20,7 +20,7 @@ buildOctavePackage rec {
   ];
 
   propagatedBuildInputs = [
-    postgresql
+    libpq
   ];
 
   requiredOctavePackages = [

--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  postgresql,
+  libpq,
   unittestCheckHook,
 }:
 
@@ -18,12 +18,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     unittestCheckHook
-    postgresql
   ];
 
   unittestFlagsArray = [ "test" ];
 
-  propagatedBuildInputs = [ postgresql ];
+  propagatedBuildInputs = [ libpq ];
 
   meta = with lib; {
     homepage = "https://github.com/markdrago/pgsanity";

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -8,7 +8,7 @@
   substituteAll,
 
   # build
-  postgresql,
+  libpq,
   setuptools,
 
   # propagates
@@ -29,6 +29,7 @@
   pproxy,
   pytest-randomly,
   pytestCheckHook,
+  postgresql,
   postgresqlTestHook,
 }:
 
@@ -46,7 +47,7 @@ let
   patches = [
     (substituteAll {
       src = ./ctypes.patch;
-      libpq = "${postgresql.lib}/lib/libpq${stdenv.hostPlatform.extensions.sharedLibrary}";
+      libpq = "${libpq}/lib/libpq${stdenv.hostPlatform.extensions.sharedLibrary}";
       libc = "${stdenv.cc.libc}/lib/libc.so.6";
     })
   ];
@@ -74,13 +75,13 @@ let
     nativeBuildInputs = [
       cython
       # needed to find pg_config with strictDeps
-      postgresql
+      libpq
       setuptools
       tomli
     ];
 
     buildInputs = [
-      postgresql
+      libpq
     ];
 
     # tested in psycopg

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -18,7 +18,7 @@
 # (to make gems behave if necessary).
 
 { lib, fetchurl, fetchpatch, fetchpatch2, writeScript, ruby, libkrb5, libxml2, libxslt, python2, stdenv, which
-, libiconv, postgresql, nodejs, clang, sqlite, zlib, imagemagick, lasem
+, libiconv, libpq, nodejs, clang, sqlite, zlib, imagemagick, lasem
 , pkg-config , ncurses, xapian, gpgme, util-linux, tzdata, icu, libffi
 , cmake, libssh2, openssl, openssl_1_1, libmysqlclient, git, perl, pcre2, gecode_3, curl
 , libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk3, lerc, buildRubyGem
@@ -660,7 +660,7 @@ in
     # an unnecessary reference to the entire postgresql package.
     buildFlags = [ "--with-pg-config=ignore" ];
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ postgresql ];
+    buildInputs = [ libpq ];
   };
 
   psych = attrs: {
@@ -813,7 +813,7 @@ in
   };
 
   sequel_pg = attrs: {
-    buildInputs = [ postgresql ];
+    buildInputs = [ libpq ];
   };
 
   snappy = attrs: {

--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -16,7 +16,7 @@
 , mysqlSupport ? false
 , libmysqlclient
 , postgresSupport ? false
-, postgresql
+, libpq
 , sqliteSupport ? false
 , sqlite
 , tlsSupport ? false
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     [ autoreconfHook pkg-config bison ];
   buildInputs = [ libgcrypt libxcrypt pcre json_c libxml2 ]
     ++ lib.optional mccpSupport zlib ++ lib.optional mysqlSupport libmysqlclient
-    ++ lib.optional postgresSupport postgresql
+    ++ lib.optional postgresSupport libpq
     ++ lib.optional sqliteSupport sqlite ++ lib.optional tlsSupport openssl
     ++ lib.optional pythonSupport python310
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -4,7 +4,7 @@
   lib,
   fetchurl,
   perl,
-  postgresql,
+  libpq,
   nixosTests,
   withPostgres ? true,
   ...
@@ -36,7 +36,7 @@ callPackage ../nginx/generic.nix args rec {
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ postgresql ];
+  buildInputs = [ libpq ];
 
   postPatch = ''
     patchShebangs configure bundle/

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -25,7 +25,7 @@
   withMySQL ? false,
   libmysqlclient,
   withPgSQL ? false,
-  postgresql,
+  libpq,
   withSQLite ? true,
   sqlite,
   withLua ? false,
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
       inotify-tools
     ]
     ++ lib.optional withMySQL libmysqlclient
-    ++ lib.optional withPgSQL postgresql
+    ++ lib.optional withPgSQL libpq
     ++ lib.optional withSQLite sqlite
     ++ lib.optional withLua lua5_3;
 

--- a/pkgs/servers/mail/opensmtpd/extras.nix
+++ b/pkgs/servers/mail/opensmtpd/extras.nix
@@ -10,7 +10,7 @@
   lua5,
   perl,
   libmysqlclient,
-  postgresql,
+  libpq,
   sqlite,
   hiredis,
   enableLua ? true,
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     lua5
     perl
     libmysqlclient
-    postgresql
+    libpq
     sqlite
     hiredis
   ];

--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -21,7 +21,7 @@
   withLDAP ? true,
   openldap,
   withPgSQL ? false,
-  postgresql,
+  libpq,
   withMySQL ? false,
   libmysqlclient,
   withSQLite ? false,
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
       libnsl
       pcre2
     ]
-    ++ lib.optional withPgSQL postgresql
+    ++ lib.optional withPgSQL libpq
     ++ lib.optional withMySQL libmysqlclient
     ++ lib.optional withSQLite sqlite
     ++ lib.optional withLDAP openldap;

--- a/pkgs/servers/monitoring/icinga2/default.nix
+++ b/pkgs/servers/monitoring/icinga2/default.nix
@@ -11,7 +11,7 @@
   openssl,
   patchelf,
   mariadb-connector-c,
-  postgresql,
+  libpq,
   zlib,
   tzdata,
   # Databases
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
     boost
     openssl
     systemd
-  ] ++ lib.optional withPostgresql postgresql;
+  ] ++ lib.optional withPostgresql libpq;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -19,7 +19,7 @@
   mysqlSupport ? false,
   libmysqlclient,
   postgresqlSupport ? false,
-  postgresql,
+  libpq,
 }:
 
 # ensure exactly one database type is selected
@@ -55,7 +55,7 @@ import ./versions.nix (
       ++ optional sqliteSupport sqlite
       ++ optional sshSupport libssh2
       ++ optional mysqlSupport libmysqlclient
-      ++ optional postgresqlSupport postgresql;
+      ++ optional postgresqlSupport libpq;
 
     configureFlags =
       [

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -24,7 +24,7 @@
   mysqlSupport ? false,
   libmysqlclient,
   postgresqlSupport ? false,
-  postgresql,
+  libpq,
   ipmiSupport ? false,
   openipmi,
 }:
@@ -67,7 +67,7 @@ import ./versions.nix (
       ++ optional snmpSupport net-snmp
       ++ optional sshSupport libssh2
       ++ optional mysqlSupport libmysqlclient
-      ++ optional postgresqlSupport postgresql
+      ++ optional postgresqlSupport libpq
       ++ optional ipmiSupport openipmi;
 
     configureFlags =

--- a/pkgs/servers/mx-puppet-discord/default.nix
+++ b/pkgs/servers/mx-puppet-discord/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, pkgs, lib, node-pre-gyp, nodejs_18, pkg-config
-, libjpeg, pixman, cairo, pango, which, postgresql }:
+, libjpeg, pixman, cairo, pango, which, libpq }:
 
 let
   nodejs = nodejs_18;
@@ -23,7 +23,7 @@ in myNodePackages.package.override {
   inherit version src;
 
   nativeBuildInputs = [ node-pre-gyp nodejs.pkgs.node-gyp-build pkg-config which ];
-  buildInputs = [ libjpeg pixman cairo pango postgresql ];
+  buildInputs = [ libjpeg pixman cairo pango libpq ];
 
   postRebuild = ''
     # Build typescript stuff

--- a/pkgs/servers/nominatim/default.nix
+++ b/pkgs/servers/nominatim/default.nix
@@ -13,7 +13,7 @@
   pandoc,
   nlohmann_json,
   # Nominatim needs to be built with the same postgres version it will target
-  postgresql,
+  libpq,
   python3,
   php,
   lua,
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     # python3Packages.pylint  # We don't want to run pylint because the package could break on pylint bumps which is really annoying.
     # python3Packages.pytest  # disabled since I can't get it to run tests anyway
     # python3Packages.behave  # disabled since I can't get it to run tests anyway
-    postgresql
+    libpq
   ];
 
   postPatch = ''

--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -8,7 +8,7 @@
 , curl
 , ffmpeg
 , libmysqlclient
-, postgresql
+, libpq
 , spandsp3
 , sofia_sip
 , libks
@@ -114,7 +114,7 @@ in
 
   databases = {
     mariadb = mk "databases/mod_mariadb" [ libmysqlclient ];
-    pgsql = mk "databases/mod_pgsql" [ postgresql ];
+    pgsql = mk "databases/mod_pgsql" [ libpq ];
   };
 
   dialplans = {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -30,6 +30,8 @@ let
       )
     ) versions;
 
+  libpq = self.callPackage ./libpq.nix { };
+
 in
 # variations without and with JIT
-(mkAttributes false) // (mkAttributes true)
+(mkAttributes false) // (mkAttributes true) // { inherit libpq; }

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -1,0 +1,146 @@
+{
+  # utils
+  stdenv,
+  fetchurl,
+  lib,
+
+  # runtime dependencies
+  openssl,
+  tzdata,
+  zlib,
+
+  # build dependencies
+  bison,
+  flex,
+  perl,
+  pkg-config,
+
+  # passthru / meta
+  postgresql,
+
+  # GSSAPI
+  gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic,
+  libkrb5,
+
+  # NLS
+  nlsSupport ? false,
+  gettext,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libpq";
+  version = "17.2";
+
+  src = fetchurl {
+    url = "mirror://postgresql/source/v${finalAttrs.version}/postgresql-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-gu8nwK83UWldf2Ti2WNYMAX7tqDD32PQ5LQiEdcCEWQ=";
+  };
+
+  __structuredAttrs = true;
+
+  hardeningEnable = lib.optionals (!stdenv.cc.isClang) [ "pie" ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+  outputChecks.out = {
+    disallowedReferences = [ "dev" ];
+    disallowedRequisites = [
+      stdenv.cc
+    ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+  };
+
+  buildInputs =
+    [
+      zlib
+      openssl
+    ]
+    ++ lib.optionals gssSupport [ libkrb5 ]
+    ++ lib.optionals nlsSupport [ gettext ];
+
+  nativeBuildInputs = [
+    bison
+    flex
+    perl
+    pkg-config
+  ];
+
+  # causes random build failures
+  enableParallelBuilding = false;
+
+  separateDebugInfo = true;
+
+  buildFlags = [
+    "submake-libpgport"
+    "submake-libpq"
+  ];
+
+  # libpgcommon.a and libpgport.a contain all paths normally returned by pg_config and are
+  # linked into all shared libraries. However, almost no binaries actually use those paths.
+  # The following flags will remove unused sections from all shared libraries - including
+  # those paths. This avoids a lot of circular dependency problems with different outputs,
+  # and allows splitting them cleanly.
+  env.CFLAGS =
+    "-fdata-sections -ffunction-sections"
+    + (if stdenv.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
+
+  configureFlags =
+    [
+      "--enable-debug"
+      "--sysconfdir=/etc"
+      "--with-openssl"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--without-icu"
+      "--without-perl"
+      "--without-readline"
+    ]
+    ++ lib.optionals gssSupport [ "--with-gssapi" ]
+    ++ lib.optionals nlsSupport [ "--enable-nls" ];
+
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
+    ./patches/socketdir-in-run-13+.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    make -C src/bin/pg_config install
+    make -C src/common install
+    make -C src/include install
+    make -C src/interfaces/libpq install
+    make -C src/port install
+
+    moveToOutput bin/pg_config "$dev"
+    moveToOutput "lib/*.a" "$dev"
+
+    rm -rfv $out/share
+    rm -rfv $dev/lib/*_shlib.a
+
+    runHook postInstall
+  '';
+
+  # PostgreSQL always builds both shared and static libs, so we delete those we don't want.
+  postInstall =
+    if stdenv.hostPlatform.isStatic then
+      ''
+        rm -rfv $out/lib/*.so*
+        touch $out/empty
+      ''
+    else
+      "rm -rfv $dev/lib/*.a";
+
+  doCheck = false;
+
+  meta = {
+    inherit (postgresql.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "C application programmer's interface to PostgreSQL";
+    changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
+    pkgConfigModules = [ "libpq" ];
+  };
+})

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -4,7 +4,7 @@
   rustPlatform,
   fetchFromGitHub,
   openssl,
-  postgresql,
+  libpq,
   libiconv,
   Security,
   SystemConfiguration,
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = pinData.serverCargoHash;
 
   buildInputs =
-    [ postgresql ]
+    [ libpq ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       libiconv
       Security

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   sqlite,
-  postgresql,
+  libpq,
   zlib,
   acl,
   ncurses,
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      postgresql
+      libpq
       sqlite
       zlib
       ncurses
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   configureFlags =
     [
       "--with-sqlite3=${sqlite.dev}"
-      "--with-postgresql=${lib.getDev postgresql}"
+      "--with-postgresql=${lib.getDev libpq}"
       "--with-logdir=/var/log/bacula"
       "--with-working-dir=/var/lib/bacula"
       "--mandir=\${out}/share/man"

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -8,7 +8,7 @@
   systemd ? null,
   ejabberd ? null,
   mariadb ? null,
-  postgresql ? null,
+  libpq ? null,
   subversion ? null,
   mongodb ? null,
   mongodb-tools ? null,
@@ -41,7 +41,7 @@
 }:
 
 assert enableMySQLDatabase -> mariadb != null;
-assert enablePostgreSQLDatabase -> postgresql != null;
+assert enablePostgreSQLDatabase -> libpq != null;
 assert enableSubversionRepository -> subversion != null;
 assert enableEjabberdDump -> ejabberd != null;
 assert enableMongoDatabase -> (mongodb != null && mongodb-tools != null);
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.hostPlatform.isLinux systemd
     ++ lib.optional enableEjabberdDump ejabberd
     ++ lib.optional enableMySQLDatabase mariadb.out
-    ++ lib.optional enablePostgreSQLDatabase postgresql
+    ++ lib.optional enablePostgreSQLDatabase libpq
     ++ lib.optional enableSubversionRepository subversion
     ++ lib.optionals enableMongoDatabase [
       mongodb

--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -13,7 +13,7 @@
   SystemConfiguration,
   dbBackend ? "sqlite",
   libmysqlclient,
-  postgresql,
+  libpq,
 }:
 
 let
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
       SystemConfiguration
     ]
     ++ lib.optional (dbBackend == "mysql") libmysqlclient
-    ++ lib.optional (dbBackend == "postgresql") postgresql;
+    ++ lib.optional (dbBackend == "postgresql") libpq;
 
   buildFeatures = dbBackend;
 

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -19,6 +19,7 @@
   gdk-pixbuf,
   liboping,
   libpcap,
+  libpq,
   libsigrok,
   libvirt,
   libxml2,
@@ -31,7 +32,6 @@
   openldap,
   openipmi,
   perl,
-  postgresql,
   protobufc,
   python3,
   rabbitmq-c,
@@ -132,7 +132,7 @@ let
     perl.buildInputs = [ perl ];
     pinba.buildInputs = [ protobufc ];
     ping.buildInputs = [ liboping ];
-    postgresql.buildInputs = [ postgresql ];
+    postgresql.buildInputs = [ libpq ];
     python.buildInputs = [ python3 ];
     redis.buildInputs = [ hiredis ];
     rrdcached.buildInputs = [

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -18,7 +18,7 @@
   withMysql ? true,
   libmysqlclient,
   withPostgres ? true,
-  postgresql,
+  libpq,
   withDbi ? true,
   libdbi,
   withNetSnmp ? true,
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional withKrb5 libkrb5
     ++ lib.optional withJemalloc jemalloc
-    ++ lib.optional withPostgres postgresql
+    ++ lib.optional withPostgres libpq
     ++ lib.optional withDbi libdbi
     ++ lib.optional withNetSnmp net-snmp
     ++ lib.optional withUuid libuuid

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -20,7 +20,7 @@
   glibcLocales,
   mpfr,
   more,
-  postgresql,
+  libpq,
   hiredis,
   expat,
   tre,
@@ -165,7 +165,7 @@ let
     pgsql = buildExtension {
       inherit gawkextlib;
       name = "pgsql";
-      extraBuildInputs = [ postgresql ];
+      extraBuildInputs = [ libpq ];
     };
     redis = buildExtension {
       inherit gawkextlib;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1039,9 +1039,7 @@ with pkgs;
     systemd = pkgs.systemd;
   };
 
-  nominatim = callPackage ../servers/nominatim {
-    postgresql = postgresql_14;
-  };
+  nominatim = callPackage ../servers/nominatim { };
 
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };
 
@@ -11685,6 +11683,8 @@ with pkgs;
 
   postgresqlVersions = import ../servers/sql/postgresql pkgs;
   inherit (postgresqlVersions)
+    libpq
+
     postgresql_13
     postgresql_14
     postgresql_15

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1540,7 +1540,7 @@ let
     posix-types = callPackage ../development/ocaml-modules/posix/types.nix { };
 
     postgresql = callPackage ../development/ocaml-modules/postgresql {
-      inherit (pkgs) postgresql;
+      inherit (pkgs) libpq;
     };
 
     pp = callPackage ../development/ocaml-modules/pp { };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -20,6 +20,7 @@
   libffi,
   libiconv,
   libkrb5,
+  libpq,
   libsodium,
   libxml2,
   libxslt,
@@ -33,7 +34,6 @@
   overrideSDK,
   pam,
   pcre2,
-  postgresql,
   bison,
   re2c,
   readline,
@@ -351,7 +351,6 @@ lib.makeScope pkgs.newScope (
           configureFlags = [ "--with-pdo-oci=instantclient,${pkgs.oracle-instantclient.lib}/lib" ];
 
           internalDeps = [ php.extensions.pdo ];
-
           postPatch = ''
             sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
           '';
@@ -635,7 +634,8 @@ lib.makeScope pkgs.newScope (
               {
                 name = "pdo_pgsql";
                 internalDeps = [ php.extensions.pdo ];
-                configureFlags = [ "--with-pdo-pgsql=${lib.getDev postgresql}" ];
+                buildInputs = [ libpq ];
+                configureFlags = [ "--with-pdo-pgsql=${lib.getDev libpq}" ];
                 doCheck = false;
               }
               {
@@ -647,8 +647,11 @@ lib.makeScope pkgs.newScope (
               }
               {
                 name = "pgsql";
-                buildInputs = [ pcre2 ];
-                configureFlags = [ "--with-pgsql=${lib.getDev postgresql}" ];
+                buildInputs = [
+                  pcre2
+                  libpq
+                ];
+                configureFlags = [ "--with-pgsql=${lib.getDev libpq}" ];
                 doCheck = false;
               }
               {


### PR DESCRIPTION
This creates a separate libpq package as discussed in https://github.com/NixOS/nixpkgs/issues/61580#issuecomment-2381375407.

This brings down the number of rebuilds after updating `postgresql` to about 1.2k darwin and 2.5k linux. Before, they were ~ around 5k, IIRC.

Unfortunately, we are still not anywhere low enough to be able to merge `postgresql` updates directly into master. I think the nr. 1 reason for that is `postgresqlTestHook` - and the fact that many packages use a very simple postgresql server in their build dependencies for the check phase.

The only way to get the number of rebuilds lower would be to package `postgresqlTestHook` as a separate postgresql derivation. The idea would be, that security related issues are irrelevant for the check phase of other packages - and thus updating this separately could easily go through staging with a certain delay. This derivation could also be one that is built with the minimal feature set, making it slimmer overall.

I still think that introducing `libpq` is a good thing on it's own, thus this PR.

Closes #61580 and #191920

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (the directly changed packages)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
