### PR TITLE
nixos/kanidm: rename options to match upstream nomenclature

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -90,6 +90,8 @@
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
 
+- Some `kanidm` provisioning options were renamed to match upstream nomenclature. In particular, this affects the two oauth2 options `originUrl` and `originLanding` which are now called `redirectUri` and `landingUrl` respectively.
+
 - Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
 
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -23,6 +23,7 @@ let
     hasPrefix
     isStorePath
     last
+    mapAttrs
     mapAttrsToList
     mkEnableOption
     mkForce
@@ -30,9 +31,10 @@ let
     mkMerge
     mkOption
     mkPackageOption
+    mkRenamedOptionModule
     optional
-    optionals
     optionalString
+    optionals
     splitString
     subtractLists
     types
@@ -139,9 +141,31 @@ let
 
   filterPresent = filterAttrs (_: v: v.present);
 
-  provisionStateJson = pkgs.writeText "provision-state.json" (
-    builtins.toJSON { inherit (cfg.provision) groups persons systems; }
-  );
+  provisionStateJson =
+    let
+      # Make sure the resulting state json does not contain any of our renamed options.
+      applyRenames =
+        state:
+        state
+        // {
+          systems.oauth2 = mapAttrs (
+            _: x:
+            removeAttrs x [
+              "redirectUri"
+              "landingUrl"
+            ]
+            // {
+              originUrl = x.redirectUri;
+              originLanding = x.landingUrl;
+            }
+          ) state.systems.oauth2;
+        };
+    in
+    pkgs.writeText "provision-state.json" (
+      builtins.toJSON {
+        inherit (applyRenames cfg.provision) groups persons systems;
+      }
+    );
 
   # Only recover the admin account if a password should explicitly be provisioned
   # for the account. Otherwise it is not needed for provisioning.
@@ -502,6 +526,11 @@ in
         default = { };
         type = types.attrsOf (
           types.submodule {
+            imports = [
+              (mkRenamedOptionModule [ "originUrl" ] [ "redirectUri" ])
+              (mkRenamedOptionModule [ "originLanding" ] [ "landingUrl" ])
+            ];
+
             options = {
               present = mkPresentOption "oauth2 resource server";
 
@@ -517,7 +546,7 @@ in
                 example = "Some Service";
               };
 
-              originUrl = mkOption {
+              redirectUri = mkOption {
                 description = "The redirect URL of the service. These need to exactly match the OAuth2 redirect target";
                 type =
                   let
@@ -527,7 +556,7 @@ in
                 example = "https://someservice.example.com/auth/login";
               };
 
-              originLanding = mkOption {
+              landingUrl = mkOption {
                 description = "When redirecting from the Kanidm Apps Listing page, some linked applications may need to land on a specific page to trigger oauth2/oidc interactions.";
                 type = types.str;
                 example = "https://someservice.example.com/home";

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -95,8 +95,8 @@ import ./make-test-python.nix (
               groups.service1-admin = { };
               systems.oauth2.service1 = {
                 displayName = "Service One";
-                originUrl = "https://one.example.com/";
-                originLanding = "https://one.example.com/landing";
+                redirectUri = "https://one.example.com/";
+                landingUrl = "https://one.example.com/landing";
                 basicSecretFile = pkgs.writeText "bs-service1" "very-strong-secret-for-service1";
                 scopeMaps.service1-access = [
                   "openid"
@@ -111,8 +111,8 @@ import ./make-test-python.nix (
 
               systems.oauth2.service2 = {
                 displayName = "Service Two";
-                originUrl = "https://two.example.com/";
-                originLanding = "https://landing2.example.com/";
+                redirectUri = "https://two.example.com/";
+                landingUrl = "https://landing2.example.com/";
                 # Test not setting secret
                 # basicSecretFile =
                 allowInsecureClientDisablePkce = true;
@@ -159,11 +159,11 @@ import ./make-test-python.nix (
               systems.oauth2.service1 = {
                 displayName = "Service One (changed)";
                 # multiple origin urls
-                originUrl = [
+                redirectUri = [
                   "https://changed-one.example.com/"
                   "https://changed-one.example.org/"
                 ];
-                originLanding = "https://changed-one.example.com/landing-changed";
+                landingUrl = "https://changed-one.example.com/landing-changed";
                 basicSecretFile = pkgs.writeText "bs-service1" "changed-very-strong-secret-for-service1";
                 scopeMaps.service1-access = [
                   "openid"
@@ -178,8 +178,8 @@ import ./make-test-python.nix (
 
               systems.oauth2.service2 = {
                 displayName = "Service Two (changed)";
-                originUrl = "https://changed-two.example.com/";
-                originLanding = "https://changed-landing2.example.com/";
+                redirectUri = "https://changed-two.example.com/";
+                landingUrl = "https://changed-landing2.example.com/";
                 # Test not setting secret
                 # basicSecretFile =
                 allowInsecureClientDisablePkce = false;
@@ -210,8 +210,8 @@ import ./make-test-python.nix (
               groups.service1-admin = { };
               systems.oauth2.service1 = {
                 displayName = "Service One (changed)";
-                originUrl = "https://changed-one.example.com/";
-                originLanding = "https://changed-one.example.com/landing-changed";
+                redirectUri = "https://changed-one.example.com/";
+                landingUrl = "https://changed-one.example.com/landing-changed";
                 basicSecretFile = pkgs.writeText "bs-service1" "changed-very-strong-secret-for-service1";
                 # Removing maps requires setting them to the empty list
                 scopeMaps.service1-access = [ ];
@@ -220,8 +220,8 @@ import ./make-test-python.nix (
 
               systems.oauth2.service2 = {
                 displayName = "Service Two (changed)";
-                originUrl = "https://changed-two.example.com/";
-                originLanding = "https://changed-landing2.example.com/";
+                redirectUri = "https://changed-two.example.com/";
+                landingUrl = "https://changed-landing2.example.com/";
               };
             };
           };


### PR DESCRIPTION
This renames `originUrl` to `redirectUri`  and `originLanding` to `landingUrl`,
as previously discussed [here](https://github.com/NixOS/nixpkgs/pull/355216#discussion_r1837065340).

I tried every way I could come up with to get the module to issue a warning when users use the old option,
but unfortunately I had to give up. There seems to be no way to make it work within a submodule.
See this [related issue](https://github.com/NixOS/nixpkgs/issues/96006).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
