### PR TITLE
to-html: 0.1.4 -> 0.1.6

### DIFF
--- a/pkgs/by-name/to/to-html/package.nix
+++ b/pkgs/by-name/to/to-html/package.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, installShellFiles
 , rustPlatform
 }:
 
@@ -18,6 +19,14 @@ rustPlatform.buildRustPackage rec {
 
   # Requires external resources
   doCheck = false;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion \
+      $releaseDir/build/to-html-*/out/to-html.{bash,fish} \
+      --zsh $releaseDir/build/to-html-*/out/_to-html
+  '';
 
   meta = {
     description = "Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML";

--- a/pkgs/by-name/to/to-html/package.nix
+++ b/pkgs/by-name/to/to-html/package.nix
@@ -4,17 +4,17 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  version = "0.1.4";
+  version = "0.1.6";
   pname = "to-html";
 
   src = fetchFromGitHub {
     owner = "Aloso";
     repo = "to-html";
     rev = "v${version}";
-    hash = "sha256-zkTBjsMFhRz7lVRh8i+XkaJ/qWmTAMPnkH5aDhbHf8U=";
+    hash = "sha256-eNFt9/yK4oHOspNM8PMTewhx8APaHzmgNdrWqrUuQSU=";
   };
 
-  cargoHash = "sha256-hXc+lB3DKnRZkp1U5wW/vPKSZ0c1UknQCAxDfE7Eubg=";
+  cargoHash = "sha256-UxDyk7m6eWvuWPHWUY2OJI59p43/bag8pcZyeGJr/QA=";
 
   # Requires external resources
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated the `to-html` package to the latest version and installs the shell completions included in the new release. The shell completions are generated at compile time through the `clap_complete` crate, so I based the changes off of the `hyperfine` package which has a similar setup

- [0.1.5 CHANGELOG entry](https://github.com/Aloso/to-html/blob/main/CHANGELOG.md#015---2023-11-30)
- [0.1.6 CHANGELOG entry](https://github.com/Aloso/to-html/blob/main/CHANGELOG.md#016---2024-11-29)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
