### PR TITLE
Run GitHub Actions on automatic backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,26 +8,31 @@ on:
 # the GitHub repository. This means that it should not evaluate user input in a
 # way that allows code injection.
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backport:
-    permissions:
-      contents: write # for korthout/backport-action to create branch
-      pull-requests: write # for korthout/backport-action to create PR to backport
     name: Backport Pull Request
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs
+      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Create backport PRs
         uses: korthout/backport-action@bd410d37cdcae80be6d969823ff5a225fe5c833f # v3.0.2
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
           copy_labels_pattern: 'severity:\ssecurity'
+          github_token: ${{ steps.app-token.outputs.token }}
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 


### PR DESCRIPTION
GitHub Actions currently don't get triggered for the automated Nixpkgs backports, e.g. see https://github.com/NixOS/nixpkgs/pull/360258. This happens because the PR is created by the default GitHub Actions bot account, which has some built-in infinite recursion prevention measures.

We can fix this by using a separate GitHub App bot account instead. Depends on https://github.com/NixOS/org/issues/38.

## Things done
- [x] Tested: https://github.com/Infinisil-s-Test-Organization/nixpkgs/pull/35#issuecomment-2508743338

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
