### PR TITLE
nzbget: 24.3 -> 24.5

### DIFF
--- a/pkgs/by-name/nz/nzbget/package.nix
+++ b/pkgs/by-name/nz/nzbget/package.nix
@@ -17,16 +17,29 @@
 , nixosTests
 }:
 
+let
+  par2TurboSrc = fetchFromGitHub {
+    owner = "nzbgetcom";
+    repo = "par2cmdline-turbo";
+    rev = "v1.1.1-nzbget-20241128"; # from cmake/par2-turbo.cmake
+    hash = "sha256-YBv61DAUWgf4jGQciTsGX7SAC2oZZ6h/lnJgJ40gMZE=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nzbget";
-  version = "24.3";
+  version = "24.5";
 
   src = fetchFromGitHub {
     owner = "nzbgetcom";
     repo = "nzbget";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Gci9bVjmewoEii6OiOuRpLgEBEKApmMmlA5v3OedCo4=";
+    hash = "sha256-HftzgdG6AjCyJVMV2btjBRLJLQ0wc1f8FJzGDWrdxR4=";
   };
+
+  patches = [
+    # remove git usage for fetching modified+vendored par2cmdline-turbo
+    ./remove-git-usage.patch
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
@@ -42,6 +55,12 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     zlib
   ];
+
+  preConfigure = ''
+    mkdir -p build/par2-turbo/src
+    cp -r ${par2TurboSrc} build/par2-turbo/src/par2-turbo
+    chmod -R u+w build/par2-turbo/src/par2-turbo
+  '';
 
   postPatch = ''
     substituteInPlace daemon/util/Util.cpp \

--- a/pkgs/by-name/nz/nzbget/remove-git-usage.patch
+++ b/pkgs/by-name/nz/nzbget/remove-git-usage.patch
@@ -1,0 +1,29 @@
+diff --git a/cmake/par2-turbo.cmake b/cmake/par2-turbo.cmake
+index 4fa76b54..cf293452 100644
+--- a/cmake/par2-turbo.cmake
++++ b/cmake/par2-turbo.cmake
+@@ -24,17 +24,13 @@ if(CMAKE_SYSROOT)
+ 	)
+ endif()
+ 
+-ExternalProject_add(
+-	par2-turbo
+-	PREFIX			par2-turbo
+-	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
+-	GIT_TAG			v1.1.1-nzbget-20241128
+-	TLS_VERIFY		TRUE
+-	GIT_SHALLOW		TRUE
+-	GIT_PROGRESS	TRUE
+-	DOWNLOAD_EXTRACT_TIMESTAMP	TRUE
+-	CMAKE_ARGS		${CMAKE_ARGS}
+-	INSTALL_COMMAND	""
++
++ExternalProject_Add(
++    par2-turbo
++    PREFIX par2-turbo 
++    SOURCE_DIR ${CMAKE_BINARY_DIR}/par2-turbo/src/par2-turbo
++    CMAKE_ARGS ${CMAKE_ARGS}
++    INSTALL_COMMAND ""
+ )
+ 
+ if(WIN32) 


### PR DESCRIPTION
https://github.com/nzbgetcom/nzbget/compare/v24.3...v24.5

- added patch and steps to pre-fetch and handle modified+vendored `par2cmdline-turbo` from nzbget's fork

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
