### PR TITLE
nixos/scion: fix nixosTest dates and validity period for TRCs

### DIFF
--- a/nixos/tests/scion/freestanding-deployment/bootstrap.sh
+++ b/nixos/tests/scion/freestanding-deployment/bootstrap.sh
@@ -5,18 +5,18 @@ mkdir AS{1..5}
 
 # Create voting and root keys and (self-signed) certificates for core ASes
 pushd AS1
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=sensitive-voting <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 sensitive voting cert"}') sensitive-voting.pem sensitive-voting.key
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=regular-voting <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 regular voting cert"}') regular-voting.pem regular-voting.key
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-root <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 cp root cert"}') cp-root.pem cp-root.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=sensitive-voting <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 sensitive voting cert"}') sensitive-voting.pem sensitive-voting.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=regular-voting <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 regular voting cert"}') regular-voting.pem regular-voting.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-root <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 cp root cert"}') cp-root.pem cp-root.key
 popd
 
 pushd AS2
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-root <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 cp root cert"}') cp-root.pem cp-root.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-root <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 cp root cert"}') cp-root.pem cp-root.key
 popd
 
 pushd AS3
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=sensitive-voting <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 sensitive voting cert"}') sensitive-voting.pem sensitive-voting.key
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=regular-voting <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 regular voting cert"}') regular-voting.pem regular-voting.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=sensitive-voting <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 sensitive voting cert"}') sensitive-voting.pem sensitive-voting.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=regular-voting <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 regular voting cert"}') regular-voting.pem regular-voting.key
 popd
 
 # Create the TRC (Trust Root Configuration)
@@ -34,7 +34,7 @@ cert_files = ["AS1/sensitive-voting.pem", "AS1/regular-voting.pem", "AS1/cp-root
 
 [validity]
 not_before = '0'
-validity = "36500d"' \
+validity = "3650d"' \
 > trc-B1-S1-pld.tmpl
 
 scion-pki trc payload --out=tmp/ISD42-B1-S1.pld.der --template trc-B1-S1-pld.tmpl
@@ -51,18 +51,18 @@ rm tmp -r
 
 # Create CA key and certificate for issuing ASes
 pushd AS1
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-ca <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 CA cert"}') cp-ca.pem cp-ca.key --ca cp-root.pem --ca-key cp-root.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-ca <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 CA cert"}') cp-ca.pem cp-ca.key --ca cp-root.pem --ca-key cp-root.key
 popd
 pushd AS2
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-ca <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 CA cert"}') cp-ca.pem cp-ca.key --ca cp-root.pem --ca-key cp-root.key
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-ca <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 CA cert"}') cp-ca.pem cp-ca.key --ca cp-root.pem --ca-key cp-root.key
 popd
 
 # Create AS key and certificate chains
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 AS cert"}') AS1/cp-as.pem AS1/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 AS cert"}') AS2/cp-as.pem AS2/cp-as.key --ca AS2/cp-ca.pem --ca-key AS2/cp-ca.key --bundle
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 AS cert"}') AS3/cp-as.pem AS3/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:4", "common_name": "42-ffaa:1:4 AS cert"}') AS4/cp-as.pem AS4/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
-scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-11-02T15:41:22Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:5", "common_name": "42-ffaa:1:5 AS cert"}') AS5/cp-as.pem AS5/cp-as.key --ca AS2/cp-ca.pem --ca-key AS2/cp-ca.key --bundle
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:1", "common_name": "42-ffaa:1:1 AS cert"}') AS1/cp-as.pem AS1/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:2", "common_name": "42-ffaa:1:2 AS cert"}') AS2/cp-as.pem AS2/cp-as.key --ca AS2/cp-ca.pem --ca-key AS2/cp-ca.key --bundle
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:3", "common_name": "42-ffaa:1:3 AS cert"}') AS3/cp-as.pem AS3/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:4", "common_name": "42-ffaa:1:4 AS cert"}') AS4/cp-as.pem AS4/cp-as.key --ca AS1/cp-ca.pem --ca-key AS1/cp-ca.key --bundle
+scion-pki certificate create --not-before="1970-01-01T00:00:00Z" --not-after="2124-01-01T00:00:00Z" --profile=cp-as <(echo '{"isd_as": "42-ffaa:1:5", "common_name": "42-ffaa:1:5 AS cert"}') AS5/cp-as.pem AS5/cp-as.key --ca AS2/cp-ca.pem --ca-key AS2/cp-ca.key --bundle
 
 for i in {1..5}
 do


### PR DESCRIPTION
The validity period for TRCs cannot be set to an rfc3339 date, only an offset from the current system time, which if set to 3650d rather than 36500d will still give us quite a long time before it becomes invalid, which is acceptable for the time being.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
