### PR TITLE
backlight-control-rs: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5777,6 +5777,12 @@
     githubId = 129093;
     name = "Desmond O. Chang";
   };
+  dod-101 = {
+    email = "david.thievon@proton.me";
+    github = "DOD-101";
+    githubId = 131907205;
+    name = "David Thievon";
+  };
   domenkozar = {
     email = "domen@dev.si";
     github = "domenkozar";

--- a/nixos/modules/programs/backlight-control-rs.nix
+++ b/nixos/modules/programs/backlight-control-rs.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.backlight-control-rs;
+in
+{
+  options = {
+    programs.backlight-control-rs = {
+      enable = lib.mkEnableOption ''
+        backlight-control-rs, and add udev rules granting access to members of the "video" group.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.backlight-control-rs ];
+    services.udev.packages = [ pkgs.backlight-control-rs ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ dod-101 ];
+}

--- a/pkgs/by-name/ba/backlight-control-rs/package.nix
+++ b/pkgs/by-name/ba/backlight-control-rs/package.nix
@@ -1,0 +1,36 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  coreutils,
+  lib,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "backlight_control_rs";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "DOD-101";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yFQASeTmk1a9zmglE7s2Wg3EvNKeQ0qNjWvsCFLYX9U=";
+  };
+
+  cargoHash = "sha256-e6gZ8vYNzhqYbeYSS8x4YuTtaDDoZTBtuRtz32HHXS8=";
+
+  postInstall = ''
+    substituteInPlace 90-backlight.rules --replace-fail /bin ${coreutils}/bin
+    install -Dm644 ./90-backlight.rules -t $out/lib/udev/rules.d
+  '';
+
+  meta = {
+    description = "Re-written version of backlight_control with a few key improvements";
+    homepage = "https://github.com/DOD-101/backlight_control_rs";
+    mainProgram = "backlight_control_rs";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ dod-101 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adding [backlight_control_rs](https://github.com/DOD-101/backlight_control_rs) as a package and a NixOS module. 

backlight_control_rs is a simple utility written in rust which allows the user to change the brightness of their backlight.

Originally I was going to package [backlight_control](https://github.com/Hendrikto/backlight_control/) for NixOS, but since this wasn't possible I went ahead and create an alternative with a few improvements and made it NixOS compatible. 

This is similar to [light](https://gitlab.com/dpeukert/light), but I still think, that this is a valuable alternative and considering that `backlight_control` was being used by at least a handful of people on Arch Linux, there are probably people using nix who would appreciate an analogous offering. 

I have also added myself as a maintainer, for both the package and the NixOS module.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
