### PR TITLE
Apparmor: Adopt package, nixos module and nixos tests

### DIFF
--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -210,5 +210,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ julm ];
+  meta.maintainers = with lib.maintainers; [ julm grimmauld ];
 }

--- a/nixos/tests/apparmor.nix
+++ b/nixos/tests/apparmor.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ... } : {
   name = "apparmor";
-  meta.maintainers = with lib.maintainers; [ julm ];
+  meta.maintainers = with lib.maintainers; [ julm grimmauld ];
 
   nodes.machine =
     { lib, pkgs, config, ... }:

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -29,7 +29,7 @@ let
     homepage = "https://apparmor.net/";
     description = "Mandatory access control system - ${component}";
     license = with licenses; [ gpl2Only lgpl21Only ];
-    maintainers = with maintainers; [ julm thoughtpolice ];
+    maintainers = with maintainers; [ julm thoughtpolice grimmauld ];
     platforms = platforms.linux;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds me (@LordGrimmauld ) to the maintainers of AppArmor things. I use aa, and i plan on improving aa support in NixOS.

I already started work on aa things, and wrote some posts on my hedgedoc about my approach:
- [AppArmor and apparmor.d on NixOS - HedgeDoc 1](https://hedgedoc.grimmauld.de/s/hWcvJEniW#)
- [The Glob is dead, long live the alias! - AppArmor on NixOS Part 2 - HedgeDoc 1](https://hedgedoc.grimmauld.de/s/03eJUe0X3#)

Now i plan on upstreaming some of my work and overall improving the state of apparmor in NixOS.

Currently, the situation is quite sad:
- my other apparmor PR (#356796 ) is looking for reviewers, with none of the current aa maintainers reacting
- sections of the apparmor package refer to build issues from 9 years ago, arguing why certain things are the way they are.
- the apparmor nixos tests are broken
- the apparmor nixos tests aren't even relevant, they just check the apparmor rules being put in place. They do not check for the rules catching anything. At least they check for apparmor successfully parsing those rules!
- Rule packages like roddhjav-apparmor-rules are completely broken, for multiple reasons. For one, the build system in place for those rules is entirely ignored. Second, those rule packages expect FHS compliant systems, which NixOS is not. I honestly wonder how those packages even made it in, being so broken they literally never worked for anyone.
- Forum posts and GH issues about these things go unanswered for months, if not years.

I am in contact with various upstreams, including roddjav of the afforementioned broken apparmor rule package, as well as apparmor itself to try and make NixOS support work. Adopting the relevant parts in nixpkgs is reasonable i think.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
