### PR TITLE
ldmud: various build fixes

### DIFF
--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -7,7 +7,7 @@
 , libiconv
 , pcre
 , libgcrypt
-, libxcrypt
+, libxcrypt-legacy
 , json_c
 , libxml2
 , ipv6Support ? false
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [ autoreconfHook pkg-config bison ];
-  buildInputs = [ libgcrypt libxcrypt pcre json_c libxml2 ]
+  buildInputs = [ libgcrypt libxcrypt-legacy pcre json_c libxml2 ]
     ++ lib.optional mccpSupport zlib ++ lib.optional mysqlSupport libmysqlclient
     ++ lib.optional postgresSupport libpq
     ++ lib.optional sqliteSupport sqlite ++ lib.optional tlsSupport openssl

--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-PkrjP7tSZMaj61Hsn++7+CumhqFPLbf0+eAI6afP9HA=";
   };
 
-  patches = [ ./libxml2-2.12.0-compat.patch ];
+  patches = [ ./libxml2-2.12.0-compat.patch ./mysql-compat.patch ];
 
   sourceRoot = "${src.name}/src";
 

--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-PkrjP7tSZMaj61Hsn++7+CumhqFPLbf0+eAI6afP9HA=";
   };
 
+  patches = [ ./libxml2-2.12.0-compat.patch ];
+
   sourceRoot = "${src.name}/src";
 
   nativeBuildInputs =

--- a/pkgs/games/ldmud/libxml2-2.12.0-compat.patch
+++ b/pkgs/games/ldmud/libxml2-2.12.0-compat.patch
@@ -1,0 +1,18 @@
+diff --git src/pkg-xml2.c src/pkg-xml2.c
+index 048ca38c..9ea4de35 100644
+--- src/pkg-xml2.c
++++ src/pkg-xml2.c
+@@ -507,8 +507,13 @@ f_xml_generate (svalue_t *sp)
+     return sp;
+ }
+ 
++#if LIBXML_VERSION >= 21200
++static void
++xml_pkg_error_handler(void * userData, const xmlError *error)
++#else
+ static void
+ xml_pkg_error_handler(void * userData, xmlErrorPtr error)
++#endif
+ {
+     if (error)
+     {

--- a/pkgs/games/ldmud/mysql-compat.patch
+++ b/pkgs/games/ldmud/mysql-compat.patch
@@ -1,0 +1,13 @@
+diff --git src/autoconf/configure.ac src/autoconf/configure.ac
+index 156e97f4..6d70bf33 100644
+--- src/autoconf/configure.ac
++++ src/autoconf/configure.ac
+@@ -1410,7 +1410,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <mysql.h>
+ #include <errmsg.h>
+ 
+-struct MYSQL * foo(void)
++struct st_mysql * foo(void)
+ {
+     static MYSQL var;
+     


### PR DESCRIPTION
## libxcrypt-legacy

The LDMud game engine defaults to using a legacy DES hash that is (sensibly) only enabled in the `libxcrypt-legacy` derivation, not `libxcrypt`.

This commit switches LDMud to that build input instead of `libxcrypt`. This fixes a runtime error when calling `efun::crypt()` from LPC that would print a confusing error message like "crypt() is not available.".

See also https://github.com/NixOS/nixpkgs/pull/223034

## libxml2 2.12+ compat

The v2.12.0 release of `libxml2` changed the definition of the callback used with `xmlSetStructuredErrorFunc()` (ref `libxml2` [NEWS](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS)).

A fix is underway upstream (https://github.com/ldmud/ldmud/pull/95), but the release cadence is such that we should expect to fix this locally for some time, so a local patch with a fix is applied.

## mariadb-connector-c compat

The upstream `configure.ac`'s `AC_LANG_PROGRAM` for mysql feature detection seems to be incompatible with the `mariadb-connector-c` package, resulting in support not being detected. 

Digging in to the `config.log` we can see it's a type mismatch error from the test program `.c`:

```
configure:11661: checking for mySQL
configure:11694: gcc -c -g -O2 -fwrapv -I/usr/inet6/include -I/nix/store/ya8wpj6dqz39024v6xrv504i9kyidpil-mariadb-connector-c-3.1.21-dev/include/mysql conftest.c >&5
conftest.c: In function 'foo':
conftest.c:90:12: error: returning 'MYSQL *' {aka 'struct st_mysql *'} from a function with incompatible return type 'struct MYSQL *' [-Wincompatible-pointer-types]
90 |     return &var;
|            ^~~~
```

We resolves the issue locally by applying a small patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
