### PR TITLE
notepadqq: fix build

### DIFF
--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -23,6 +23,12 @@ mkDerivation rec {
     sha256 = "sha256-XA9Ay9kJApY+bDeOf0iPv+BWYFuTmIuqsLEPgRTCZCE=";
   };
 
+  patches = [
+    # Fix: chmod in the Makefile fails randomly
+    # Move it to preFixup instead
+    ./fix-configure.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     which
@@ -37,6 +43,8 @@ mkDerivation rec {
     qtwebsockets
   ];
 
+  strictDeps = false; # breaks qmake
+
   preConfigure = ''
     export LRELEASE="lrelease"
   '';
@@ -44,6 +52,7 @@ mkDerivation rec {
   dontWrapQtApps = true;
 
   preFixup = ''
+    chmod +x $out/bin/notepadqq
     wrapQtApp $out/bin/notepadqq
   '';
 

--- a/pkgs/applications/editors/notepadqq/fix-configure.patch
+++ b/pkgs/applications/editors/notepadqq/fix-configure.patch
@@ -1,0 +1,22 @@
+diff --git a/src/ui/ui.pro b/src/ui/ui.pro
+index a1346eb..f8052a2 100644
+--- a/src/ui/ui.pro
++++ b/src/ui/ui.pro
+@@ -293,16 +293,9 @@ unix:!macx {
+     appstream.path = "$$INSTALL_ROOT$$PREFIX/share/metainfo/"
+     appstream.files += "$$INSTALLFILESDIR/notepadqq.appdata.xml"
+ 
+-    # == Dummy target used to fix permissions at the end of the install ==
+-    # A random path. Without one, qmake refuses to create the rule.
+-    set_permissions.path = "$$INSTALL_ROOT$$PREFIX/bin/"
+-    # We want to keep $$INSTALL_ROOT as a variable in the makefile, so we use $(INSTALL_ROOT)
+-    unix:set_permissions.extra = chmod 755 $(INSTALL_ROOT)\"$$PREFIX/bin/notepadqq\"
+-
+     # MAKE INSTALL
+     INSTALLS += target \
+          icon_h16 icon_h22 icon_h24 icon_h32 icon_h48 icon_h64 icon_h96 icon_h128 icon_h256 icon_h512 icon_hscalable \
+-         misc_data launch shortcuts appstream \
+-         set_permissions
++         misc_data launch shortcuts appstream
+ 
+ }


### PR DESCRIPTION
For some reason, the chmod in the Makefile fails randomly. Move it to preFixup to fix. I also set `strictDeps = false` explicitly, as qmake depends on that currently.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).