### PR TITLE
philipstv: init at 2.1.1

### DIFF
--- a/pkgs/development/python-modules/philipstv/default.nix
+++ b/pkgs/development/python-modules/philipstv/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  poetry-core,
+  poetry-dynamic-versioning,
+  installShellFiles,
+  pytestCheckHook,
+  requests-mock,
+  requests,
+  pydantic,
+  click,
+  appdirs,
+  stdenv,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "philipstv";
+  version = "2.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "bcyran";
+    repo = "philipstv";
+    rev = "refs/tags/${version}";
+    hash = "sha256-BvQurZls9NjtHhTXLQ9t8fHkAF/QU/c6mmRvNmE0v90=";
+  };
+
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  dependencies = [
+    requests
+    pydantic
+    click
+    appdirs
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd philipstv \
+      --bash <(_PHILIPSTV_COMPLETE=bash_source $out/bin/philipstv) \
+      --zsh <(_PHILIPSTV_COMPLETE=zsh_source $out/bin/philipstv) \
+      --fish <(_PHILIPSTV_COMPLETE=fish_source $out/bin/philipstv)
+  '';
+
+  pythonImportsCheck = [ "philipstv" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI and library to control Philips Android-powered TVs";
+    homepage = "https://github.com/bcyran/philipstv";
+    changelog = "https://github.com/bcyran/philipstv/releases/tag/${version}";
+    license = lib.licenses.mit;
+    mainProgram = "philipstv";
+    maintainers = with lib.maintainers; [ bcyran ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18470,6 +18470,8 @@ with pkgs;
 
   pgmodeler = qt6Packages.callPackage ../applications/misc/pgmodeler { };
 
+  philipstv = with python3Packages; toPythonApplication philipstv;
+
   pjsip = darwin.apple_sdk_11_0.callPackage ../applications/networking/pjsip {
     inherit (darwin.apple_sdk_11_0.frameworks) AppKit CoreFoundation Security;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10141,6 +10141,8 @@ self: super: with self; {
 
   phik = callPackage ../development/python-modules/phik { };
 
+  philipstv = callPackage ../development/python-modules/philipstv { };
+
   phone-modem = callPackage ../development/python-modules/phone-modem { };
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };


### PR DESCRIPTION
Adding [`philipstv`](https://github.com/bcyran/philipstv) - Python library and CLI application for remote controlling Philips TVs running on Android TV.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
