### PR TITLE
oxigraph: 0.3.22 -> 0.4.7

### DIFF
--- a/pkgs/servers/oxigraph/default.nix
+++ b/pkgs/servers/oxigraph/default.nix
@@ -2,34 +2,48 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
+, installShellFiles
 , IOKit
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "oxigraph";
-  version = "0.3.22";
+  version = "0.4.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-zwUiUDWdrmLF+Qj9Jy6JGXHaBskRnm+pMKW2GKGGeN8=";
+    hash = "sha256-xkmCfOLlNvQe8VwUS/jFHACxzo8RwIvX3jGGarj1LSg=";
     fetchSubmodules = true;
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-UnXWBq+oS7tXFCsOhlTkq0L1j8pqzXZ0QKrdYayLunA=";
+  cargoHash = "sha256-sAAwQnV7p7x0bQb/VIJ9hh+UncYB6aGRorjhD2wgosk=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
+    installShellFiles
   ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ IOKit Security ];
 
-  cargoBuildFlags = [ "--package" "oxigraph_server" ];
+  buildAndTestSubdir = "cli";
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "rustls-webpki" "geosparql" ];
 
-  # requires packaging of the associated python modules
-  doCheck = false;
+  # Man pages and autocompletion
+  postInstall = ''
+    MAN_DIR="$(find target/*/release -name man)"
+    installManPage "$MAN_DIR"/*.1
+    COMPLETE_DIR="$(find target/*/release -name complete)"
+    installShellCompletion --bash --name oxigraph.bash "$COMPLETE_DIR/oxigraph.bash"
+    installShellCompletion --fish --name oxigraph.fish "$COMPLETE_DIR/oxigraph.fish"
+    installShellCompletion --zsh --name _oxigraph "$COMPLETE_DIR/_oxigraph"
+  '';
+
+  cargoCheckNoDefaultFeatures = true;
+  cargoCheckFeatures = buildFeatures;
 
   meta = with lib; {
     homepage = "https://github.com/oxigraph/oxigraph";
@@ -37,6 +51,6 @@ rustPlatform.buildRustPackage rec {
     platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     maintainers = with maintainers; [ astro ];
     license = with licenses; [ asl20 mit ];
-    mainProgram = "oxigraph_server";
+    mainProgram = "oxigraph";
   };
 }


### PR DESCRIPTION
Looks like the project shuffled some things around and now the oxigraph_server functionality is in oxigraph-cli.

As for testing: I used it to load some files into a database, serve its webinterface via http, and run queries from a script via the cli option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC: maintainer @astro 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
