### PR TITLE
lomiri.lomiri-mediaplayer-app: init at 1.1.0

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -90,6 +90,7 @@ in
             lomiri-filemanager-app
             lomiri-gallery-app
             lomiri-history-service
+            lomiri-mediaplayer-app
             lomiri-polkit-agent
             lomiri-schemas # exposes some required dbus interfaces
             lomiri-session # wrappers to properly launch the session

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -562,6 +562,7 @@ in {
   lomiri-clock-app = runTest ./lomiri-clock-app.nix;
   lomiri-docviewer-app = runTest ./lomiri-docviewer-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
+  lomiri-mediaplayer-app = runTest ./lomiri-mediaplayer-app.nix;
   lomiri-gallery-app = runTest ./lomiri-gallery-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};

--- a/nixos/tests/lomiri-mediaplayer-app.nix
+++ b/nixos/tests/lomiri-mediaplayer-app.nix
@@ -1,0 +1,77 @@
+{ lib, ... }:
+let
+  ocrContent = "Video Test";
+  videoFile = "test.webm";
+in
+{
+  name = "lomiri-mediaplayer-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        # Setup video
+        etc."${videoFile}".source =
+          pkgs.runCommand videoFile
+            {
+              nativeBuildInputs = with pkgs; [
+                ffmpeg # produce video for OCR
+                (imagemagick.override { ghostscriptSupport = true; }) # produce OCR-able image
+              ];
+            }
+            ''
+              magick -size 400x400 canvas:white -pointsize 40 -fill black -annotate +100+100 '${ocrContent}' output.png
+              ffmpeg -re -loop 1 -i output.png -c:v libvpx -b:v 100K -t 120 $out -loglevel fatal
+            '';
+        systemPackages = with pkgs.lomiri; [
+          suru-icon-theme
+          lomiri-mediaplayer-app
+        ];
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts = {
+        packages = with pkgs; [
+          # Intended font & helps with OCR
+          ubuntu-classic
+        ];
+      };
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("lomiri mediaplayer launches"):
+        machine.succeed("lomiri-mediaplayer-app >&2 &")
+        machine.wait_for_text("Choose from")
+        machine.screenshot("lomiri-mediaplayer_open")
+
+    machine.succeed("pkill -f lomiri-mediaplayer-app")
+
+    with subtest("lomiri mediaplayer plays video"):
+        machine.succeed("lomiri-mediaplayer-app /etc/${videoFile} >&2 &")
+        machine.wait_for_text("${ocrContent}")
+        machine.screenshot("lomiri-mediaplayer_playback")
+
+    machine.succeed("pkill -f lomiri-mediaplayer-app")
+
+    with subtest("lomiri mediaplayer localisation works"):
+        # OCR struggles with finding identifying the translated window title, and lomiri-content-hub QML isn't translated
+        # Cause an error, and look for the error popup
+        machine.succeed("touch invalid.mp4")
+        machine.succeed("env LANG=de_DE.UTF-8 lomiri-mediaplayer-app invalid.mp4 >&2 &")
+        machine.wait_for_text("Fehler")
+        machine.screenshot("lomiri-mediaplayer_localised")
+  '';
+}

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -1,0 +1,164 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  gettext,
+  gst_all_1,
+  lomiri-action-api,
+  lomiri-content-hub,
+  lomiri-ui-toolkit,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+  qtxmlpatterns,
+  wrapGAppsHook3,
+  wrapQtAppsHook,
+  xvfb-run,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-mediaplayer-app";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-mediaplayer-app";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-Pq1TA7eoHDRRzr6zT2cmIye91uz/0YsmQ8Qp79244wg=";
+  };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/35 merged & in release
+    (fetchpatch {
+      name = "0001-lomiri-mediaplayer-app-Fix-GNUInstallDirs-usage.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/baaa0ea7cba2a9f8bc7f223246857eba1cd5d8e4.patch";
+      hash = "sha256-RChPRi4zrAWJEl4Urznh5FRYuTnxCFzG+gZurrF7Ym0=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/36 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-mediaplayer-app-Drop-NO_DEFAULT_PATH-for-qmltestrunner.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/3bf4ebae7eb59176af984d07ad72b67ee0bd1b8f.patch";
+      hash = "sha256-dJCW0dKe7Tq1Mg9CSdVQHamObVrPS7COXsdv41SWnHg=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/37 merged & in release
+    (fetchpatch {
+      name = "0003-lomiri-mediaplayer-app-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/df1aadb82d73177133bc096307ec1ef1e2b0c2ed.patch";
+      hash = "sha256-dvkGjG0ptCmLDIAWzDjOzu+Q/5bgVdb/+RmE6v8fV0Q=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/38 merged & in release
+    (fetchpatch {
+      name = "0004-lomiri-mediaplayer-app-bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/bd927e823205214f9ea01dfb1f93171a8952ecf9.patch";
+      hash = "sha256-/lg0elv9weNnRGq1oD94/sE511EZ0TmXZsURcauQobI=";
+    })
+    (fetchpatch {
+      name = "0005-lomiri-mediaplayer-app-Fix-title-localisation.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/c4cba819dd55e7e85c4ea496626bed9aa78470a5.patch";
+      hash = "sha256-EiUxaCa5ANnRSciB8IodQOGnmG4rE/g/M+K4XcyqTI8=";
+    })
+  ];
+
+  postPatch = ''
+    # We don't want absolute paths in desktop files
+    substituteInPlace data/lomiri-mediaplayer-app.desktop.in.in \
+      --replace-fail 'Icon=@MEDIAPLAYER_DIR@/@LOMIRI_MEDIAPLAYER_APP_ICON@' 'Icon=lomiri-mediaplayer-app' \
+      --replace-fail 'X-Lomiri-SymbolicIcon=@MEDIAPLAYER_DIR@/@LOMIRI_MEDIAPLAYER_APP_SYMBOLIC_ICON@' 'X-Lomiri-SymbolicIcon=lomiri-app-launch/symbolic/lomiri-mediaplayer-app.svg' \
+      --replace-fail 'X-Lomiri-Splash-Image=@MEDIAPLAYER_DIR@/@LOMIRI_MEDIAPLAYER_APP_SPLASH@' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-mediaplayer-app.svg'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapGAppsHook3
+    wrapQtAppsHook
+  ];
+
+  buildInputs =
+    [
+      qtbase
+      qtmultimedia
+
+      # QML
+      lomiri-action-api
+      lomiri-content-hub
+      lomiri-ui-toolkit
+      qtxmlpatterns
+    ]
+    # QtMultimedia playback support
+    ++ (with gst_all_1; [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-bad
+    ]);
+
+  nativeCheckInputs = [
+    qtdeclarative # qmltestrunner
+    xvfb-run
+  ];
+
+  checkInputs = [ lomiri-ui-toolkit ];
+
+  dontWrapGApps = true;
+
+  cmakeFlags = [ (lib.cmakeBool "ENABLE_AUTOPILOT" false) ];
+
+  # Only test segfaults in Nix sandbox, see LSS for details
+  doCheck = false;
+
+  preCheck =
+    let
+      listToQtVar =
+        list: suffix: lib.strings.concatMapStringsSep ":" (drv: "${lib.getBin drv}/${suffix}") list;
+    in
+    ''
+      export QT_PLUGIN_PATH=${listToQtVar [ qtbase ] qtbase.qtPluginPrefix}
+      export QML2_IMPORT_PATH=${
+        listToQtVar [
+          lomiri-ui-toolkit
+          qtmultimedia
+          qtxmlpatterns
+        ] qtbase.qtQmlPrefix
+      }
+    '';
+
+  postInstall = ''
+    mkdir -p $out/share/{icons/hicolor/256x256/apps,lomiri-app-launch/{symbolic,splash}}
+
+    ln -s $out/share/{lomiri-mediaplayer-app,icons/hicolor/256x256/apps}/lomiri-mediaplayer-app.png
+    ln -s $out/share/{lomiri-mediaplayer-app/lomiri-mediaplayer-app-splash.svg,lomiri-app-launch/splash/lomiri-mediaplayer-app.svg}
+    ln -s $out/share/{lomiri-mediaplayer-app/lomiri-mediaplayer-app-symbolic.svg,lomiri-app-launch/symbolic/lomiri-mediaplayer-app.svg}
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Media Player application for Ubuntu Touch devices";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app/-/blob/${finalAttrs.version}/ChangeLog";
+    license = with lib.licenses; [
+      gpl3Only
+      cc-by-sa-30
+    ];
+    mainProgram = "lomiri-mediaplayer-app";
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   cmake,
   gettext,
   gst_all_1,
@@ -146,6 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-mediaplayer-app;
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -20,6 +20,7 @@ let
       lomiri-docviewer-app = callPackage ./applications/lomiri-docviewer-app { };
       lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
       lomiri-gallery-app = callPackage ./applications/lomiri-gallery-app { };
+      lomiri-mediaplayer-app = callPackage ./applications/lomiri-mediaplayer-app { };
       lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
       lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };
       lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };


### PR DESCRIPTION
Working towards https://github.com/NixOS/nixpkgs/issues/99090.

[Lomiri Mediaplayer App](https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app) is the video player app of the Lomiri DE.

I'm not sure if the test video setup in the VM test should be kept as-is - as a `runCommand` derivation built ahead-of-time, to have less things done during the test - or if it would be better to keep it generated on every run.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
