### PR TITLE
lib.modules.mkRenamedOption*: warn as eagerly as possible

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1341,6 +1341,21 @@ let
       toOf = attrByPath to
         (abort "Renaming error: option `${showOption to}' does not exist.");
       toType = let opt = attrByPath to {} options; in opt.type or (types.submodule {});
+      prefix = lib.take (lib.length options._module.args.loc - 2) options._module.args.loc;
+      # Memoized warning
+      # This can be triggered in two ways, and this `let` binding ensures that it
+      # only triggers once.
+      # We trigger the evaluation of this warning in two places:
+      #   - When the new option is accessed.
+      #     This ensures that a warning is shown also in submodules that don't have
+      #     a `warnings` option.
+      #   - When the `warnings` option is evaluated.
+      #     This ensures that even if the value is not used, a warning is shown.
+      definitionWarning =
+        lib.warnIf
+          (warn && fromOpt.isDefined)
+          "The option `${showOption (prefix ++ from)}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption (prefix ++ to)}'."
+          null;
     in
     {
       options = setAttrByPath from (mkOption {
@@ -1352,12 +1367,14 @@ let
       });
       config = mkIf condition (mkMerge [
         (optionalAttrs (options ? warnings) {
-          warnings = optional (warn && fromOpt.isDefined)
-            "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
+          # NOTE: We use the warning option to trigger the warning immediately, instead of adding to the list.
+          #       Otherwise, we could show the warning twice; see `definitionWarning`.
+          warnings = mkIf (builtins.seq definitionWarning false) (lib.mkOverride 10000 []);
         })
         (if withPriority
-          then mkAliasAndWrapDefsWithPriority (setAttrByPath to) fromOpt
-          else mkAliasAndWrapDefinitions (setAttrByPath to) fromOpt)
+          then mkAliasAndWrapDefsWithPriority (d: setAttrByPath to (builtins.seq definitionWarning d)) fromOpt
+          else mkAliasAndWrapDefinitions (d: setAttrByPath to (builtins.seq definitionWarning d)) fromOpt
+        )
       ]);
     };
 


### PR DESCRIPTION
... i.e. without adding _any_ new strictness

This adds support for warnings in submodules.

Fixes https://github.com/NixOS/nixpkgs/issues/96006

To recap, https://github.com/NixOS/nixpkgs/pull/97023 didn't make it because of unexpected infinite recursions. Context:
  - Attaching a warning to an expression can create an otherwise unnecessary data dependency, which can lead to infinite mutual recursion when a (typically very necessary) dependency exists in the other direction.
  - The `warnings` option is largely independent of the evaluation of the configuration, because it only reads from it. Nothing except `system.build.toplevel` reads from `warnings`. Not cyclical, everyone happy.
  - #97023 created data dependencies at submodule roots, not just `toplevel`

While something like #97023 is a very general solution that would solve this `mkRenamedOptionModule` with ease, we don't need it for this particular problem.
Specifically, in this case, we already have a data dependency where the new option has a definition based on the old option. So, we can attach the
 warning to the `mkIf` condition of that definition and make it trigger when
the old option is about to be read anyway.

As a side effect of this change, these particular warnings don't appear in the `warnings` option anymore. Maybe someone used those for testing, but `mkRenamed`* usages aren't really worth testing, so this is a small price to pay for support for renames in submodules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## TODO

- [ ] more tests (this function did not have any tests in `lib/tests/modules.sh`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
