### PR TITLE
python312Packages.nbmake: disable unreliable tests

### DIFF
--- a/pkgs/development/python-modules/nbmake/default.nix
+++ b/pkgs/development/python-modules/nbmake/default.nix
@@ -60,6 +60,9 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
+  # https://github.com/treebeardtech/nbmake/issues/129
+  doCheck = false;
+
   __darwinAllowLocalNetworking = true;
 
   meta = {


### PR DESCRIPTION
The tests are highly unreliable. See https://github.com/treebeardtech/nbmake/issues/129

I would estimate >= 50% of test runs simply fail for no real reason.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).