### PR TITLE
julia.withPackages: Darwin support

### DIFF
--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -134,11 +134,16 @@ let
       "${juliaWrapped}/bin/julia" \
       "${if lib.versionAtLeast julia.version "1.7" then ./extract_artifacts.jl else ./extract_artifacts_16.jl}" \
       '${lib.generators.toJSON {} (import ./extra-libs.nix)}' \
+      '${lib.generators.toJSON {} (stdenv.hostPlatform.isDarwin)}' \
       "$out"
   '';
 
   # Import the artifacts Nix to build Overrides.toml (IFD)
-  artifacts = import artifactsNix { inherit lib fetchurl pkgs glibc stdenv; };
+  artifacts = import artifactsNix ({
+    inherit lib fetchurl pkgs stdenv;
+  } // lib.optionalAttrs (!stdenv.targetPlatform.isDarwin) {
+    inherit glibc;
+  });
   overridesJson = writeTextFile {
     name = "Overrides.json";
     text = lib.generators.toJSON {} artifacts;

--- a/pkgs/development/julia-modules/depot.nix
+++ b/pkgs/development/julia-modules/depot.nix
@@ -6,6 +6,7 @@
 , git
 , julia
 , python3
+, stdenv
 
 , closureYaml
 , extraLibs
@@ -15,6 +16,20 @@
 , precompile
 , registry
 }:
+
+let
+  # On darwin, we don't want to specify JULIA_SSL_CA_ROOTS_PATH. If we do (using a -bin julia derivation, which is the
+  # only kind darwin currently supports), you get an error like this:
+  #
+  # GitError(Code:ERROR, Class:SSL, Your Julia is built with a SSL/TLS engine that libgit2 doesn't know how to configure
+  # to use a file or directory of certificate authority roots, but your environment specifies one via the SSL_CERT_FILE
+  # variable. If you believe your system's root certificates are safe to use, you can `export JULIA_SSL_CA_ROOTS_PATH=""`
+  # in your environment to use those instead.)
+  setJuliaSslCaRootsPath = if stdenv.targetPlatform.isDarwin
+    then ''export JULIA_SSL_CA_ROOTS_PATH=""''
+    else ''export JULIA_SSL_CA_ROOTS_PATH="${cacert}/etc/ssl/certs/ca-bundle.crt"'';
+
+in
 
 runCommand "julia-depot" {
     nativeBuildInputs = [curl git julia (python3.withPackages (ps: with ps; [pyyaml]))] ++ extraLibs;
@@ -38,7 +53,7 @@ runCommand "julia-depot" {
   # export JULIA_DEBUG=Pkg
   # export JULIA_DEBUG=loading
 
-  export JULIA_SSL_CA_ROOTS_PATH="${cacert}/etc/ssl/certs/ca-bundle.crt"
+  ${setJuliaSslCaRootsPath}
 
   # Only precompile if configured to below
   export JULIA_PKG_PRECOMPILE_AUTO=0

--- a/pkgs/development/julia-modules/python/extract_artifacts.py
+++ b/pkgs/development/julia-modules/python/extract_artifacts.py
@@ -32,22 +32,30 @@ archive_extensions = [
   ".zip"
   ]
 
-def get_archive_derivation(uuid, artifact_name, url, sha256, closure_dependencies_dag, dependency_uuids, extra_libs):
+def get_archive_derivation(uuid, artifact_name, url, sha256, closure_dependencies_dag, dependency_uuids, extra_libs, is_darwin):
   depends_on = set()
   if closure_dependencies_dag.has_node(uuid):
     depends_on = set(closure_dependencies_dag.get_dependencies(uuid)).intersection(dependency_uuids)
 
   other_libs = extra_libs.get(uuid, [])
 
-  fixup = f"""fixupPhase = let
-          libs = lib.concatMap (lib.mapAttrsToList (k: v: v.path))
+  if is_darwin:
+    fixup = f"""fixupPhase = let
+            libs = lib.concatMap (lib.mapAttrsToList (k: v: v.path))
                                [{" ".join(["uuid-" + x for x in depends_on])}];
-          in ''
-            find $out -type f -executable -exec \
-              patchelf --set-rpath \$ORIGIN:\$ORIGIN/../lib:${{lib.makeLibraryPath (["$out" glibc] ++ libs ++ (with pkgs; [{" ".join(other_libs)}]))}} {{}} \;
-            find $out -type f -executable -exec \
-              patchelf --set-interpreter ${{glibc}}/lib/ld-linux-x86-64.so.2 {{}} \;
-          ''"""
+            in ''
+
+            ''"""
+  else:
+    fixup = f"""fixupPhase = let
+            libs = lib.concatMap (lib.mapAttrsToList (k: v: v.path))
+                               [{" ".join(["uuid-" + x for x in depends_on])}];
+            in ''
+              find $out -type f -executable -exec \
+                patchelf --set-rpath \$ORIGIN:\$ORIGIN/../lib:${{lib.makeLibraryPath (["$out" glibc] ++ libs ++ (with pkgs; [{" ".join(other_libs)}]))}} {{}} \;
+              find $out -type f -executable -exec \
+                patchelf --set-interpreter ${{glibc}}/lib/ld-linux-x86-64.so.2 {{}} \;
+            ''"""
 
   return f"""stdenv.mkDerivation {{
         name = "{artifact_name}";
@@ -73,7 +81,7 @@ def get_plain_derivation(url, sha256):
       }}"""
 
 def process_item(args):
-  item, julia_path, extract_artifacts_script, closure_dependencies_dag, dependency_uuids, extra_libs = args
+  item, julia_path, extract_artifacts_script, closure_dependencies_dag, dependency_uuids, extra_libs, is_darwin = args
   uuid, src = item
   lines = []
 
@@ -94,7 +102,7 @@ def process_item(args):
 
     parsed_url = urlparse(url)
     if any(parsed_url.path.endswith(x) for x in archive_extensions):
-      derivation = get_archive_derivation(uuid, artifact_name, url, sha256, closure_dependencies_dag, dependency_uuids, extra_libs)
+      derivation = get_archive_derivation(uuid, artifact_name, url, sha256, closure_dependencies_dag, dependency_uuids, extra_libs, is_darwin)
     else:
       derivation = get_plain_derivation(url, sha256)
 
@@ -113,7 +121,8 @@ def main():
   julia_path = Path(sys.argv[3])
   extract_artifacts_script = Path(sys.argv[4])
   extra_libs = json.loads(sys.argv[5])
-  out_path = Path(sys.argv[6])
+  is_darwin = json.loads(sys.argv[6])
+  out_path = Path(sys.argv[7])
 
   with open(dependencies_path, "r") as f:
     dependencies = yaml.safe_load(f)
@@ -133,13 +142,17 @@ def main():
         closure_dependencies_dag.add_node(uuid, dependencies=contents["depends_on"].values())
 
   with open(out_path, "w") as f:
-    f.write("{ lib, fetchurl, glibc, pkgs, stdenv }:\n\n")
+    if is_darwin:
+      f.write("{ lib, fetchurl, pkgs, stdenv }:\n\n")
+    else:
+      f.write("{ lib, fetchurl, glibc, pkgs, stdenv }:\n\n")
+
     f.write("rec {\n")
 
     with multiprocessing.Pool(10) as pool:
       # Create args tuples for each item
       process_args = [
-        (item, julia_path, extract_artifacts_script, closure_dependencies_dag, dependency_uuids, extra_libs)
+        (item, julia_path, extract_artifacts_script, closure_dependencies_dag, dependency_uuids, extra_libs, is_darwin)
         for item in dependencies.items()
       ]
       for s in pool.map(process_item, process_args):


### PR DESCRIPTION
This PR adds macOS support to `julia.withPackages`. It is broken up into 3 commits:

1. Fix our usage of the Python `multiprocessing` library in `extract_artifacts.py` to be compatible with macOS. On macOS it uses `spawn` instead of `fork` to launch new processes, so all in-memory state has to be defined in such a way that it can be pickled and moved to the new process. This requires moving the worker callback to the top level and a few other changes.
2. Change the artifact `fixupPhase` to be compatible with macOS. We don't need to call `patchelf` or change the interpreter of any binaries. Indeed, AFAICT we don't need to do any fixing up at all on macOS (see testing notes below).
3. Set `JULIA_SSL_CA_ROOTS_PATH=""` on macOS, as explained in the comment.

Test results:
* On my normal `x86-64-linux` machine with `julia`, I got 8 failing packages out of the top 1000 packages.
* On my `aarch64-darwin` machine with `julia-bin`, I got 7 failing packages out of the top 500 packages. (I have less disk space on this machine so I ran 500 instead of 1000.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
