### PR TITLE
pcsx2: 2.1.127 -> 2.3.39

### DIFF
--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -17,6 +17,7 @@
   makeWrapper,
   pkg-config,
   qt6,
+  shaderc,
   soundtouch,
   strip-nondeterminism,
   vulkan-headers,
@@ -45,6 +46,7 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "PACKAGE_MODE" true)
     (lib.cmakeBool "DISABLE_ADVANCE_SIMD" true)
     (lib.cmakeBool "USE_LINKED_FFMPEG" true)
     (lib.cmakeFeature "PCSX2_GIT_REV" finalAttrs.src.rev)
@@ -73,7 +75,7 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
     qttools
     qtwayland
     SDL2
-    sources.shaderc-patched
+    shaderc
     soundtouch
     vulkan-headers
     wayland
@@ -82,17 +84,12 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp -a bin/pcsx2-qt bin/resources $out/bin/
-
+  postInstall = ''
     install -Dm644 $src/pcsx2-qt/resources/icons/AppIcon64.png $out/share/pixmaps/PCSX2.png
     install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
 
-    zip -jq $out/bin/resources/patches.zip ${sources.pcsx2_patches.src}/patches/*
-    strip-nondeterminism $out/bin/resources/patches.zip
-    runHook postInstall
+    zip -jq $out/share/PCSX2/resources/patches.zip ${sources.pcsx2_patches.src}/patches/*
+    strip-nondeterminism $out/share/PCSX2/resources/patches.zip
   '';
 
   qtWrapperArgs =
@@ -100,7 +97,7 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
       libs = lib.makeLibraryPath (
         [
           vulkan-loader
-          sources.shaderc-patched
+          shaderc
         ]
         ++ cubeb.passthru.backendLibs
       );

--- a/pkgs/by-name/pc/pcsx2/sources.nix
+++ b/pkgs/by-name/pc/pcsx2/sources.nix
@@ -1,22 +1,20 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
-  shaderc,
 }:
 
 let
   pcsx2 = let
     self = {
       pname = "pcsx2";
-      version = "2.1.127";
+      version = "2.3.39";
       src = fetchFromGitHub {
         pname = "pcsx2-source";
         inherit (self) version;
         owner = "PCSX2";
         repo = "pcsx2";
         rev = "v${self.version}";
-        hash = "sha256-zvvrGxGjIQjSmo18BDG2J3+PoysXj8WxpwtrcXK8LH8=";
+        hash = "sha256-Knlkf4GcN8OCgrd1nwdnYVCDA/7lyAfcoV4mLCkrHtg=";
       };
     };
   in
@@ -27,47 +25,19 @@ let
   pcsx2_patches = let
     self = {
       pname = "pcsx2_patches";
-      version = "0-unstable-2024-09-05";
+      version = "0-unstable-2024-11-23";
       src = fetchFromGitHub {
         pname = "pcsx2_patches-source";
         inherit (self) version;
         owner = "PCSX2";
         repo = "pcsx2_patches";
-        rev = "377f30ae19acde655cc412086fa1840d16d54a93";
-        hash = "sha256-g2SMMC/oHSF0G3+zwvk1vOoQgYFrPd3eaZ0jgGJIr5g=";
+        rev = "5cc1d09a72c0afcd04e2ca089a6b279108328fda";
+        hash = "sha256-or77ZsWU0YWtxj9LKJ/m8nDvKSyiF1sO140QaH6Jr64=";
       };
     };
   in
     self;
-
-  shaderc-patched = let
-    pname = "shaderc-patched-for-pcsx2";
-    version = "2024.1";
-    src = fetchFromGitHub {
-      owner = "google";
-      repo = "shaderc";
-      rev = "v${version}";
-      hash = "sha256-2L/8n6KLVZWXt6FrYraVlZV5YqbPHD7rzXPCkD0d4kg=";
-    };
-  in
-    shaderc.overrideAttrs (old: {
-      inherit pname version src;
-      patches = (old.patches or [ ]) ++ [
-        (fetchpatch {
-          url = "file://${pcsx2.src}/.github/workflows/scripts/common/shaderc-changes.patch";
-          hash = "sha256-/qX2yD0RBuPh4Cf7n6OjVA2IyurpaCgvCEsIX/hXFdQ=";
-          excludes = [
-            "libshaderc/CMakeLists.txt"
-            "third_party/CMakeLists.txt"
-          ];
-        })
-      ];
-      cmakeFlags = (old.cmakeFlags or [ ]) ++ [
-        (lib.cmakeBool "SHADERC_SKIP_EXAMPLES" true)
-        (lib.cmakeBool "SHADERC_SKIP_TESTS" true)
-      ];
-    });
 in
 {
-  inherit pcsx2 pcsx2_patches shaderc-patched;
+  inherit pcsx2 pcsx2_patches;
 }


### PR DESCRIPTION
Patched shaderc isn't necessary anymore, and `PACKAGE_MODE` was restored upstream.

Tested game on both Vulkan and OpenGL, and whether game patches were functional.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
