### PR TITLE
openbsd.makedev: init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/makedev/bash.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/makedev/bash.patch
@@ -1,0 +1,18 @@
+diff --git a/etc/MAKEDEV.common b/etc/MAKEDEV.common
+index 1e7bb3d235a..1cc64a38985 100644
+--- a/etc/MAKEDEV.common
++++ b/etc/MAKEDEV.common
+@@ -315,10 +315,10 @@ _mkdev(pty, pty*, {-if [ $U -gt 15 ]; then
+ 		echo bad unit for pty in: $i
+ 		continue
+ 	fi
+-	set -A letters p q r s t u v w x y z P Q R S T
+-	set -A suffixes 0 1 2 3 4 5 6 7 8 9 a b c d e f g h i j k l m n o p q \
++	letters=(p q r s t u v w x y z P Q R S T)
++	suffixes=(0 1 2 3 4 5 6 7 8 9 a b c d e f g h i j k l m n o p q \
+ 	    r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X \
+-	    Y Z
++	    Y Z)
+ 
+ 	name=${letters[$U]}
+ 	n=0

--- a/pkgs/os-specific/bsd/openbsd/pkgs/makedev/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/makedev/package.nix
@@ -1,0 +1,37 @@
+{
+  mkDerivation,
+  runtimeShell,
+  m4,
+}:
+
+mkDerivation {
+  pname = "MAKEDEV";
+  path = "etc";
+
+  patches = [ ./bash.patch ];
+
+  extraNativeBuildInputs = [
+    m4
+  ];
+
+  preBuild = ''
+    mkdir -p $out/share/doc
+  '';
+  buildTargets = [ "MAKEDEV" ];
+
+  # patch some build artifacts
+  # gnu m4 doesn't seem to recognize the expr() macro but it's only used for simple arithmetic so we convert it to bash
+  postBuild = ''
+    substituteInPlace etc.$TARGET_MACHINE_ARCH/MAKEDEV --replace-fail "/bin/sh -" "${runtimeShell}"
+    sed -E -i -e '/^PATH=.*/d' -e 's/expr\((.*)\)/$((\1))/g' etc.$TARGET_MACHINE_ARCH/MAKEDEV
+  '';
+
+  # The install procedure is also weird since this is supposed to live in /dev
+  postInstall = ''
+    mkdir -p $out/bin
+    cp etc.$TARGET_MACHINE_ARCH/MAKEDEV $out/bin
+    chmod +x $out/bin/MAKEDEV
+  '';
+
+  meta.mainProgram = "MAKEDEV";
+}


### PR DESCRIPTION
MAKEDEV is a shell script that can generate OpenBSD device nodes. It is useful on an OpenBSD system for disaster recovery and also on a non-OpenBSD system for cross-compilation with a little bit of instrumentation :)

This PR depends on https://github.com/NixOS/nixpkgs/pull/359473

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross from linux)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
