### PR TITLE
nixosTests.vscodium: Workaround OCR tests

### DIFF
--- a/nixos/tests/vscodium.nix
+++ b/nixos/tests/vscodium.nix
@@ -3,7 +3,8 @@ let
     wayland = { pkgs, ... }: {
       imports = [ ./common/wayland-cage.nix ];
 
-      services.cage.program = "${pkgs.vscodium}/bin/codium";
+      # We scale vscodium to help OCR find the small "Untitled" text.
+      services.cage.program = "${pkgs.vscodium}/bin/codium --force-device-scale-factor=2";
 
       environment.variables.NIXOS_OZONE_WL = "1";
       environment.variables.DISPLAY = "do not use";
@@ -16,7 +17,7 @@ let
       virtualisation.memorySize = 2047;
       services.xserver.enable = true;
       services.xserver.displayManager.sessionCommands = ''
-        ${pkgs.vscodium}/bin/codium
+        ${pkgs.vscodium}/bin/codium --force-device-scale-factor=2
       '';
       test-support.displayManager.auto.user = "alice";
     };
@@ -46,7 +47,7 @@ let
         codium_running.wait() # type: ignore[union-attr]
         with codium_running: # type: ignore[union-attr]
             # Wait until vscodium is visible. "File" is in the menu bar.
-            machine.wait_for_text('Welcome')
+            machine.wait_for_text('Get Started with')
             machine.screenshot('start_screen')
 
             test_string = 'testfile'


### PR DESCRIPTION
An attempt to help https://hydra.nixos.org/build/279535629/nixlog/1.

The "Get Started with" text is much easier to find. Also scale vscodium to help OCR find the "Untitled" text.

(Lets see what ofborg says with this, note that wayland test already fails on aarch64-linux before)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

