### PR TITLE
freebsd.makefs: uncomment code which can copy rdev information from mtree

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/makefs-rdev.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/makefs-rdev.patch
@@ -1,0 +1,30 @@
+The freebsd makefs code is imported directly from netbsd, with minor changes.
+One of these changes is commenting out a piece of code we need in order to
+cross-build filesystem images for openbsd with nix: the ability to copy device
+node information from an mtree. This is especially important in nix because the
+only other way to generate device nodes is to have them be resident on the
+build system's filesystem, which is not possible without root, and openbsd does
+not have a devfs and requires that all device nodes are simply present on the
+root filesystem in order to boot.
+
+Uncomment it.
+
+diff --git a/usr.sbin/makefs/walk.c b/usr.sbin/makefs/walk.c
+index 56e2d19c6f00..c3bf8faac2aa 100644
+--- a/usr.sbin/makefs/walk.c
++++ b/usr.sbin/makefs/walk.c
+@@ -540,12 +540,12 @@ apply_specentry(const char *dir, NODE *specnode, fsnode *dirnode)
+ 		dirnode->inode->st.st_flags = specnode->st_flags;
+ 	}
+ #endif
+-/*	if (specnode->flags & F_DEV) {
++	if (specnode->flags & F_DEV) {
+ 		ASEPRINT("rdev", "%#llx",
+ 		    (unsigned long long)dirnode->inode->st.st_rdev,
+ 		    (unsigned long long)specnode->st_rdev);
+ 		dirnode->inode->st.st_rdev = specnode->st_rdev;
+-	}*/
++	}
+ #undef ASEPRINT
+ 
+ 	dirnode->flags |= FSNODE_F_HASSPEC;


### PR DESCRIPTION
The freebsd makefs code is imported directly from netbsd, with minor changes. One of these changes is commenting out a piece of code we need in order to cross-build filesystem images for openbsd with nix: the ability to copy device node information from an mtree. This is especially important in nix because the only other way to generate device nodes is to have them be resident on the build system's filesystem, which is not possible without root, and openbsd does not have a devfs and requires that all device nodes are simply present on the root filesystem in order to boot.

In this PR, we uncomment this netbsd code.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
