### PR TITLE
[24.11] Revert "nginx: upgrade pcre to pcre2"

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,4 +1,4 @@
-outer@{ lib, stdenv, fetchurl, fetchpatch, openssl, zlib-ng, pcre2, libxml2, libxslt
+outer@{ lib, stdenv, fetchurl, fetchpatch, openssl, zlib-ng, pcre, libxml2, libxslt
 , nginx-doc
 
 , nixosTests
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     removeReferencesTo
   ] ++ nativeBuildInputs;
 
-  buildInputs = [ openssl zlib-ng pcre2 libxml2 libxslt perl ]
+  buildInputs = [ openssl zlib-ng pcre libxml2 libxslt perl ]
     ++ buildInputs
     ++ mapModules "inputs"
     ++ lib.optional withGeoIP geoip


### PR DESCRIPTION
This reverts commit https://github.com/NixOS/nixpkgs/commit/861b05cff266cb78a2fd7204bb9476f4e82549a5.

See https://github.com/NixOS/nixpkgs/pull/355989 & https://github.com/NixOS/nixpkgs/pull/360008. The pcre2 switch seems to needs more testing and polish.

If we can be certain #360008 fixes the issue, we can also merge and backport that PR instead.