### PR TITLE
rustfinity: init at 0.2.13

### DIFF
--- a/pkgs/by-name/ru/rustfinity/package.nix
+++ b/pkgs/by-name/ru/rustfinity/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchCrate,
+  pkg-config,
+  openssl,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "rustfinity";
+  version = "0.2.13";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-yBWhY4Uta/K/Ka5DzhpZUiv0Y3Yfn4dI4ZARpJqTqY8=";
+  };
+
+  cargoHash = "sha256-jeV4R9UwKF5ZW2AZl/WZE2KTMGCzX4/dpP8uUIUD3CI=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
+
+  OPENSSL_NO_VENDOR = 1;
+
+  # Requires network and fs access
+  checkFlags = [
+    "--skip=challenge::tests::test_challenge_exists"
+    "--skip=crates_io::tests::test_get_latest_version"
+    "--skip=dir::tests::test_get_current_dir"
+    "--skip=download::tests::download_file::test_downloads_file"
+    "--skip=download::tests::download_file::test_renames_starter"
+  ];
+
+  meta = {
+    description = "CLI for Rustfinity challenges solving";
+    homepage = "https://github.com/dcodesdev/rustfinity.com/tree/main/crates/cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "rustfinity";
+  };
+}


### PR DESCRIPTION
[Command-Line interface](https://github.com/dcodesdev/rustfinity.com/tree/main/crates/cli) for solving [Rustfinity](https://www.rustfinity.com) challenges locally.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
