### PR TITLE
thtk: init at 12-unstable-2025-05-06

### DIFF
--- a/pkgs/by-name/th/thtk/package.nix
+++ b/pkgs/by-name/th/thtk/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  flex,
+  bison,
+  pkg-config,
+  zlib,
+  libpng,
+  unstableGitUpdater,
+  validatePkgConfig,
+  testers,
+}:
+let
+  thtypes = fetchFromGitHub {
+    owner = "thpatch";
+    repo = "thtypes";
+    rev = "29ed7d6e1db555ad15fd29edcc0763754ad5b764";
+    hash = "sha256-j3lrToLuS7SbzzdL3/8uB0nL1z04GtmfmKIC/v37jwI=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "thtk";
+  version = "12-unstable-2025-05-06";
+
+  src = fetchFromGitHub {
+    owner = "thpatch";
+    repo = "thtk";
+    rev = "97dc32f48efb704a131acff4a18bc401b0662748";
+    hash = "sha256-rgSl5VEMQkxMAhg1cMW/c9hH64MZJQ7WxqGsOYiANPM=";
+  };
+
+  # Required header files for the build phase
+  env.NIX_CFLAGS_COMPILE = "-I${thtypes}";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    zlib
+    libpng
+    flex
+    bison
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_LIBPNG_SOURCE" false)
+  ];
+
+  postInstall = ''
+    # Substitute includedir and libdir bad path prefix
+    substituteInPlace "$out/lib/pkgconfig/thtk.pc" \
+      --replace-fail "//nix" "/nix"
+  '';
+
+  meta = {
+    description = "Touhou Toolkit";
+    homepage = "https://github.com/thpatch/thtk";
+    changelog = "https://github.com/thpatch/thtk/releases";
+    license = lib.licenses.bsd2;
+    pkgConfigModules = [ "thtk" ];
+    platforms = with lib.platforms; linux ++ windows;
+    maintainers = with lib.maintainers; [ theobori ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #359985

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
