### PR TITLE
release notes: Move cacheNetwork note to 25.05

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -917,8 +917,6 @@
 
 - `freecad` now supports addons and custom configuration in nix-way, which can be used by calling `freecad.customize`.
 
-- `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
-
 ## Detailed migration information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -58,6 +58,6 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->


### PR DESCRIPTION
Added in https://github.com/NixOS/nixpkgs/pull/335832, which was merged after the branch-off, so it's not in 24.11

Ping @getchoo @GetPsyched @TobTobXX @peti 

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
