### PR TITLE
linuxPackages.drbd: 9.2.8 -> 9.2.12

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -286,6 +286,7 @@ in {
   drawterm = discoverTests (import ./drawterm.nix);
   drbd = handleTest ./drbd.nix {};
   druid = handleTestOn [ "x86_64-linux" ] ./druid {};
+  drbd-driver = handleTest ./drbd-driver.nix {};
   dublin-traceroute = handleTest ./dublin-traceroute.nix {};
   earlyoom = handleTestOn ["x86_64-linux"] ./earlyoom.nix {};
   early-mount-options = handleTest ./early-mount-options.nix {};

--- a/nixos/tests/drbd-driver.nix
+++ b/nixos/tests/drbd-driver.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "drbd-driver";
+    meta.maintainers = with pkgs.lib.maintainers; [ birkb ];
+
+    nodes = {
+      machine =
+        { config, pkgs, ... }:
+        {
+          boot = {
+            kernelModules = [ "drbd" ];
+            extraModulePackages = with config.boot.kernelPackages; [ drbd ];
+            kernelPackages = pkgs.linuxPackages;
+          };
+        };
+    };
+
+    testScript = ''
+      machine.start();
+      machine.succeed("modinfo drbd | grep --extended-regexp '^version:\s+${pkgs.linuxPackages.drbd.version}$'")
+    '';
+  }
+)

--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -1,12 +1,21 @@
-{ stdenv, lib, fetchurl, kernel, nixosTests, flex, coccinelle, python3 }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  kernel,
+  nixosTests,
+  flex,
+  coccinelle,
+  python3,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "drbd";
-  version = "9.2.9";
+  version = "9.2.12";
 
   src = fetchurl {
     url = "https://pkg.linbit.com//downloads/drbd/9/drbd-${finalAttrs.version}.tar.gz";
-    hash = "sha256-MLG0hGvAjjkNxhszbpnb8fkzWUQC1zPhkeOaU0V5x3g=";
+    hash = "sha256-amdcyPTynGTaaZh558Q3KnGuGyyLJKnsY+NBCO26Jq0=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -17,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     coccinelle
     python3
   ];
+
+  enableParallelBuilding = true;
 
   makeFlags = kernel.makeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, fetchurl, kernel, flex, coccinelle, python3 }:
+{ stdenv, lib, fetchurl, kernel, nixosTests, flex, coccinelle, python3 }:
 
-stdenv.mkDerivation rec {
-  name = "drbd-${version}-${kernel.version}";
-  version = "9.2.8";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "drbd";
+  version = "9.2.9";
 
   src = fetchurl {
-    url = "https://pkg.linbit.com//downloads/drbd/9/drbd-${version}.tar.gz";
-    hash = "sha256-LqK1lPucab7wKvcB4VKGdvBIq+K9XtuO2m0DP5XtK3M=";
+    url = "https://pkg.linbit.com//downloads/drbd/9/drbd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-MLG0hGvAjjkNxhszbpnb8fkzWUQC1zPhkeOaU0V5x3g=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -18,40 +18,22 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  makeFlags = [
+  makeFlags = kernel.makeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KVER=${kernel.version}"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+    "M=$(sourceRoot)"
     "SPAAS=false"
   ];
 
-  # 6.4 and newer provide a in-tree version of the handshake module https://www.kernel.org/doc/html/v6.4/networking/tls-handshake.html
-  installPhase = ''
-    runHook preInstall
-    install -D drbd/drbd.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
-    install -D drbd/drbd_transport_tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
-    install -D drbd/drbd_transport_lb-tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
-    install -D drbd/drbd_transport_rdma.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
-    ${lib.optionalString (lib.versionOlder kernel.version "6.4") ''
-      install -D drbd/drbd-kernel-compat/handshake/handshake.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
-    ''}
-    runHook postInstall
-  '';
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
 
   postPatch = ''
     patchShebangs .
     substituteInPlace Makefile --replace 'SHELL=/bin/bash' 'SHELL=${builtins.getEnv "SHELL"}'
   '';
 
-  # builder.pl had complained about the same file (drbd.ko.xz) provided by two different packages
-  # builder.pl also had complained about different permissions between the files from the two packages
-  # The compression is required because the kernel has the CONFIG_MODULE_COMPRESS_XZ option enabled
-  postFixup = ''
-    for ko in $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9/*.ko; do
-      xz --compress -6 --threads=0 $ko
-      chmod 0444 $ko.xz
-    done
-  '';
-
-  enableParallelBuilding = true;
+  passthru.tests.drbd-driver = nixosTests.drbd-driver;
 
   meta = with lib; {
     homepage = "https://github.com/LINBIT/drbd";
@@ -60,9 +42,8 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ birkb ];
     longDescription = ''
-       DRBD is a software-based, shared-nothing, replicated storage solution
-       mirroring the content of block devices (hard disks, partitions, logical volumes, and so on) between hosts.
+      DRBD is a software-based, shared-nothing, replicated storage solution
+      mirroring the content of block devices (hard disks, partitions, logical volumes, and so on) between hosts.
     '';
-    broken = lib.versionAtLeast kernel.version "6.8"; # wait until next DRBD release for 6.8 support https://github.com/LINBIT/drbd/issues/87#issuecomment-2059323084
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is a rebased, updated and fixed version of #312011.

It updates the drbd kernel module to the most recent version and fixes the kernel module for all supported kernel versions. (Minus `linux_latest_libre`, which is currently broken.)

@birkb Feel free to fold this into your PR, if you want.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
