### PR TITLE
rl-2411: Match to master branch

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -749,11 +749,8 @@
   - The `atlassian-crowd` package and its `services.crowd` NixOS module
   - The `atlassian-jira` package and its `services.jira` NixOS module
 
-
 - `python3Packages.nose` has been removed, as it has been deprecated and unmaintained for almost a decade and does not work on Python 3.12.
   Please switch to `pytest` or another test runner/framework.
-
-- torq has been removed because upstreamed went closed source.
 
 - `dotnet-sdk`, `dotnet-runtime`, and all other dotnet packages now use a
   wrapper package containing `bin/dotnet`, build hooks, etc. If you need to
@@ -768,6 +765,8 @@
 - `dotnet-sdk`, `dotnet-runtime`, and `dotnet-aspnetcore` now point to dotnet 8
   rather than dotnet 6. For packages that still need dotnet 6, use
   `dotnet-sdk_6`, etc.
+
+- torq has been removed because upstreamed went closed source.
 
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 


### PR DESCRIPTION
Other than https://github.com/NixOS/nixpkgs/pull/359942 and https://github.com/NixOS/nixpkgs/pull/359946, this is the only difference between the file on master vs release-24.11

Doing this allows backporting restructuring of this document on master without having to resolve merge conflicts. Not sure if the release editors plan to do any restructuring of release notes though :)

Found using
```
git diff upstream/master upstream/release-24.11 -- nixos/doc/manual/release-notes/rl-2411.section.md
```

Ping @getchoo @GetPsyched 

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
