### PR TITLE
ruff: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/by-name/ru/ruff/package.nix
+++ b/pkgs/by-name/ru/ruff/package.nix
@@ -1,22 +1,22 @@
 {
   lib,
-  rustPlatform,
-  fetchFromGitHub,
-  installShellFiles,
   stdenv,
   python3Packages,
-  darwin,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
   rust-jemalloc-sys,
-  ruff-lsp,
-  nix-update-script,
   versionCheckHook,
-  libiconv,
+
+  # passthru
+  ruff-lsp,
   nixosTests,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonPackage rec {
   pname = "ruff";
-  version = "0.8.0";
+  version = "0.8.1";
   pyproject = true;
 
   outputs = [
@@ -28,7 +28,7 @@ python3Packages.buildPythonPackage rec {
     owner = "astral-sh";
     repo = "ruff";
     rev = "refs/tags/${version}";
-    hash = "sha256-yenGZ7TuiHtY/3AIjMPlHVtQPP6PHMc1wdezfZdVtK0=";
+    hash = "sha256-N3TplR+vPu2r56VP/vnOfkxN3Lh2o92kE2hFZKLXO04=";
   };
 
   # Do not rely on path lookup at runtime to find the ruff binary
@@ -41,7 +41,7 @@ python3Packages.buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-O5+uVYWtSMEj7hBrc/FUuqRBN4hUlEbtDPF42kpL7PA=";
+    hash = "sha256-iddUzip2LmBMOB+MfpI4k3OitdPbwAZkc4szDPB6duM=";
   };
 
   nativeBuildInputs =
@@ -52,14 +52,9 @@ python3Packages.buildPythonPackage rec {
       cargoCheckHook
     ]);
 
-  buildInputs =
-    [
-      rust-jemalloc-sys
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.CoreServices
-      libiconv
-    ];
+  buildInputs = [
+    rust-jemalloc-sys
+  ];
 
   postInstall =
     ''
@@ -73,14 +68,6 @@ python3Packages.buildPythonPackage rec {
         --fish <($bin/bin/ruff generate-shell-completion fish) \
         --zsh <($bin/bin/ruff generate-shell-completion zsh)
     '';
-
-  passthru = {
-    tests = {
-      inherit ruff-lsp;
-      nixos-test-driver-busybox = nixosTests.nixos-test-driver.busybox;
-    };
-    updateScript = nix-update-script { };
-  };
 
   # Run cargo tests
   cargoCheckType = "debug";
@@ -122,6 +109,17 @@ python3Packages.buildPythonPackage rec {
   versionCheckProgramArg = [ "--version" ];
 
   pythonImportsCheck = [ "ruff" ];
+
+  passthru = {
+    tests =
+      {
+        inherit ruff-lsp;
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        nixos-test-driver-busybox = nixosTests.nixos-test-driver.busybox;
+      };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Extremely fast Python linter";


### PR DESCRIPTION
## Things done

Changelog: https://github.com/astral-sh/ruff/releases/tag/0.8.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
