### PR TITLE
nixos/luksroot: add timeout option for devices

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -1337,42 +1337,58 @@ in
     boot.initrd.systemd.services =
       let
         devicesWithClevis = filterAttrs (device: _: (hasAttr device clevis.devices)) luks.devices;
+        devicesWithTimeout = filterAttrs (_: dev: dev.timeout != null) luks.devices;
       in
-      mkIf (clevis.enable && systemd.enable) (
-        mapAttrs' (
-          name: _:
-          nameValuePair "cryptsetup-clevis-${name}" {
-            wantedBy = [ "systemd-cryptsetup@${utils.escapeSystemdPath name}.service" ];
-            before = [
-              "systemd-cryptsetup@${utils.escapeSystemdPath name}.service"
-              "initrd-switch-root.target"
-              "shutdown.target"
-            ];
-            wants = optional clevis.useTang "network-online.target";
-            after = [
-              "systemd-modules-load.service"
-              "tpm2.target"
-            ]
-            ++ optional clevis.useTang "network-online.target";
-            script = ''
-              mkdir -p /clevis-${name}
-              mount -t ramfs none /clevis-${name}
-              umask 277
-              clevis decrypt < /etc/clevis/${name}.jwe > /clevis-${name}/decrypted
-            '';
-            conflicts = [
-              "initrd-switch-root.target"
-              "shutdown.target"
-            ];
-            unitConfig.DefaultDependencies = "no";
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = true;
-              ExecStop = "${config.boot.initrd.systemd.package.util-linux}/bin/umount /clevis-${name}";
-            };
-          }
-        ) devicesWithClevis
-      );
+      mkMerge [
+        (mkIf (clevis.enable && systemd.enable) (
+          mapAttrs' (
+            name: _:
+            nameValuePair "cryptsetup-clevis-${name}" {
+              wantedBy = [ "systemd-cryptsetup@${utils.escapeSystemdPath name}.service" ];
+              before = [
+                "systemd-cryptsetup@${utils.escapeSystemdPath name}.service"
+                "initrd-switch-root.target"
+                "shutdown.target"
+              ];
+              wants = optional clevis.useTang "network-online.target";
+              after = [
+                "systemd-modules-load.service"
+                "tpm2.target"
+              ]
+              ++ optional clevis.useTang "network-online.target";
+              script = ''
+                mkdir -p /clevis-${name}
+                mount -t ramfs none /clevis-${name}
+                umask 277
+                clevis decrypt < /etc/clevis/${name}.jwe > /clevis-${name}/decrypted
+              '';
+              conflicts = [
+                "initrd-switch-root.target"
+                "shutdown.target"
+              ];
+              unitConfig.DefaultDependencies = "no";
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+                ExecStop = "${config.boot.initrd.systemd.package.util-linux}/bin/umount /clevis-${name}";
+              };
+            }
+          ) devicesWithClevis
+        ))
+
+        (mkIf systemd.enable (
+          mapAttrs' (
+            name: dev:
+            nameValuePair "systemd-cryptsetup@${utils.escapeSystemdPath name}" {
+              overrideStrategy = "asDropin";
+              unitConfig = {
+                JobTimeoutSec = dev.timeout;
+                JobTimeoutAction = "poweroff";
+              };
+            }
+          ) devicesWithTimeout
+        ))
+      ];
 
     environment.systemPackages = [ pkgs.cryptsetup ];
   };

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -610,15 +610,19 @@ let
       ${commonFunctions}
 
       get_timeout_for_device() {
-          ${lib.concatStringsSep "\n" (
-            lib.mapAttrsToList (name: dev: ''
-              if [ "$1" = "${lib.escapeShellArg dev.device}" ]; then
-                  echo "${toString dev.timeout}"
-                  return
-              fi
-            '') luks.devices
-          )}
-          echo "0"
+          ${lib.pipe luks.devices [
+            (lib.filterAttrs (name: dev: dev.timeout != luks.timeout))
+            (lib.mapAttrsToList (
+              name: dev: ''
+                if [ "$1" = "${lib.escapeShellArg dev.device}" ]; then
+                    echo "${toString dev.timeout}"
+                    return
+                fi
+              ''
+            ))
+            (lib.concatStringsSep "\n")
+          ]}
+          echo "${builtins.toString luks.timeout}"
       }
 
       while true; do
@@ -1076,7 +1080,8 @@ in
 
                 timeout = mkOption {
                   type = types.nullOr types.ints.positive;
-                  default = null;
+                  default = luks.timeout;
+                  defaultText = "{option}`boot.initrd.luks.timeout`";
                   description = ''
                     The amount of time in seconds to wait on the passphrase prompt.
                     If the timeout is reached, the system will power off.
@@ -1124,6 +1129,15 @@ in
       type = types.bool;
       description = ''
         Enables support for authenticating with FIDO2 devices.
+      '';
+    };
+
+    boot.initrd.luks.timeout = mkOption {
+      type = types.nullOr types.ints.positive;
+      default = null;
+      description = ''
+        The amount of time in seconds to wait on the passphrase prompt.
+        If the timeout is reached, the system will power off.
       '';
     };
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -199,6 +199,7 @@ let
           while true; do
               echo -n "Passphrase for ${dev.device}: "
               passphrase=
+              ${lib.optionalString (dev.timeout != null) "time_passed=0"}
               while true; do
                   if [ -e /crypt-ramfs/passphrase ]; then
                       echo "reused"
@@ -229,6 +230,13 @@ let
                          echo
                          break
                       fi
+                      ${lib.optionalString (dev.timeout != null) ''
+                        time_passed=$((time_passed + 1))
+                        if [ $time_passed -ge ${builtins.toString dev.timeout} ]; then
+                          echo "Timeout reached"
+                          poweroff -f
+                        fi
+                      ''}
                   fi
               done
               echo -n "Verifying passphrase for ${dev.device}..."
@@ -328,6 +336,7 @@ let
                 ${optionalString dev.yubikey.twoFactor ''
                   echo -n "Enter two-factor passphrase: "
                   k_user=
+                  ${lib.optionalString (dev.timeout != null) "time_passed=0"}
                   while true; do
                       if [ -e /crypt-ramfs/passphrase ]; then
                           echo "reused"
@@ -351,6 +360,13 @@ let
                              echo
                              break
                           fi
+                          ${lib.optionalString (dev.timeout != null) ''
+                            time_passed=$((time_passed + 1))
+                            if [ $time_passed -ge ${builtins.toString dev.timeout} ]; then
+                              echo "Timeout reached"
+                              poweroff -f
+                            fi
+                          ''}
                       fi
                   done
                 ''}
@@ -451,6 +467,7 @@ let
             for try in $(seq 3); do
                 echo -n "PIN for GPG Card associated with device ${dev.device}: "
                 pin=
+                ${lib.optionalString (dev.timeout != null) "time_passed=0"}
                 while true; do
                     if [ -e /crypt-ramfs/passphrase ]; then
                         echo "reused"
@@ -474,6 +491,13 @@ let
                            echo
                            break
                         fi
+                        ${lib.optionalString (dev.timeout != null) ''
+                          time_passed=$((time_passed + 1))
+                          if [ $time_passed -ge ${builtins.toString dev.timeout} ]; then
+                            echo "Timeout reached"
+                            poweroff -f
+                          fi
+                        ''}
                     fi
                 done
                 echo -n "Verifying passphrase for ${dev.device}..."
@@ -523,8 +547,22 @@ let
                 ''
               else
                 ''
-                  read -rsp "FIDO2 salt for ${dev.device}: " passphrase
-                  echo
+                  ${lib.optionalString (dev.timeout != null) "time_passed=0"}
+                  echo -n "FIDO2 salt for ${dev.device}: "
+                  while true; do
+                    IFS= read -t 1 -rs passphrase
+                    if [ -n "$passphrase" ]; then
+                      echo
+                      break
+                    fi
+                    ${lib.optionalString (dev.timeout != null) ''
+                      time_passed=$((time_passed + 1))
+                      if [ $time_passed -ge ${builtins.toString dev.timeout} ]; then
+                        echo "Timeout reached"
+                        poweroff -f
+                      fi
+                    ''}
+                  done
                 ''
             }
             ${optionalString (lib.versionOlder kernelPackages.kernel.version "5.4") ''
@@ -562,27 +600,58 @@ let
       ${dev.postOpenCommands}
     '';
 
-  askPass = pkgs.writeScriptBin "cryptsetup-askpass" ''
-    #!/bin/sh
+  askPass =
+    let
+      configHasTimeouts = lib.any (dev: dev.timeout != null) (lib.attrValues luks.devices);
+    in
+    pkgs.writeScriptBin "cryptsetup-askpass" ''
+      #!/bin/sh
 
-    ${commonFunctions}
+      ${commonFunctions}
 
-    while true; do
-        wait_target "luks" /crypt-ramfs/device 10 "LUKS to request a passphrase" || die "Passphrase is not requested now"
-        device=$(cat /crypt-ramfs/device)
+      get_timeout_for_device() {
+          ${lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (name: dev: ''
+              if [ "$1" = "${lib.escapeShellArg dev.device}" ]; then
+                  echo "${toString dev.timeout}"
+                  return
+              fi
+            '') luks.devices
+          )}
+          echo "0"
+      }
 
-        echo -n "Passphrase for $device: "
-        IFS= read -rs passphrase
-        ret=$?
-        echo
-        if [ $ret -ne 0 ]; then
-          die "End of file reached. Exiting shell."
-        fi
+      while true; do
+          wait_target "luks" /crypt-ramfs/device 10 "LUKS to request a passphrase" || die "Passphrase is not requested now"
+          device=$(cat /crypt-ramfs/device)
+          ${lib.optionalString configHasTimeouts "time_passed=0"}
+          timeout=$(get_timeout_for_device $device)
 
-        rm /crypt-ramfs/device
-        echo -n "$passphrase" > /crypt-ramfs/passphrase
-    done
-  '';
+          echo -n "Passphrase for $device: "
+          while true; do
+              IFS= read -t 1 -r passphrase
+              ret=$?
+              if [ $ret -eq 1 ]; then
+                  echo
+                  die "End of file reached. Exiting shell."
+              fi
+              if [ -n "$passphrase" ]; then
+                  echo
+                  break
+              fi
+              ${lib.optionalString configHasTimeouts ''
+                time_passed=$((time_passed + 1))
+                if [ $timeout -gt 0 && $time_passed -ge $timeout ]; then
+                    echo "Timeout reached"
+                    poweroff -f
+                fi
+              ''}
+          done
+
+          rm /crypt-ramfs/device
+          echo -n "$passphrase" > /crypt-ramfs/passphrase
+      done
+    '';
 
   preLVM = filterAttrs (n: v: v.preLVM) luks.devices;
   postLVM = filterAttrs (n: v: !v.preLVM) luks.devices;
@@ -1002,6 +1071,15 @@ in
                     Only used with systemd stage 1.
 
                     Extra options to append to the last column of the generated crypttab file.
+                  '';
+                };
+
+                timeout = mkOption {
+                  type = types.nullOr types.ints.positive;
+                  default = null;
+                  description = ''
+                    The amount of time in seconds to wait on the passphrase prompt.
+                    If the timeout is reached, the system will power off.
                   '';
                 };
               };


### PR DESCRIPTION
This option allows for setting timeout on password prompt for LUKS device unlocking, and upon reaching timeout, it will poweroff the system. Useful for systems that are battery powered to not drain battery over several hours or days.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - `nixosTests.luks`
  - Tested on my system through module replacement.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
