### PR TITLE
linuxPackages.efa: init at 2.13.0

### DIFF
--- a/pkgs/os-specific/linux/efa/cmake-fix-makefile.patch
+++ b/pkgs/os-specific/linux/efa/cmake-fix-makefile.patch
@@ -1,0 +1,26 @@
+diff --git a/config/Makefile b/config/Makefile
+index e0599f2..bbd3420 100644
+--- a/config/Makefile
++++ b/config/Makefile
+@@ -7,7 +7,7 @@ KBUILD_CPPFLAGS += -Werror -Wno-unused-variable -Wno-uninitialized -Wno-maybe-un
+ obj-m += $(DRIVER_NAME).o
+ $(DRIVER_NAME)-objs := main.o
+
+-KERNEL_DIR ?= /lib/modules/$(shell uname -r)/build
++KERNEL_DIR ?= @KERNEL_DIR@
+
+ modules:
+        $(MAKE) -C $(KERNEL_DIR) M=$(CURDIR) modules
+diff --git a/config/efa.cmake b/config/efa.cmake
+index fc601a2..67e6953 100644
+--- a/config/efa.cmake
++++ b/config/efa.cmake
+@@ -10,7 +10,7 @@ function(set_conf_tmp_dir prologue body)
+   set(tmp_dir "tmp_${rand}")
+   set(tmp_dir ${tmp_dir} PARENT_SCOPE)
+   configure_file(${CMAKE_SOURCE_DIR}/config/main.c.in ${tmp_dir}/main.c @ONLY)
+-  configure_file(${CMAKE_SOURCE_DIR}/config/Makefile ${tmp_dir} COPYONLY)
++  configure_file(${CMAKE_SOURCE_DIR}/config/Makefile ${tmp_dir} @ONLY)
+ endfunction()
+
+ function(try_compile_prog_test)

--- a/pkgs/os-specific/linux/efa/cmake-fixups.patch
+++ b/pkgs/os-specific/linux/efa/cmake-fixups.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f30f7c4..471d6c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,19 +6,18 @@ project(efa C)
+ 
+ set(KERNEL_VER "" CACHE STRING "Kernel version to build for")
+ if(NOT KERNEL_VER)
+-  execute_process(COMMAND uname -r OUTPUT_VARIABLE uname_r
+-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  set(KERNEL_DIR "/lib/modules/${uname_r}/build")
+-else()
+-  set(KERNEL_DIR "/lib/modules/${KERNEL_VER}/build")
++  message(FATAL_ERROR "Nix build requires KERNEL_VER to be set.")
+ endif()
+ 
+-unset(KERNEL_MAKEFILE CACHE)
+-find_file(KERNEL_MAKEFILE Makefile PATHS ${KERNEL_DIR} NO_DEFAULT_PATH)
++set(KERNEL_DIR "" CACHE STRING "Kernel version to build for")
++if(NOT KERNEL_DIR)
++  message(FATAL_ERROR "Nix build requires KERNEL_DIR to be set.")
++endif()
++
++set(KERNEL_MAKEFILE "" CACHE STRING "Kernel Makefile to use")
+ if(NOT KERNEL_MAKEFILE)
+-  message(FATAL_ERROR "No kernel Makefile")
++  message(FATAL_ERROR "Nix build requires KERNEL_MAKEFILE to be set.")
+ endif()
+-message("-- Kernel directory - ${KERNEL_DIR}")
+ 
+ set(GCOV_PROFILE OFF CACHE BOOL "Enable GCOV profiling")
+ set(ENABLE_P2P ON CACHE BOOL "Enable Peer-to-peer memory")

--- a/pkgs/os-specific/linux/efa/default.nix
+++ b/pkgs/os-specific/linux/efa/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  coreutils,
+  fetchFromGitHub,
+  gitUpdater,
+  kernel,
+}:
+let
+  rev-prefix = "efa_linux_";
+  version = "2.13.0";
+  src = fetchFromGitHub {
+    owner = "amzn";
+    repo = "amzn-drivers";
+    rev = "${rev-prefix}${version}";
+    hash = "sha256-Nt/MU25E0jZ7d7xhLE0fqY699hap64XFWnj3jB8cY44=";
+  };
+
+  sourceRoot = "${src}/kernel/linux/efa/";
+in
+stdenv.mkDerivation {
+  inherit version;
+  src = sourceRoot;
+  name = "efa-${version}-${kernel.version}";
+
+  patches = [
+    ./cmake-fixups.patch
+    ./cmake-fix-makefile.patch
+  ];
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ [
+    cmake
+    coreutils
+  ];
+  makeFlags = kernel.makeFlags;
+  cmakeFlags = [
+    "-DKERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "-DKERNEL_MAKEFILE=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build/Makefile"
+    "-DKERNEL_VER=${kernel.modDirVersion}"
+  ];
+  postPatch = ''
+    patchShebangs --build config/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    echo $(pwd)
+    $STRIP -S src/efa.ko
+    dest=$out/lib/modules/${kernel.modDirVersion}/misc
+    mkdir -p $dest
+    cp src/efa.ko $dest/
+    xz $dest/efa.ko
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater {
+    inherit rev-prefix;
+  };
+
+  meta = with lib; {
+    description = "Amazon Elastic Fabric Adapter (EFA) driver for Linux";
+    homepage = "https://github.com/amzn/amzn-drivers";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [
+      sielicki
+    ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This driver exists in-tree in newer kernels, but similar to linuxPackages.ena, benefits from an out-of-tree build from the github:amzn/amzn-drivers repo.

Add the driver.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
