### PR TITLE
coredns: allow specifying position for externalPlugins

### DIFF
--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -10,28 +10,9 @@
 }:
 
 let
-  attrsToPlugins =
-    attrs:
-    builtins.map (
-      {
-        name,
-        repo,
-        version,
-      }:
-      "${name}:${repo}"
-    ) attrs;
-  attrsToSources =
-    attrs:
-    builtins.map (
-      {
-        name,
-        repo,
-        version,
-      }:
-      "${repo}@${version}"
-    ) attrs;
-in
-buildGoModule rec {
+  attrsToSources = attrs:
+    builtins.map ({repo, version, ...}: "${repo}@${version}") attrs;
+in buildGoModule rec {
   pname = "coredns";
   version = "1.11.3";
 
@@ -53,7 +34,32 @@ buildGoModule rec {
 
   # Override the go-modules fetcher derivation to fetch plugins
   modBuildPhase = ''
-    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do echo $plugin >> plugin.cfg; done
+    cp plugin.cfg plugin.cfg.orig
+    ${(lib.concatMapStringsSep "\n" (plugin:
+      let
+        position = plugin.position or "end-of-file";
+        formatPlugin = {name, repo, ...}: "${name}:${repo}";
+      in if position == "end-of-file" then
+        "echo ${formatPlugin plugin} >> plugin.cfg"
+      else if position == "start-of-file" then
+        "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
+      else if lib.hasAttrByPath ["before"] position then
+        "sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg"
+      else if lib.hasAttrByPath ["after"] position then
+        "sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg"
+      else
+        throw ''
+          Unsupported position value in externalPlugin:
+            ${builtins.toJSON plugin}.
+          Valid values for position attr are:
+            - position = "end-of-file" (the default)
+            - position = "start-of-file"
+            - position.before = "{other plugin}"
+            - position.after = "{other plugin}"
+        ''
+      )
+      externalPlugins)}
+    diff -u plugin.cfg.orig plugin.cfg || true
     for src in ${builtins.toString (attrsToSources externalPlugins)}; do go get $src; done
     GOOS= GOARCH= go generate
     go mod vendor

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
           formatPlugin = { name, repo, ... }: "${name}:${repo}";
         in
         if position == "end-of-file" then
-          "echo ${formatPlugin plugin} >> plugin.cfg"
+          "echo '${formatPlugin plugin}' >> plugin.cfg"
         else if position == "start-of-file" then
           "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
         else if lib.hasAttrByPath [ "before" ] position then

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -47,9 +47,21 @@ buildGoModule rec {
         else if position == "start-of-file" then
           "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
         else if lib.hasAttrByPath [ "before" ] position then
-          "sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg"
+          ''
+            if ! grep -q '^${position.before}:' plugin.cfg; then
+              echo 'Failed to insert ${plugin.name} before ${position.before} in plugin.cfg: ${position.before} is not in plugin.cfg'
+              exit 1
+            fi
+            sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg
+          ''
         else if lib.hasAttrByPath [ "after" ] position then
-          "sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg"
+          ''
+            if ! grep -q '^${position.after}:' plugin.cfg; then
+              echo 'Failed to insert ${plugin.name} after ${position.after} in plugin.cfg: ${position.after} is not in plugin.cfg'
+              exit 1
+            fi
+            sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg
+          ''
         else
           throw ''
             Unsupported position value in externalPlugin:


### PR DESCRIPTION
This adds a new `position` attr in `externalPlugins` that allows users to control where their external plugins are placed in the `plugin.cfg` file.

Valid values are:

  - `position = "end-of-file"` (the default)
  - `position = "end-of-file"`
  - `position.before = "{other plugin}"`
  - `position.after = "{other plugin}"`

Controlling the order of the items in `plugin.cfg` is very important when installing an external plugin into CoreDNS. This is because the order of items in this file controls the order of execution and therefor priority of plugins. See [the header comment of `plugin.cfg`](https://github.com/coredns/coredns/blob/7429380b1cacebde73084ad3cb6fb676c69bd6b8/plugin.cfg#L1-L5)

Fixes #354869 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

I tested my changes with the following file:

<details>
<summary>__scratch/coredns-test.nix</summary>

```nix
let
  pkgs = import ./.. {};
in
  pkgs.coredns.override {
    externalPlugins = [
      {
        name = "blocklist0";
        repo = "github.com/relekang/coredns-blocklist";
        version = "v1.12.0";
      }
      {
        name = "blocklist1";
        repo = "github.com/relekang/coredns-blocklist";
        version = "v1.12.0";
        position = "end-of-file";
      }
      {
        name = "blocklist2";
        repo = "github.com/relekang/coredns-blocklist";
        version = "v1.12.0";
        position = "start-of-file";
      }
      {
        name = "blocklist3";
        repo = "github.com/relekang/coredns-blocklist";
        version = "v1.12.0";
        position.before = "hosts";
      }
      {
        name = "blocklist4";
        repo = "github.com/relekang/coredns-blocklist";
        version = "v1.12.0";
        position.after = "hosts";
      }
      # This one generates an error to test the error case
      # {
      #   name = "blocklist4";
      #   repo = "github.com/relekang/coredns-blocklist";
      #   version = "v1.12.0";
      #   position = "bogus";
      # }
    ];
    vendorHash = "sha256-omff6rCwUqU0Kn1vozabT4xMT34B7XRpLnWCb5kNjJU=";
  }
```

</details>

I ran this with the following command and I inspected the contents of `result/plugin.cfg`

```sh
nix build -L --file __scratch/coredns-test.nix goModules
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
