### PR TITLE
home-assistant-custom-components.huawei_solar: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23183,6 +23183,12 @@
     githubId = 8597964;
     name = "Anton Shkurenko";
   };
+  Toomoch = {
+    email = "vallsfustearnau@gmail.com";
+    github = "Toomoch";
+    githubId = 14185777;
+    name = "Arnau Valls";
+  };
   toonn = {
     email = "nixpkgs@toonn.io";
     matrix = "@toonn:matrix.org";

--- a/pkgs/development/python-modules/huawei-solar/default.nix
+++ b/pkgs/development/python-modules/huawei-solar/default.nix
@@ -1,0 +1,54 @@
+{
+  backoff,
+  buildPythonPackage,
+  fetchFromGitLab,
+  lib,
+  hatchling,
+  hatch-vcs,
+  pytz,
+  pymodbus,
+  pyserial-asyncio,
+  typing-extensions,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "huawei-solar";
+  version = "2.3.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "Emilv2";
+    repo = "huawei-solar";
+    rev = version;
+    hash = "sha256-PcpyyEH3Ad9oyr4aPlUgxU5S/NPoIDUZj+Ncs7FXhVA=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    backoff
+    pytz
+    pymodbus
+    typing-extensions
+    pyserial-asyncio
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python library for connecting to Huawei SUN2000 Inverters over Modbus";
+    homepage = "https://gitlab.com/Emilv2/huawei-solar/";
+    changelog = "https://gitlab.com/Emilv2/huawei-solar/-/tags/${version}";
+    maintainers = with maintainers; [ Toomoch ];
+    license = licenses.agpl3Only;
+    broken = lib.versionAtLeast pymodbus.version "3.7.0";
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/huawei_solar/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/huawei_solar/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  huawei-solar,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "wlcrs";
+  domain = "huawei_solar";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "wlcrs";
+    repo = "huawei_solar";
+    rev = version;
+    hash = "sha256-NQusnrXZOmRVVcX6a/GvwOeW62MrkypTG01+y+L6Ihs=";
+  };
+
+  dependencies = [ huawei-solar ];
+
+  meta = with lib; {
+    description = "Home Assistant integration for Huawei Solar inverters via Modbus";
+    homepage = "https://github.com/wlcrs/huawei_solar";
+    changelog = "https://github.com/wlcrs/huawei_solar/releases/tag/${version}";
+    maintainers = with maintainers; [ Toomoch ];
+    license = licenses.agpl3Only;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6066,6 +6066,8 @@ self: super: with self; {
 
   huawei-lte-api = callPackage ../development/python-modules/huawei-lte-api { };
 
+  huawei-solar = callPackage ../development/python-modules/huawei-solar { };
+
   huepy = callPackage ../development/python-modules/huepy { };
 
   huey = callPackage ../development/python-modules/huey { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

-->
## Description of changes
Home Assistant integration for SUN2000 inverters. It depends on a python library named `huawei-solar`, which depends on `pymodbus` < 3.7. Tested with my  SUN2000-4KTL-L1 inverter over modbus RS485 with Home Assistant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
