### PR TITLE
pkgsStatic.ruff: fixup tests

### DIFF
--- a/pkgs/by-name/ru/ruff/package.nix
+++ b/pkgs/by-name/ru/ruff/package.nix
@@ -78,30 +78,36 @@ python3Packages.buildPythonPackage rec {
   # Failing on darwin for an unclear reason.
   # According to the maintainers, those tests are from an experimental crate that isn't actually
   # used by ruff currently and can thus be safely skipped.
-  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "--skip=added_package"
-    "--skip=add_search_path"
-    "--skip=changed_file"
-    "--skip=changed_versions_file"
-    "--skip=deleted_file"
-    "--skip=directory_deleted"
-    "--skip=directory_moved_to_trash"
-    "--skip=directory_moved_to_workspace"
-    "--skip=directory_renamed"
-    "--skip=hard_links_in_workspace"
-    "--skip=hard_links_to_target_outside_workspace"
-    "--skip=move_file_to_trash"
-    "--skip=move_file_to_workspace"
-    "--skip=nested_packages_delete_root"
-    "--skip=new_file"
-    "--skip=new_ignored_file"
-    "--skip=removed_package"
-    "--skip=rename_file"
-    "--skip=search_path"
-    "--skip=unix::changed_metadata"
-    "--skip=unix::symlinked_module_search_path"
-    "--skip=unix::symlink_inside_workspace"
-  ];
+  checkFlags =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      "--skip=added_package"
+      "--skip=add_search_path"
+      "--skip=changed_file"
+      "--skip=changed_versions_file"
+      "--skip=deleted_file"
+      "--skip=directory_deleted"
+      "--skip=directory_moved_to_trash"
+      "--skip=directory_moved_to_workspace"
+      "--skip=directory_renamed"
+      "--skip=hard_links_in_workspace"
+      "--skip=hard_links_to_target_outside_workspace"
+      "--skip=move_file_to_trash"
+      "--skip=move_file_to_workspace"
+      "--skip=nested_packages_delete_root"
+      "--skip=new_file"
+      "--skip=new_ignored_file"
+      "--skip=removed_package"
+      "--skip=rename_file"
+      "--skip=search_path"
+      "--skip=unix::changed_metadata"
+      "--skip=unix::symlinked_module_search_path"
+      "--skip=unix::symlink_inside_workspace"
+    ]
+    # Ignore a couple doctests that trigger a "error: linker `cc` not found" error.
+    ++ lib.optionals stdenv.hostPlatform.isStatic [
+      "--skip=module_name::ModuleName"
+      "--skip=cache_key::CacheKey"
+    ];
 
   nativeCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
This ignores doctest tests in the `red_knot_python_semantic` subcrate when running compilation in static mode.

For a reason that is unclear to me, it tries to reach out to `cc` as linker:
```
---- crates/red_knot_python_semantic/src/module_name.rs - module_name::ModuleName::parent (line 84) stdout ----
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: aborting due to 1 previous error

Couldn't compile the test.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
