### PR TITLE
splice.nix: Handle maybe throw sets

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -25,8 +25,21 @@ let
     , pkgsHostHost
     , pkgsHostTarget
     , pkgsTargetTarget
-    }:
+    }@args:
     let
+      tryGetAttrs = value0:
+        let
+          inherit (builtins.tryEval value0) success value;
+        in
+            lib.optionalAttrs success value;
+
+      pkgsBuildBuild = tryGetAttrs args.pkgsBuildBuild;
+      pkgsBuildHost = tryGetAttrs args.pkgsBuildHost;
+      pkgsBuildTarget = tryGetAttrs args.pkgsBuildTarget;
+      pkgsHostHost = tryGetAttrs args.pkgsHostHost;
+      pkgsHostTarget = tryGetAttrs args.pkgsHostTarget;
+      pkgsTargetTarget = tryGetAttrs args.pkgsTargetTarget;
+
       mash =
         # Other pkgs sets
         pkgsBuildBuild // pkgsBuildTarget // pkgsHostHost // pkgsTargetTarget


### PR DESCRIPTION
The [mash](https://www.github.com/NixOS/nixpkgs/blob/86fcbea3f26cf17e4d6560ec722f3ca893053a89/pkgs/top-level/splice.nix#L32) will trigger the throw in `pkgsBuildX` in the [recursive `spliceReal`](https://www.github.com/NixOS/nixpkgs/blob/a4b5e0bb8f309fb1623d8e619c1610df75761c12/pkgs/top-level/splice.nix#L82) of `pkgsi686Linux`.

```
$ nix repl --file . --system aarch64-linux
nix-repl> :p pkgsCross.gnu64.__splicedPackages.pkgsi686Linux.bash.__spliced
{
  hostHost = «derivation /nix/store/0w1mahsn6biqmasm5vg85a9lh5rvyr9j-bash-i686-unknown-linux-gnu-5.2p37.drv»;
  hostTarget = «repeated»;
}
```

Fixes

```sh
$ nix eval --impure --expr '(import ./. { localSystem.system = "aarch64-linux"; crossSystem.system = "x86_64-linux"; config.allowUnfree = true; }).steam'
«error: i686 Linux package set can only be used with the x86 family.»
```

Alternatively `pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix` could change all `pkgsi686Linux` to `pkgsHostTarget.pkgsi686Linux`.

Concerned about performance

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
