### PR TITLE
libsoup: apply patches for CVE-2024-52532, CVE-2024-52531 and CVE-2024-52530

### DIFF
--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, fetchpatch
 , glib
 , libxml2
 , meson
@@ -28,6 +29,34 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "sha256-5Ld8Qc/EyMWgNfzcMgx7xs+3XvfFoDQVPfFBP6HZLxM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-52530.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/04df03bc092ac20607f3e150936624d4f536e68b.patch";
+      hash = "sha256-WRLiW2B/xxr3hW0nmeRNrXtZL44S0nTptPRdTqBV8Iw=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-52531_1.patch";
+      url = "https://git.launchpad.net/ubuntu/+source/libsoup2.4/patch/?id=4ce2f2dc8ba0c458edce0f039a087fb3ac57787e";
+      hash = "sha256-wg1qz8xHcnTiinBTF0ECMkrsD8W6M4IbiKGgbJ1gp9o=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-52531_2.patch";
+      url = "https://git.launchpad.net/ubuntu/+source/libsoup2.4/patch/?id=5866d63aed3500700c5f1d2868ff689bb2ba8b82";
+      hash = "sha256-e/VXtKX+agCw+ESGbgQ83NaVNbB3jLTxL7+VgNGbZ7U=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-52532_1.patch";
+      url = "https://git.launchpad.net/ubuntu/+source/libsoup2.4/patch/?id=98e096a0d2142e3c63de2cca7d4023f9c52ed2c6";
+      hash = "sha256-h7k+HpcKlsVYlAONxTOiupMhsMkf2v246ouxLejurcY=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-52532_2.patch";
+      url = "https://git.launchpad.net/ubuntu/+source/libsoup2.4/patch/?id=030e72420e8271299c324273f393d92f6d4bb53e";
+      hash = "sha256-0BEJpEKgjmKACf53lHMglxhmevKsSXR4ejEoTtr4wII=";
+    })
+  ];
 
   depsBuildBuild = [
     pkg-config


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2024-52530
https://www.cve.org/CVERecord?id=CVE-2024-52531
https://www.cve.org/CVERecord?id=CVE-2024-52532

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
