### PR TITLE
workflows/eval: add markdown of added, removed and changed

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -210,7 +210,7 @@ jobs:
             --arg beforeResultDir ./baseResult \
             --arg afterResultDir ./prResult \
             -o comparison
-
+          cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
           # TODO: Request reviews from maintainers for packages whose files are modified in the PR
 
       - name: Upload the combined results

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -261,6 +261,11 @@ let
           --slurpfile after ${afterResultDir}/outpaths.json \
           > $out/changed-paths.json
 
+        jq -r '
+        "## Added\n" + (.attrdiff.added | map("- \(. )") | join("\n")) + "\n" +
+        "## Removed\n" + (.attrdiff.removed | map("- \(. )") | join("\n")) + "\n" +
+        "## Changed\n" + (.attrdiff.changed | map("- \(. )") | join("\n")) + "\n"
+        ' < $out/changed-paths.json > $out/step-summary.md
         # TODO: Compare eval stats
       '';
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -261,11 +261,7 @@ let
           --slurpfile after ${afterResultDir}/outpaths.json \
           > $out/changed-paths.json
 
-        jq -r '
-        "## Added\n" + (.attrdiff.added | map("- \(. )") | join("\n")) + "\n" +
-        "## Removed\n" + (.attrdiff.removed | map("- \(. )") | join("\n")) + "\n" +
-        "## Changed\n" + (.attrdiff.changed | map("- \(. )") | join("\n")) + "\n"
-        ' < $out/changed-paths.json > $out/step-summary.md
+        jq -r -f ${./generate-step-summary.jq} < $out/changed-paths.json > $out/step-summary.md
         # TODO: Compare eval stats
       '';
 

--- a/ci/eval/generate-step-summary.jq
+++ b/ci/eval/generate-step-summary.jq
@@ -1,0 +1,14 @@
+def truncate(xs; n):
+  if xs | length > n then xs[:n] + ["..."]
+  else xs
+  end;
+
+def itemize_packages(xs):
+  truncate(xs; 3000) | map("- \(. )") | join("\n");
+
+def section(title; xs):
+  "## " + title + " (" + (xs | length | tostring) + ")\n" + itemize_packages(xs);
+
+section("Added"; .attrdiff.added) + "\n\n" +
+section("Removed"; .attrdiff.removed) + "\n\n" +
+section("Changed"; .attrdiff.changed)

--- a/ci/eval/generate-step-summary.jq
+++ b/ci/eval/generate-step-summary.jq
@@ -4,11 +4,12 @@ def truncate(xs; n):
   end;
 
 def itemize_packages(xs):
-  truncate(xs; 3000) | map("- \(. )") | join("\n");
+  # we truncate the list to stay below the GitHub limit of 1MB per step summary.
+  truncate(xs; 3000) | map("- [\(.)](https://search.nixos.org/packages?channel=unstable&show=\(.)&from=0&size=50&sort=relevance&type=packages&query=\(.))") | join("\n");
 
 def section(title; xs):
-  "## " + title + " (" + (xs | length | tostring) + ")\n" + itemize_packages(xs);
+  "<details> <summary>" + title + " (" + (xs | length | tostring) + ")</summary>\n\n" + itemize_packages(xs) + "</details>";
 
-section("Added"; .attrdiff.added) + "\n\n" +
-section("Removed"; .attrdiff.removed) + "\n\n" +
-section("Changed"; .attrdiff.changed)
+section("Added packages"; .attrdiff.added) + "\n\n" +
+section("Removed packages"; .attrdiff.removed) + "\n\n" +
+section("Changed packages"; .attrdiff.changed)


### PR DESCRIPTION
Makes the github action for eval output the added, removed and changed paths in the summary.

The paths were already available in json format in `changed-paths.json`.
This PR adds a human-readable representation to the summary of the format (not in a code block)
```
## Added


## Removed

graalvmCEPackages.graalvm-ce-musl
graalvmCEPackages.stdenv

## Changed

babashka
babashka-unwrapped
bbin
certificate-ripper
clj-kondo
cljfmt
clojure-lsp
cq
dapl-native
dbqn-native
graalvm-ce
graalvmCEPackages.graaljs
graalvmCEPackages.graalnodejs
graalvmCEPackages.graalpy
graalvmCEPackages.graalvm-ce
graalvmCEPackages.truffleruby
jet
neil
obb
scala-update
tests.writers.bin.babashka
tests.writers.simple.babashka
tests.writers.wrapping.babashka
tests.writers.wrapping.babashka-bin
vscode-extensions.betterthantomorrow.calva
yamlscript
zprint
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
created https://github.com/itepastra/nixpkgs/pull/3 to see what the result looks like

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
