### PR TITLE
python312Packages.asteroid-filterbanks: fix tests

### DIFF
--- a/pkgs/development/python-modules/asteroid-filterbanks/default.nix
+++ b/pkgs/development/python-modules/asteroid-filterbanks/default.nix
@@ -1,17 +1,20 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
-  wheel,
-  black,
-  coverage,
-  librosa,
+
+  # dependencies
   numpy,
-  pre-commit,
-  pytest,
-  scipy,
   torch,
+  typing-extensions,
+
+  # tests
+  pytestCheckHook,
+  scipy,
 }:
 
 buildPythonPackage rec {
@@ -22,32 +25,58 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "asteroid-team";
     repo = "asteroid-filterbanks";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Z5M2Xgj83lzqov9kCw/rkjJ5KXbjuP+FHYCjhi5nYFE=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-    wheel
-  ];
+  # np.float is deprecated
+  postPatch = ''
+    substituteInPlace asteroid_filterbanks/multiphase_gammatone_fb.py \
+      --replace-fail "np.float(" "float("
+  '';
 
-  propagatedBuildInputs = [
-    black
-    coverage
-    librosa
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
-    pre-commit
-    pytest
-    scipy
     torch
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "asteroid_filterbanks" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+  ];
+
+  disabledTests =
+    [
+      # RuntimeError: cannot cache function '__o_fold': no locator available for file
+      # '/nix/store/d1znhn1n48z2raj0j9zbz80hhg4k2shw-python3.12-librosa-0.10.2.post1/lib/python3.12/site-packages/librosa/core/notation.py'
+      "test_melgram_encoder"
+      "test_melscale"
+
+      # AssertionError: The values for attribute 'shape' do not match
+      "test_torch_stft"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Issue with JIT on darwin:
+      # RuntimeError: required keyword attribute 'value' has the wrong type
+      "test_jit_filterbanks"
+      "test_jit_filterbanks_enc"
+      "test_pcen_jit"
+      "test_stateful_pcen_jit"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # Flaky: AssertionError: Tensor-likes are not close!
+      "test_fb_def_and_forward_lowdim"
+    ];
+
+  meta = {
     description = "PyTorch-based audio source separation toolkit for researchers";
     homepage = "https://github.com/asteroid-team/asteroid-filterbanks";
-    license = licenses.mit;
-    maintainers = with maintainers; [ matthewcroughan ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
   };
 }


### PR DESCRIPTION
## Things done

Work around the various failing tests.

cc @MatthewCroughan

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
