### PR TITLE
WIP: Rename with nested attr paths

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -435,6 +435,11 @@ rec {
          then part
          else lib.strings.escapeNixIdentifier part;
     in (concatStringsSep ".") (map escapeOptionPart parts);
+
+  showOptionPathSet =
+    set:
+    "TODO";
+
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
 
   showDefs = defs: concatMapStrings (def:

--- a/nixos/modules/services/monitoring/prometheus/xmpp-alerts.nix
+++ b/nixos/modules/services/monitoring/prometheus/xmpp-alerts.nix
@@ -10,8 +10,9 @@ in
 {
   imports = [
     (mkRenamedOptionModule
-      [ "services" "prometheus" "xmpp-alerts" "configuration" ]
-      [ "services" "prometheus" "xmpp-alerts" "settings" ])
+      { services.prometheus.xmpp-alerts.configuration = null; }
+      { services.prometheus.xmpp-alerts.settings = null; }
+    )
   ];
 
   options.services.prometheus.xmpp-alerts = {


### PR DESCRIPTION
Just a quick PoC for https://github.com/NixOS/nixpkgs/pull/359668, allows

```nix
imports = [
  (mkRenamedOptionModule
    { services.prometheus.xmpp-alerts.configuration = null; }
    { services.prometheus.xmpp-alerts.settings = null; }
  )
]
```

without double-conversions.

Ping @Atemu

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
