### PR TITLE
buildGoModule: form `GOFLAGS` from `goFlags`

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -117,6 +117,10 @@ The root directory of the Go module that contains the `go.mod` file.
 
 Defaults to `./`, which is the root of `src`.
 
+### `goFlags` {#var-go-goFlags}
+
+A string list of flags to form the environment variable `GOFLAGS` at the beginning of `buildPhase` and `checkPhase`, overridable via `overrideAttrs`.
+
 ### `ldflags` {#var-go-ldflags}
 
 A string list of flags to pass to the Go linker tool via the `-ldflags` argument of `go build`. Possible values can be retrieved by running `go tool link --help`.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -40,6 +40,8 @@
 - `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
   See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
 
+- `buildGoModule` receives a new argument `goFlags` to form the environment variable `GOFLAGS` during build. `GOFLAGS` specified as a `buildGoModule` argument is assimilated into `goFlags` during evaluation for compatibility purposes, but such way of specification is deprecated and the compatibility behaviour would be removed in future releases.
+
 - `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
 
 - `timescaledb` requires manual upgrade steps.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -385,6 +385,25 @@ appendToVar() {
     fi
 }
 
+removeAllPrefixedFromVar() {
+    local varName="$1"
+    local -n nameref="$varName"
+    shift
+    if ! [[ -z "${nameref[*]-}" ]] || (("$#" == 0)); then
+        return
+    fi
+    if [[ "$(declare -p "$varName")" =~ "declare -a" ]]; then
+        for prefix in "$@"; do
+            nameref=("${nameref[@]/$prefix}")
+        done
+    else
+        local _arr=()
+        read -ra _arr <<<"$nameref"
+        removeAllPrefixedFromVar _arr "$@"
+        nameref="${_arr[*]}"
+    fi
+}
+
 # Accumulate flags from the named variables $2+ into the indexed array $1.
 #
 # Arrays are simply concatenated, strings are split on whitespace.


### PR DESCRIPTION
This PR introduces a new argument, `goFlags`, to form `GOFLAGS` at build time at the beginning of `buildPhase` and `checkPhase`.

This PR also adds a helper Bash function to `setup.sh` named `removeAllPrefixedFromVar`, which removes all the elements with given prefixes from the Bash array/IFS-separated string variable of the given name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
