### PR TITLE
traefik: 3.1.4 -> 3.2.1

### DIFF
--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -1,17 +1,22 @@
-{ lib, fetchzip, buildGo123Module, nixosTests }:
+{
+  lib,
+  fetchzip,
+  buildGo123Module,
+  nixosTests,
+}:
 
 buildGo123Module rec {
   pname = "traefik";
-  version = "3.1.4";
+  version = "3.2.1";
 
   # Archive with static assets for webui
   src = fetchzip {
     url = "https://github.com/traefik/traefik/releases/download/v${version}/traefik-v${version}.src.tar.gz";
-    hash = "sha256-e77PCMeN6Ck6hQ3Rx7MU4EL+f/1kpA2E+gVcISoUnf4=";
+    hash = "sha256-MOYSq7LjAPnyjYALzeMdunTQtQykOOP1ILvpYOgFsYA=";
     stripRoot = false;
   };
 
-  vendorHash = "sha256-iYwA/y9AuHomyEckOyl4845lkQkeBAFDsGiZWESylqs=";
+  vendorHash = "sha256-NQB8vPcnLKvZhf/n/y+L/fFhhOB1EdViCI8j1XUdHtw=";
 
   subPackages = [ "cmd/traefik" ];
 
@@ -28,7 +33,9 @@ buildGo123Module rec {
 
   doCheck = false;
 
-  passthru.tests = { inherit (nixosTests) traefik; };
+  passthru.tests = {
+    inherit (nixosTests) traefik;
+  };
 
   meta = with lib; {
     homepage = "https://traefik.io";


### PR DESCRIPTION
* https://github.com/traefik/traefik/releases/tag/v3.2.0
* https://github.com/traefik/traefik/releases/tag/v3.2.1