### PR TITLE
appimageTools: use version

### DIFF
--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -9,7 +9,6 @@
 mkDerivation rec {
   pname = "soulseekqt";
   version = "2018-1-30";
-  name="${pname}-${version}";
 
   src = fetchzip {
       url = "https://www.slsknet.org/SoulseekQt/Linux/SoulseekQt-${version}-64bit-appimage.tgz";
@@ -17,7 +16,7 @@ mkDerivation rec {
   };
 
   appextracted = appimageTools.extractType2 {
-    inherit name;
+    inherit pname version;
     src="${src}/SoulseekQt-2018-1-30-64bit.AppImage";
   };
 

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -26,7 +26,9 @@ rec {
     ];
   };
 
-  extract = args@{ name ? "${args.pname}-${args.version}", postExtract ? "", src, ... }: pkgs.runCommand "${name}-extracted" {
+  extract = args@{ pname, version, name ? null, postExtract ? "", src, ... }:
+    assert lib.assertMsg (name == null) "The `name` argument is deprecated. Use `pname` and `version` instead to construct the name.";
+    pkgs.runCommand "${pname}-${version}-extracted" {
       buildInputs = [ appimage-exec ];
     } ''
       appimage-exec.sh -x $out ${src}
@@ -58,7 +60,7 @@ rec {
   wrapType2 = args@{ src, extraPkgs ? pkgs: [ ], ... }: wrapAppImage
     (args // {
       inherit extraPkgs;
-      src = extract (lib.filterAttrs (key: value: builtins.elem key [ "name" "pname" "version" "src" ]) args);
+      src = extract (lib.filterAttrs (key: value: builtins.elem key [ "pname" "version" "src" ]) args);
 
       # passthru src to make nix-update work
       # hack to keep the origin position (unsafeGetAttrPos)

--- a/pkgs/by-name/ca/cables/package.nix
+++ b/pkgs/by-name/ca/cables/package.nix
@@ -18,17 +18,15 @@ let
   appimageContents = appimageTools.extract {
     inherit pname version src;
     postExtract = ''
-      substituteInPlace $out/${name}.desktop --replace 'Exec=AppRun' 'Exec=cables'
+      substituteInPlace $out/${pname}-${version}.desktop --replace 'Exec=AppRun' 'Exec=cables'
     '';
   };
 
 in
 appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/cables
-
     install -m 444 -D ${appimageContents}/${name}.desktop $out/share/applications/cables.desktop
     install -m 444 -D ${appimageContents}/${name}.png $out/share/icons/hicolor/512x512/apps/cables.png
   '';

--- a/pkgs/by-name/de/deskreen/package.nix
+++ b/pkgs/by-name/de/deskreen/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-0jI/mbXaXanY6ay2zn+dPWGvsqWRcF8aYHRvfGVsObE=";
   };
   deskreenUnwrapped = appimageTools.wrapType2 {
-    name = "deskreen";
+    inherit (finalAttrs) pname version;
     src = finalAttrs.src;
   };
 

--- a/pkgs/by-name/qu/quba/package.nix
+++ b/pkgs/by-name/qu/quba/package.nix
@@ -7,20 +7,18 @@
 let
   version = "1.4.0";
   pname = "quba";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/ZUGFeRD/quba-viewer/releases/download/v${version}/Quba-${version}.AppImage";
     hash = "sha256-EsTF7W1np5qbQQh3pdqsFe32olvGK3AowGWjqHPEfoM=";
   };
 
-  appimageContents = appimageTools.extractType1 { inherit name src; };
+  appimageContents = appimageTools.extractType1 { inherit pname version src; };
 in
 appimageTools.wrapType1 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/by-name/sa/saleae-logic-2/package.nix
+++ b/pkgs/by-name/sa/saleae-logic-2/package.nix
@@ -1,14 +1,14 @@
 { lib, fetchurl, makeDesktopItem, appimageTools }:
 let
-  name = "saleae-logic-2";
+  pname = "saleae-logic-2";
   version = "2.4.13";
   src = fetchurl {
     url = "https://downloads.saleae.com/logic2/Logic-${version}-linux-x64.AppImage";
     hash = "sha256-0GIZQKQDY3arDUlxjQKWOHDB3j76xVwkx5H+8q+d0Rc=";
   };
   desktopItem = makeDesktopItem {
-    inherit name;
-    exec = name;
+    name = "saleae-logic-2";
+    exec = "saleae-logic-2";
     icon = "Logic";
     comment = "Software for Saleae logic analyzers";
     desktopName = "Saleae Logic";
@@ -17,11 +17,11 @@ let
   };
 in
 appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands =
     let
-      appimageContents = appimageTools.extractType2 { inherit name src; };
+      appimageContents = appimageTools.extractType2 { inherit pname version src; };
     in
       ''
         mkdir -p $out/etc/udev/rules.d

--- a/pkgs/by-name/ss/ssb-patchwork/package.nix
+++ b/pkgs/by-name/ss/ssb-patchwork/package.nix
@@ -11,12 +11,11 @@ let
   };
 
   binary = appimageTools.wrapType2 {
-    name = pname;
-    inherit src;
+    inherit pname version src;
   };
   # we only use this to extract the icon
   appimage-contents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
   desktopItem = makeDesktopItem {

--- a/pkgs/by-name/st/steam-rom-manager/package.nix
+++ b/pkgs/by-name/st/steam-rom-manager/package.nix
@@ -1,7 +1,7 @@
 { lib, appimageTools, fetchurl }:
 
 appimageTools.wrapType2 rec {
-  name = "steam-rom-manager";
+  pname = "steam-rom-manager";
   version = "2.5.22";
 
   src = fetchurl {
@@ -10,11 +10,11 @@ appimageTools.wrapType2 rec {
   };
 
   extraInstallCommands = let
-    appimageContents = appimageTools.extract { inherit name src; };
+    appimageContents = appimageTools.extract { inherit pname version src; };
     in ''
-      install -m 444 -D ${appimageContents}/${name}.desktop -t $out/share/applications
-      substituteInPlace $out/share/applications/${name}.desktop \
-        --replace 'Exec=AppRun' 'Exec=${name}'
+      install -m 444 -D ${appimageContents}/steam-rom-manager.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/steam-rom-manager.desktop \
+        --replace 'Exec=AppRun' 'Exec=steam-rom-manager'
       cp -r ${appimageContents}/usr/share/icons $out/share
     '';
 


### PR DESCRIPTION
part of #336576 and #103997

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
