### PR TITLE
Declare attrpaths using attrset nesting

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -519,12 +519,6 @@ rec {
       containing the rest of the attrpath declaration or a string which
       terminates the attrpath declaration.
 
-    # Type
-
-    ```
-    TODO
-    ```
-
     # Examples
     :::{.example}
     ## `lib.attrsets.associateWithAttrPath'` usage example
@@ -548,74 +542,86 @@ rec {
     else
       combine (associateWithAttrPath' pack combine currentPath) remaining;
 
-  # This function associates arbitrary strings with attribute paths in the form
-  # of a list of name-value pairs consumable by `builtins.listToAttrs`.
-  #
-  # To declare the attribute paths, you simply declare an attrset with
-  # (optionally) nested attributes that describe the paths and set the final
-  # attributes equal to the strings which you want to associate the paths with.
-  #
-  # This also works with paths that require quoting; simply quote your
-  # specification's attributes as usual.
-  #
-  # {
-  #   foo.bar = "somestring";
-  #   foo.baz = "otherstring";
-  #   any.path."can.be".expressed.here = "otherstring";
-  # }
-  #
-  # results in:
-  #
-  # [
-  #   {
-  #     name = "somestring";
-  #     value = [ "foo" "bar" ];
-  #   }
-  #   {
-  #     name = "otherstring";
-  #     value = [ "foo" "baz" ];
-  #   }
-  #   {
-  #     name = "otherstring";
-  #     value = [ "any" "path" "can.be" "expressed" "here" ];
-  #   }
-  # ]
-  # TODO document arguments
-  #
-  # Each strings can be associated with multiple attribute paths.
-  #
-  # In most cases, you'd typically use the singular variant of this function.
+  /**
+    This function associates arbitrary strings with attribute paths in the form
+    of a list of name-value pairs consumable by `builtins.listToAttrs`.
+
+    To declare the attribute paths, you simply declare an attrset with
+    (optionally) nested attributes that describe the paths and set the final
+    attributes equal to the strings which you want to associate the paths with.
+
+    This also works with paths that require quoting; simply quote your
+    specification's attributes as usual.
+
+    Each string can be associated with multiple attribute paths, resulting in
+    multiple list elements with the same name.
+
+    In most cases, you'd typically use the singular variant of this function.
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.associateWithAttrPathMultiple` usage example
+
+    ```Nix
+    lib.attrsets.associateWithAttrPathMultiple {
+      foo.bar = "somestring";
+      foo.baz = "otherstring";
+      any.path."can.be".expressed.here = "otherstring";
+    }
+    =>
+    [
+      {
+        name = "somestring";
+        value = [ "foo" "bar" ];
+      }
+      {
+        name = "otherstring";
+        value = [ "foo" "baz" ];
+      }
+      {
+        name = "otherstring";
+        value = [ "any" "path" "can.be" "expressed" "here" ];
+      }
+    ]
+    ```
+    :::
+  */
   associateWithAttrPathMultiple = associateWithAttrPath' (name: path: [ (nameValuePair name path) ]) (
     recursor: remaining: concatMap (next: recursor next remaining.${next}) (attrNames remaining)
   );
 
-  # This function associates arbitrary strings with attribute paths in the form
-  # of an attrset.
-  #
-  # To declare the attribute paths, you simply declare an attrset with
-  # (optionally) nested attributes that describe the paths and set the final
-  # attributes equal to the strings which you want to associate the paths with.
-  #
-  # This also works with paths that require quoting; simply quote your
-  # specification's attributes as usual.
-  #
-  # Example:
-  #
-  # {
-  #   foo.bar = "from";
-  #   foo."bar.baz" = "to";
-  # }
-  #
-  # Results in:
-  #
-  # {
-  #   from = [ "foo" "bar" ];
-  #   to = [ "foo" "bar.baz" ];
-  # }
-  #
-  # The same string MUST NOT be associated with multiple attribute paths. This
-  # results in undefined behaviour. Use associateWithAttrPath' instead if you
-  # need to handle multiple instances of the same string.
+  /**
+    This function associates arbitrary strings with attribute paths in the form
+    of an attrset.
+
+    To declare the attribute paths, you simply declare an attrset with
+    (optionally nested) attributes that describe the paths and set the final
+    attributes equal to the strings which you want to associate the paths with.
+
+    This also works with paths that require quoting; simply quote your
+    specification's attributes as usual.
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.associateWithAttrPath` usage example
+
+    ```Nix
+    lib.attrsets.associateWithAttrPath {
+      foo.bar = "from";
+      foo."bar.baz" = "to";
+    }
+    =>
+    {
+      from = [ "foo" "bar" ];
+      to = [ "foo" "bar.baz" ];
+    }
+    ```
+    :::
+
+    The same string MUST NOT be associated with multiple attribute paths. This
+    results in undefined behaviour. Use associateWithAttrPath' instead if you
+    need to handle multiple instances of the same string.
+  */
   associateWithAttrPath = associateWithAttrPath' (name: path: { ${name} = path; }) (
     recursor: remaining: concatMapAttrs recursor remaining
   ) [ ] null;

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -517,16 +517,16 @@ rec {
   #
   # In most cases, you'd typically use the non-' version of this function.
   associateWithAttrPath' =
-    previousPath: name: remaining:
+    previousPath: current: remaining:
     let
-      currentPath = previousPath ++ optional (name != null) name; # Null denotes the root
+      currentPath = previousPath ++ optional (current != null) current; # Null denotes the root
     in
     if
       isString remaining # Any string is a terminator
     then
       [ (nameValuePair remaining currentPath) ]
     else
-      concatMap (nextName: associateWithAttrPath' currentPath nextName remaining.${nextName}) (
+      concatMap (next: associateWithAttrPath' currentPath next remaining.${next}) (
         attrNames remaining
       );
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -516,15 +516,19 @@ rec {
   # Each strings can be associated with multiple attribute paths.
   #
   # In most cases, you'd typically use the non-' version of this function.
-  associateWithAttrPath' = previousPath: name: remaining:
+  associateWithAttrPath' =
+    previousPath: name: remaining:
     let
       currentPath = previousPath ++ optional (name != null) name; # Null denotes the root
     in
-    if isString remaining # Any string is a terminator
-    then [ (nameValuePair remaining currentPath) ]
-    else concatMap
-      (nextName: associateWithAttrPath' currentPath nextName remaining.${nextName})
-      (attrNames remaining);
+    if
+      isString remaining # Any string is a terminator
+    then
+      [ (nameValuePair remaining currentPath) ]
+    else
+      concatMap (nextName: associateWithAttrPath' currentPath nextName remaining.${nextName}) (
+        attrNames remaining
+      );
 
   # This function associates arbitrary strings with attribute paths in the form
   # of an attrset.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -482,9 +482,9 @@ rec {
   # This function associates arbitrary strings with attribute paths in the form
   # of a list of name-value pairs consumable by `builtins.listToAttrs`.
   #
-  # To declare the attribute path, you simply declare an attrset containing the
-  # path and set its final attribute equal to the string which you want to
-  # associate the path with.
+  # To declare the attribute paths, you simply declare an attrset with
+  # (optionally) nested attributes that describe the paths and set the final
+  # attributes equal to the strings which you want to associate the paths with.
   #
   # This also works with paths that require quoting; simply quote your
   # specification's attributes as usual.
@@ -529,9 +529,9 @@ rec {
   # This function associates arbitrary strings with attribute paths in the form
   # of an attrset.
   #
-  # To declare the attribute path, you simply declare an attrset containing the
-  # path and set its final attribute equal to the string which you want to
-  # associate the path with.
+  # To declare the attribute paths, you simply declare an attrset with
+  # (optionally) nested attributes that describe the paths and set the final
+  # attributes equal to the strings which you want to associate the paths with.
   #
   # This also works with paths that require quoting; simply quote your
   # specification's attributes as usual.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -560,7 +560,9 @@ rec {
   # The same string MUST NOT be associated with multiple attribute paths. This
   # results in undefined behaviour. Use associateWithAttrPath' instead if you
   # need to handle multiple instances of the same string.
-  associateWithAttrPath = spec: listToAttrs (associateWithAttrPathMultiple [ ] null spec);
+  associateWithAttrPath = associateWithAttrPath' (name: path: { ${name} = path; }) (
+    recursor: remaining: concatMapAttrs (name: value: recursor name value) remaining
+  ) [ ] null;
 
   /**
     Return the specified attributes from a set.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -561,7 +561,7 @@ rec {
   # results in undefined behaviour. Use associateWithAttrPath' instead if you
   # need to handle multiple instances of the same string.
   associateWithAttrPath = associateWithAttrPath' (name: path: { ${name} = path; }) (
-    recursor: remaining: concatMapAttrs (name: value: recursor name value) remaining
+    recursor: remaining: concatMapAttrs recursor remaining
   ) [ ] null;
 
   /**

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -479,11 +479,67 @@ rec {
 
   in updates: value: go 0 true value updates;
 
-  # TODO document
+  /**
+
+    The abstract version of `lib.attrsets.associateWithAttrPath` which can
+    return arbitrary data formats through use of custom packing and combining
+    functions.
+
+    # Inputs
+
+    `pack`
+
+    : A function which takes a name and a value as its arguments. It's expected
+      to pack the arguments into your desired representation of one terminating
+      string + attrpath pair.
+
+    `combine`
+
+    : A function which takes the recursive function and the remaining subtree as
+      arguments. It's expected to call the function with all names and values of
+      the remaining subtree. It then needs to combine the results of those calls
+      into your desired representation of multiple string + attrpath pairs.
+
+    `pathPrefix`
+
+    : The attrpath prefix of the current iteration. This will be prepended to
+      the resulting attrpath. Pass the empty list (`[ ]`) for no prefix.
+      Recursive calls pass this attrpath with the current attribute name
+      appended.
+
+    `current`
+
+    : The name of the current attribute that will be appended to the resulting
+      path in this iteration of the recursive call. Pass `null` to signify the
+      root directory; it will not be appended.
+
+    `remaining`
+
+    : The value of the current attribute. This can either be an attrset
+      containing the rest of the attrpath declaration or a string which
+      terminates the attrpath declaration.
+
+    # Type
+
+    ```
+    TODO
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.associateWithAttrPath'` usage example
+
+    ```nix
+    attrValues {c = 3; a = 1; b = 2;}
+    => [1 2 3]
+    ```
+
+    :::
+  */
   associateWithAttrPath' =
-    pack: combine: previousPath: current: remaining:
+    pack: combine: pathPrefix: current: remaining:
     let
-      currentPath = previousPath ++ optional (current != null) current; # Null denotes the root
+      currentPath = pathPrefix ++ optional (current != null) current; # Null denotes the root
     in
     if
       isString remaining # Any string is a terminator
@@ -528,7 +584,7 @@ rec {
   #
   # Each strings can be associated with multiple attribute paths.
   #
-  # In most cases, you'd typically use the non-' version of this function.
+  # In most cases, you'd typically use the singular variant of this function.
   associateWithAttrPathMultiple = associateWithAttrPath' (name: path: [ (nameValuePair name path) ]) (
     recursor: remaining: concatMap (next: recursor next remaining.${next}) (attrNames remaining)
   );

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1264,7 +1264,15 @@ let
       (opt.highestPrio or defaultOverridePriority)
       (f opt.value);
 
-  # Spec is an attrpath spec, extra is an additional argument, depending on the action
+  /**
+
+    # Spec is an attrpath spec, extra is an additional argument, depending on the action
+
+    A modern version of `lib.modules.doRename` that is used using attrpath
+    declarations as defined in `lib.modules.associateWithAttrPath`.
+
+    # Inputs
+  */
   doRename2 = spec: extra:
     let
       attrPaths = lib.attrsets.associateWithAttrPath spec;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1287,6 +1287,7 @@ let
         mkRenamedOptionModule (getPathForOp "from") (getPathForOp "to")
     else if existsInSpec "original" || existsInSpec "alias" then
       assert (lib.assertMsg (existsInSpec "original" && existsInSpec "alias") "The rename spec provided to doRename must contain `original` and `alias`.");
+      # TODO alias since?
       mkAliasOptionModule (getPathForOp "original") (getPathForOp "alias")
     else if existsInSpec "remove" then
       mkRemovedOptionModule (getPathForOp "remove") extra

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1344,11 +1344,12 @@ let
       existsInSpec = op: spec != { } && hasAttr attrPaths op;
       getPathForOp =
         op:
-        if existsInSpec op
-        then attrPaths.${op}
-        else if args.${op} != null
-        then args.${op}
-        else abort "You must provide `doRename` with the `${op}` attribute path.";
+        if existsInSpec op then
+          attrPaths.${op}
+        else if args.${op} != null then
+          args.${op}
+        else
+          abort "You must provide `doRename` with the `${op}` attribute path.";
 
       pathTo = getPathForOp "to";
       pathFrom = getPathForOp "from";

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1340,7 +1340,7 @@ let
   }:
     { config, options, ... }:
     let
-      attrPaths = lib.attrsets.pathOperationsToAttrPaths spec;
+      attrPaths = lib.attrsets.associateWithAttrPath spec;
       existsInSpec = op: spec != { } && hasAttr attrPaths op;
       getPathForOp =
         op:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1341,7 +1341,7 @@ let
     { config, options, ... }:
     let
       attrPaths = lib.attrsets.associateWithAttrPath spec;
-      existsInSpec = op: spec != { } && hasAttr attrPaths op;
+      existsInSpec = op: spec != { } && hasAttr op attrPaths;
       getPathForOp =
         op:
         if existsInSpec op then

--- a/lib/tests/attrsets.nix
+++ b/lib/tests/attrsets.nix
@@ -1,5 +1,10 @@
 let
   lib = import ../default.nix;
+
+  inherit (lib.attrsets)
+    pathOperationsToAttrPaths
+    pathOperationsToAttrPaths'
+    ;
 in
 
 lib.runTests {
@@ -7,7 +12,7 @@ lib.runTests {
   # pathOperationsToAttrPaths; the other functions need to be tested too.
 
   testPathOperationsToAttrPaths'Immediate = {
-    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" "from";
+    expr = pathOperationsToAttrPaths' [ ] "foo" "from";
     expected = [
       {
         name = "from";
@@ -16,7 +21,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths'Nested1 = {
-    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
+    expr = pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
     expected = [
       {
         name = "from";
@@ -28,7 +33,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths'Nested2 = {
-    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
+    expr = pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
     expected = [
       {
         name = "from";
@@ -41,7 +46,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths'NestedInSame = {
-    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" {
+    expr = pathOperationsToAttrPaths' [ ] "foo" {
       bar = "from";
       baz = "to";
     };
@@ -63,7 +68,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths'CommonPrefix = {
-    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" {
+    expr = pathOperationsToAttrPaths' [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
     };
@@ -89,7 +94,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths = {
-    expr = lib.attrsets.pathOperationsToAttrPaths {
+    expr = pathOperationsToAttrPaths {
       foo.bar = "from";
       baz.quux = "to";
     };

--- a/lib/tests/attrsets.nix
+++ b/lib/tests/attrsets.nix
@@ -2,17 +2,18 @@ let
   lib = import ../default.nix;
 
   inherit (lib.attrsets)
-    pathOperationsToAttrPaths
-    pathOperationsToAttrPaths'
+    associateWithAttrPath
+    associateWithAttrPath'
     ;
 in
 
 lib.runTests {
   # FIXME there weren't any lib.attrsets tests until I(@Atemu) added
-  # pathOperationsToAttrPaths; the other functions need to be tested too.
+  # associateWithAttrPath' and pathOperationsToAttrPaths; the other functions
+  # need to be tested too.
 
-  testPathOperationsToAttrPaths'Immediate = {
-    expr = pathOperationsToAttrPaths' [ ] "foo" "from";
+  testAssociateWithAttrPathImmediate = {
+    expr = associateWithAttrPath' [ ] "foo" "from";
     expected = [
       {
         name = "from";
@@ -20,8 +21,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'Nested1 = {
-    expr = pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
+  testAssociateWithAttrPathNested1 = {
+    expr = associateWithAttrPath' [ ] "foo" { bar = "from"; };
     expected = [
       {
         name = "from";
@@ -32,8 +33,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'Nested2 = {
-    expr = pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
+  testAssociateWithAttrPathNested2 = {
+    expr = associateWithAttrPath' [ ] "foo" { bar.baz = "from"; };
     expected = [
       {
         name = "from";
@@ -45,8 +46,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'NestedInSame = {
-    expr = pathOperationsToAttrPaths' [ ] "foo" {
+  testAssociateWithAttrPathNestedInSame = {
+    expr = associateWithAttrPath' [ ] "foo" {
       bar = "from";
       baz = "to";
     };
@@ -67,8 +68,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'CommonPrefix = {
-    expr = pathOperationsToAttrPaths' [ ] "foo" {
+  testAssociateWithAttrPathCommonPrefix = {
+    expr = associateWithAttrPath' [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
     };
@@ -94,7 +95,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths = {
-    expr = pathOperationsToAttrPaths {
+    expr = associateWithAttrPath {
       foo.bar = "from";
       baz.quux = "to";
     };

--- a/lib/tests/attrsets.nix
+++ b/lib/tests/attrsets.nix
@@ -3,6 +3,9 @@ let
 in
 
 lib.runTests {
+  # FIXME there weren't any lib.attrsets tests until I(@Atemu) added
+  # pathOperationsToAttrPaths; the other functions need to be tested too.
+
   testPathOperationsToAttrPaths'Immediate = {
     expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" "from";
     expected = [

--- a/lib/tests/attrsets.nix
+++ b/lib/tests/attrsets.nix
@@ -2,18 +2,18 @@ let
   lib = import ../default.nix;
 
   inherit (lib.attrsets)
-    associateWithAttrPath
     associateWithAttrPath'
+    associateWithAttrPath
+    associateWithAttrPathMultiple
     ;
 in
 
 lib.runTests {
   # FIXME there weren't any lib.attrsets tests until I(@Atemu) added
-  # associateWithAttrPath' and pathOperationsToAttrPaths; the other functions
-  # need to be tested too.
+  # associateWithAttrPath; the other functions need to be tested too.
 
   testAssociateWithAttrPathImmediate = {
-    expr = associateWithAttrPath' [ ] "foo" "from";
+    expr = associateWithAttrPathMultiple [ ] "foo" "from";
     expected = [
       {
         name = "from";
@@ -22,7 +22,7 @@ lib.runTests {
     ];
   };
   testAssociateWithAttrPathNested1 = {
-    expr = associateWithAttrPath' [ ] "foo" { bar = "from"; };
+    expr = associateWithAttrPathMultiple [ ] "foo" { bar = "from"; };
     expected = [
       {
         name = "from";
@@ -34,7 +34,7 @@ lib.runTests {
     ];
   };
   testAssociateWithAttrPathNested2 = {
-    expr = associateWithAttrPath' [ ] "foo" { bar.baz = "from"; };
+    expr = associateWithAttrPathMultiple [ ] "foo" { bar.baz = "from"; };
     expected = [
       {
         name = "from";
@@ -47,7 +47,7 @@ lib.runTests {
     ];
   };
   testAssociateWithAttrPathNestedInSame = {
-    expr = associateWithAttrPath' [ ] "foo" {
+    expr = associateWithAttrPathMultiple [ ] "foo" {
       bar = "from";
       baz = "to";
     };
@@ -69,7 +69,7 @@ lib.runTests {
     ];
   };
   testAssociateWithAttrPathCommonPrefix = {
-    expr = associateWithAttrPath' [ ] "foo" {
+    expr = associateWithAttrPathMultiple [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
     };

--- a/lib/tests/rename-spect.nix
+++ b/lib/tests/rename-spect.nix
@@ -3,7 +3,7 @@ let
 in
 
 lib.runTests {
-  testProcessAttrImmediate = {
+  testPathOperationsToAttrPaths'_Immediate = {
     expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" "from";
     expected = [
       {
@@ -12,7 +12,7 @@ lib.runTests {
       }
     ];
   };
-  testProcessAttrNested1 = {
+  testPathOperationsToAttrPaths'_Nested1 = {
     expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
     expected = [
       {
@@ -24,7 +24,20 @@ lib.runTests {
       }
     ];
   };
-  testProcessAttrNestedInSame = {
+  testPathOperationsToAttrPaths'_Nested2 = {
+    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
+    expected = [
+      {
+        name = "from";
+        value = [
+          "foo"
+          "bar"
+          "baz"
+        ];
+      }
+    ];
+  };
+  testPathOperationsToAttrPaths'_NestedInSame = {
     expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
       bar = "from";
       baz = "to";
@@ -46,7 +59,7 @@ lib.runTests {
       }
     ];
   };
-  testProcessAttrNestedInSameDeeper = {
+  testPathOperationsToAttrPaths'_commonPrefix = {
     expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
@@ -72,7 +85,7 @@ lib.runTests {
       }
     ];
   };
-  testRenameSpec = {
+  testPathOperationsToAttrPaths = {
     expr = lib.modules.pathOperationsToAttrPaths {
       foo.bar = "from";
       baz.quux = "to";

--- a/lib/tests/rename-spect.nix
+++ b/lib/tests/rename-spect.nix
@@ -4,7 +4,7 @@ in
 
 lib.runTests {
   testProcessAttrImmediate = {
-    expr = lib.modules.processAttr [ ] "foo" "from";
+    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" "from";
     expected = [
       {
         name = "from";
@@ -13,7 +13,7 @@ lib.runTests {
     ];
   };
   testProcessAttrNested1 = {
-    expr = lib.modules.processAttr [ ] "foo" { bar = "from"; };
+    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
     expected = [
       {
         name = "from";
@@ -25,7 +25,7 @@ lib.runTests {
     ];
   };
   testProcessAttrNestedInSame = {
-    expr = lib.modules.processAttr [ ] "foo" {
+    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
       bar = "from";
       baz = "to";
     };
@@ -47,7 +47,7 @@ lib.runTests {
     ];
   };
   testProcessAttrNestedInSameDeeper = {
-    expr = lib.modules.processAttr [ ] "foo" {
+    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
     };
@@ -73,7 +73,7 @@ lib.runTests {
     ];
   };
   testRenameSpec = {
-    expr = lib.modules.transformRenameSpec {
+    expr = lib.modules.pathOperationsToAttrPaths {
       foo.bar = "from";
       baz.quux = "to";
     };

--- a/lib/tests/rename-spect.nix
+++ b/lib/tests/rename-spect.nix
@@ -1,0 +1,91 @@
+let
+  lib = import ../default.nix;
+in
+
+lib.runTests {
+  testProcessAttrImmediate = {
+    expr = lib.modules.processAttr [ ] "foo" "from";
+    expected = [
+      {
+        name = "from";
+        value = [ "foo" ];
+      }
+    ];
+  };
+  testProcessAttrNested1 = {
+    expr = lib.modules.processAttr [ ] "foo" { bar = "from"; };
+    expected = [
+      {
+        name = "from";
+        value = [
+          "foo"
+          "bar"
+        ];
+      }
+    ];
+  };
+  testProcessAttrNestedInSame = {
+    expr = lib.modules.processAttr [ ] "foo" {
+      bar = "from";
+      baz = "to";
+    };
+    expected = [
+      {
+        name = "from";
+        value = [
+          "foo"
+          "bar"
+        ];
+      }
+      {
+        name = "to";
+        value = [
+          "foo"
+          "baz"
+        ];
+      }
+    ];
+  };
+  testProcessAttrNestedInSameDeeper = {
+    expr = lib.modules.processAttr [ ] "foo" {
+      common.prefix.bar = "from";
+      common.prefix.baz = "to";
+    };
+    expected = [
+      {
+        name = "from";
+        value = [
+          "foo"
+          "common"
+          "prefix"
+          "bar"
+        ];
+      }
+      {
+        name = "to";
+        value = [
+          "foo"
+          "common"
+          "prefix"
+          "baz"
+        ];
+      }
+    ];
+  };
+  testRenameSpec = {
+    expr = lib.modules.transformRenameSpec {
+      foo.bar = "from";
+      baz.quux = "to";
+    };
+    expected = {
+      from = [
+        "foo"
+        "bar"
+      ];
+      to = [
+        "baz"
+        "quux"
+      ];
+    };
+  };
+}

--- a/lib/tests/rename-spect.nix
+++ b/lib/tests/rename-spect.nix
@@ -3,8 +3,8 @@ let
 in
 
 lib.runTests {
-  testPathOperationsToAttrPaths'_Immediate = {
-    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" "from";
+  testPathOperationsToAttrPaths'Immediate = {
+    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" "from";
     expected = [
       {
         name = "from";
@@ -12,8 +12,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'_Nested1 = {
-    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
+  testPathOperationsToAttrPaths'Nested1 = {
+    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" { bar = "from"; };
     expected = [
       {
         name = "from";
@@ -24,8 +24,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'_Nested2 = {
-    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
+  testPathOperationsToAttrPaths'Nested2 = {
+    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" { bar.baz = "from"; };
     expected = [
       {
         name = "from";
@@ -37,8 +37,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'_NestedInSame = {
-    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
+  testPathOperationsToAttrPaths'NestedInSame = {
+    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" {
       bar = "from";
       baz = "to";
     };
@@ -59,8 +59,8 @@ lib.runTests {
       }
     ];
   };
-  testPathOperationsToAttrPaths'_commonPrefix = {
-    expr = lib.modules.pathOperationsToAttrPaths' [ ] "foo" {
+  testPathOperationsToAttrPaths'CommonPrefix = {
+    expr = lib.attrsets.pathOperationsToAttrPaths' [ ] "foo" {
       common.prefix.bar = "from";
       common.prefix.baz = "to";
     };
@@ -86,7 +86,7 @@ lib.runTests {
     ];
   };
   testPathOperationsToAttrPaths = {
-    expr = lib.modules.pathOperationsToAttrPaths {
+    expr = lib.attrsets.pathOperationsToAttrPaths {
       foo.bar = "from";
       baz.quux = "to";
     };


### PR DESCRIPTION
This provides a simple method of declaring attrpaths using attrset syntax rather than lists of trings. This is intended to be a less unwieldy alternative that also formats better due to not requiring lists with many elements. 

I'll squash and add proper commit messages later.

I've done a bit of testing and it seems to work alright.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
