### PR TITLE
bitwig-studio: 5.2.5 -> 5.2.7, fix Onset and Beat detection

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -29,12 +29,12 @@
 
 stdenv.mkDerivation rec {
   pname = "bitwig-studio";
-  version = "5.2.5";
+  version = "5.2.7";
 
   src = fetchurl {
     name = "bitwig-studio-${version}.deb";
     url = "https://www.bitwig.com/dl/Bitwig%20Studio/${version}/installer_linux/";
-    hash = "sha256-x6Uw6o+a3nArMm1Ev5ytGtLDGQ3r872WqlC022zT8Hk=";
+    hash = "sha256-Tyi7qYhTQ5i6fRHhrmz4yHXSdicd4P4iuF9FRKRhkMI=";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook3 ];

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -28,7 +28,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "bitwig-studio";
+  pname = "bitwig-studio-unwrapped";
   version = "5.2.7";
 
   src = fetchurl {

--- a/pkgs/applications/audio/bitwig-studio/bitwig-wrapper.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-wrapper.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  bubblewrap,
+  mktemp,
+  writeShellScript,
+  bitwig-studio-unwrapped,
+}:
+stdenv.mkDerivation {
+  inherit (bitwig-studio-unwrapped) version;
+
+  pname = "bitwig-studio";
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase =
+    let
+      wrapper = writeShellScript "bitwig-studio" ''
+        set -e
+
+        echo "Creating temporary directory"
+        TMPDIR=$(${mktemp}/bin/mktemp --directory)
+        echo "Temporary directory: $TMPDIR"
+        echo "Copying default Vamp Plugin settings"
+        cp -r ${bitwig-studio-unwrapped}/libexec/resources/VampTransforms $TMPDIR
+        echo "Changing permissions to be writable"
+        chmod -R u+w $TMPDIR/VampTransforms
+
+        echo "Starting Bitwig Studio in Bubblewrap Environment"
+        ${bubblewrap}/bin/bwrap --bind / / --bind $TMPDIR/VampTransforms ${bitwig-studio-unwrapped}/libexec/resources/VampTransforms ${bitwig-studio-unwrapped}/bin/bitwig-studio || true
+
+        echo "Bitwig exited, removing temporary directory"
+        rm -rf $TMPDIR
+      '';
+    in
+    ''
+      mkdir -p $out/bin
+      cp ${wrapper} $out/bin/bitwig-studio
+      cp -r ${bitwig-studio-unwrapped}/share $out
+    '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13405,8 +13405,12 @@ with pkgs;
   bitwig-studio4 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio4.nix {
     libjpeg = libjpeg8;
   };
-  bitwig-studio5 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio5.nix {
+  bitwig-studio5-unwrapped =  callPackage ../applications/audio/bitwig-studio/bitwig-studio5.nix {
     libjpeg = libjpeg8;
+  };
+
+  bitwig-studio5 = callPackage ../applications/audio/bitwig-studio/bitwig-wrapper.nix {
+    bitwig-studio-unwrapped = bitwig-studio5-unwrapped;
   };
 
   bitwig-studio = bitwig-studio5;


### PR DESCRIPTION
Update Bitwig to latest stable release 5.2.7.

I also noticed that Onset and Beat detection got broken in the 5.2-series. The fix is a wrapper script that launches Bitwig in a Bubblewrap environment. This is also part of this PR. All the details as to why this is required are in this discourse thread: https://discourse.nixos.org/t/fixing-permissions-when-program-copies-out-of-nix-store/56705

I've contacted the manufacturer but the interest was rather limited after I mentioned not using Ubuntu. Still, if this ever gets fixed upstream, we can just remove the wrapper again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
