### PR TITLE
binwalk: fix `checkPhase` on Darwin

### DIFF
--- a/pkgs/by-name/bi/binwalk/package.nix
+++ b/pkgs/by-name/bi/binwalk/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   fontconfig,
   bzip2,
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,12 +31,27 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # skip broken tests
-  checkFlags = [
-    "--skip=binwalk::Binwalk"
-    "--skip=binwalk::Binwalk::analyze"
-    "--skip=binwalk::Binwalk::extract"
-    "--skip=binwalk::Binwalk::scan"
-  ];
+  checkFlags =
+    [
+      "--skip=binwalk::Binwalk"
+      "--skip=binwalk::Binwalk::scan"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--skip=binwalk::Binwalk::analyze"
+      "--skip=binwalk::Binwalk::extract"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "--skip=extractors::common::Chroot::append_to_file"
+      "--skip=extractors::common::Chroot::carve_file"
+      "--skip=extractors::common::Chroot::create_block_device"
+      "--skip=extractors::common::Chroot::create_character_device"
+      "--skip=extractors::common::Chroot::create_directory"
+      "--skip=extractors::common::Chroot::create_fifo"
+      "--skip=extractors::common::Chroot::create_file"
+      "--skip=extractors::common::Chroot::create_socket"
+      "--skip=extractors::common::Chroot::create_symlink"
+      "--skip=extractors::common::Chroot::make_executable"
+    ];
 
   meta = {
     description = "Firmware Analysis Tool";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The following tests fail on Darwin (https://gist.github.com/al3xtjames/a7c48cda4927cde5d22c73d66d9b38be#file-binwalk-3-1-0-drv-L313-L325):

```
failures:
    src/binwalk.rs - binwalk::Binwalk (line 42)
    src/binwalk.rs - binwalk::Binwalk::scan (line 225)
    src/extractors/common.rs - extractors::common::Chroot::append_to_file (line 429)
    src/extractors/common.rs - extractors::common::Chroot::carve_file (line 258)
    src/extractors/common.rs - extractors::common::Chroot::create_block_device (line 347)
    src/extractors/common.rs - extractors::common::Chroot::create_character_device (line 315)
    src/extractors/common.rs - extractors::common::Chroot::create_directory (line 482)
    src/extractors/common.rs - extractors::common::Chroot::create_fifo (line 379)
    src/extractors/common.rs - extractors::common::Chroot::create_file (line 216)
    src/extractors/common.rs - extractors::common::Chroot::create_socket (line 404)
    src/extractors/common.rs - extractors::common::Chroot::create_symlink (line 574)
    src/extractors/common.rs - extractors::common::Chroot::make_executable (line 513)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
