### PR TITLE
runInLinuxVM: refactor structuredAttrs support, fix disko

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -88,10 +88,6 @@ rec {
           set -- $(IFS==; echo $o)
           command=$2
           ;;
-        out=*)
-          set -- $(IFS==; echo $o)
-          export out=$2
-          ;;
       esac
     done
 
@@ -153,7 +149,7 @@ rec {
     fi
 
     echo "starting stage 2 ($command)"
-    exec switch_root /fs $command $out
+    exec switch_root /fs $command
   '';
 
 
@@ -225,7 +221,6 @@ rec {
       -device virtio-rng-pci \
       -virtfs local,path=${storeDir},security_model=none,mount_tag=store \
       -virtfs local,path=/build,security_model=none,mount_tag=sa \
-      -virtfs local,path=$TMPDIR/xchg,security_model=none,mount_tag=xchg \
       ''${diskImage:+-drive file=$diskImage,if=virtio,cache=unsafe,werror=report} \
       -kernel ${kernel}/${img} \
       -initrd ${initrd}/initrd \
@@ -261,8 +256,6 @@ rec {
     cat > ./run-vm <<EOF
     #! ${bash}/bin/sh
     ''${diskImage:+diskImage=$diskImage}
-    TMPDIR=$TMPDIR
-    cd $TMPDIR
     ${qemuCommand}
     EOF
 

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -230,11 +230,11 @@ rec {
 
 
   vmRunCommand = qemuCommand: writeText "vm-run" ''
+    export > saved-env
     if [ -f "''${NIX_ATTRS_SH_FILE-}" ]; then
       source "$NIX_ATTRS_SH_FILE"
     fi
     source $stdenv/setup
-    export > saved-env
 
     PATH=${coreutils}/bin
     mkdir xchg

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -169,7 +169,6 @@ rec {
     if [ -f "''${NIX_ATTRS_SH_FILE-}" ]; then
       source "$NIX_ATTRS_SH_FILE"
     fi
-    source $stdenv/setup
 
     export NIX_STORE=${storeDir}
     export NIX_BUILD_TOP=/tmp
@@ -177,6 +176,7 @@ rec {
     export PATH=/empty
     cd "$NIX_BUILD_TOP"
 
+    source $stdenv/setup
     if ! test -e /bin/sh; then
       ${coreutils}/bin/mkdir -p /bin
       ${coreutils}/bin/ln -s ${bash}/bin/sh /bin/sh

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -230,15 +230,14 @@ rec {
 
 
   vmRunCommand = qemuCommand: writeText "vm-run" ''
-    export > saved-env
+    ${coreutils}/bin/mkdir xchg
+    export > xchg/saved-env
+    PATH=${coreutils}/bin
+
     if [ -f "''${NIX_ATTRS_SH_FILE-}" ]; then
       source "$NIX_ATTRS_SH_FILE"
     fi
     source $stdenv/setup
-
-    PATH=${coreutils}/bin
-    mkdir xchg
-    mv saved-env xchg/
 
     eval "$preVM"
 

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -24,6 +24,7 @@ in
   buildPatchelfInVM = runInLinuxVM patchelf;
 
   buildHelloInVM = runInLinuxVM hello;
+  buildStructuredAttrsHelloInVM = runInLinuxVM (hello.overrideAttrs { __structuredAttrs = true; });
 
   buildPcmanrmInVM = runInLinuxVM (pcmanfm.overrideAttrs (old: {
     # goes out-of-memory with many cores


### PR DESCRIPTION
In #354535 we fixed runInLinuxVM with structuredAttrs. However, this broke some out of tree users, e.g. disko: https://github.com/nix-community/disko/issues/900.

In this series of commits I'm going through the structuredAttrs support for runInLinuxVM step-by-step again. After some cleanups and improvements, I decided to change the approach a bit. To make `.attrs.sh` available in stage2, we mounted the `/build` folder instead of only `/tmp/xchg` in #354535. I'm reverting back to `/tmp/xchg` here and instead am copying the attrs files into that folder as well.

This makes cases like disko work, which:
- create their own TMPDIR: https://github.com/nix-community/disko/blob/b71e3faca99b40fb801f03fd950fbefbbba691a4/lib/make-disk-image.nix#L144-L146
- and override the `saved-env` file in that directory anyway: https://github.com/nix-community/disko/blob/b71e3faca99b40fb801f03fd950fbefbbba691a4/lib/make-disk-image.nix#L204

This was previously not picked up anymore after changing the folder to `/build`.

Could you test / confirm that this branch fixes it for you, @iFreilicht?

cc @Ma27

Resolves #359782

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux:
    - nix-build pkgs/build-support/vm/test.nix -A buildStructuredAttrsHelloInVM -A buildHelloInVM
    - nix-build -A apptainer.tests.image-hello-cowsay
    - nix-build -A nixosTests.systemd-boot
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
