### PR TITLE
various: simplify handling of some *Phases in setup hooks

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -14,7 +14,7 @@ glibPreInstallPhase() {
 }
 appendToVar preInstallPhases glibPreInstallPhase
 
-glibPreFixupPhase() {
+glibPostInstallHook() {
     # Move gschemas in case the install flag didn't help
     if [ -d "$prefix/share/glib-2.0/schemas" ]; then
         mkdir -p "${!outputLib}/share/gsettings-schemas/$name/glib-2.0"
@@ -25,10 +25,7 @@ glibPreFixupPhase() {
 }
 
 # gappsWrapperArgsHook expects GSETTINGS_SCHEMAS_PATH variable to be set by this.
-# Until we have dependency mechanism in generic builder, we need to use this ugly hack.
-if [[ " ${preFixupPhases:-} " =~ " gappsWrapperArgsHook " ]]; then
-    preFixupPhases+=" "
-    preFixupPhases="${preFixupPhases/ gappsWrapperArgsHook / glibPreFixupPhase gappsWrapperArgsHook }"
-else
-    preFixupPhases+=" glibPreFixupPhase"
-fi
+# Until we have dependency mechanism in generic builder, we need to use this hack.
+# This relies on the fact that postInstallHooks are run *after* postInstall passed to
+# mkDerivation.
+postInstallHooks+=(glibPostInstallHook)

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -19,13 +19,8 @@ giDiscoverSelf() {
 }
 
 # gappsWrapperArgsHook expects GI_TYPELIB_PATH variable to be set by this.
-# Until we have dependency mechanism in generic builder, we need to use this ugly hack.
-if [[ " ${preFixupPhases:-} " =~ " gappsWrapperArgsHook " ]]; then
-    preFixupPhases+=" "
-    preFixupPhases="${preFixupPhases/ gappsWrapperArgsHook / giDiscoverSelf gappsWrapperArgsHook }"
-else
-    preFixupPhases+=" giDiscoverSelf"
-fi
+# Until we have dependency mechanism in generic builder, we need to use this hack.
+postInstallHooks+=(giDiscoverSelf)
 
 _multioutMoveGlibGir() {
   moveToOutput share/gir-1.0 "${!outputDev}"

--- a/pkgs/development/python-modules/pytest-forked/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-forked/setup-hook.sh
@@ -12,21 +12,7 @@ pytestForkedHook() {
     fi
 }
 
-# the flags should be added before pytestCheckHook runs so
-# until we have dependency mechanism in generic builder, we need to use this ugly hack.
-
 if [ -z "${dontUsePytestForked-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
-    if [[ " ${preDistPhases[*]:-} " =~ " pytestCheckPhase " ]]; then
-        _preDistPhases="${preDistPhases[*]} "
-        _preDistPhases="${_preDistPhases/ pytestCheckPhase / pytestForkedHook pytestCheckPhase }"
-        if [[ -n "${__structuredAttrs-}" ]]; then
-            preDistPhases=()
-        else
-            preDistPhases=""
-        fi
-        appendToVar preDistPhases $_preDistPhases
-        unset _preDistPhases
-    else
-        appendToVar preDistPhases pytestForkedHook
-    fi
+    # The flags should be added before pytestCheckHook runs in preDistPhases.
+    postInstallCheckHooks+=(pytestForkedHook)
 fi

--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -4,21 +4,7 @@ pytestXdistHook() {
     )
 }
 
-# the flags should be added before pytestCheckHook runs so
-# until we have dependency mechanism in generic builder, we need to use this ugly hack.
-
 if [ -z "${dontUsePytestXdist-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
-    if [[ " ${preDistPhases[*]:-} " =~ " pytestCheckPhase " ]]; then
-        _preDistPhases="${preDistPhases[*]} "
-        _preDistPhases="${_preDistPhases/ pytestCheckPhase / pytestXdistHook pytestCheckPhase }"
-        if [[ -n "${__structuredAttrs-}" ]]; then
-            preDistPhases=()
-        else
-            preDistPhases=""
-        fi
-        appendToVar preDistPhases $_preDistPhases
-        unset _preDistPhases
-    else
-        appendToVar preDistPhases pytestXdistHook
-    fi
+    # The flags should be added before pytestCheckHook runs in preDistPhases.
+    preInstallCheckHooks+=(pytestXdistHook)
 fi


### PR DESCRIPTION
This is to unblock #352709 and remove all the special cases of `preFixupPhases` and `preDistPhases`.

My reasoning can be found in https://github.com/NixOS/nixpkgs/pull/352709#pullrequestreview-2411234446 and following. I did **not** move `pytestCheckHook` to the installCheckPhase - we don't need that and can still use `postInstallHooks` in pytest-forked and pytest-xdist.

I'm very sure that this works - but I couldn't verify against a broken case. Just removing the `if` etc. didn't show any obvious breakage in the few random packages that I looked at.

cc @ShamrockLee @emilazy 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
