### PR TITLE
qt6.qtwebengine: fix build on darwin, disable metal shader compilation

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -163,7 +163,7 @@ let
       qtwayland = callPackage ./modules/qtwayland.nix { };
       qtwebchannel = callPackage ./modules/qtwebchannel.nix { };
       qtwebengine = callPackage ./modules/qtwebengine {
-        inherit (darwin) autoSignDarwinBinariesHook bootstrap_cmds;
+        inherit (darwin) bootstrap_cmds;
       };
       qtwebsockets = callPackage ./modules/qtwebsockets.nix { };
       qtwebview = callPackage ./modules/qtwebview.nix { };

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -62,7 +62,6 @@
   libgbm,
   enableProprietaryCodecs ? true,
   # darwin
-  autoSignDarwinBinariesHook,
   bootstrap_cmds,
   cctools,
   xcbuild,
@@ -84,9 +83,6 @@ qtModule {
       which
       gn
       nodejs
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-      autoSignDarwinBinariesHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       bootstrap_cmds
@@ -124,6 +120,24 @@ qtModule {
       extraPrefix = "src/3rdparty/chromium/third_party/xnnpack/src/";
       hash = "sha256-GUESVNR88I1K2V5xr0e09ec4j2eselMhNN06+PCcINM=";
     })
+
+    # The latest version of Clang changed what macros it predefines on Apple
+    # targets, causing errors about predefined macros in zlib.
+    (fetchpatch {
+      url = "https://github.com/chromium/chromium/commit/2f39ac8d0a414dd65c0e1d5aae38c8f97aa06ae9.patch";
+      stripLen = 1;
+      extraPrefix = "src/3rdparty/chromium/";
+      hash = "sha256-07hWANY9JGFmqvjdOD6SFmVI6sQRRyvW+7wxGZF5GVo=";
+    })
+
+    # The latest version of Clang changed what macros it predefines on Apple
+    # targets, causing errors about predefined macros in libpng.
+    (fetchpatch {
+      url = "https://github.com/chromium/chromium/commit/66defc14abe47c0494da9faebebfa0a5b6efcf38.patch";
+      stripLen = 1;
+      extraPrefix = "src/3rdparty/chromium/";
+      hash = "sha256-FWIi1VsBZFqOoPIkPxPkcfexPkx1458rB5ldtA7T2uE=";
+    })
   ];
 
   postPatch =
@@ -151,6 +165,10 @@ qtModule {
 
       substituteInPlace configure.cmake src/gn/CMakeLists.txt \
         --replace "AppleClang" "Clang"
+
+      # Disable metal shader compilation, Xcode only
+      substituteInPlace src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/metal_backend.gni \
+        --replace-fail 'angle_has_build && !is_ios && target_os == host_os' "false"
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -148,6 +148,9 @@ qtModule {
         --replace "QLibraryInfo::path(QLibraryInfo::DataPath)" "\"$out\"" \
         --replace "QLibraryInfo::path(QLibraryInfo::TranslationsPath)" "\"$out/translations\"" \
         --replace "QLibraryInfo::path(QLibraryInfo::LibraryExecutablesPath)" "\"$out/libexec\""
+
+      substituteInPlace configure.cmake src/gn/CMakeLists.txt \
+        --replace "AppleClang" "Clang"
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
@@ -157,8 +160,6 @@ qtModule {
         src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace configure.cmake src/gn/CMakeLists.txt \
-        --replace "AppleClang" "Clang"
       substituteInPlace cmake/Functions.cmake \
         --replace "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
     '';


### PR DESCRIPTION
Currently qt6.qtwebengine [failed][1] on Hydra with this log:

```
[5018/29770] ACTION //third_party/angle/src/libANGLE/renderer/metal:angle_metal_internal_shaders_to_air(//build/toolchain/mac:clang_arm64)
FAILED: gen/angle/mtl_internal_shaders_autogen.air 
/nix/store/rjk36fiki39274zlidarq3y14bm585pi-python3-3.12.7-env/bin/python3 ../../../../../src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py /nix/store/h3skf4182jjbmli12nqggaj0x5kqq63l-apple-sdk-15.0/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal -c ../../../../../src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_autogen.metal -o gen/angle/mtl_internal_shaders_autogen.air --std=macos-metal2.1 -mmacosx-version-min=10.14
Traceback (most recent call last):
  File "/nix/store/8b82j10fpjq8r5gbhs0pwjwrw0vyrzm2-qtwebengine-6.8.0/.build/qtwebengine-everywhere-src-6.8.0/build/src/core/Release/arm64/../../../../../src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py", line 15, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/nix/store/8b82j10fpjq8r5gbhs0pwjwrw0vyrzm2-qtwebengine-6.8.0/.build/qtwebengine-everywhere-src-6.8.0/build/src/core/Release/arm64/../../../../../src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py", line 11, in main
    return subprocess.run(args, stdout=subprocess.PIPE, text=True).returncode
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7/lib/python3.12/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/h3skf4182jjbmli12nqggaj0x5kqq63l-apple-sdk-15.0/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal'
```

[1]: https://hydra.nixos.org/build/280010408/nixlog/1

It seems that is a Xcode only feature introduce by https://github.com/google/angle/commit/a9b01747f6454356a53c377c980c6b549e982fb4

I was trying to workaround that by disabling metal shader compilation:

``` diff
diff --git a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
index c97dd03779..c569843fb5 100644
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -143,6 +143,8 @@
       --replace "AppleClang" "Clang"
     substituteInPlace cmake/Functions.cmake \
       --replace "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
+    substituteInPlace src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/metal_backend.gni \
+      --replace-fail 'angle_has_build && !is_ios && target_os == host_os' "false"
   '';
 
   cmakeFlags = [
```

~~It seems the workaround did the job (failed at [15832/29764] instead of [5019/29770]), but encountered another error:~~

Edit: The workaround works, and the following error can be fixed using clang 17.

<details><summary>Error log</summary>

```
FAILED: obj/device/bluetooth/bluetooth/bluetooth_discovery_filter.o 
../../../../../../../../v39c0h6xv6hvki2k1bsyp5n090q8y2bp-clang-wrapper-16.0.6/bin/clang++ -MMD -MF obj/device/bluetooth/bluetooth/bluetooth_discovery_filter.o
.d -DDEVICE_BLUETOOTH_IMPLEMENTATION -DTOOLKIT_QT -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE -DCR_XC
ODE_VERSION=0010 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_ENABLE_SKSL -DSK_UNTIL_CRBUG_1187654_IS_FIXED -DSK_USER_CONFIG_HEADER=\"../../skia/
config/SkUserConfig.h\" -DSK_WIN_FONTMGR_NO_SIMULATIONS -DSK_DISABLE_LEGACY_SKSURFACE_METHODS -DSK_DISABLE_LEGACY_GRAPHITE_IMAGE_FACTORIES -DSK_DISABLE_LEGACY
_GRAPHITE_IMAGE_METHODS -DSK_DISABLE_LEGACY_SKSURFACE_FACTORIES -DSK_DISABLE_LEGACY_SKSURFACE_FLUSH -DSK_DISABLE_LEGACY_SKSURFACE_AS_IMAGE -DSK_DISABLE_LEGACY
_SKSURFACE_DISPLAYLIST -DSK_DISABLE_LEGACY_IMAGE_SUBSET_METHODS -DSK_DISABLE_LEGACY_IMAGE_COLORSPACE_METHODS -DSK_DISABLE_LEGACY_IMAGE_RELEASE_PROCS -DSK_DISA
BLE_LEGACY_GL_BACKEND_SURFACE -DSK_DISABLE_LEGACY_INIT_DECODERS -DSK_DISABLE_LEGACY_GRDIRECTCONTEXT_FLUSH -DSK_DISABLE_LEGACY_GRDIRECTCONTEXT_BOOLS -DSK_DISAB
LE_LEGACY_GL_GRDIRECTCONTEXT_FACTORIES -DSK_DISABLE_LEGACY_PNG_WRITEBUFFER -DSK_SLUG_DISABLE_LEGACY_DESERIALIZE -DSK_DISABLE_LEGACY_VK_GRDIRECTCONTEXT_FACTORI
ES -DSK_DEFAULT_TYPEFACE_IS_EMPTY -DSK_DISABLE_LEGACY_DEFAULT_TYPEFACE -DSK_DISABLE_LEGACY_VULKAN_BACKENDSEMAPHORE -DSK_DISABLE_LEGACY_CREATE_CHARACTERIZATION
 -DSK_DISABLE_LEGACY_FONTMGR_REFDEFAULT -DSK_DISABLE_LEGACY_FONTMGR_FACTORY -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_BUI
LD_FOR_MAC -DSK_GANESH -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DSK_GL -DSK_GRAPHITE -DWEBP_EXTERN=extern -DU_USING_ICU
_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UT
IL_DATA_FILE -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DGOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE=0 -DHAVE_PTHREAD -Igen -I../../.
./../../src/3rdparty/chromium -I../../../../../src/3rdparty/chromium/third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/pe
rfetto -I../../../../../src/3rdparty/chromium/net/third_party/quiche/overrides -I../../../../../src/3rdparty/chromium/net/third_party/quiche/src/quiche/common
/platform/default -I../../../../../src/3rdparty/chromium/net/third_party/quiche/src -I../../../../../src/3rdparty/chromium/third_party/skia -Igen/third_party/
skia -I../../../../../src/3rdparty/chromium/third_party/wuffs/src/release/c -I../../../../../src/3rdparty/chromium/third_party/libwebp/src/src -I../../../../.
./src/3rdparty/chromium/base/allocator/partition_allocator/src -Igen/base/allocator/partition_allocator/src -I../../../../../src/3rdparty/chromium/third_party
/abseil-cpp -I../../../../../src/3rdparty/chromium/third_party/boringssl/src/include -I../../../../../src/3rdparty/chromium/third_party/protobuf/src -Igen/pro
toc_out -I../../../../../src/3rdparty/chromium/third_party/ipcz/include -I../../../../../src/3rdparty/chromium/third_party/ced/src -I../../../../../src/3rdpar
ty/chromium/third_party/icu/source/common -I../../../../../src/3rdparty/chromium/third_party/icu/source/i18n -Igen/net/third_party/quiche/src -I../../../../..
/src/3rdparty/chromium/third_party/re2/src -Wall -Wextra -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wimplicit-fallthrough -Wthread-safety -Wunguarded-availability
 -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wloop-analysis -Wno-unneeded-internal-declaration -Wno-deprecated-declarations -Wenum-compa
re-conditional -Wno-ignored-pragma-optimize -Wno-deprecated-builtins -Wno-bitfield-constant-conversion -Wno-deprecated-this-capture -Wno-invalid-offsetof -Wno
-vla-extension -Wno-thread-safety-reference-return -Wshadow -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing -fstack-protector -Wno-unknown-arg
ument -Wno-unknown-attributes -Wno-unknown-warning-option -Wno-ignored-attributes -Wno-predefined-identifier-outside-function -Wno-self-assign -Wno-unknown-pr
agmas -fcolor-diagnostics -fmerge-all-constants --target=arm64-apple-macos -mno-outline -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= 
-O2 -fno-math-errno -fno-omit-frame-pointer -g0 -isysroot ../../../../../../../../h3skf4182jjbmli12nqggaj0x5kqq63l-apple-sdk-15.0/Platforms/MacOSX.platform/De
veloper/SDKs/MacOSX15.0.sdk -mmacos-version-min=11.0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -DPROTOBUF_ALLOW_
DEPRECATED=1 -Wno-c++11-narrowing-const-reference -Wno-parentheses-equality -Wno-tautological-compare -Wno-thread-safety-attributes -Wno-undefined-bool-conver
sion -Wno-tautological-undefined-compare -std=c++20 -Wno-trigraphs -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../../../../src/3rdparty/chromi
um/device/bluetooth/bluetooth_discovery_filter.cc -o obj/device/bluetooth/bluetooth/bluetooth_discovery_filter.o
In file included from ../../../../../src/3rdparty/chromium/device/bluetooth/bluetooth_discovery_filter.cc:5:
In file included from ../../../../../src/3rdparty/chromium/device/bluetooth/bluetooth_discovery_filter.h:15:
In file included from ../../../../../src/3rdparty/chromium/base/containers/flat_set.h:11:
../../../../../src/3rdparty/chromium/base/containers/flat_tree.h:354:22: error: invalid operands to binary expression ('const container_type' (aka 'const std:
:vector<device::BluetoothUUID>') and 'const container_type')
    return lhs.body_ <=> rhs.body_;
           ~~~~~~~~~ ^   ~~~~~~~~~
./../../../../src/3rdparty/chromium/device/bluetooth/bluetooth_discovery_filter.cc:39:18: note: in instantiation of member function 'base::internal::operator<=>' requested here
    return uuids < other.uuids;
                 ^
/nix/store/0mmz5i705116bfykc7i1r9jxqwyghj2a-libcxx-16.0.6-dev/include/c++/v1/__threading_support:680:17: note: candidate function not viable: no known conversion from 'const container_type' (aka 'const std::vector<device::BluetoothUUID>') to '__thread_id' for 1st argument
strong_ordering operator<=>(__thread_id __x, __thread_id __y) noexcept {
```

Full log https://gist.githubusercontent.com/azuwis/fff9587f6c9e55798fb0baf711a4a432/raw/5bc8795fce95340b5e0d350b22ff136f82a7afa2/qtwebengine.log

</details>

Any idea? @emilazy @K900

Fixes #353924

ZHF: #352882

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
