### PR TITLE
freecad-qt6: Qt6 version (with wayland per default)

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -1,37 +1,38 @@
-{ lib
-, callPackage
-, cmake
-, coin3d
-, doxygen
-, eigen
-, fetchFromGitHub
-, fmt
-, gfortran
-, gts
-, hdf5
-, libf2c
-, libGLU
-, libredwg
-, libsForQt5
-, libspnav
-, libXmu
-, medfile
-, mpi
-, ninja
-, ode
-, opencascade-occt_7_6
-, pkg-config
-, python311Packages
-, spaceNavSupport ? stdenv.hostPlatform.isLinux
-, ifcSupport ? false
-, stdenv
-, swig
-, vtk
-, wrapGAppsHook3
-, xercesc
-, yaml-cpp
-, zlib
-, withWayland ? false
+{
+  lib,
+  callPackage,
+  cmake,
+  coin3d,
+  doxygen,
+  eigen,
+  fetchFromGitHub,
+  fmt,
+  gfortran,
+  gts,
+  hdf5,
+  libf2c,
+  libGLU,
+  libredwg,
+  libsForQt5,
+  libspnav,
+  libXmu,
+  medfile,
+  mpi,
+  ninja,
+  ode,
+  opencascade-occt_7_6,
+  pkg-config,
+  python311Packages,
+  spaceNavSupport ? stdenv.hostPlatform.isLinux,
+  ifcSupport ? false,
+  stdenv,
+  swig,
+  vtk,
+  wrapGAppsHook3,
+  xercesc,
+  yaml-cpp,
+  zlib,
+  withWayland ? false,
 }:
 let
   opencascade-occt = opencascade-occt_7_6;
@@ -63,146 +64,146 @@ let
     ;
   freecad-utils = callPackage ./freecad-utils.nix { };
 in
-freecad-utils.makeCustomizable (stdenv.mkDerivation (finalAttrs: {
-  pname = "freecad";
-  version = "1.0.0";
+freecad-utils.makeCustomizable (
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "freecad";
+    version = "1.0.0";
 
-  src = fetchFromGitHub {
-    owner = "FreeCAD";
-    repo = "FreeCAD";
-    rev = finalAttrs.version;
-    hash = "sha256-u7RYSImUMAgKaAQSAGCFha++RufpZ/QuHAirbSFOUCI=";
-    fetchSubmodules = true;
-  };
+    src = fetchFromGitHub {
+      owner = "FreeCAD";
+      repo = "FreeCAD";
+      rev = finalAttrs.version;
+      hash = "sha256-u7RYSImUMAgKaAQSAGCFha++RufpZ/QuHAirbSFOUCI=";
+      fetchSubmodules = true;
+    };
 
-  nativeBuildInputs = [
-    cmake
-    ninja
-    pkg-config
-    pyside2-tools
-    gfortran
-    wrapQtAppsHook
-    wrapGAppsHook3
-  ];
-
-  buildInputs =
-    [
-      gitpython # for addon manager
-      boost
-      coin3d
-      doxygen
-      eigen
-      fmt
-      gts
-      hdf5
-      libGLU
-      libXmu
-      libf2c
-      matplotlib
-      medfile
-      mpi
-      ode
-      opencascade-occt
-      pivy
-      ply # for openSCAD file support
-      pybind11
-      pycollada
-      pyside2
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
       pyside2-tools
-      python
-      pyyaml # (at least for) PyrateWorkbench
-      qtbase
-      qttools
-      qtwayland
-      qtwebengine
-      qtxmlpatterns
-      scipy
-      shiboken2
-      soqt
-      swig
-      vtk
-      xercesc
-      yaml-cpp
-      zlib
-    ]
-    ++ lib.optionals spaceNavSupport [
-      libspnav
-      qtx11extras
-    ]
-    ++ lib.optionals ifcSupport [
-      ifcopenshell
+      gfortran
+      wrapQtAppsHook
+      wrapGAppsHook3
     ];
 
-  patches = [
-    ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
-    ./0002-FreeCad-OndselSolver-pkgconfig.patch
-    ./0003-Gui-take-in-account-module-path-argument.patch
-  ];
+    buildInputs =
+      [
+        gitpython # for addon manager
+        boost
+        coin3d
+        doxygen
+        eigen
+        fmt
+        gts
+        hdf5
+        libGLU
+        libXmu
+        libf2c
+        matplotlib
+        medfile
+        mpi
+        ode
+        opencascade-occt
+        pivy
+        ply # for openSCAD file support
+        pybind11
+        pycollada
+        pyside2
+        pyside2-tools
+        python
+        pyyaml # (at least for) PyrateWorkbench
+        qtbase
+        qttools
+        qtwayland
+        qtwebengine
+        qtxmlpatterns
+        scipy
+        shiboken2
+        soqt
+        swig
+        vtk
+        xercesc
+        yaml-cpp
+        zlib
+      ]
+      ++ lib.optionals spaceNavSupport [
+        libspnav
+        qtx11extras
+      ]
+      ++ lib.optionals ifcSupport [
+        ifcopenshell
+      ];
 
-  cmakeFlags = [
-    "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
-    "-DBUILD_FLAT_MESH:BOOL=ON"
-    "-DBUILD_QT5=ON"
-    "-DBUILD_DRAWING=ON"
-    "-DBUILD_FLAT_MESH:BOOL=ON"
-    "-DINSTALL_TO_SITEPACKAGES=OFF"
-    "-DFREECAD_USE_PYBIND11=ON"
-    "-DSHIBOKEN_INCLUDE_DIR=${shiboken2}/include"
-    "-DSHIBOKEN_LIBRARY=Shiboken2::libshiboken"
-    (
-      "-DPYSIDE_INCLUDE_DIR=${pyside2}/include"
-      + ";${pyside2}/include/PySide2/QtCore"
-      + ";${pyside2}/include/PySide2/QtWidgets"
-      + ";${pyside2}/include/PySide2/QtGui"
-    )
-    "-DPYSIDE_LIBRARY=PySide2::pyside2"
-  ];
+    patches = [
+      ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+      ./0002-FreeCad-OndselSolver-pkgconfig.patch
+      ./0003-Gui-take-in-account-module-path-argument.patch
+    ];
 
-  # This should work on both x86_64, and i686 linux
-  preBuild = ''
-    export NIX_LDFLAGS="-L${gfortran.cc.lib}/lib64 -L${gfortran.cc.lib}/lib $NIX_LDFLAGS";
-  '';
+    cmakeFlags = [
+      "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
+      "-DBUILD_FLAT_MESH:BOOL=ON"
+      "-DBUILD_QT5=ON"
+      "-DBUILD_DRAWING=ON"
+      "-DBUILD_FLAT_MESH:BOOL=ON"
+      "-DINSTALL_TO_SITEPACKAGES=OFF"
+      "-DFREECAD_USE_PYBIND11=ON"
+      "-DSHIBOKEN_INCLUDE_DIR=${shiboken2}/include"
+      "-DSHIBOKEN_LIBRARY=Shiboken2::libshiboken"
+      (
+        "-DPYSIDE_INCLUDE_DIR=${pyside2}/include"
+        + ";${pyside2}/include/PySide2/QtCore"
+        + ";${pyside2}/include/PySide2/QtWidgets"
+        + ";${pyside2}/include/PySide2/QtGui"
+      )
+      "-DPYSIDE_LIBRARY=PySide2::pyside2"
+    ];
 
-  preConfigure = ''
-    qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
-  '';
+    # This should work on both x86_64, and i686 linux
+    preBuild = ''
+      export NIX_LDFLAGS="-L${gfortran.cc.lib}/lib64 -L${gfortran.cc.lib}/lib $NIX_LDFLAGS";
+    '';
 
-  qtWrapperArgs =
-    [
+    preConfigure = ''
+      qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
+    '';
+
+    qtWrapperArgs = [
       "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
       "--prefix PATH : ${libredwg}/bin"
-    ]
-    ++ lib.optionals (!withWayland) [ "--set QT_QPA_PLATFORM xcb" ];
+    ] ++ lib.optionals (!withWayland) [ "--set QT_QPA_PLATFORM xcb" ];
 
-  postFixup = ''
-    mv $out/share/doc $out
-    ln -s $out/bin/FreeCAD $out/bin/freecad
-    ln -s $out/bin/FreeCADCmd $out/bin/freecadcmd
-  '';
-
-  passthru.tests = callPackage ./tests {};
-
-  meta = {
-    homepage = "https://www.freecad.org";
-    description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
-    longDescription = ''
-      FreeCAD is an open-source parametric 3D modeler made primarily to design
-      real-life objects of any size. Parametric modeling allows you to easily
-      modify your design by going back into your model history and changing its
-      parameters.
-
-      FreeCAD allows you to sketch geometry constrained 2D shapes and use them
-      as a base to build other objects. It contains many components to adjust
-      dimensions or extract design details from 3D models to create high quality
-      production ready drawings.
-
-      FreeCAD is designed to fit a wide range of uses including product design,
-      mechanical engineering and architecture. Whether you are a hobbyist, a
-      programmer, an experienced CAD user, a student or a teacher, you will feel
-      right at home with FreeCAD.
+    postFixup = ''
+      mv $out/share/doc $out
+      ln -s $out/bin/FreeCAD $out/bin/freecad
+      ln -s $out/bin/FreeCADCmd $out/bin/freecadcmd
     '';
-    license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ srounce ];
-    platforms = lib.platforms.linux;
-  };
-}))
+
+    passthru.tests = callPackage ./tests { };
+
+    meta = {
+      homepage = "https://www.freecad.org";
+      description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
+      longDescription = ''
+        FreeCAD is an open-source parametric 3D modeler made primarily to design
+        real-life objects of any size. Parametric modeling allows you to easily
+        modify your design by going back into your model history and changing its
+        parameters.
+
+        FreeCAD allows you to sketch geometry constrained 2D shapes and use them
+        as a base to build other objects. It contains many components to adjust
+        dimensions or extract design details from 3D models to create high quality
+        production ready drawings.
+
+        FreeCAD is designed to fit a wide range of uses including product design,
+        mechanical engineering and architecture. Whether you are a hobbyist, a
+        programmer, an experienced CAD user, a student or a teacher, you will feel
+        right at home with FreeCAD.
+      '';
+      license = lib.licenses.lgpl2Plus;
+      maintainers = with lib.maintainers; [ srounce ];
+      platforms = lib.platforms.linux;
+    };
+  })
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16129,6 +16129,7 @@ with pkgs;
   flightgear = libsForQt5.callPackage ../games/flightgear { };
 
   freecad-wayland = freecad.override { withWayland = true; };
+  freecad-qt6 = freecad.override { withWayland = true; qtVersion = 6; };
 
   freeciv = callPackage ../games/freeciv {
     sdl2Client = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A "parallel" package for FreeCAD built with Qt6 only, intended as "staging" to eventually supersede the Qt5 version permanently. ~~Could probably be~~ done on a shared code base (of `package.nix`)~~, but that would be more disruptive~~.

It appears to work well by just "naively" replacing/removing Qt5 libraries and build switches.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
