### PR TITLE
freebsd: fix clang 19 build and improve overridability again

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/ath-hal-clang19.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/ath-hal-clang19.patch
@@ -1,0 +1,239 @@
+commit 36d486cc2ecdb9c290dba65bd5668b7e50d0d822
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Wed Jul 31 11:43:50 2024 +0200
+
+    Fix enum warning in ath_hal's ar9002
+    
+    This fixes a clang 19 warning:
+    
+        sys/dev/ath/ath_hal/ar9002/ar9285_btcoex.c:57:32: error: comparison of different enumeration types ('HAL_BOOL' and 'HAL_ANT_SETTING') [-Werror,-Wenum-compare]
+           57 |             (AH5212(ah)->ah_diversity != HAL_ANT_VARIABLE)) {
+              |              ~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~
+    
+    The `ah_diversity` field of `struct ath_hal_5212` is of type `HAL_BOOL`,
+    not the enum type `HAL_ANT_SETTING`. In other code, `ah_diversity` is
+    set to `AH_TRUE` whenever the related field `ah_antControl` is set to
+    `HAL_ANT_VARIABLE`.
+    
+    It is not entirely clear to me what the intended statement is here: the
+    test as it is written now compares the enum value 0 to `ah_diversity`,
+    so in effect it enables the following block whenever `ah_diversity` is
+    `AH_TRUE`. Write it like that, to avoid the compiler warning.
+    
+    MFC after:      3 days
+
+diff --git a/sys/dev/ath/ath_hal/ar9002/ar9285_btcoex.c b/sys/dev/ath/ath_hal/ar9002/ar9285_btcoex.c
+index 01a224cbbfe9..fb2700771ffa 100644
+--- a/sys/dev/ath/ath_hal/ar9002/ar9285_btcoex.c
++++ b/sys/dev/ath/ath_hal/ar9002/ar9285_btcoex.c
+@@ -54,7 +54,7 @@ ar9285BTCoexAntennaDiversity(struct ath_hal *ah)
+ 	    !! (ahp->ah_btCoexFlag & HAL_BT_COEX_FLAG_ANT_DIV_ENABLE));
+ 
+ 	if ((ahp->ah_btCoexFlag & HAL_BT_COEX_FLAG_ANT_DIV_ALLOW) ||
+-	    (AH5212(ah)->ah_diversity != HAL_ANT_VARIABLE)) {
++	    (AH5212(ah)->ah_diversity == AH_TRUE)) {
+ 	if ((ahp->ah_btCoexFlag & HAL_BT_COEX_FLAG_ANT_DIV_ENABLE) &&
+ 	     (AH5212(ah)->ah_antControl == HAL_ANT_VARIABLE)) {
+ 		/* Enable antenna diversity */
+commit 82246ac5d890e031c9978052e5a431e0960182d5
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Wed Jul 31 11:37:20 2024 +0200
+
+    Fix enum warnings in ath_hal's ar9300
+    
+    This fixes a number of clang 19 warnings:
+    
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300_eeprom.c:709:25: error: comparison of different enumeration types ('HAL_BOOL' and 'HAL_FREQ_BAND') [-Werror,-Wenum-compare]
+          709 |         freq_array[i] = FBIN2FREQ(p_freq_bin[i], is_2ghz);
+              |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h:148:11: note: expanded from macro 'FBIN2FREQ'
+          148 |     (((y) == HAL_FREQ_BAND_2GHZ) ? (2300 + x) : (4800 + 5 * x))
+              |       ~~~ ^  ~~~~~~~~~~~~~~~~~~
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300_eeprom.c:745:25: error: comparison of different enumeration types ('HAL_BOOL' and 'HAL_FREQ_BAND') [-Werror,-Wenum-compare]
+          745 |         freq_array[i] = FBIN2FREQ(p_freq_bin[i], is_2ghz);
+              |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h:148:11: note: expanded from macro 'FBIN2FREQ'
+          148 |     (((y) == HAL_FREQ_BAND_2GHZ) ? (2300 + x) : (4800 + 5 * x))
+              |       ~~~ ^  ~~~~~~~~~~~~~~~~~~
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300_eeprom.c:781:25: error: comparison of different enumeration types ('HAL_BOOL' and 'HAL_FREQ_BAND') [-Werror,-Wenum-compare]
+          781 |         freq_array[i] = FBIN2FREQ(p_freq_bin[i], is_2ghz);
+              |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h:148:11: note: expanded from macro 'FBIN2FREQ'
+          148 |     (((y) == HAL_FREQ_BAND_2GHZ) ? (2300 + x) : (4800 + 5 * x))
+              |       ~~~ ^  ~~~~~~~~~~~~~~~~~~
+    
+    The `FBIN2FREQ()` and `FREQ2FBIN()` macros in `ar9300eep.h` are invoked
+    in most places around the `ath_hal` code with a (effectively) boolean
+    second argument, corresponding to "is this 2GHz?". But in the code that
+    is warned about, the value `HAL_FREQ_BAND_2GHZ` is of a different
+    non-boolean type, `HAL_FREQ_BAND`.
+    
+    Update the `FBIN2FREQ()` and `FREQ2FBIN()` macros to interpret the
+    second argument as boolean value, and rename the macro parameter names
+    to better describe their meaning.
+    
+    Reviewed by:    adrian, bz
+    MFC after:      3 days
+    Differential Revision: https://reviews.freebsd.org/D46201
+
+diff --git a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h
+index 9230fd57e2e4..b2a0862c7aee 100644
+--- a/sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h
++++ b/sys/contrib/dev/ath/ath_hal/ar9300/ar9300eep.h
+@@ -142,10 +142,10 @@ enum Ar9300EepromTemplate
+ #define OSPREY_EEPMISC_WOW           0x02
+ #define OSPREY_CUSTOMER_DATA_SIZE    20
+ 
+-#define FREQ2FBIN(x,y) \
+-    (u_int8_t)(((y) == HAL_FREQ_BAND_2GHZ) ? ((x) - 2300) : (((x) - 4800) / 5))
+-#define FBIN2FREQ(x,y) \
+-    (((y) == HAL_FREQ_BAND_2GHZ) ? (2300 + x) : (4800 + 5 * x))
++#define FREQ2FBIN(freq,is_2ghz) \
++    (u_int8_t)((is_2ghz) ? ((freq) - 2300) : (((freq) - 4800) / 5))
++#define FBIN2FREQ(freq,is_2ghz) \
++    ((is_2ghz) ? (2300 + freq) : (4800 + 5 * freq))
+ #define OSPREY_MAX_CHAINS            3
+ #define OSPREY_ANT_16S               25
+ #define OSPREY_FUTURE_MODAL_SZ       6
+commit 1bd66fac35ec27fa64d6158f82fdcbdc26098679
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Wed Jul 31 13:14:17 2024 +0200
+
+    Fix enum warning in isci
+    
+    This fixes a clang 19 warning:
+    
+        sys/dev/isci/scil/scif_sas_smp_remote_device.c:197:26: error: comparison of different enumeration types ('SCI_IO_STATUS' (aka 'enum _SCI_IO_STATUS') and 'enum _SCI_STATUS') [-Werror,-Wenum-compare]
+          197 |    if (completion_status == SCI_FAILURE_RETRY_REQUIRED)
+              |        ~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+    The `completion_status` variable is of type `SCI_IO_STATUS`, not
+    `SCI_STATUS`. In this case, we can seamlessly replace the value with
+    `SCI_IO_FAILURE_RETRY_REQUIRED`, which is numerically equal to
+    `SCI_FAILURE_RETRY_REQUIRED`.
+    
+    MFC after:      3 days
+
+diff --git a/sys/dev/isci/scil/scif_sas_smp_remote_device.c b/sys/dev/isci/scil/scif_sas_smp_remote_device.c
+index d6055adc13f9..c72402f66889 100644
+--- a/sys/dev/isci/scil/scif_sas_smp_remote_device.c
++++ b/sys/dev/isci/scil/scif_sas_smp_remote_device.c
+@@ -194,7 +194,7 @@ SCI_STATUS scif_sas_smp_remote_device_decode_smp_response(
+ 
+    //if Core set the status of this io to be RETRY_REQUIRED, we should
+    //retry the IO without even decode the response.
+-   if (completion_status == SCI_FAILURE_RETRY_REQUIRED)
++   if (completion_status == SCI_IO_FAILURE_RETRY_REQUIRED)
+    {
+       scif_sas_smp_remote_device_continue_current_activity(
+          fw_device, fw_request, SCI_FAILURE_RETRY_REQUIRED
+commit 357378bbdedf24ce2b90e9bd831af4a9db3ec70a
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Wed Jul 31 14:21:25 2024 +0200
+
+    Fix enum warnings in qat
+    
+    This fixes a number of clang 19 warnings:
+    
+        sys/dev/qat/qat_api/common/compression/dc_session.c:154:15: error: comparison of different enumeration types ('enum _CpaBoolean' and 'icp_qat_hw_compression_delayed_match_t') [-Werror,-Wenum-compare]
+          154 |         if (CPA_TRUE == pService->comp_device_data.enableDmm) {
+              |             ~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        sys/dev/qat/qat_api/common/compression/dc_session.c:285:17: error: comparison of different enumeration types ('enum _CpaBoolean' and 'icp_qat_hw_compression_delayed_match_t') [-Werror,-Wenum-compare]
+          285 |                     (CPA_TRUE == pService->comp_device_data.enableDmm) ?
+              |                      ~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+    The `enableDmm` field of variable `comp_device_data` is of type
+    `icp_qat_hw_compression_delayed_match_t`, not `CpaBoolean`. In this
+    case, we can seamlessly replace the value with
+    `ICP_QAT_HW_COMPRESSION_DELAYED_MATCH_ENABLED`, which is numerically
+    equal to `CPA_TRUE`.
+    
+    MFC after:      3 days
+
+diff --git a/sys/dev/qat/qat_api/common/compression/dc_session.c b/sys/dev/qat/qat_api/common/compression/dc_session.c
+index c92d6eebdc47..60f4410dac32 100644
+--- a/sys/dev/qat/qat_api/common/compression/dc_session.c
++++ b/sys/dev/qat/qat_api/common/compression/dc_session.c
+@@ -151,7 +151,8 @@ dcCompHwBlockPopulate(sal_compression_service_t *pService,
+ 	}
+ 
+ 	/* Set delay match mode */
+-	if (CPA_TRUE == pService->comp_device_data.enableDmm) {
++	if (ICP_QAT_HW_COMPRESSION_DELAYED_MATCH_ENABLED ==
++	    pService->comp_device_data.enableDmm) {
+ 		dmm = ICP_QAT_HW_COMPRESSION_DELAYED_MATCH_ENABLED;
+ 	} else {
+ 		dmm = ICP_QAT_HW_COMPRESSION_DELAYED_MATCH_DISABLED;
+@@ -282,7 +283,8 @@ dcCompHwBlockPopulateGen4(sal_compression_service_t *pService,
+ 		hw_comp_lower_csr.hash_update =
+ 		    ICP_QAT_HW_COMP_20_SKIP_HASH_UPDATE_DONT_ALLOW;
+ 		hw_comp_lower_csr.edmm =
+-		    (CPA_TRUE == pService->comp_device_data.enableDmm) ?
++		    (ICP_QAT_HW_COMPRESSION_DELAYED_MATCH_ENABLED ==
++			pService->comp_device_data.enableDmm) ?
+ 		    ICP_QAT_HW_COMP_20_EXTENDED_DELAY_MATCH_MODE_EDMM_ENABLED :
+ 		    ICP_QAT_HW_COMP_20_EXTENDED_DELAY_MATCH_MODE_EDMM_DISABLED;
+ 
+commit 67be1e195acfaec99ce4fffeb17111ce085755f7
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Wed Jul 31 13:01:20 2024 +0200
+
+    Fix enum warning in iavf
+    
+    This fixes a clang 19 warning:
+    
+        sys/dev/iavf/iavf_lib.c:514:39: error: comparison of different enumeration types ('enum virtchnl_vsi_type' and 'enum iavf_vsi_type') [-Werror,-Wenum-compare]
+          514 |                 if (sc->vf_res->vsi_res[i].vsi_type == IAVF_VSI_SRIOV)
+              |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~
+    
+    The `vsi_type` field of `struct virtchnl_vsi_resource` is of type `enum
+    virtchnl_vsi_type`, not `enum iavf_vsi_type`. In this case, we can
+    seamlessly replace the value with `VIRTCHNL_VSI_SRIOV`, which is
+    numerically equal to `IAVF_VSI_SRIOV`.
+    
+    MFC after:      3 days
+
+diff --git a/sys/dev/iavf/iavf_lib.c b/sys/dev/iavf/iavf_lib.c
+index 883a722b3a03..f80e3765448f 100644
+--- a/sys/dev/iavf/iavf_lib.c
++++ b/sys/dev/iavf/iavf_lib.c
+@@ -511,7 +511,7 @@ iavf_get_vsi_res_from_vf_res(struct iavf_sc *sc)
+ 
+ 	for (int i = 0; i < sc->vf_res->num_vsis; i++) {
+ 		/* XXX: We only use the first VSI we find */
+-		if (sc->vf_res->vsi_res[i].vsi_type == IAVF_VSI_SRIOV)
++		if (sc->vf_res->vsi_res[i].vsi_type == VIRTCHNL_VSI_SRIOV)
+ 			sc->vsi_res = &sc->vf_res->vsi_res[i];
+ 	}
+ 	if (!sc->vsi_res) {
+commit 6f25b46721a18cf4f036d041e7e5d275800a00b3
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Tue Jul 30 20:31:47 2024 +0200
+
+    Fix enum warning in heimdal
+    
+    This fixes a clang 19 warning:
+    
+    crypto/heimdal/lib/krb5/deprecated.c:75:17: error: comparison of different enumeration types ('krb5_keytype' (aka 'enum ENCTYPE') and 'enum krb5_keytype_old') [-Werror,-Wenum-compare]
+       75 |     if (keytype != KEYTYPE_DES || context->etypes_des == NULL)
+          |         ~~~~~~~ ^  ~~~~~~~~~~~
+    
+    In https://github.com/heimdal/heimdal/commit/3bebbe5323 this was solved
+    by adding a cast. That commit is rather large, so I'm only applying the
+    one-liner here.
+    
+    MFC after:      3 days
+
+diff --git a/crypto/heimdal/lib/krb5/deprecated.c b/crypto/heimdal/lib/krb5/deprecated.c
+index e7c0105ebf7f..02cf7614f932 100644
+--- a/crypto/heimdal/lib/krb5/deprecated.c
++++ b/crypto/heimdal/lib/krb5/deprecated.c
+@@ -72,7 +72,7 @@ krb5_keytype_to_enctypes_default (krb5_context context,
+     unsigned int i, n;
+     krb5_enctype *ret;
+ 
+-    if (keytype != KEYTYPE_DES || context->etypes_des == NULL)
++    if (keytype != (krb5_keytype)KEYTYPE_DES || context->etypes_des == NULL)
+ 	return krb5_keytype_to_enctypes (context, keytype, len, val);
+ 
+     for (n = 0; context->etypes_des[n]; ++n)

--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/mk-werror-clang19.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/mk-werror-clang19.patch
@@ -1,0 +1,25 @@
+commit d575077527d448ee45b923fa8c6b0cb7216ca5c5
+Author: Dimitry Andric <dim@FreeBSD.org>
+Date:   Tue Jul 30 20:28:51 2024 +0200
+
+    bsd.sys.mk: for clang >= 19, similar to gcc >= 8.1, turn off -Werror for
+    -Wcast-function-type-mismatch.
+    
+    PR:             280562
+    MFC after:      1 month
+
+diff --git a/share/mk/bsd.sys.mk b/share/mk/bsd.sys.mk
+index 52c3d07746c7..1934a79a5427 100644
+--- a/share/mk/bsd.sys.mk
++++ b/share/mk/bsd.sys.mk
+@@ -88,6 +88,10 @@ CWARNFLAGS.clang+=	-Wno-unused-const-variable
+ .if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 150000
+ CWARNFLAGS.clang+=	-Wno-error=unused-but-set-parameter
+ .endif
++.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 190000
++# Similar to gcc >= 8.1 -Wno-error=cast-function-type below
++CWARNFLAGS.clang+=	-Wno-error=cast-function-type-mismatch
++.endif
+ .endif # WARNS <= 6
+ .if ${WARNS} <= 3
+ CWARNFLAGS.clang+=	-Wno-tautological-compare -Wno-unused-value\

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -11,6 +11,7 @@
   freebsd-lib,
   expat,
   zlib,
+  extraSrc ? [ ],
 }:
 
 let
@@ -115,7 +116,8 @@ mkDerivation {
 
       # idk bro
       "sys/sys/kbio.h"
-    ];
+    ]
+    ++ extraSrc;
 
   preBuild =
     ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
@@ -2,7 +2,6 @@
 mkDerivation {
   path = "sbin/init";
   extraPaths = [ "sbin/mount" ];
-  NO_FSCHG = "yes";
   MK_TESTS = "no";
 
   meta.broken = !stdenv.hostPlatform.isStatic;

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcMinimal.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcMinimal.nix
@@ -6,6 +6,7 @@
   byacc,
   gencat,
   csu,
+  extraSrc ? [ ],
 }:
 
 mkDerivation {
@@ -31,7 +32,7 @@ mkDerivation {
     "etc/group"
     "etc/master.passwd"
     "etc/shells"
-  ];
+  ] ++ extraSrc;
 
   outputs = [
     "out"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libmd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libmd.nix
@@ -13,15 +13,17 @@
   # this is set to true when used as the dependency of install
   # this is set to false when used as the dependency of libc
   bootstrapInstallation ? false,
+  extraSrc ? [ ],
 }:
 
 mkDerivation (
   {
+    pname = "libmd" + lib.optionalString bootstrapInstallation "-boot";
     path = "lib/libmd";
     extraPaths = [
       "sys/crypto"
       "sys/sys"
-    ];
+    ] ++ extraSrc;
 
     outputs = [
       "out"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libprocstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libprocstat.nix
@@ -7,6 +7,7 @@
   libutil,
   libelf,
   csu,
+  extraSrc ? [ ],
 }:
 
 mkDerivation {
@@ -17,7 +18,7 @@ mkDerivation {
     "sys/contrib/pcg-c"
     "sys/opencrypto"
     "sys/crypto"
-  ];
+  ] ++ extraSrc;
 
   outputs = [
     "out"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
@@ -4,6 +4,7 @@
   include,
   libgcc,
   csu,
+  extraSrc ? [ ],
 }:
 
 mkDerivation {
@@ -12,7 +13,7 @@ mkDerivation {
     "lib/libthread_db"
     "lib/libc" # needs /include + arch-specific files
     "libexec/rtld-elf"
-  ];
+  ] ++ extraSrc;
 
   outputs = [
     "out"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
@@ -5,6 +5,7 @@
   flex,
   byacc,
   csu,
+  extraSrc ? [ ],
 }:
 
 mkDerivation {
@@ -26,7 +27,7 @@ mkDerivation {
     "sys/kern"
     "sys/libkern"
     "sys/crypto"
-  ];
+  ] ++ extraSrc;
 
   outputs = [
     "out"


### PR DESCRIPTION
1. When you build on staging, you get clang 19 now, which has enabled some warnings that cause build failures for FreeBSD. These failures have already been corrected upstream, so just pick those patches. They'll get removed from nixpkgs when whichever of 15.0 or 14.3 (the 14.2 feature freeze seems to have missed the clang 19 release) come out sooner.
2. Followup to https://github.com/NixOS/nixpkgs/pull/339912 - this adds piecemeal a feature that was cut from the previous pull request, the ability to add sources to individual freebsd source tree derivations without copying the entire derivation. The derivations I added these to are the ones that were necessary to change in order to [build 15.0-CURRENT](https://github.com/nixos-bsd/nixbsd/pull/34).

## Things done


- Built on platform(s)
  - [x] x86_64-linux (freebsd cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
