### PR TITLE
ntfy-alertmanager: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/by-name/nt/ntfy-alertmanager/package.nix
+++ b/pkgs/by-name/nt/ntfy-alertmanager/package.nix
@@ -16,12 +16,14 @@ buildGoModule rec {
   vendorHash = "sha256-WKImEc7FvZm/6noC2+Lz4g+ASFEuRBE8nzTEDbXaWic=";
 
   meta = with lib; {
-    description = "A bridge between ntfy and Alertmanager.";
+    description = "A bridge between ntfy and Alertmanager";
     homepage = "https://git.xenrox.net/~xenrox/ntfy-alertmanager";
     license = licenses.agpl3Only;
+    mainProgram = "ntfy-alertmanager";
     maintainers = with maintainers; [
       bleetube
       fpletz
     ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/nt/ntfy-alertmanager/package.nix
+++ b/pkgs/by-name/nt/ntfy-alertmanager/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "ntfy-alertmanager";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchurl {
     url = "https://git.xenrox.net/~xenrox/ntfy-alertmanager/refs/download/v${version}/ntfy-alertmanager-${version}.tar.gz";
-    hash = "sha256-8VDHeK77dcbATSFfqknlhMSP93OlDNmkzRJxLN4rCVE=";
+    hash = "sha256-5rQzJZ0BaLtfj2MfyZZJ3PEiWnaTjWOMlsJYeYENW7U=";
   };
 
-  vendorHash = "sha256-WKImEc7FvZm/6noC2+Lz4g+ASFEuRBE8nzTEDbXaWic=";
+  vendorHash = "sha256-8a6dvBERegpFYFHQGJppz5tlQioQAudCe3/Q7vro+ZI=";
 
   meta = with lib; {
     description = "A bridge between ntfy and Alertmanager";


### PR DESCRIPTION
I added mainProgram and platforms to meta atrributes as well. Apologies to fpletz for missing his comment about adding mainProgram the first time around!

[Release notes](https://git.xenrox.net/~xenrox/ntfy-alertmanager/refs/v0.4.0):

**Added**

- Support self-signed certificates for ntfy.
- Priority setting for resolved alerts.
- The config file can contain an "include" directive which will import the
  linked file into the main configuration.
- The alert's GeneratorURL can be displayed in the notification.
- A label can set its own ntfy topic.
- The topic can be set through URL query parameters as well.

**Changed**

- Multiple logging improvements - structured logging with "log/slog".
- The docker compose file uses valkey instead of redis.
- The ntfy server is set separately from the topic in the config file.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
