### PR TITLE
ocamlPackages.js_of_ocaml: 5.8.2 → 5.9.1

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,16 +1,20 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, ocaml, buildDunePackage
 , cmdliner, yojson, ppxlib, findlib
 , menhir, menhirLib, sedlex
+, version ? if lib.versionAtLeast ocaml.version "4.11" then "5.9.1" else "5.8.2"
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "js_of_ocaml-compiler";
-  version = "5.8.2";
+  inherit version;
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-    hash = "sha256-ciAZS9L5sU2VgVOlogZ1A1nXtJ3hL+iNdFDThc7L8Eo=";
+    hash = {
+      "5.9.1" = "sha256-aMlcYIcdjpyaVMgvNeLtUEE7y0QPIg0LNRayoe4ccwc=";
+      "5.8.2" = "sha256-ciAZS9L5sU2VgVOlogZ1A1nXtJ3hL+iNdFDThc7L8Eo=";
+    }."${version}";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, js_of_ocaml-compiler
-, ppxlib, uchar
+, ppxlib
 }:
 
 buildDunePackage {
@@ -9,7 +9,7 @@ buildDunePackage {
 
   buildInputs = [ ppxlib ];
 
-  propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
+  propagatedBuildInputs = [ js_of_ocaml-compiler ];
 
   meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, js_of_ocaml-compiler, js_of_ocaml-ppx
-, js_of_ocaml, ocaml_lwt, lwt_log
+, js_of_ocaml, lwt, lwt_log
 }:
 
 buildDunePackage {
@@ -9,7 +9,7 @@ buildDunePackage {
 
   buildInputs = [ js_of_ocaml-ppx ];
 
-  propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
+  propagatedBuildInputs = [ js_of_ocaml lwt lwt_log ];
 
   meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }


### PR DESCRIPTION
May need: #359890 (I only tested on top of it).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
