### PR TITLE
gg-jj: init at 0.23.0

### DIFF
--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  yq,
+
+  cargo-tauri,
+  cargo,
+  rustc,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  wrapGAppsHook3,
+
+  openssl,
+  webkitgtk_4_1,
+  apple-sdk_11,
+
+  versionCheckHook,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gg";
+  version = "0.23.0";
+
+  src = fetchFromGitHub {
+    owner = "gulbanana";
+    repo = "gg";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-iQxPJgMxBtyindkNdQkehwPf7ZgWCI09PToqs2y1Hfw=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  # FIXME: Switch back to cargoHash when https://github.com/NixOS/nixpkgs/issues/356811 is fixed
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    hash = "sha256-Lr/0GkWHvfDy/leRLxisuTzGPZYFo2beHq9UCl6XlDo=";
+
+    nativeBuildInputs = [ yq ];
+
+    # Work around https://github.com/rust-lang/cargo/issues/10801
+    # See https://discourse.nixos.org/t/rust-tauri-v2-error-no-matching-package-found/56751/4
+    preBuild = ''
+      tomlq -it '.dependencies.tauri.features += ["native-tls"]' Cargo.toml
+    '';
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-SMz1ohPSF5tvf2d3is4PXhnjHG9hHuS5NYmHbe46HaU=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      webkitgtk_4_1
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_11;
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  postInstall = lib.optionals stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin
+    ln -s $out/Applications/gg.app/Contents/MacOS/gg $out/bin/gg
+  '';
+
+  # The generated Darwin bundle cannot be tested in the same way as a standalone Linux executable
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GUI for the version control system Jujutsu";
+    homepage = "https://github.com/gulbanana/gg";
+    changelog = "https://github.com/gulbanana/gg/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [ asl20 ];
+    inherit (cargo-tauri.hook.meta) platforms;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "gg";
+  };
+})


### PR DESCRIPTION
Closes #299856

It actually works this time.
![image](https://github.com/user-attachments/assets/a82b61b7-3339-4434-8afe-3886dbab223c)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
