### PR TITLE
lib.filesystem.packagesFromDirectoryRecursive: refactor

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -18,7 +18,10 @@ let
     ;
 
   inherit (lib.filesystem)
+    pathIsDirectory
+    pathIsRegularFile
     pathType
+    packagesFromDirectoryRecursive
     ;
 
   inherit (lib.strings)
@@ -360,52 +363,30 @@ in
       directory,
       ...
     }:
+    assert pathIsDirectory directory;
     let
-      # Determine if a directory entry from `readDir` indicates a package or
-      # directory of packages.
-      directoryEntryIsPackage = basename: type:
-        type == "directory" || hasSuffix ".nix" basename;
-
-      # List directory entries that indicate packages in the given `path`.
-      packageDirectoryEntries = path:
-        filterAttrs directoryEntryIsPackage (readDir path);
-
-      # Transform a directory entry (a `basename` and `type` pair) into a
-      # package.
-      directoryEntryToAttrPair = subdirectory: basename: type:
-        let
-          path = subdirectory + "/${basename}";
-        in
-        if type == "regular"
-        then
-        {
-          name = removeSuffix ".nix" basename;
-          value = callPackage path { };
-        }
-        else
-        if type == "directory"
-        then
-        {
-          name = basename;
-          value = packagesFromDirectory path;
-        }
-        else
-        throw
-          ''
-            lib.filesystem.packagesFromDirectoryRecursive: Unsupported file type ${type} at path ${toString subdirectory}
-          '';
-
-      # Transform a directory into a package (if there's a `package.nix`) or
-      # set of packages (otherwise).
-      packagesFromDirectory = path:
-        let
-          defaultPackagePath = path + "/package.nix";
-        in
-        if pathExists defaultPackagePath
-        then callPackage defaultPackagePath { }
-        else mapAttrs'
-          (directoryEntryToAttrPair path)
-          (packageDirectoryEntries path);
+      inherit (lib.path) append;
+      defaultPath = append directory "package.nix";
     in
-    packagesFromDirectory directory;
+    if pathIsRegularFile defaultPath then
+      # if `${directory}/package.nix` exists, call it directly
+      callPackage defaultPath {}
+    else lib.concatMapAttrs (name: type:
+      # otherwise, for each directory entry
+      let path = append directory name; in
+      if type == "directory" then {
+        # recurse into directories
+        "${name}" = packagesFromDirectoryRecursive {
+          inherit callPackage;
+          directory = path;
+        };
+      } else if type == "regular" && hasSuffix ".nix" name then {
+        # call .nix files
+        "${lib.removeSuffix ".nix" name}" = callPackage path {};
+      } else if type == "regular" then {
+        # ignore non-nix files
+      } else throw ''
+        lib.filesystem.packagesFromDirectoryRecursive: Unsupported file type ${type} at path ${toString path}
+      ''
+    ) (builtins.readDir directory);
 }


### PR DESCRIPTION
Refactor `lib.filesystem.packagesFromDirectoryRecursive` (no functional change)

- Shrink the function's code by ~2/3rd :tada:
- Centralize the logic classifying files/directories of interest, which was spread between `directoryEntryIsPackage` and `directoryEntryToAttrPair`.  I find it much easier to reason about, as a result.
- Replace a composition of `mapAttrs'` and `filterAttrs` with `concatMapAttrs`.
- Simplify future improvements, such as creating nested scopes for subdirs, or ignoring unsupported files.
  I wrote this as a prelude to supporting nested scopes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested with `nix-instantiate --eval --strict lib/tests/misc.nix`
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
