### PR TITLE
icu: make darwin.ICU the default on Darwin

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
@@ -24,6 +24,10 @@ let
     sourceRoot = "source/icu/icu4c/source";
 
     patches = [
+      # Apple defaults to `uint16_t` for compatibility with building one of their private frameworks,
+      # but nixpkgs needs `char16_t` for compatibility with packages that expect upstream ICU with `char16_t`.
+      # According to `unicode/umachine.h`, these types are bit-compatible but distinct in C++.
+      ./patches/define-uchar-as-char16_t.patch
       # Skip MessageFormatTest test, which is known to crash sometimes and should be suppressed if it does.
       ./patches/suppress-icu-check-crash.patch
     ];

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
@@ -5,6 +5,7 @@
   fixDarwinDylibNames,
   mkAppleDerivation,
   python3,
+  stdenv, # Necessary for compatibility with python3Packages.tensorflow, which tries to override the stdenv
   testers,
 }:
 

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
@@ -28,6 +28,8 @@ let
       # but nixpkgs needs `char16_t` for compatibility with packages that expect upstream ICU with `char16_t`.
       # According to `unicode/umachine.h`, these types are bit-compatible but distinct in C++.
       ./patches/define-uchar-as-char16_t.patch
+      # Enable the C++ API by default to match the upstream ICU packaging in nixpkgs
+      ./patches/enable-cxx-api-by-default.patch
       # Skip MessageFormatTest test, which is known to crash sometimes and should be suppressed if it does.
       ./patches/suppress-icu-check-crash.patch
     ];

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/patches/define-uchar-as-char16_t.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/patches/define-uchar-as-char16_t.patch
@@ -1,0 +1,53 @@
+diff --git a/icu/icu4c/source/common/unicode/umachine.h b/icu/icu4c/source/common/unicode/umachine.h
+index 9483031569..e451ad7c02 100644
+--- a/common/unicode/umachine.h
++++ b/common/unicode/umachine.h
+@@ -387,39 +387,6 @@
+  * @stable ICU 4.4
+  */
+ 
+-#if APPLE_ICU_CHANGES
+-// rdar://121241618 (StarlightE: VideosUI-883.40.54#24 has failed to build in install; cannot initialize a variable of type 'const UChar *' (aka 'const char16_t)
+-#if 0
+- // #if 1 is normal (Apple uses 0 to force us to still use uint16_t). UChar defaults to char16_t in C++.
+- // For configuration testing of UChar=uint16_t temporarily change this to #if 0.
+- // The intltest Makefile #defines UCHAR_TYPE=char16_t,
+- // so we only #define it to uint16_t if it is undefined so far.
+-#elif !defined(UCHAR_TYPE)
+-#   define UCHAR_TYPE uint16_t
+-#endif
+-
+-#if defined(U_COMBINED_IMPLEMENTATION) || defined(U_COMMON_IMPLEMENTATION) || \
+-        defined(U_I18N_IMPLEMENTATION) || defined(U_IO_IMPLEMENTATION) || \
+-        defined (U_TOOLUTIL_IMPLEMENTATION)
+-    // Inside the ICU library code, never configurable.
+-    typedef char16_t UChar;
+-#elif defined(T_CTEST_IMPLEMENTATION)
+-    // internally to ctestfw, we want to use char16_t in C++ and uint_16 in C
+-    #if U_CPLUSPLUS_VERSION != 0
+-        typedef char16_t UChar;  // C++
+-    #else
+-        typedef uint16_t UChar;  // C
+-    #endif
+-#elif defined(UCHAR_TYPE)
+-    typedef UCHAR_TYPE UChar;
+-#elif U_CPLUSPLUS_VERSION != 0
+-    typedef char16_t UChar;  // C++
+-#else
+-    typedef uint16_t UChar;  // C
+-#endif
+-
+-#else
+-
+ #if 1
+     // #if 1 is normal. UChar defaults to char16_t in C++.
+     // For configuration testing of UChar=uint16_t temporarily change this to #if 0.
+@@ -441,8 +408,6 @@
+     typedef uint16_t UChar;  // C
+ #endif
+ 
+-#endif // APPLE_ICU_CHANGES
+-
+ /**
+  * \var OldUChar
+  * Default ICU 58 definition of UChar.

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/patches/enable-cxx-api-by-default.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/patches/enable-cxx-api-by-default.patch
@@ -1,0 +1,54 @@
+diff --git a/icu/icu4c/source/common/unicode/utypes.h b/icu/icu4c/source/common/unicode/utypes.h
+index a3e0ec911c..e361c658ef 100644
+--- a/common/unicode/utypes.h
++++ b/common/unicode/utypes.h
+@@ -66,20 +66,6 @@
+  * \def U_SHOW_CPLUSPLUS_API
+  * @internal
+  */
+-#if APPLE_ICU_CHANGES
+-// rdar://60884991 #58 Replace installsrc patching with changes directly in header files
+-// Apple modifies the default to be 0, not 1
+-#ifdef __cplusplus
+-#   ifndef U_SHOW_CPLUSPLUS_API
+-#       define U_SHOW_CPLUSPLUS_API 0
+-#   endif
+-#else
+-#   undef U_SHOW_CPLUSPLUS_API
+-#   define U_SHOW_CPLUSPLUS_API 0
+-#endif
+-
+-#else
+-
+ #ifdef __cplusplus
+ #   ifndef U_SHOW_CPLUSPLUS_API
+ #       define U_SHOW_CPLUSPLUS_API 1
+@@ -89,28 +75,6 @@
+ #   define U_SHOW_CPLUSPLUS_API 0
+ #endif
+ 
+-#endif // APPLE_ICU_CHANGES
+-
+-
+-#if APPLE_ICU_CHANGES
+-// rdar://30624081 64b8ed9b89.. Add #if U_SHOW_CPLUSPLUS_API..#endif around C++ interfaces that don’t have it
+-// rdar://24075048 0f5f76d43c.. update ICU for AAS to use VS2015, remove old ICU 4.0 shims, fix build issues
+-/* 
+- * Apple-specific warning if U_SHOW_CPLUSPLUS_API set and the compile
+- * is not for a build of ICU itself (ICU_DATA_DIR is always defined
+- * for ICU builds, and is unlikely to be defined for client builds).
+- * Windows VSC compliler does not like #warning, skip for it.
+- */
+-#if U_SHOW_CPLUSPLUS_API
+-#ifndef ICU_DATA_DIR
+-#if U_PLATFORM!=U_PF_WINDOWS
+-#warning Do not set U_SHOW_CPLUSPLUS_API for code that ships with the OS, it is only for local tools.
+-#warning ICU C++ functionality may not be used by any OS client, it is not binary compatible across updates.
+-#endif
+-#endif
+-#endif
+-#endif // APPLE_ICU_CHANGES
+-
+ /** @{ API visibility control */
+ 
+ /**

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9376,7 +9376,12 @@ with pkgs;
     icu76
   ;
 
-  icu = icu74;
+  # Use Apple’s fork of ICU by default, which provides additional APIs that are not present in upstream ICU.
+  #
+  # `icuReal` is provided in case the upstream icu package is needed on Darwin instead of the fork.
+  # Note that the versioned icu packages always correspond to the upstream versions.
+  icuReal = icu74;
+  icu = if stdenv.hostPlatform.isDarwin then darwin.ICU else icuReal;
 
   idasen = with python3Packages; toPythonApplication idasen;
 


### PR DESCRIPTION
Rather than maintain darwin.ICU for the few packages that need it (such as .NET), use it by default everywhere. This version corresponds roughly to icu74, which is currently the default in nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
