### PR TITLE
Burpsuite: 2024.10.1 -> 2024.11

### DIFF
--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -9,20 +9,20 @@
 }:
 
 let
-  version = "2024.10.1";
+  version = "2024.11.1";
 
   product =
     if proEdition then
       {
         productName = "pro";
         productDesktop = "Burp Suite Professional Edition";
-        hash = "sha256-r/j7nATyd8GbfoLNby5x1/5BVeRv5B/8Ri1fPUwaCoQ=";
+        hash = "sha256-T2mihC/E9P2ARDs3aN6Acg62W86zNR4rTjngriGl3aU=";
       }
     else
       {
         productName = "community";
         productDesktop = "Burp Suite Community Edition";
-        hash = "sha256-uvX1LTe2slPINrn+ywY3nyu/K+FTczvsW/FnP0z43Q8=";
+        hash = "sha256-feTqtqnYtT7i+HtJAERcKK3QAdPkXm+JUtl6JZLEHJA=";
       };
 
   src = fetchurl {


### PR DESCRIPTION
# Upgrde to Burpsuite 2024.11

## edit 2024.11.1: This release fixes a bug that was preventing the scan launcher from displaying correctly.


## Release notes:

This release introduces site map filter Bambdas, match and replace Bambdas, dynamic authentication tokens for [API scanning](https://portswigger.net/burp/vulnerability-scanner/api-security-testing), and Enhanced payload management for Intruder attacks. We’ve also made several quality of life improvements, performance improvements, and some bug fixes.

## Filtering the site map with Bambdas
We're introducing Bambdas into more areas of Burp. These Java-based code snippets enable you to customize Burp directly from the UI.

This release introduces Bambdas into the site map filter. This enables you to customize the site map to capture exactly what you need, helping you to focus your analysis by filtering out unnecessary traffic.

To learn more about Bambdas in Burp, see [Bambdas](https://portswigger.net/burp/documentation/desktop/extensions/bambdas).

## Advanced match and replace rules with Bambdas
We've extended the capabilities of match and replace Bambdas by adding access to a subset of the MontoyaAPI functionality. This enables you to create more complex Bambdas for advanced use cases.

Please use the MontoyaAPI functionality carefully. While we've restricted access to known dangerous functionality, certain methods may still potentially impact Burp's performance or cause memory leaks.

## Dynamic authentication tokens for API-only scans
We’ve introduced support for dynamic authentication tokens in API-only scans. Burp can now automatically handle token renewal during scans, ensuring uninterrupted access to secured endpoints without the need for you to intervene.

This functionality is available for bearer tokens and our new custom method, which gives you the flexibility to specify where the token is placed in requests. Both methods support fixed and dynamic tokens.

## Enhanced payload management for Intruder attacks
We've made a number of changes to improve payload marker handling when configuring Intruder attacks.

The use of the § character as a payload marker is now purely visual. This means that you can run an Intruder attack on a request that includes the § character - it won't be interpreted as defining a payload position.

When you're configuring a Pitchfork or Cluster bomb attack, the Payload position dropdown in the Payloads side panel now shows the enclosed text of the payload position as well as the payload position number. In addition, if you click a payload position in the request, Burp automatically selects the corresponding item from the Payload position dropdown. These updates help you quickly identify and manage payload sets when configuring an attack.

## Output console for debugging Bambdas
We’ve added the ability to print or log output to a console when writing Bambdas. Use the provided logging object to debug more efficiently with real-time feedback on code execution, making it easy to inspect variables, track errors, and test your code.

## Quality of life improvements
We've made the following quality of life improvements:

We've added a new setting that allows you to choose whether Burp Suite prioritizes IPv4 or IPv6 for DNS resolution. This is especially useful if your routing restrictions allow only IPv4 or IPv6 traffic.

The cookie jar now displays whether each cookie has HTTPOnly and Secure flags, giving you a more complete view of cookie attributes.

## Performance improvements
We've made the following performance improvements:

The scanner now prioritizes authenticated items over unauthenticated ones when all other factors are the same.

We’ve improved the scanner’s ability to parse large resource files, significantly reducing processing times that were sometimes causing scans to time out.

## Bug fixes
We've fixed the following bugs:

A bug in the [recorded logins](https://portswigger.net/burp/vulnerability-scanner/authenticated-scanning) replayer causing drop-down selections to reset incorrectly.

A bug in the recorded logins recorder causing it to capture only partial login sequences, and preventing logins from being copied to the clipboard.

## Browser upgrade
We've upgraded Burp's browser to Chromium 131.0.6778.86 for Windows & Mac and 131.0.6778.85 for Linux. For more information, see the [Chromium release notes](https://chromereleases.googleblog.com/2024/11/stable-channel-update-for-desktop_19.html).

## Changelog
https://portswigger.net/burp/releases/professional-community-2024-11


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


