### PR TITLE
youplot: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/by-name/yo/youplot/Gemfile.lock
+++ b/pkgs/by-name/yo/youplot/Gemfile.lock
@@ -1,13 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    enumerable-statistics (2.0.7)
+    csv (3.3.0)
+    enumerable-statistics (2.0.8)
     unicode_plot (0.0.5)
       enumerable-statistics (>= 2.0.1)
-    youplot (0.4.5)
+    youplot (0.4.6)
+      csv
       unicode_plot (>= 0.0.5)
 
 PLATFORMS
+  x86_64-linux
   arm64-darwin-22
   ruby
 
@@ -15,4 +18,4 @@ DEPENDENCIES
   youplot
 
 BUNDLED WITH
-   2.5.3
+   2.5.16

--- a/pkgs/by-name/yo/youplot/gemset.nix
+++ b/pkgs/by-name/yo/youplot/gemset.nix
@@ -1,13 +1,23 @@
 {
+  csv = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zfn40dvgjk1xv1z8l11hr9jfg3jncwsc9yhzsz4l4rivkpivg8b";
+      type = "gem";
+    };
+    version = "3.3.0";
+  };
   enumerable-statistics = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0dlnfncz0lbyczakgdlys44pksj6h447npj665xk41b36y0lbf7f";
+      sha256 = "1cqksgv0cf69cd30kxk2r0lq1y784wn5nvlyabfqilf1vvy6j38y";
       type = "gem";
     };
-    version = "2.0.7";
+    version = "2.0.8";
   };
   unicode_plot = {
     dependencies = ["enumerable-statistics"];
@@ -21,14 +31,14 @@
     version = "0.0.5";
   };
   youplot = {
-    dependencies = ["unicode_plot"];
+    dependencies = ["csv" "unicode_plot"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0imy65wjkgdkpqfympbz8lp2ih866538vk55fwz9a909ib9sbdri";
+      sha256 = "1p1vbb7p4h5a4r2rwl64gwv6cmf350grjn97zrpjhvrjih81y3yg";
       type = "gem";
     };
-    version = "0.4.5";
+    version = "0.4.6";
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/red-data-tools/YouPlot/releases/tag/v0.4.6

currently packaged version emits a warning about `csv` on every invocation. This is fixed in 0.4.6.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
