### PR TITLE
nginxModules.subsFilter: 2022-01-24

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -853,8 +853,8 @@ let self = {
       name = "subsFilter";
       owner = "yaoweibin";
       repo = "ngx_http_substitutions_filter_module";
-      rev = "b8a71eacc7f986ba091282ab8b1bbbc6ae1807e0";
-      sha256 = "027jxzx66q9a6ycn47imjh40xmnqr0z423lz0ds3w4rf1c2x130f";
+      rev = "e12e965ac1837ca709709f9a26f572a54d83430e";
+      sha256 = "sha256-3sWgue6QZYwK69XSi9q8r3WYGVyMCIgfqqLvPBHqJKU=";
     };
 
     meta = with lib; {


### PR DESCRIPTION
b8a71eacc7f986ba091282ab8b1bbbc6ae1807e0 → e12e965ac1837ca709709f9a26f572a54d83430e

Fixes issues with newer PCRE (broke last nixpkgs-unstable)

```
       > gcc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -Wno-deprecated-declarations -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /usr/incl
ude/libxml2 -I objs \                                                                                                                                                                                        
       >         -o objs/ngx_modules.o \                                                                                                                                                                     
       >         objs/ngx_modules.c                                                                                                                                                                          
       > sed -e "s|%%PREFIX%%|/nix/store/g7r9vfsjflxjkn7l1hcrra0xkjxbpwk1-nginx-1.27.2|" \                                                                                                                   
       >         -e "s|%%PID_PATH%%|/var/log/nginx/nginx.pid|" \                                                                                                                                             
       >         -e "s|%%CONF_PATH%%|/nix/store/g7r9vfsjflxjkn7l1hcrra0xkjxbpwk1-nginx-1.27.2/conf/nginx.conf|" \                                                                                            
       >         -e "s|%%ERROR_LOG_PATH%%|/var/log/nginx/error.log|" \                                                                                                                                       
       >         < man/nginx.8 > objs/nginx.8                                                                                                                                                                
       > /nix/store/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.c: In function 'ngx_http_subs_regex_capture_count':                                                              
       > /nix/store/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.c:1252:10: error: implicit declaration of function 'pcre_fullinfo' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning
-Options.html#index-Wimplicit-function-declaration-Werror=implicit-function-declaration8;;]                                                                                                                  
       >  1252 |     rc = pcre_fullinfo(re->code, NULL, PCRE_INFO_CAPTURECOUNT, &n);                                                                                                                         
       >       |          ^~~~~~~~~~~~~                                                                                                                                                                      
       > /nix/store/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.c:1252:26: error: invalid use of incomplete typedef 'ngx_regex_t' {aka 'struct pcre2_real_code_8'}               
       >  1252 |     rc = pcre_fullinfo(re->code, NULL, PCRE_INFO_CAPTURECOUNT, &n);                                                                                                                         
       >       |                          ^~                                                                                                                                                                 
       > /nix/store/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.c:1252:40: error: 'PCRE_INFO_CAPTURECOUNT' undeclared (first use in this function); did you mean 'PCRE2_INFO_CAPT
URECOUNT'?                                                                                                                                                                                                   
       >  1252 |     rc = pcre_fullinfo(re->code, NULL, PCRE_INFO_CAPTURECOUNT, &n);                                                                                                                         
       >       |                                        ^~~~~~~~~~~~~~~~~~~~~~                                                                                                                               
       >       |                                        PCRE2_INFO_CAPTURECOUNT                                                                                                                              
       > /nix/store/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.c:1252:40: note: each undeclared identifier is reported only once for each function it appears in                
       > cc1: all warnings being treated as errors                                                    
       > make[1]: *** [objs/Makefile:1914: objs/addon/nqrq7yvky19z276pqjsrl54c5mqsv97j-subsFilter/ngx_http_subs_filter_module.o] Error 1                                                                     
       > make[1]: *** Waiting for unfinished jobs....                                                 
       > make[1]: Leaving directory '/build/nginx-1.27.2'                                             
       > make: *** [Makefile:10: build] Error 2               
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
