### PR TITLE
pointless: init at 1.11.0-unstable-2024-03-23

### DIFF
--- a/pkgs/by-name/po/pointless/package.nix
+++ b/pkgs/by-name/po/pointless/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  rustPlatform,
+  yarnConfigHook,
+  nodejs,
+  cargo-tauri_1,
+  pkg-config,
+  wrapGAppsHook3,
+  libsoup,
+  webkitgtk_4_0,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pointless";
+  # typescript is not resolved in yarn.lock in 1.11.0
+  version = "1.11.0-unstable-2024-03-23";
+
+  src = fetchFromGitHub {
+    owner = "kkoomen";
+    repo = "pointless";
+    rev = "66e7f479cef4b9a6bea8ea64f6fca8b9725af8f4";
+    hash = "sha256-DIwVOhEWjLbcdCIv33yXHG3s6joeLZ7aCAUWGeso9i8=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-9h6JBkTC9VG4LF1JjNi62S18RCSb3sPHCrxdfuTTUrk=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    hash = "sha256-Ezv21J5GIB331Zuxls7O12xOFWC5a/YSXyEABK6ftcQ=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    nodejs
+    rustPlatform.cargoSetupHook
+    cargo-tauri_1.hook
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libsoup
+    webkitgtk_4_0
+  ];
+
+  meta = {
+    description = "Endless drawing canvas desktop app made with Tauri (Rust) and React";
+    homepage = "https://github.com/kkoomen/pointless";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "pointless";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/c65a91d2-bb00-4980-879e-01f06a70dc04)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
