### PR TITLE
lib.packagesFromDirectoryRecursive: Improved documentation

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -318,18 +318,12 @@ in
 
     # Inputs
 
-    Structured function argument
+    `callPackage`
+    : The function used to convert a Nix file's path into a leaf of the attribute set.
+      It is typically the `callPackage` function, taken from either `pkgs` or a new scope corresponding to the `directory`.
 
-    : Attribute set containing the following attributes.
-      Additional attributes are ignored.
-
-      `callPackage`
-
-      : `pkgs.callPackage`
-
-      `directory`
-
-      : The directory to read package files from
+    `directory`
+    : The directory to read package files from.
 
 
     # Examples

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -306,6 +306,16 @@ in
         As a result, directories with no `.nix` files (including empty
         directories) will be transformed into empty attribute sets.
 
+    # Type
+
+    ```
+    packagesFromDirectoryRecursive :: {
+      callPackage :: Path -> {} -> a,
+      directory :: Path,
+      ...
+    } -> AttrSet
+    ```
+
     # Inputs
 
     Structured function argument
@@ -317,20 +327,10 @@ in
 
       : `pkgs.callPackage`
 
-        Type: `Path -> AttrSet -> a`
-
       `directory`
 
       : The directory to read package files from
 
-        Type: `Path`
-
-
-    # Type
-
-    ```
-    packagesFromDirectoryRecursive :: AttrSet -> AttrSet
-    ```
 
     # Examples
     :::{.example}


### PR DESCRIPTION
For `lib.filesystem.packagesFromDirectoryRecursive`:
- provide a more-precise type signature than `AttrSet -> AttrSet` ;
- explain what the `callPackage` parameter is, provide a more-precise type signature for it as part of the function's ;
- remove boilerplate from the “Inputs” section to improve readability ;
- explain each example ;
- warn of the function's limitation with scopes, *i.e.* that it is unable to make nested scopes for sub-directories.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested building the nixpkgs manual (`nix-build doc/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
