### PR TITLE
forgejo-runner: 4.0.1 -> 5.0.3, various quality-of-life improvements

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -1,9 +1,9 @@
-{ lib
-, buildGoModule
-, fetchFromGitea
-, testers
-, forgejo-runner
-, nixosTests
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+  nixosTests,
+  versionCheckHook,
 }:
 
 let
@@ -37,12 +37,13 @@ buildGoModule rec {
     "-skip ${lib.concatStringsSep "|" disabledTests}"
   ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = [ "--version" ];
+
   passthru.tests = {
     inherit (nixosTests.forgejo) sqlite3;
-    version = testers.testVersion {
-      package = forgejo-runner;
-      version = src.rev;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -53,7 +53,11 @@ buildGoModule rec {
     homepage = "https://code.forgejo.org/forgejo/runner";
     changelog = "https://code.forgejo.org/forgejo/runner/src/tag/${src.rev}/RELEASE-NOTES.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ kranzes emilylange ];
+    maintainers = with maintainers; [
+      kranzes
+      emilylange
+      christoph-heiss
+    ];
     mainProgram = "act_runner";
   };
 }

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildGoModule,
   fetchFromGitea,
@@ -45,7 +46,9 @@ buildGoModule rec {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.sqlite3 = nixosTests.forgejo.sqlite3;
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      sqlite3 = nixosTests.forgejo.sqlite3;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -6,6 +6,13 @@
 , nixosTests
 }:
 
+let
+  # tests which assume network access in some form
+  disabledTests = [
+    "Test_runCreateRunnerFile"
+    "Test_ping"
+  ];
+in
 buildGoModule rec {
   pname = "forgejo-runner";
   version = "5.0.3";
@@ -26,7 +33,9 @@ buildGoModule rec {
     "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=${src.rev}"
   ];
 
-  doCheck = false; # Test try to lookup code.forgejo.org.
+  checkFlags = [
+    "-skip ${lib.concatStringsSep "|" disabledTests}"
+  ];
 
   passthru.tests = {
     inherit (nixosTests.forgejo) sqlite3;

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -8,17 +8,17 @@
 
 buildGoModule rec {
   pname = "forgejo-runner";
-  version = "4.0.1";
+  version = "5.0.3";
 
   src = fetchFromGitea {
     domain = "code.forgejo.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${version}";
-    hash = "sha256-hG8gCohf+U8T9A9Abqey9upErJklbCp8HuzHQKFcu3E=";
+    hash = "sha256-c1s2n4s2LY4KvQrPZJpAnXzJCTe6Fbc0cf1plwHZPiA=";
   };
 
-  vendorHash = "sha256-yRXI9/LVj4f7qFdScqfpL5WCsK+lJXa6yQmdbUhfrKY=";
+  vendorHash = "sha256-DQcVknodbVlHygJkrGSfVGPKXR9kLGeyivNjYmjtFNs=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitea,
   nixosTests,
   versionCheckHook,
+  nix-update-script,
 }:
 
 let
@@ -42,8 +43,9 @@ buildGoModule rec {
   versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
   versionCheckProgramArg = [ "--version" ];
 
-  passthru.tests = {
-    inherit (nixosTests.forgejo) sqlite3;
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.sqlite3 = nixosTests.forgejo.sqlite3;
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://code.forgejo.org/forgejo/runner/src/branch/main/RELEASE-NOTES.md#5.0.3 (and following)

Also includes some quality-of-life improvements to the package itself:
- enable running package tests by only disabling those that require network access
- add nix-update-script passthru for automated updates
- use (new-ish) `versionCheckHook` for running the `--version` check

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
