### PR TITLE
pywal16: 3.6.0 -> 3.7.2; add {manpage,optional-dependencies,updateScript}

### DIFF
--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   imagemagick,
   installShellFiles,
+  nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -49,6 +50,8 @@ python3.pkgs.buildPythonApplication rec {
       haishoku
     ];
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "16 colors fork of pywal";

--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -37,6 +37,19 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "pywal" ];
 
+  optional-dependencies = with python3.pkgs; {
+    colorthief = [ colorthief ];
+    colorz = [ colorz ];
+    fast-colorthief = [ fast-colorthief ];
+    haishoku = [ haishoku ];
+    all = [
+      colorthief
+      colorz
+      ast-colorthief
+      haishoku
+    ];
+  };
+
   meta = {
     description = "16 colors fork of pywal";
     homepage = "https://github.com/eylles/pywal16";

--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -7,17 +7,17 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "pywal16";
-  version = "3.6.0";
+  version = "3.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eylles";
     repo = "pywal16";
     rev = "refs/tags/${version}";
-    hash = "sha256-YKHOH1bEsZHTgYm8AYpfA6C8RtWxAqNQ+GHMcdaj/JU=";
+    hash = "sha256-XDOmpeONPW6b1ZEGk272wwraTLR8PjjniIXm0M9BGU4=";
   };
 
-  nativeBuildInputs = [ python3.pkgs.setuptools ];
+  build-system = [ python3.pkgs.setuptools ];
 
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook

--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -3,6 +3,7 @@
   python3,
   fetchFromGitHub,
   imagemagick,
+  installShellFiles,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -19,10 +20,16 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = [ python3.pkgs.setuptools ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook
     imagemagick
   ];
+
+  postInstall = ''
+    installManPage data/man/man1/wal.1
+  '';
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -9,14 +9,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "pywal16";
-  version = "3.7.1";
+  version = "3.7.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eylles";
     repo = "pywal16";
-    rev = "refs/tags/${version}";
-    hash = "sha256-XDOmpeONPW6b1ZEGk272wwraTLR8PjjniIXm0M9BGU4=";
+    tag = version;
+    hash = "sha256-aizuON8Y321i7bF2SuC5UC1iOWHY217ccfzY9WmaevQ=";
   };
 
   build-system = [ python3.pkgs.setuptools ];
@@ -56,7 +56,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "16 colors fork of pywal";
     homepage = "https://github.com/eylles/pywal16";
-    changelog = "https://github.com/eylles/pywal16/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/eylles/pywal16/blob/refs/tags/${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ moraxyc ];
     mainProgram = "wal";


### PR DESCRIPTION
- **pywal16: 3.6.0 -> 3.7.1**
- **pywal16: add man page**
- **pywal16: add optional-dependencies**
- **pywal16: add updateScript**
- **pywal16: 3.7.1 -> 3.7.2**

Full Changelog: https://github.com/eylles/pywal16/compare/3.7.0...3.7.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
