### PR TITLE
switch-to-configuration: Better handling of socket-activated units

### DIFF
--- a/nixos/doc/manual/development/unit-handling.section.md
+++ b/nixos/doc/manual/development/unit-handling.section.md
@@ -58,11 +58,16 @@ checks:
     before the activation script is run. This behavior is different when the
     service is socket-activated, as outlined in the following steps.
 
-  - The last thing that is taken into account is whether the unit is a service
-    and socket-activated. If `X-StopIfChanged` is **not** set, the service
-    is **restart**ed with the others. If it is set, both the service and the
-    socket are **stop**ped and the socket is **start**ed, leaving socket
-    activation to start the service when it's needed.
+  - The last thing that is taken into account is whether the unit is a
+    service and socket-activated. A correspondence between a
+    `.service` and its `.socket` unit is detected automatically, but
+    services can **opt out** of that detection by setting
+    `X-NotSocketActivated` to `yes` in their `[Service]`
+    section. Otherwise, if `X-StopIfChanged` is **not** set, the
+    service is **restart**ed with the others. If it is set, both the
+    service and the socket are **stop**ped and the socket is
+    **start**ed, leaving socket activation to start the service when
+    it's needed.
 
 ## Sysinit reactivation {#sec-sysinit-reactivation}
 

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -579,7 +579,8 @@ in rec {
       '' else "")
        + optionalString (def ? stopIfChanged && !def.stopIfChanged) ''
          X-StopIfChanged=false
-       '' + optionalString (def ? notSocketActivated && def.notSocketActivated) ''
+      ''
+       + optionalString (def ? notSocketActivated && def.notSocketActivated) ''
          X-NotSocketActivated=true
       '' + attrsToSection def.serviceConfig);
     };

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -579,6 +579,8 @@ in rec {
       '' else "")
        + optionalString (def ? stopIfChanged && !def.stopIfChanged) ''
          X-StopIfChanged=false
+       '' + optionalString (def ? notSocketActivated && def.notSocketActivated) ''
+         X-NotSocketActivated=true
       '' + attrsToSection def.serviceConfig);
     };
 

--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -540,7 +540,7 @@ in rec {
         default = false;
         description = ''
           If set, a changed unit is never assumed to be
-          socket-activated on configuration activation, even if
+          socket-activated on configuration switch, even if
           it might have associated socket units. Instead, the unit
           will be restarted (or stopped/started) as if it had no
           associated sockets.

--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -535,6 +535,18 @@ in rec {
         '';
       };
 
+      notSocketActivated = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set, a changed unit is never assumed to be
+          socket-activated on configuration activation, even if
+          it might have associated socket units. Instead, the unit
+          will be restarted (or stopped/started) as if it had no
+          associated sockets.
+        '';
+      };
+
       startAt = mkOption {
         type = with types; either str (listOf str);
         default = [];

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -434,10 +434,9 @@ in
     '';
 
     systemd.services.systemd-udevd = {
-        restartTriggers = [ config.environment.etc."udev/rules.d".source ];
-        notSocketActivated = true;
-      };
-
+      restartTriggers = [ config.environment.etc."udev/rules.d".source ];
+      notSocketActivated = true;
+    };
   };
 
   imports = [

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -433,8 +433,9 @@ in
       fi
     '';
 
-    systemd.services.systemd-udevd =
-      { restartTriggers = [ config.environment.etc."udev/rules.d".source ];
+    systemd.services.systemd-udevd = {
+        restartTriggers = [ config.environment.etc."udev/rules.d".source ];
+        notSocketActivated = true;
       };
 
   };

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -530,6 +530,13 @@ sub handle_modified_unit { ## no critic(Subroutines::ProhibitManyArgs, Subroutin
                     }
                 }
 
+                if (parse_systemd_bool(\%new_unit_info, "Service", "X-NotSocketActivated", 0)) {
+                    # If the unit explicitly opts out of socket
+                    # activation, restart it as if it weren't (but do
+                    # restart its sockets, that's fine):
+                    $socket_activated = 0;
+                }
+
                 # If the unit is not socket-activated, record
                 # that this unit needs to be started below.
                 # We write this to a file to ensure that the

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -2883,6 +2883,7 @@ let
           config.environment.etc."systemd/networkd.conf".source
         ];
         aliases = [ "dbus-org.freedesktop.network1.service" ];
+        notSocketActivated = true;
       };
 
       networking.iproute2 = mkIf (cfg.config.addRouteTablesToIPRoute2 && cfg.config.routeTables != { }) {

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -68,6 +68,8 @@ const RELOAD_LIST_FILE: &str = "/run/nixos/reload-list";
 // `stopIfChanged = true` is ignored, switch-to-configuration will handle `restartIfChanged =
 // false` and `reloadIfChanged = true`. This is the same as specifying a restart trigger in the
 // NixOS module.
+// In addition, switch-to-configuration will handle notSocketActivated=true to disable treatment
+// of units as "socket-activated" even though they might have any associated sockets.
 //
 // The reload file asks this program to reload a unit. This is the same as specifying a reload
 // trigger in the NixOS module and can be ignored if the unit is restarted in this activation.
@@ -583,6 +585,8 @@ fn handle_modified_unit(
             } else {
                 // If this unit is socket-activated, then stop the socket unit(s) as well, and
                 // restart the socket(s) instead of the service.
+                // We count as "socket-activated" any unit that doesn't declare itself not so
+                // via X-NotSocketActivated, that has any associated .socket units.
                 let mut socket_activated = false;
                 if unit.ends_with(".service") {
                     let mut sockets = if let Some(Some(Some(sockets))) = new_unit_info.map(|info| {
@@ -633,6 +637,12 @@ fn handle_modified_unit(
                             }
                         }
                     }
+                }
+                if parse_systemd_bool(new_unit_info, "Service", "X-NotSocketActivated", false) {
+                    // If the unit explicitly opts out of socket
+                    // activation, restart it as if it weren't (but do
+                    // restart its sockets, that's fine):
+                    socket_activated = false;
                 }
 
                 // If the unit is not socket-activated, record that this unit needs to be started


### PR DESCRIPTION
Previously, if any unit had a socket associated with it, stc-ng counted it as "socket-activated", meaning that the unit would get stopped and the socket get restarted. That can wreak havoc on units like systemd-udevd and systemd-networkd.

Instead, let units set the new flag notSocketActivated, which sets a boolean on the unit indicating to stc-ng that the unit wants to be treated like any other non-socket-activated unit instead. That will stop/start or restart these units on upgrades, without unnecessarily tearing down any machinery that the system needs to run.

This addresses what @ElvishJerricco and I thought was a systemd bug (https://github.com/systemd/systemd/issues/35371) but is really a bug in how socket-activated services are handled in stc (and -ng).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
