### PR TITLE
tilp: init at 1.18

### DIFF
--- a/pkgs/by-name/ti/tilp/package.nix
+++ b/pkgs/by-name/ti/tilp/package.nix
@@ -1,0 +1,44 @@
+{
+  libticonv,
+  libtifiles2,
+  libticables2,
+  libticalcs2,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  gtk2,
+  intltool,
+  pkg-config,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tilp";
+  version = "1.18";
+  src = fetchFromGitHub {
+    owner = "debrouxl";
+    repo = "tilp_and_gfm";
+    rev = "9fb0fab9e91b5d5a43a1d907197734264b68fc6d";
+    hash = "sha256-/XkxEfWzJiOkM5aoenp/GQSkkNg9qoXkFtcj/nenFEw=";
+  };
+  sourceRoot = finalAttrs.src.name + "/tilp/trunk/";
+  nativeBuildInputs = [
+    autoreconfHook
+    intltool
+    pkg-config
+  ];
+  buildInputs = [
+    libticonv
+    libtifiles2
+    libticables2
+    libticalcs2
+    gtk2
+  ];
+  meta = {
+    description = "TILP is a program allowing a computer to communicate with TI graphing calculators";
+    homepage = "http://lpg.ticalc.org/prj_tilp";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "tilp";
+    maintainers = with lib.maintainers; [ clevor ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
TILP is a program that allows for communication with TI graphing calculators. TILP [was added to Nixpkgs](https://github.com/NixOS/nixpkgs/pull/101796) in 2020, but was [dropped](https://github.com/NixOS/nixpkgs/pull/155061/commits/5ffbf9ed8114485a3fd99efcce55ec9518522e26) in 2022 due to its dependency on libglade, which [wasn't actually necessary](https://github.com/NixOS/nixpkgs/issues/76098#issuecomment-2504152186). Fixes https://github.com/CE-Programming/CEmu/issues/507

I renamed the package to tilp due to this guideline:
> - For the `pname` attribute:
>
>   - It _should_ be identical to the upstream package name.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
