### PR TITLE
xcbuild: fix interactive applications run by xcrun

### DIFF
--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/Use-system-toolchain-for-usr-bin.patch
     # Suppress warnings due to newer SDKs with unknown keys
     ./patches/Suppress-unknown-key-warnings.patch
+    # Don't pipe stdout / stderr of processes launched by xcrun
+    ./patches/fix-interactive-apps.patch
   ];
 
   prePatch = ''

--- a/pkgs/by-name/xc/xcbuild/patches/fix-interactive-apps.patch
+++ b/pkgs/by-name/xc/xcbuild/patches/fix-interactive-apps.patch
@@ -1,0 +1,141 @@
+diff --git a/Libraries/process/Headers/process/DefaultLauncher.h b/Libraries/process/Headers/process/DefaultLauncher.h
+index cee6e145..698ffe84 100644
+--- a/Libraries/process/Headers/process/DefaultLauncher.h
++++ b/Libraries/process/Headers/process/DefaultLauncher.h
+@@ -20,11 +20,14 @@ namespace process {
+  */
+ class DefaultLauncher : public Launcher {
+ public:
+-    DefaultLauncher();
++    DefaultLauncher(bool sync_output);
+     ~DefaultLauncher();
+ 
+ public:
+     virtual ext::optional<int> launch(libutil::Filesystem *filesystem, Context const *context);
++
++private:
++    bool sync_output_;
+ };
+ 
+ }
+diff --git a/Libraries/process/Sources/DefaultLauncher.cpp b/Libraries/process/Sources/DefaultLauncher.cpp
+index a7f14e1a..e9aaf330 100644
+--- a/Libraries/process/Sources/DefaultLauncher.cpp
++++ b/Libraries/process/Sources/DefaultLauncher.cpp
+@@ -91,9 +91,18 @@ EscapedToken(const WideString &token)
+ }
+ #endif
+ 
++namespace {
++    enum class PipeStatus {
++        UNUSED,
++        CREATED,
++        ERROR
++    };
++}
++
+ DefaultLauncher::
+-DefaultLauncher() :
+-    Launcher()
++DefaultLauncher(bool sync_output) :
++    Launcher(),
++    sync_output_{sync_output}
+ {
+ }
+ 
+@@ -199,10 +208,14 @@ launch(Filesystem *filesystem, Context const *context)
+ 
+     /* Setup parent-child stdout/stderr pipe. */
+     int pfd[2];
+-    bool pipe_setup_success = true;
+-    if (pipe(pfd) == -1) {
+-        ::perror("pipe");
+-        pipe_setup_success = false;
++    PipeStatus pipe_status = PipeStatus::UNUSED;
++    if (sync_output_) {
++        if (pipe(pfd) == -1) {
++            ::perror("pipe");
++            pipe_status = PipeStatus::ERROR;
++        } else {
++            pipe_status = PipeStatus::CREATED;
++        }
+     }
+ 
+     /*
+@@ -214,22 +227,25 @@ launch(Filesystem *filesystem, Context const *context)
+         return ext::nullopt;
+     } else if (pid == 0) {
+         /* Fork succeeded, new process. */
+-        if (pipe_setup_success) {
+-            /* Setup pipe to parent, redirecting both stdout and stderr */
+-            dup2(pfd[1], STDOUT_FILENO);
+-            dup2(pfd[1], STDERR_FILENO);
+-            close(pfd[0]);
+-            close(pfd[1]);
+-        } else {
+-            /* No parent-child pipe setup, just ignore outputs from child */
+-            int nullfd = open("/dev/null", O_WRONLY);
+-            if (nullfd == -1) {
+-                ::perror("open");
+-                ::_exit(1);
+-            }
+-            dup2(nullfd, STDOUT_FILENO);
+-            dup2(nullfd, STDERR_FILENO);
+-            close(nullfd);
++        switch (pipe_status) {
++            case PipeStatus::CREATED:
++                /* Setup pipe to parent, redirecting both stdout and stderr */
++                dup2(pfd[1], STDOUT_FILENO);
++                dup2(pfd[1], STDERR_FILENO);
++                close(pfd[0]);
++                close(pfd[1]);
++                break;
++            case PipeStatus::ERROR:
++                /* No parent-child pipe setup, just ignore outputs from child */
++                int nullfd = open("/dev/null", O_WRONLY);
++                if (nullfd == -1) {
++                    ::perror("open");
++                    ::_exit(1);
++                }
++                dup2(nullfd, STDOUT_FILENO);
++                dup2(nullfd, STDERR_FILENO);
++                close(nullfd);
++                break;
+         }
+ 
+         if (::chdir(cDirectory) == -1) {
+@@ -243,7 +259,7 @@ launch(Filesystem *filesystem, Context const *context)
+         return ext::nullopt;
+     } else {
+         /* Fork succeeded, existing process. */
+-        if (pipe_setup_success) {
++        if (pipe_status == PipeStatus::CREATED) {
+             close(pfd[1]);
+             /* Read child's stdout/stderr through pipe, and output stdout */
+             while (true) {
+diff --git a/Libraries/xcdriver/Tools/xcbuild.cpp b/Libraries/xcdriver/Tools/xcbuild.cpp
+index 3a1baadc..c9340ff5 100644
+--- a/Libraries/xcdriver/Tools/xcbuild.cpp
++++ b/Libraries/xcdriver/Tools/xcbuild.cpp
+@@ -19,7 +19,7 @@ main(int argc, char **argv)
+ {
+     DefaultFilesystem filesystem = DefaultFilesystem();
+     process::DefaultContext processContext = process::DefaultContext();
+-    process::DefaultLauncher processLauncher = process::DefaultLauncher();
++    process::DefaultLauncher processLauncher = process::DefaultLauncher(true);
+     process::DefaultUser user = process::DefaultUser();
+     return xcdriver::Driver::Run(&user, &processContext, &processLauncher, &filesystem);
+ }
+diff --git a/Libraries/xcsdk/Tools/xcrun.cpp b/Libraries/xcsdk/Tools/xcrun.cpp
+index 9d6d4576..c177b273 100644
+--- a/Libraries/xcsdk/Tools/xcrun.cpp
++++ b/Libraries/xcsdk/Tools/xcrun.cpp
+@@ -469,7 +469,7 @@ main(int argc, char **argv)
+ {
+     DefaultFilesystem filesystem = DefaultFilesystem();
+     process::DefaultContext processContext = process::DefaultContext();
+-    process::DefaultLauncher processLauncher = process::DefaultLauncher();
++    process::DefaultLauncher processLauncher = process::DefaultLauncher(false);
+     process::DefaultUser user = process::DefaultUser();
+     return Run(&filesystem, &user, &processContext, &processLauncher);
+ }


### PR DESCRIPTION
Fixes #358795. Commands like `nix develop .#hello -c /usr/bin/git log` now works normally.

```console
❯ nix develop .#hello -c /usr/bin/python3 -c 'import os; import sys; print(os.isatty(sys.stdout.fileno()))'
True
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
