### PR TITLE
rl-2411: Match to release branch

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -915,7 +915,7 @@
 
 - `freecad` now supports addons and custom configuration in nix-way, which can be used by calling `freecad.customize`.
 
-## Detailed migration information {#sec-release-24.11-migration}
+## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}
 


### PR DESCRIPTION
This specific change was already done before the branch-off in https://github.com/NixOS/nixpkgs/pull/346059, but
https://github.com/NixOS/nixpkgs/pull/335832 reverted it accidentally on master after the branch-off.

Follow-up to https://github.com/NixOS/nixpkgs/pull/359949, this is actually the last diff remaining (other than the backport of https://github.com/NixOS/nixpkgs/pull/360006) :)

Ping @GetPsyched @getchoo 

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
