### PR TITLE
workflows/eval: Make sure to compare against the push run

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           # Get the latest eval.yml workflow run for the PR's base commit
           if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
-            -f head_sha="$BASE_SHA" \
+            -f head_sha="$BASE_SHA" -f event=push \
             --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
             || [[ -z "$run" ]]; then
             echo "Could not find an eval.yml workflow run for $BASE_SHA, cannot make comparison"


### PR DESCRIPTION
For PRs whose commits end up as HEAD of master like https://github.com/NixOS/nixpkgs/commit/bcc5c141bf43460909b83740e96ceeea6d0f7e12, there might be workflow runs associated with both PRs and pushes.

Only the push event is the one that will run fully and should be used to compare against. So far it didn't distinguish between the two events, causing it to sometimes pick the wrong one and then fail to download non-existent artifacts: https://github.com/NixOS/nixpkgs/actions/runs/12092053414/job/33721377179

This commit fixes that by ensuring that the push event result is compared against

Having a hard time testing this, but for the above commit, this returns a push and a pull request event:
```
gh api /repos/NixOS/nixpkgs/actions/workflows/eval.yml/runs --method GET \
  -f head_sha=bcc5c141bf43460909b83740e96ceeea6d0f7e12 
```

with the pull request one being more recent (that's what `eval.yml` orders it by) and therefore being used here: https://github.com/NixOS/nixpkgs/actions/runs/12092053414/job/33721377179. Adding `-f event=push` makes it only return the one `push` event.

Follow-up to https://github.com/NixOS/nixpkgs/pull/359704

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
