### PR TITLE
python3Packages.flake8-class-newline, flake8-deprecated: init

### DIFF
--- a/pkgs/development/python-modules/flake8-class-newline/default.nix
+++ b/pkgs/development/python-modules/flake8-class-newline/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  setuptools,
+  flake8,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "flake8-class-newline";
+  version = "1.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-UUxJI8iOuLPdUttLVbjTSDUg24nbgK9rqBKkrxVCH/E=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ flake8 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "flake8_class_newline" ];
+
+  meta = with lib; {
+    description = "Flake8 extension to check if a new line is present after a class definition";
+    homepage = "https://github.com/alexandervaneck/flake8-class-newline";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/development/python-modules/flake8-deprecated/default.nix
+++ b/pkgs/development/python-modules/flake8-deprecated/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  pythonOlder,
+  fetchPypi,
+  buildPythonPackage,
+  hatchling,
+  flake8,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "flake8-deprecated";
+  version = "2.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    pname = "flake8_deprecated";
+    inherit version;
+    hash = "sha256-7pbKAB0coFYfqORvI+LSRgsYqGaWNzyrZE4QKuD/KqI=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ flake8 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "run_tests.py" ];
+
+  pythonImportsCheck = [ "flake8_deprecated" ];
+
+  meta = with lib; {
+    description = "Flake8 plugin that warns about deprecated method calls";
+    homepage = "https://github.com/gforcada/flake8-deprecated";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4583,6 +4583,8 @@ self: super: with self; {
 
   flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
 
+  flake8-deprecated = callPackage ../development/python-modules/flake8-deprecated { };
+
   flake8-docstrings = callPackage ../development/python-modules/flake8-docstrings { };
 
   flake8-future-import = callPackage ../development/python-modules/flake8-future-import { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4579,6 +4579,8 @@ self: super: with self; {
 
   flake8-length = callPackage ../development/python-modules/flake8-length { };
 
+  flake8-class-newline = callPackage ../development/python-modules/flake8-class-newline { };
+
   flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
 
   flake8-docstrings = callPackage ../development/python-modules/flake8-docstrings { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add two new flake8 extensions that were recently added as dependencies of the ROS package [`ament_flake8`](https://index.ros.org/p/ament_flake8). These packages will be used in [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
