### PR TITLE
python312Packages.boost-histogram: skip failing test on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -1,18 +1,27 @@
 {
   lib,
-  fetchPypi,
   buildPythonPackage,
-  pythonOlder,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
+
+  # build-system
   pybind11,
   nanobind,
   ninja,
+  scikit-build-core,
   setuptools-scm,
+
+  # buildInputs
   boost,
+
+  # dependencies
   numpy,
+
+  # tests
   pytestCheckHook,
   pytest-benchmark,
-  scikit-build-core,
 }:
 
 buildPythonPackage rec {
@@ -20,12 +29,11 @@ buildPythonPackage rec {
   version = "1.5.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
-
-  src = fetchPypi {
-    pname = "boost_histogram";
-    inherit version;
-    hash = "sha256-BiPwEObFLl0Bh2dyOVloYJDbB/ww8NHYR1tdZjxd2yw=";
+  src = fetchFromGitHub {
+    owner = "scikit-hep";
+    repo = "boost-histogram";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GsgzJqZTrtc4KRkGn468m0e+sgX9rzJdwA9JMPSSPWk=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -49,10 +57,11 @@ buildPythonPackage rec {
     pytest-benchmark
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python bindings for the C++14 Boost::Histogram library";
     homepage = "https://github.com/scikit-hep/boost-histogram";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ veprbl ];
+    changelog = "https://github.com/scikit-hep/boost-histogram/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ veprbl ];
   };
 }

--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -55,6 +56,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-benchmark
+  ];
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # Segfaults: boost_histogram/_internal/hist.py", line 799 in sum
+    # Fatal Python error: Segmentation fault
+    "test_numpy_conversion_4"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

- **python312Packages.boost-histogram: modernize derivation; use fetchFromGitHub**
- **python312Packages.boost-histogram: skip crashing test on aarch64-darwin**

cc @veprbl

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
