### PR TITLE
krunker: init at 2.1.3

### DIFF
--- a/pkgs/by-name/kr/krunker/darwin.nix
+++ b/pkgs/by-name/kr/krunker/darwin.nix
@@ -1,0 +1,32 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "krunker";
+  version = "2.1.3";
+
+  src = fetchurl {
+    url = "https://client2.krunker.io/Official%20Krunker.io%20Client-${finalAttrs.version}.dmg";
+    hash = "sha512-brvrOPCsXkkrUGcRxsa8bzpFsrY7GF3llt29ZIax6dC0XBsILKXUleESJ5LpurMOgSBsfxNYjZLPJhicIAtuUA==";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    undmg
+  ];
+
+  postInstall = ''
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    makeBinaryWrapper \
+      $out/Applications/Official\ Krunker.io\ Client.app/Contents/MacOS/Official\ Krunker.io\ Client \
+      $out/bin/krunker
+  '';
+})

--- a/pkgs/by-name/kr/krunker/linux.nix
+++ b/pkgs/by-name/kr/krunker/linux.nix
@@ -1,0 +1,30 @@
+{ appimageTools, fetchurl }:
+
+let
+  pname = "krunker";
+  version = "2.1.3";
+
+  appId = "io.krunker.desktop";
+
+  src = fetchurl {
+    url = "https://client2.krunker.io/Official%20Krunker.io%20Client-${version}.AppImage";
+    hash = "sha512-a8E5heLsKXOtv/wRKlrnV0GD48cY1mOiSSDW93c7YZ+HoeuBQDxtRaHKg5EqU51Yi+d4tPF5nOh10jZW36c7WQ==";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    install -Dm644 ${appimageContents}/${appId}.desktop -t $out/share/applications
+    install -Dm644 ${appimageContents}/${appId}.png -t $out/share/pixmaps
+
+    substituteInPlace $out/share/applications/${appId}.desktop \
+      --replace-fail 'Exec=AppRun' "Exec=$pname"
+  '';
+}

--- a/pkgs/by-name/kr/krunker/package.nix
+++ b/pkgs/by-name/kr/krunker/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+}:
+
+let
+  package =
+    if stdenv.hostPlatform.isDarwin then callPackage ./darwin.nix { } else callPackage ./linux.nix { };
+in
+
+package.overrideAttrs (
+  finalAttrs: oldAttrs: {
+    passthru = {
+      updateScript = ./update.sh;
+    } // oldAttrs.passthru or { };
+
+    # Point `nix edit`, etc. to the file that defines the attribute, not this
+    # entry point
+    pos = builtins.unsafeGetAttrPos "pname" finalAttrs;
+
+    meta = {
+      description = "Easy to get into fully moddable First Person Shooter with advanced movement mechanics";
+      homepage = "https://krunker.io";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [ getchoo ];
+      mainProgram = "krunker";
+      platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    } // oldAttrs.meta or { };
+  }
+)

--- a/pkgs/by-name/kr/krunker/update.sh
+++ b/pkgs/by-name/kr/krunker/update.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env nix-shell
+#! nix-shell --pure -i bash -p bash cacert common-updater-scripts curl yq
+# shellcheck shell=bash
+set -euo pipefail
+
+root=$(readlink -f "$0" | xargs dirname)
+script_name="krunker-update"
+updater_url="client2.krunker.io"
+
+log() {
+    echo "$script_name: $*"
+}
+
+panic() {
+    log "$*"
+    exit 1
+}
+
+update() {
+    platform="${1:-}"
+    if [ -z "$platform" ]; then
+        panic "error: a platform must be supplied to \`update()\`!"
+    fi
+
+    nixfile="$root"/"$platform".nix
+    if [ ! -f "$nixfile" ]; then
+        panic "error: $platform is not supported!"
+    fi
+
+    electron_suffix=""
+    system="x86_64-linux"
+    if [ "$platform" == "darwin" ]; then
+        electron_suffix="-mac"
+        system="aarch64-darwin"
+    elif [ "$platform" == "linux" ]; then
+        electron_suffix="-linux"
+    fi
+
+    url="https://$updater_url/latest${electron_suffix}.yml"
+    log "fetching update information from from $url"
+    response="$(curl -sSL "$url")"
+    version="$(yq --raw-output '.version' <<<"$response")"
+    sha512="$(yq \
+        --raw-output \
+        '.files | map(select(.url | contains("dmg") or contains("AppImage"))) | first | .sha512' \
+        <<<"$response")"
+
+    update-source-version krunker "$version" sha512-"$sha512" --file="$nixfile" --system="$system"
+}
+
+supported_platforms=(
+    "darwin"
+    "linux"
+)
+
+for platform in "${supported_platforms[@]}"; do
+    update "$platform"
+done


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/359808

~~Draft until when/if I can find a static URL for versions. Should be possible to get from their updater (fingers crossed)~~ Done!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
