### PR TITLE
taskwarrior3: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -1,13 +1,19 @@
 {
-  rustPlatform,
   lib,
   stdenv,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
-  libuuid,
-  nixosTests,
-  xdg-utils,
+  rustPlatform,
   installShellFiles,
+
+  # buildInputs
+  libuuid,
+  xdg-utils,
+
+  # passthru.tests
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "taskwarrior";
@@ -35,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   nativeBuildInputs = [
     cmake
-    installShellFiles
     rustPlatform.cargoSetupHook
+    installShellFiles
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
+  preConfigure = ''
+    export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
+  '';
+
   nativeBuildInputs = [
     cmake
     libuuid
@@ -49,10 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
   checkTarget = "build_tests";
-
-  preConfigure = ''
-    export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
-  '';
 
   postInstall = ''
     # ZSH is installed automatically from some reason, only bash and fish need

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -13,13 +13,13 @@
   xdg-utils,
   installShellFiles,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "taskwarrior";
   version = "3.1.0";
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "taskwarrior";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-iKpOExj1xM9rU/rIcOLLKMrZrAfz7y9X2kt2CjfMOOQ=";
     fetchSubmodules = true;
   };
@@ -44,9 +44,9 @@ stdenv.mkDerivation rec {
   checkTarget = "build_tests";
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    name = "${pname}-${version}-cargo-deps";
-    inherit src;
-    sourceRoot = src.name;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = finalAttrs.src.name;
     hash = "sha256-L+hYYKXSOG4XYdexLMG3wdA7st+A9Wk9muzipSNjxrA=";
   };
   cargoRoot = "./";
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   passthru.tests.nixos = nixosTests.taskchampion-sync-server;
 
   meta = {
-    changelog = "https://github.com/GothenburgBitFactory/taskwarrior/blob/${src.rev}/ChangeLog";
+    changelog = "https://github.com/GothenburgBitFactory/taskwarrior/blob/${finalAttrs.src.rev}/ChangeLog";
     description = "Highly flexible command-line tool to manage TODO lists";
     homepage = "https://taskwarrior.org";
     license = lib.licenses.mit;
@@ -85,4 +85,4 @@ stdenv.mkDerivation rec {
     mainProgram = "task";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -6,6 +6,8 @@
   # nativeBuildInputs
   cmake,
   rustPlatform,
+  rustc,
+  cargo,
   installShellFiles,
 
   # buildInputs
@@ -14,34 +16,61 @@
 
   # passthru.tests
   nixosTests,
+
+  # nativeCheckInputs
+  python3,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "taskwarrior";
-  version = "3.1.0";
+  version = "3.2.0-unstable-2024-12-17";
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "taskwarrior";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-iKpOExj1xM9rU/rIcOLLKMrZrAfz7y9X2kt2CjfMOOQ=";
+    rev = "cc505e488184e958bcaedad6fed86f91d128e6bd";
+    hash = "sha256-M9pRoilxTHppX/efvppBI+QiPYXBEkvWxiEnodjqryk=";
     fetchSubmodules = true;
   };
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
     inherit (finalAttrs) src;
-    sourceRoot = finalAttrs.src.name;
-    hash = "sha256-L+hYYKXSOG4XYdexLMG3wdA7st+A9Wk9muzipSNjxrA=";
+    hash = "sha256-QPnW+FWbsjvjQr5CRuOGLIaUWSGItlFDwLEtZfRbihA="; # For fetchCargoTarball with name arguments
   };
-  cargoRoot = "./";
 
   postPatch = ''
     substituteInPlace src/commands/CmdNews.cpp \
       --replace-fail "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
+  '';
+  # The CMakeLists files used by upstream issue a `cargo install` command to
+  # install a rust tool (cxxbridge-cmd) that is supposed to be included in the Cargo.toml's and
+  # `Cargo.lock` files of upstream. Setting CARGO_HOME like that helps `cargo
+  # install` find the dependencies we prefetched. See also:
+  # https://github.com/GothenburgBitFactory/taskwarrior/issues/3705
+  postUnpack = ''
+    export CARGO_HOME=$PWD/.cargo
+  '';
+  # Test failures, see:
+  # https://github.com/GothenburgBitFactory/taskwarrior/issues/3727
+  failingTests = [
+    "bash_completion.test.py"
+    "hooks.env.test.py"
+    "hooks.on-add.test.py"
+    "hooks.on-launch.test.py"
+    "hooks.on-modify.test.py"
+    "hooks.on-exit.test.py"
+  ];
+  preConfigure = ''
+    substituteInPlace test/CMakeLists.txt \
+      ${lib.concatMapStringsSep "\\\n  " (t: "--replace-fail ${t} '' ") finalAttrs.failingTests}
   '';
 
   strictDeps = true;
   nativeBuildInputs = [
     cmake
     rustPlatform.cargoSetupHook
+    # To install cxxbridge-cmd before configurePhase, see above linked upstream
+    # issue.
+    rustc
+    cargo
     installShellFiles
   ];
 
@@ -50,7 +79,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-  checkTarget = "build_tests";
+  preCheck = ''
+    # See:
+    # https://github.com/GothenburgBitFactory/taskwarrior/blob/v3.2.0/doc/devel/contrib/development.md#run-the-test-suite
+    make test_runner
+    # Otherwise all '/usr/bin/env python' shebangs are not found by ctest
+    patchShebangs test/*.py test/*/*.py
+  '';
+  nativeCheckInputs = [
+    python3
+  ];
 
   postInstall = ''
     # ZSH is installed automatically from some reason, only bash and fish need

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/commands/CmdNews.cpp \
-      --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
+      --replace-fail "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -1,15 +1,11 @@
 {
   rustPlatform,
-  rustc,
-  cargo,
-  corrosion,
   lib,
   stdenv,
   fetchFromGitHub,
   cmake,
   libuuid,
   nixosTests,
-  python3,
   xdg-utils,
   installShellFiles,
 }:
@@ -36,18 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  preConfigure = ''
-    export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
-  '';
-
   strictDeps = true;
   nativeBuildInputs = [
     cmake
-    python3
     installShellFiles
-    corrosion
-    cargo
-    rustc
     rustPlatform.cargoSetupHook
   ];
 

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -12,7 +12,6 @@
   python3,
   xdg-utils,
   installShellFiles,
-  darwin,
 }:
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
@@ -30,22 +29,16 @@ stdenv.mkDerivation rec {
       --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  nativeBuildInputs =
-    [
-      cmake
-      libuuid
-      python3
-      installShellFiles
-      corrosion
-      cargo
-      rustc
-      rustPlatform.cargoSetupHook
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # darwin dependencies
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
-    ];
+  nativeBuildInputs = [
+    cmake
+    libuuid
+    python3
+    installShellFiles
+    corrosion
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
 
   doCheck = true;
   checkTarget = "build_tests";

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -23,6 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-iKpOExj1xM9rU/rIcOLLKMrZrAfz7y9X2kt2CjfMOOQ=";
     fetchSubmodules = true;
   };
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = finalAttrs.src.name;
+    hash = "sha256-L+hYYKXSOG4XYdexLMG3wdA7st+A9Wk9muzipSNjxrA=";
+  };
+  cargoRoot = "./";
 
   postPatch = ''
     substituteInPlace src/commands/CmdNews.cpp \
@@ -43,13 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   checkTarget = "build_tests";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
-    name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
-    inherit (finalAttrs) src;
-    sourceRoot = finalAttrs.src.name;
-    hash = "sha256-L+hYYKXSOG4XYdexLMG3wdA7st+A9Wk9muzipSNjxrA=";
-  };
-  cargoRoot = "./";
   preConfigure = ''
     export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
   '';

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -40,15 +40,19 @@ stdenv.mkDerivation (finalAttrs: {
     export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
   '';
 
+  strictDeps = true;
   nativeBuildInputs = [
     cmake
-    libuuid
     python3
     installShellFiles
     corrosion
     cargo
     rustc
     rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    libuuid
   ];
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
