### PR TITLE
vimPlugins: nvimRequireChecks and nvimSkipModules for new nvimRequireCheckHook

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1584,7 +1584,8 @@ in
   };
 
   lightline-bufferline = super.lightline-bufferline.overrideAttrs {
-    dependencies = with self; [ nvim-web-devicons ];
+    # Requires web-devicons but mini.icons can mock them up
+    nativeCheckInputs = [ self.nvim-web-devicons ];
   };
 
   lir-nvim = super.lir-nvim.overrideAttrs {
@@ -2349,6 +2350,11 @@ in
       "neoclip.fzf"
       "neoclip.telescope"
     ];
+  };
+
+  nvim-nonicons = super.nvim-nonicons.overrideAttrs {
+    # Requires web-devicons but mini.icons can mock them up
+    nativeCheckInputs = [ self.nvim-web-devicons ];
   };
 
   nvim-nu = super.nvim-nu.overrideAttrs {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -145,6 +145,14 @@ let
   luaPackages = neovim-unwrapped.lua.pkgs;
 in
 {
+  aerial-nvim = super.aerial-nvim.overrideAttrs {
+    # optional dependencies
+    nvimSkipModule = [
+      "lualine.components.aerial"
+      "telescope._extensions.aerial"
+    ];
+  };
+
   alpha-nvim = super.alpha-nvim.overrideAttrs {
     nvimRequireCheck = "alpha";
   };
@@ -162,6 +170,14 @@ in
     nvimRequireCheck = "astrotheme";
   };
 
+  asyncrun-vim = super.asyncrun-vim.overrideAttrs {
+    nvimSkipModule = [
+      # vim plugin with optional toggleterm integration
+      "asyncrun.toggleterm"
+      "asyncrun.toggleterm2"
+    ];
+  };
+
   animation-nvim = super.animation-nvim.overrideAttrs {
     dependencies = [ self.middleclass ];
     nvimRequireCheck = "animation";
@@ -170,6 +186,15 @@ in
   autosave-nvim = super.autosave-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "autosave";
+  };
+
+  auto-session = super.auto-session.overrideAttrs {
+    # optional telescope dependency
+    nvimSkipModule = [
+      "auto-session.session-lens.actions"
+      "auto-session.session-lens.init"
+      "telescope._extensions.session-lens"
+    ];
   };
 
   avante-nvim = super.avante-nvim.overrideAttrs (
@@ -233,6 +258,26 @@ in
     }
   );
 
+  bamboo-nvim = super.bamboo-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires config table
+      "bamboo.colors"
+      "bamboo.terminal"
+      "bamboo.highlights"
+      "bamboo-light"
+      "bamboo-vulgaris"
+      "bamboo-multiplex"
+      # Optional modules
+      "lualine.themes.bamboo"
+      "barbecue.theme.bamboo"
+    ];
+  };
+
+  barbar-nvim = super.barbar-nvim.overrideAttrs {
+    # nvim-web-devicons dependency
+    nvimSkipModule = "bufferline.utils";
+  };
+
   barbecue-nvim = super.barbecue-nvim.overrideAttrs {
     dependencies = with self; [
       nvim-lspconfig
@@ -249,6 +294,15 @@ in
 
   base46 = super.base46.overrideAttrs {
     dependencies = [ self.nvchad-ui ];
+    # Requires global config setup
+    nvimSkipModule = [
+      "nvchad.configs.cmp"
+      "nvchad.configs.gitsigns"
+      "nvchad.configs.luasnip"
+      "nvchad.configs.mason"
+      "nvchad.configs.nvimtree"
+      "nvchad.configs.telescope"
+    ];
   };
 
   # The GitHub repository returns 404, which breaks the update script
@@ -268,6 +322,19 @@ in
 
   bluloco-nvim = super.bluloco-nvim.overrideAttrs {
     dependencies = [ self.lush-nvim ];
+  };
+
+  bufferline-nvim = super.bufferline-nvim.overrideAttrs {
+    # depends on bufferline.lua being loaded first
+    nvimSkipModule = [ "bufferline.commands" ];
+  };
+
+  catppuccin-nvim = super.catppuccin-nvim.overrideAttrs {
+    nvimSkipModule = [
+      "catppuccin.groups.integrations.noice"
+      "catppuccin.groups.integrations.feline"
+      "catppuccin.lib.vim.init"
+    ];
   };
 
   ccc-nvim = super.ccc-nvim.overrideAttrs {
@@ -346,6 +413,10 @@ in
     nvimRequireCheck = "cmake-tools";
   };
 
+  cmd-parser-nvim = super.cmd-parser-nvim.overrideAttrs {
+    nvimRequireCheck = "cmd-parser";
+  };
+
   cmp-ai = super.cmp-ai.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };
@@ -419,8 +490,27 @@ in
     dependencies = [ self.vimwiki ];
   };
 
+  cmp-vimtex = super.cmp-vimtex.overrideAttrs {
+    # We aren't bundling nvim-cmp
+    nvimSkipModule = "cmp_vimtex.search";
+  };
+
   cmp-zsh = super.cmp-zsh.overrideAttrs {
     dependencies = [ zsh ];
+  };
+
+  cobalt2-nvim = super.cobalt2-nvim.overrideAttrs {
+    dependencies = with self; [ colorbuddy-nvim ];
+    # Few broken themes
+    nvimSkipModule = [
+      "cobalt2.plugins.init"
+      "cobalt2.plugins.trouble"
+      "cobalt2.plugins.gitsigns"
+      "cobalt2.plugins.package-info"
+      "cobalt2.plugins.indent-blankline"
+      "cobalt2.plugins.marks"
+      "cobalt2.theme"
+    ];
   };
 
   coc-clangd = buildVimPlugin {
@@ -653,6 +743,11 @@ in
     ];
   };
 
+  context-vim = super.context-vim.overrideAttrs {
+    # Vim plugin with optional lua highlight module
+    nvimSkipModule = "context.highlight";
+  };
+
   CopilotChat-nvim = super.CopilotChat-nvim.overrideAttrs {
     dependencies = with self; [
       copilot-lua
@@ -806,6 +901,8 @@ in
 
   darkearth-nvim = super.darkearth-nvim.overrideAttrs {
     dependencies = [ self.lush-nvim ];
+    # Lua module used to build theme
+    nvimSkipModule = "shipwright_build";
   };
 
   ddc-filter-matcher_head = super.ddc-filter-matcher_head.overrideAttrs {
@@ -904,6 +1001,11 @@ in
     ];
   };
 
+  dropbar-nvim = super.dropbar-nvim.overrideAttrs {
+    # Requires global config table
+    nvimSkipModule = "dropbar.menu";
+  };
+
   efmls-configs-nvim = super.efmls-configs-nvim.overrideAttrs {
     dependencies = [ self.nvim-lspconfig ];
   };
@@ -929,6 +1031,16 @@ in
     };
   };
 
+  feline-nvim = super.feline-nvim.overrideAttrs {
+    nvimSkipModule = "minimal_init";
+  };
+
+  flash-nvim = super.flash-nvim.overrideAttrs {
+    # Docs require lazyvim
+    # dependencies = with self; [ lazy-nvim ];
+    nvimSkipModule = "flash.docs";
+  };
+
   flit-nvim = super.flit-nvim.overrideAttrs {
     dependencies = [ self.leap-nvim ];
     nvimRequireCheck = "flit";
@@ -936,6 +1048,8 @@ in
 
   flutter-tools-nvim = super.flutter-tools-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
+    # Optional nvim-dap module
+    nvimSkipModule = "flutter-tools.dap";
   };
 
   follow-md-links-nvim = super.follow-md-links-nvim.overrideAttrs {
@@ -1053,6 +1167,31 @@ in
     nvimRequireCheck = "git-worktree";
   };
 
+  go-nvim = super.go-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Null-ls
+      "go.null_ls"
+      # _GO_NVIM_CFG
+      "go.inlay"
+      "go.project"
+      "go.comment"
+      "go.tags"
+      "go.gotests"
+      "go.format"
+      # nvim-treesitter
+      "go.gotest"
+      "go.ginkgo"
+      "go.ts.go"
+      "go.ts.utils"
+      "go.ts.nodes"
+      "go.fixplurals"
+      # Luasnip
+      "go.snips"
+      "snips.all"
+      "snips.go"
+    ];
+  };
+
   guard-collection = super.guard-collection.overrideAttrs {
     dependencies = [ self.guard-nvim ];
   };
@@ -1111,6 +1250,14 @@ in
       rev = "v${himalaya.version}";
       sha256 = "W+91hnNeS6WkDiR9r1s7xPTK9JlCWiVkI/nXVYbepY0=";
     };
+    # vim plugin with optional telescope lua module
+    nvimSkipModule = "himalaya.folder.pickers.telescope";
+  };
+
+  hover-nvim = super.hover-nvim.overrideAttrs {
+    # Single provider issue with reading from config
+    # /lua/hover/providers/fold_preview.lua:27: attempt to index local 'config' (a nil value)
+    nvimSkipModule = "hover.providers.fold_preview";
   };
 
   hunk-nvim = super.hunk-nvim.overrideAttrs {
@@ -1153,6 +1300,20 @@ in
     '';
 
     nvimRequireCheck = "image";
+  };
+
+  indent-blankline-nvim = super.indent-blankline-nvim.overrideAttrs {
+    # Meta file
+    nvimSkipModule = "ibl.config.types";
+  };
+
+  instant-nvim = super.instant-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires global variable config
+      "instant"
+      # instant/log.lua:12: cannot use '...' outside a vararg function near '...'
+      "instant.log"
+    ];
   };
 
   intellitab-nvim = super.intellitab-nvim.overrideAttrs {
@@ -1230,6 +1391,23 @@ in
   LazyVim = super.LazyVim.overrideAttrs {
     # Any other dependency is optional
     dependencies = [ self.lazy-nvim ];
+    nvimSkipModule = [
+      # attempt to index global 'LazyVim' (a nil value)
+      "lazyvim.config.keymaps"
+      "lazyvim.plugins.extras.ai.tabnine"
+      "lazyvim.plugins.extras.coding.blink"
+      "lazyvim.plugins.extras.coding.luasnip"
+      "lazyvim.plugins.extras.editor.fzf"
+      "lazyvim.plugins.extras.editor.telescope"
+      "lazyvim.plugins.extras.formatting.prettier"
+      "lazyvim.plugins.extras.lang.markdown"
+      "lazyvim.plugins.extras.lang.omnisharp"
+      "lazyvim.plugins.extras.lang.python"
+      "lazyvim.plugins.extras.lang.svelte"
+      "lazyvim.plugins.extras.lang.typescript"
+      "lazyvim.plugins.init"
+      "lazyvim.plugins.xtras"
+    ];
   };
 
   lazy-lsp-nvim = super.lazy-lsp-nvim.overrideAttrs {
@@ -1284,6 +1462,10 @@ in
 
   legendary-nvim = super.legendary-nvim.overrideAttrs {
     dependencies = [ self.sqlite-lua ];
+    nvimSkipModule = [
+      "vimdoc-gen"
+      "vimdocrc"
+    ];
   };
 
   lens-vim = super.lens-vim.overrideAttrs {
@@ -1317,6 +1499,12 @@ in
       sqlite-lua
       telescope-nvim
       plenary-nvim
+    ];
+    nvimSkipModule = [
+      # Attempt to connect to sqlitedb
+      "lispdocs.db"
+      "lispdocs.finder"
+      "lispdocs"
     ];
   };
 
@@ -1371,6 +1559,11 @@ in
 
   luasnip-latex-snippets-nvim = super.luasnip-latex-snippets-nvim.overrideAttrs {
     dependencies = [ self.luasnip ];
+    # E5108: /luasnip-latex-snippets/luasnippets/tex/utils/init.lua:3: module 'luasnip-latex-snippets.luasnippets.utils.conditions' not found:
+    # Need to fix upstream
+    nvimSkipModule = [
+      "luasnip-latex-snippets.luasnippets.tex.utils.init"
+    ];
   };
 
   lz-n = neovimUtils.buildNeovimPlugin {
@@ -1446,9 +1639,19 @@ in
     nvimRequireCheck = "mason-lspconfig";
   };
 
+  mason-nvim = super.mason-nvim.overrideAttrs {
+    # lua/mason-vendor/zzlib/inflate-bwo.lua:15: 'end' expected near '&'
+    nvimSkipModule = "mason-vendor.zzlib.inflate-bwo";
+  };
+
   mason-tool-installer-nvim = super.mason-tool-installer-nvim.overrideAttrs {
     dependencies = [ self.mason-nvim ];
     nvimRequireCheck = "mason-tool-installer";
+  };
+
+  material-vim = super.material-vim.overrideAttrs {
+    # vim plugin with optional lualine module
+    nvimSkipModule = "material.lualine";
   };
 
   meson = buildVimPlugin {
@@ -1494,6 +1697,19 @@ in
     dependencies = [ self.plenary-nvim ];
     # Requires setup call and has optional nvim-cmp dependency
     nvimRequireCheck = "mkdnflow";
+  };
+
+  modicator-nvim = super.modicator-nvim.overrideAttrs {
+    # Optional lualine integration
+    nvimSkipModule = "modicator.integration.lualine.init";
+  };
+
+  molten-nvim = super.molten-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Optional image providers
+      "load_image_nvim"
+      "load_wezterm_nvim"
+    ];
   };
 
   moveline-nvim =
@@ -1582,6 +1798,15 @@ in
   neogit = super.neogit.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "neogit";
+  };
+
+  neorepl-nvim = super.neorepl-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires main module loaded first
+      "neorepl.bufs"
+      "neorepl.map"
+      "neorepl.repl"
+    ];
   };
 
   neorg = neovimUtils.buildNeovimPlugin {
@@ -1711,7 +1936,15 @@ in
       neotest
       nvim-nio
     ];
-    nvimRequirecheck = "neotest-jest";
+    # Unit test assert
+    nvimSkipModule = "neotest-jest-assertions";
+  };
+
+  neotest-minitest = super.neotest-minitest.overrideAttrs {
+    dependencies = with self; [
+      neotest
+      plenary-nvim
+    ];
   };
 
   neotest-pest = super.neotest-pest.overrideAttrs {
@@ -1738,6 +1971,8 @@ in
       plenary-nvim
       telescope-nvim
     ];
+    # Unit test assert
+    nvimSkipModule = "neotest-playwright-assertions";
   };
 
   neotest-plenary = super.neotest-plenary.overrideAttrs {
@@ -1795,8 +2030,18 @@ in
     dependencies = with self; [
       neotest
       nvim-nio
+      plenary-nvim
     ];
-    nvimRequirecheck = "neotest-vitest";
+    # Unit test assert
+    nvimSkipModule = "neotest-vitest-assertions";
+  };
+
+  neotest-zig = super.neotest-zig.overrideAttrs {
+    dependencies = with self; [
+      neotest
+      nvim-nio
+      plenary-nvim
+    ];
   };
 
   neo-tree-nvim = super.neo-tree-nvim.overrideAttrs {
@@ -1805,6 +2050,15 @@ in
       nui-nvim
     ];
     nvimRequirecheck = "neo-tree";
+  };
+
+  netman-nvim = super.netman-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Optional neo-tree integration
+      "netman.ui.neo-tree.init"
+      "netman.ui.neo-tree.commands"
+      "netman.ui.neo-tree.components"
+    ];
   };
 
   neuron-nvim = super.neuron-nvim.overrideAttrs {
@@ -1859,10 +2113,36 @@ in
       telescope-nvim
       nvim-treesitter
     ];
+    nvimSkipModule = [
+      # Requires global config setup
+      "nvchad.configs.cmp"
+      "nvchad.configs.gitsigns"
+      "nvchad.configs.luasnip"
+      "nvchad.configs.mason"
+      "nvchad.configs.nvimtree"
+      "nvchad.configs.telescope"
+    ];
   };
 
   nvchad-ui = super.nvchad-ui.overrideAttrs {
     dependencies = [ self.nvzone-volt ];
+    nvimSkipModule = [
+      # Requires global config setup
+      "nvchad.tabufline.modules"
+      "nvchad.term.init"
+      "nvchad.themes.init"
+      "nvchad.themes.mappings"
+      "nvchad.cheatsheet.grid"
+      "nvchad.cheatsheet.simple"
+    ];
+  };
+
+  nvim-autopairs = super.nvim-autopairs.overrideAttrs {
+    nvimSkipModule = [
+      # Optional completion dependencies
+      "nvim-autopairs.completion.cmp"
+      "nvim-autopairs.completion.compe"
+    ];
   };
 
   nvim-biscuits = super.nvim-biscuits.overrideAttrs {
@@ -1879,10 +2159,6 @@ in
   nvim-coverage = super.nvim-coverage.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "coverage";
-  };
-
-  nvim-fzf-commands = super.nvim-fzf-commands.overrideAttrs {
-    dependencies = [ self.nvim-fzf ];
   };
 
   nvim-dap-lldb = super.nvim-dap-lldb.overrideAttrs {
@@ -1917,6 +2193,12 @@ in
     dependencies = [ self.nvim-dap ];
   };
 
+  nvim-fzf-commands = super.nvim-fzf-commands.overrideAttrs {
+    dependencies = [ self.nvim-fzf ];
+    # Requires global variable setup nvim_fzf_directory
+    nvimSkipModule = "fzf-commands.rg";
+  };
+
   nvim-FeMaco-lua = super.nvim-FeMaco-lua.overrideAttrs {
     dependencies = [ self.nvim-treesitter ];
   };
@@ -1948,6 +2230,11 @@ in
     nvimRequireCheck = "metals";
   };
 
+  nvim-moonwalk = super.nvim-moonwalk.overrideAttrs {
+    # Asserts log file exists before it is created
+    nvimSkipModule = "moonwalk";
+  };
+
   nvim-navbuddy = super.nvim-navbuddy.overrideAttrs {
     dependencies = with self; [
       nui-nvim
@@ -1955,6 +2242,14 @@ in
       nvim-navic
     ];
     nvimRequireCheck = "nvim-navbuddy";
+  };
+
+  nvim-neoclip-lua = super.nvim-neoclip-lua.overrideAttrs {
+    nvimSkipModule = [
+      # Optional dependencies
+      "neoclip.fzf"
+      "neoclip.telescope"
+    ];
   };
 
   nvim-nu = super.nvim-nu.overrideAttrs {
@@ -2046,6 +2341,16 @@ in
     nvimRequireCheck = "scissors";
   };
 
+  nvim-snippets = super.nvim-snippets.overrideAttrs {
+    # Optional cmp integration
+    nvimSkipModule = "snippets.utils.cmp";
+  };
+
+  nvim-surround = super.nvim-surround.overrideAttrs {
+    # Optional treesitter integration
+    nvimSkipModule = "nvim-surround.queries";
+  };
+
   nvim-teal-maker = super.nvim-teal-maker.overrideAttrs {
     postPatch = ''
       substituteInPlace lua/tealmaker/init.lua \
@@ -2057,6 +2362,11 @@ in
   nvim-treesitter = super.nvim-treesitter.overrideAttrs (
     callPackage ./nvim-treesitter/overrides.nix { } self super
   );
+
+  nvim-treesitter-context = super.nvim-treesitter-context.overrideAttrs {
+    # Meant for CI installing parsers
+    nvimSkipModule = "install_parsers";
+  };
 
   nvim-treesitter-endwise = super.nvim-treesitter-endwise.overrideAttrs {
     dependencies = [ self.nvim-treesitter ];
@@ -2093,8 +2403,15 @@ in
     nvimRequireCheck = "ufo";
   };
 
+  nvim-unception = super.nvim-unception.overrideAttrs {
+    # Attempt rpc socket connection
+    nvimSkipModule = "client.client";
+  };
+
   nvzone-menu = super.nvzone-menu.overrideAttrs {
     dependencies = [ self.nvzone-volt ];
+    # Optional nvimtree integration
+    nvimSkipModule = "menus.nvimtree";
   };
 
   nvzone-minty = super.nvzone-minty.overrideAttrs {
@@ -2123,6 +2440,21 @@ in
     configurePhase = "cd vim";
   };
 
+  omni-vim = super.omni-vim.overrideAttrs {
+    # Optional lightline integration
+    nvimSkipModule = "omni-lightline";
+  };
+
+  onedark-nvim = super.onedark-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires global config value
+      "barbecue.theme.onedark"
+      "onedark.highlights"
+      "onedark.colors"
+      "onedark.terminal"
+    ];
+  };
+
   one-nvim = super.one-nvim.overrideAttrs {
     # E5108: /lua/one-nvim.lua:14: Unknown option 't_Co'
     # https://github.com/Th3Whit3Wolf/one-nvim/issues/23
@@ -2139,7 +2471,11 @@ in
     ];
 
     # FIXME: cant find plugin root dir
-    # nvimRequireCheck = "openscad";
+    nvimSkipModule = [
+      "openscad"
+      "openscad.snippets.openscad"
+      "openscad.utilities"
+    ];
     patches = [
       (substituteAll {
         src = ./patches/openscad.nvim/program_paths.patch;
@@ -2158,6 +2494,11 @@ in
   otter-nvim = super.otter-nvim.overrideAttrs {
     dependencies = [ self.nvim-lspconfig ];
     nvimRequirecheck = "otter";
+  };
+
+  outline-nvim = super.outline-nvim.overrideAttrs {
+    # Requires setup call
+    nvimSkipModule = "outline.providers.norg";
   };
 
   overseer-nvim = super.overseer-nvim.overrideAttrs {
@@ -2187,6 +2528,16 @@ in
       nvim-parinfer
       nvim-paredit
       nvim-treesitter
+    ];
+  };
+
+  persisted-nvim = super.persisted-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # /lua/persisted/init.lua:44: attempt to index upvalue 'config' (a nil value)
+      # https://github.com/olimorris/persisted.nvim/issues/146
+      "persisted"
+      "persisted.config"
+      "persisted.utils"
     ];
   };
 
@@ -2221,6 +2572,11 @@ in
     nvimRequireCheck = "plenary";
   };
 
+  poimandres-nvim = super.poimandres-nvim.overrideAttrs {
+    # Optional treesitter support
+    nvimSkipModule = "poimandres.highlights";
+  };
+
   popup-nvim = super.popup-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };
@@ -2234,8 +2590,30 @@ in
     ];
   };
 
+  pywal-nvim = super.pywal-nvim.overrideAttrs {
+    # Optional feline integration
+    nvimSkipModule = "pywal.feline";
+  };
+
   qmk-nvim = super.qmk-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
+    nvimSkipModule = [
+      # Test assertions
+      "qmk.config.init_spec"
+      "qmk.format.keymap_spec"
+      "qmk.format.qmk_spec"
+      "qmk.format.zmk_spec"
+      "qmk.parse.qmk.init_spec"
+      "qmk.parse.zmk.init_spec"
+      "qmk_spec"
+    ];
+  };
+
+  rainbow-delimiters-nvim = super.rainbow-delimiters-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # rainbow-delimiters.types.lua
+      "rainbow-delimiters.types"
+    ];
   };
 
   range-highlight-nvim = super.range-highlight-nvim.overrideAttrs {
@@ -2391,6 +2769,45 @@ in
       sqlite-lua
       telescope-nvim
     ];
+    nvimSkipModule = [
+      # optional dependency
+      "smart-open.matching.algorithms.fzf_implementation"
+    ];
+  };
+
+  smart-splits-nvim = super.smart-splits-nvim.overrideAttrs {
+    nvimSkipModule = [
+      "vimdoc-gen"
+      "vimdocrc"
+    ];
+  };
+
+  snacks-nvim = super.snacks-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires setup call first
+      "snacks.dashboard"
+      "snacks.git"
+      "snacks.lazygit"
+      "snacks.notifier"
+      "snacks.terminal"
+      "snacks.win"
+      "snacks.words"
+    ];
+  };
+
+  snap = super.snap.overrideAttrs {
+    nvimSkipModule = [
+      "snap.consumer.fzy.all"
+      "snap.consumer.fzy.filter"
+      "snap.consumer.fzy.init"
+      "snap.consumer.fzy.positions"
+      "snap.consumer.fzy.score"
+      # circular import
+      "snap.producer.create"
+      # https://github.com/camspiers/snap/pull/97
+      "snap.preview.help"
+      "snap.producer.vim.help"
+    ];
   };
 
   sniprun =
@@ -2463,6 +2880,11 @@ in
     meta.homepage = "https://github.com/ackyshake/Spacegray.vim/";
   };
 
+  spaceman-nvim = super.spaceman-nvim.overrideAttrs {
+    # Optional telescope integration
+    nvimSkipModule = "spaceman.adapters.telescope";
+  };
+
   sqlite-lua = super.sqlite-lua.overrideAttrs (
     oa:
     let
@@ -2512,6 +2934,11 @@ in
       substituteInPlace lua/stylish/components/menu.lua --replace xwininfo ${xorg.xwininfo}/bin/xwininfo
     '';
     nvimRequireCheck = "stylish";
+  };
+
+  supermaven-nvim = super.supermaven-nvim.overrideAttrs {
+    # TODO: handle supermaven binary
+    doCheck = false;
   };
 
   sved =
@@ -2620,6 +3047,8 @@ in
       telescope-nvim
       plenary-nvim
     ];
+    # Meta
+    nvimSkipModule = "frecency.types";
   };
 
   telescope-fzf-native-nvim = super.telescope-fzf-native-nvim.overrideAttrs {
@@ -2771,14 +3200,30 @@ in
     '';
   };
 
+  text-case-nvim = super.text-case-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # some leftover from development
+      "textcase.plugin.range"
+    ];
+  };
+
   tmux-complete-vim = super.tmux-complete-vim.overrideAttrs {
     # Vim plugin with optional nvim-compe lua module
-    doCheck = false;
+    nvimSkipModule = "compe_tmux";
   };
 
   todo-comments-nvim = super.todo-comments-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "todo-comments";
+  };
+
+  tokyonight-nvim = super.tokyonight-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Meta file
+      "tokyonight.docs"
+      # Optional integration
+      "tokyonight.extra.fzf"
+    ];
   };
 
   triptych-nvim = super.triptych-nvim.overrideAttrs {
@@ -2792,6 +3237,14 @@ in
     postPatch = ''
       substituteInPlace lua/tsc/utils.lua --replace '@tsc@' ${typescript}/bin/tsc
     '';
+
+    # Unit test
+    nvimSkipModule = "tsc.better-messages-test";
+  };
+
+  trouble-nvim = super.trouble-nvim.overrideAttrs {
+    # Meta file
+    nvimSkipModule = "trouble.docs";
   };
 
   tssorter-nvim = super.tssorter-nvim.overrideAttrs {
@@ -2943,6 +3396,10 @@ in
     '';
   };
 
+  vim-apm = super.vim-apm.overrideAttrs {
+    nvimSkipModule = "run";
+  };
+
   vim-bazel = super.vim-bazel.overrideAttrs {
     dependencies = [ self.vim-maktaba ];
   };
@@ -2992,6 +3449,11 @@ in
         sha256 = "0x0xabb56xkgdqrg1mpvhbi3yw4d829n73lsnnyj5yrxjffy4ax4";
       })
     ];
+  };
+
+  vim-flog = super.vim-flog.overrideAttrs {
+    # Not intended to be required, used by vim plugin
+    nvimSkipModule = "flog.graph_bin";
   };
 
   vim-fzf-coauthorship = super.vim-fzf-coauthorship.overrideAttrs {
@@ -3067,6 +3529,11 @@ in
     buildInputs = [ vim ];
   };
 
+  vim-illuminate = super.vim-illuminate.overrideAttrs {
+    # Optional treesitter integration
+    nvimSkipModule = "illuminate.providers.treesitter";
+  };
+
   vim-isort = super.vim-isort.overrideAttrs {
     postPatch = ''
       substituteInPlace ftplugin/python_vimisort.vim \
@@ -3091,6 +3558,11 @@ in
           "'${vim-markdown-composer-bin}/bin/markdown-composer'"
       '';
     };
+
+  vim-matchup = super.vim-matchup.overrideAttrs {
+    # Optional treesitter integration
+    nvimSkipModule = "treesitter-matchup.third-party.query";
+  };
 
   vim-metamath = super.vim-metamath.overrideAttrs {
     preInstall = "cd vim";
@@ -3149,6 +3621,11 @@ in
   vim-textobj-entire = super.vim-textobj-entire.overrideAttrs {
     dependencies = [ self.vim-textobj-user ];
     meta.maintainers = with lib.maintainers; [ farlion ];
+  };
+
+  vim-tpipeline = super.vim-tpipeline.overrideAttrs {
+    # Requires global variable
+    nvimSkipModule = "tpipeline.main";
   };
 
   vim-unimpaired = super.vim-unimpaired.overrideAttrs {
@@ -3245,11 +3722,31 @@ in
     dependencies = [ self.vimproc-vim ];
   };
 
+  vim-ultest = super.vim-ultest.overrideAttrs {
+    # NOTE: vim-ultest is no longer maintained.
+    # If using Neovim, you can switch to using neotest (https://github.com/nvim-neotest/neotest) instead.
+    nvimSkipModule = "ultest";
+  };
+
   vim-zettel = super.vim-zettel.overrideAttrs {
     dependencies = with self; [
       vimwiki
       fzf-vim
     ];
+  };
+
+  virt-column-nvim = super.virt-column-nvim.overrideAttrs {
+    # Meta file
+    nvimSkipModule = "virt-column.config.types";
+  };
+
+  which-key-nvim = super.which-key-nvim.overrideAttrs {
+    nvimSkipModule = [ "which-key.docs" ];
+  };
+
+  wiki-vim = super.wiki-vim.overrideAttrs {
+    # Optional telescope integration
+    nvimSkipModule = [ "wiki.telescope" ];
   };
 
   windows-nvim = super.windows-nvim.overrideAttrs {
@@ -3267,6 +3764,14 @@ in
 
   YankRing-vim = super.YankRing-vim.overrideAttrs {
     sourceRoot = ".";
+  };
+
+  yanky-nvim = super.yanky-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Optional telescope integration
+      "yanky.telescope.mapping"
+      "yanky.telescope.yank_history"
+    ];
   };
 
   yazi-nvim = super.yazi-nvim.overrideAttrs {
@@ -3294,6 +3799,61 @@ in
       ];
       platforms = platforms.unix;
     };
+  };
+
+  zenbones-nvim = super.zenbones-nvim.overrideAttrs {
+    nvimSkipModule = [
+      # Requires global variable set
+      "randombones"
+      "randombones.palette"
+      # Optional shipwright
+      "zenbones.shipwright.runners.alacritty"
+      "zenbones.shipwright.runners.foot"
+      "zenbones.shipwright.runners.iterm"
+      "zenbones.shipwright.runners.kitty"
+      "zenbones.shipwright.runners.lightline"
+      "zenbones.shipwright.runners.lualine"
+      "zenbones.shipwright.runners.tmux"
+      "zenbones.shipwright.runners.vim"
+      "zenbones.shipwright.runners.wezterm"
+      "zenbones.shipwright.runners.windows_terminal"
+      # Optional lush-nvim integration
+      "duckbones"
+      "duckbones.palette"
+      "forestbones"
+      "forestbones.palette"
+      "kanagawabones"
+      "kanagawabones.palette"
+      "neobones"
+      "neobones.palette"
+      "nordbones"
+      "nordbones.palette"
+      "rosebones"
+      "rosebones.palette"
+      "seoulbones"
+      "seoulbones.palette"
+      "tokyobones"
+      "tokyobones.palette"
+      "vimbones"
+      "vimbones.palette"
+      "zenbones"
+      "zenbones.palette"
+      "zenbones.specs.dark"
+      "zenbones.specs.light"
+      "zenburned"
+      "zenburned.palette"
+      "zenwritten"
+      "zenwritten.palette"
+    ];
+  };
+
+  zk-nvim = super.zk-nvim.overrideAttrs {
+    # Optional integrations
+    nvimSkipModule = [
+      "zk.pickers.fzf_lua"
+      "zk.pickers.minipick"
+      "zk.pickers.telescope"
+    ];
   };
 
   zoxide-vim = super.zoxide-vim.overrideAttrs {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -158,6 +158,10 @@ in
     nvimRequireCheck = "advanced_git_search.utils";
   };
 
+  astrotheme = super.astrotheme.overrideAttrs {
+    nvimRequireCheck = "astrotheme";
+  };
+
   animation-nvim = super.animation-nvim.overrideAttrs {
     dependencies = [ self.middleclass ];
     nvimRequireCheck = "animation";
@@ -264,6 +268,12 @@ in
 
   bluloco-nvim = super.bluloco-nvim.overrideAttrs {
     dependencies = [ self.lush-nvim ];
+  };
+
+  ccc-nvim = super.ccc-nvim.overrideAttrs {
+    # ccc auto-discover requires all pass
+    # but there's a bootstrap module that hangs forever if we dont stop on first success
+    nvimRequireCheck = "ccc";
   };
 
   chadtree = super.chadtree.overrideAttrs {
@@ -1340,6 +1350,16 @@ in
     nvimRequireCheck = "lspecho";
   };
 
+  lspsaga-nvim = super.lspsaga-nvim.overrideAttrs {
+    # Other modules require setup call first
+    nvimRequireCheck = "lspsaga";
+  };
+
+  ltex_extra-nvim = super.ltex_extra-nvim.overrideAttrs {
+    # Other modules require setup call first
+    nvimRequireCheck = "ltex_extra";
+  };
+
   lualine-lsp-progress = super.lualine-lsp-progress.overrideAttrs {
     dependencies = [ self.lualine-nvim ];
   };
@@ -1472,6 +1492,8 @@ in
 
   mkdnflow-nvim = super.mkdnflow-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
+    # Requires setup call and has optional nvim-cmp dependency
+    nvimRequireCheck = "mkdnflow";
   };
 
   moveline-nvim =

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -417,87 +417,186 @@ in
     nvimRequireCheck = "cmd-parser";
   };
 
-  cmp-ai = super.cmp-ai.overrideAttrs {
-    dependencies = [ self.plenary-nvim ];
-  };
+  cmp-ai = super.cmp-ai.overrideAttrs (oa: {
+    # We dont want to bundle nvim-cmp anymore since blink.nvim can use these sources.
+    # Add to check inputs though to validate plugin
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+    dependencies = with self; [
+      plenary-nvim
+    ];
+  });
 
-  cmp-clippy = super.cmp-clippy.overrideAttrs {
-    dependencies = [ self.plenary-nvim ];
-  };
+  cmp-async-path = super.cmp-async-path.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
 
-  cmp-conjure = super.cmp-conjure.overrideAttrs {
+  cmp-beancount = super.cmp-beancount.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-clippy = super.cmp-clippy.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+    dependencies = with self; [
+      plenary-nvim
+    ];
+  });
+
+  cmp-cmdline = super.cmp-cmdline.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-conjure = super.cmp-conjure.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.conjure ];
-  };
+  });
 
-  cmp-copilot = super.cmp-copilot.overrideAttrs {
+  cmp-copilot = super.cmp-copilot.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.copilot-vim ];
-  };
+  });
 
-  cmp-dap = super.cmp-dap.overrideAttrs {
+  cmp-ctags = super.cmp-ctags.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-dap = super.cmp-dap.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.nvim-dap ];
-  };
+  });
 
-  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs {
+  cmp-dictionary = super.cmp-dictionary.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-digraphs = super.cmp-digraphs.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-fish = super.cmp-fish.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.fuzzy-nvim ];
-  };
+  });
 
-  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs {
+  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.fuzzy-nvim ];
-  };
+  });
 
-  cmp-git = super.cmp-git.overrideAttrs {
-    dependencies = [ self.plenary-nvim ];
-  };
+  cmp-git = super.cmp-git.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+    dependencies = with self; [ plenary-nvim ];
+  });
 
-  cmp_luasnip = super.cmp_luasnip.overrideAttrs {
+  cmp-greek = super.cmp-greek.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-look = super.cmp-look.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp_luasnip = super.cmp_luasnip.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.luasnip ];
-  };
+  });
 
-  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs {
+  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.neosnippet-vim ];
-  };
+  });
 
-  cmp-npm = super.cmp-npm.overrideAttrs {
+  cmp-nixpkgs-maintainers = super.cmp-nixpkgs-maintainers.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-npm = super.cmp-npm.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.plenary-nvim ];
-  };
+  });
 
-  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs {
+  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-nvim-lua = super.cmp-nvim-lua.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-nvim-ultisnips = super.cmp-nvim-ultisnips.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.plenary-nvim ];
-  };
+  });
 
-  cmp-snippy = super.cmp-snippy.overrideAttrs {
+  cmp-pandoc-references = super.cmp-pandoc-references.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-path = super.cmp-path.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-rg = super.cmp-rg.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-snippy = super.cmp-snippy.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.nvim-snippy ];
-  };
+  });
 
-  cmp-tabnine = super.cmp-tabnine.overrideAttrs {
+  cmp-tabby = super.cmp-tabby.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-tabnine = super.cmp-tabnine.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     buildInputs = [ tabnine ];
 
     postFixup = ''
       mkdir -p $target/binaries/${tabnine.version}
       ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
-  };
+  });
 
-  cmp-tmux = super.cmp-tmux.overrideAttrs {
+  cmp-tmux = super.cmp-tmux.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ tmux ];
-  };
+  });
 
-  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs {
+  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.vim-lsp ];
-  };
+  });
 
-  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs {
+  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ self.vimwiki ];
-  };
+  });
 
-  cmp-vimtex = super.cmp-vimtex.overrideAttrs {
-    # We aren't bundling nvim-cmp
-    nvimSkipModule = "cmp_vimtex.search";
-  };
+  cmp-vsnip = super.cmp-vsnip.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
 
-  cmp-zsh = super.cmp-zsh.overrideAttrs {
+  cmp-vimtex = super.cmp-vimtex.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  });
+
+  cmp-zsh = super.cmp-zsh.overrideAttrs (oa: {
+    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
     dependencies = [ zsh ];
-  };
+  });
 
   cobalt2-nvim = super.cobalt2-nvim.overrideAttrs {
     dependencies = with self; [ colorbuddy-nvim ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Pulling out the vimPlugins changes from https://github.com/NixOS/nixpkgs/pull/352277 so that plugin additions/changes don't cause merge conflicts constantly during staging cycle. They wont have any effect until the hook changes make it to master.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
