### PR TITLE
stdenv: support multi-char separators in concatStringsSep

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -4,29 +4,6 @@ echo "Sourcing pytest-check-hook"
 declare -ar disabledTests
 declare -a disabledTestPaths
 
-function _concatSep {
-    local result
-    local sep="$1"
-    local -n arr=$2
-    for index in ${!arr[*]}; do
-        if [ $index -eq 0 ]; then
-            result="${arr[index]}"
-        else
-            result+=" $sep ${arr[index]}"
-        fi
-    done
-    echo "$result"
-}
-
-function _pytestComputeDisabledTestsString() {
-    declare -a tests
-    local tests=($1)
-    local prefix="not "
-    prefixed=("${tests[@]/#/$prefix}")
-    result=$(_concatSep "and" prefixed)
-    echo "$result"
-}
-
 function pytestCheckPhase() {
     echo "Executing pytestCheckPhase"
     runHook preCheck
@@ -34,7 +11,7 @@ function pytestCheckPhase() {
     # Compose arguments
     args=" -m pytest"
     if [ -n "$disabledTests" ]; then
-        disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
+        disabledTestsString="not $(concatStringsSep " and not " disabledTests)"
         args+=" -k \""$disabledTestsString"\""
     fi
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -432,6 +432,11 @@ concatTo() {
 # $ flags=("lorem ipsum" "dolor" "sit amet")
 # $ concatStringsSep ";" flags
 # lorem ipsum;dolor;sit amet
+#
+# Also supports multi-character separators;
+# $ flags=("lorem ipsum" "dolor" "sit amet")
+# $ concatStringsSep " and " flags
+# lorem ipsum and dolor and sit amet
 concatStringsSep() {
     local sep="$1"
     local name="$2"
@@ -443,11 +448,15 @@ concatStringsSep() {
                 echo "concatStringsSep(): ERROR: trying to use concatStringsSep on an associative array." >&2
                 return 1 ;;
             -a*)
-                local IFS="$sep"
-                echo -n "${nameref[*]}" ;;
+                # \036 is the "record separator" character. We assume that this will never need to be part of
+                # an argument string we create here. If anyone ever hits this limitation: Feel free to refactor.
+                local IFS=$'\036' ;;
             *)
-                echo -n "${nameref// /"${sep}"}" ;;
+                local IFS=" " ;;
+
         esac
+        local ifs_separated="${nameref[*]}"
+        echo -n "${ifs_separated//"$IFS"/"$sep"}"
     fi
 }
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -161,6 +161,14 @@ let
           arrayWithSep="$(concatStringsSep "&" array)"
           [[ "$arrayWithSep" == "lorem ipsum&dolor&sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum&dolor&sit amet'" && false)
 
+          array=("lorem ipsum" "dolor" "sit amet")
+          arrayWithSep="$(concatStringsSep "++" array)"
+          [[ "$arrayWithSep" == "lorem ipsum++dolor++sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum++dolor++sit amet'" && false)
+
+          array=("lorem ipsum" "dolor" "sit amet")
+          arrayWithSep="$(concatStringsSep " and " array)"
+          [[ "$arrayWithSep" == "lorem ipsum and dolor and sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum and dolor and sit amet'" && false)
+
           touch $out
         '';
       };


### PR DESCRIPTION
One prominent use-case for this is pytestCheckHook. This will help making it work with structuredAttrs in the future.

As discussed in https://github.com/NixOS/nixpkgs/pull/347194/files#r1818073811.

cc @ShamrockLee @NixOS/stdenv 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
