### PR TITLE
gopass: 1.15.14 -> 1.15.15 with added updateScript

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,21 +1,25 @@
-{ lib
-, stdenv
-, makeWrapper
-, buildGoModule
-, fetchFromGitHub
-, installShellFiles
-, git
-, gnupg
-, xclip
-, wl-clipboard
-, passAlias ? false
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  git,
+  gnupg,
+  xclip,
+  wl-clipboard,
+  passAlias ? false,
 }:
 
 buildGoModule rec {
   pname = "gopass";
   version = "1.15.14";
 
-  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   src = fetchFromGitHub {
     owner = "gopasspw";
@@ -28,25 +32,33 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=${src.rev}"
+  ];
 
   wrapperPath = lib.makeBinPath (
     [
       git
       gnupg
       xclip
-    ] ++ lib.optional stdenv.hostPlatform.isLinux wl-clipboard
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux wl-clipboard
   );
 
-  postInstall = ''
-    installManPage gopass.1
-    installShellCompletion --cmd gopass \
-      --zsh zsh.completion \
-      --bash bash.completion \
-      --fish fish.completion
-  '' + lib.optionalString passAlias ''
-    ln -s $out/bin/gopass $out/bin/pass
-  '';
+  postInstall =
+    ''
+      installManPage gopass.1
+      installShellCompletion --cmd gopass \
+        --zsh zsh.completion \
+        --bash bash.completion \
+        --fish fish.completion
+    ''
+    + lib.optionalString passAlias ''
+      ln -s $out/bin/gopass $out/bin/pass
+    '';
 
   postFixup = ''
     wrapProgram $out/bin/gopass \
@@ -61,7 +73,10 @@ buildGoModule rec {
     description = "Slightly more awesome Standard Unix Password Manager for Teams. Written in Go";
     homepage = "https://www.gopass.pw/";
     license = licenses.mit;
-    maintainers = with maintainers; [ rvolosatovs sikmir ];
+    maintainers = with maintainers; [
+      rvolosatovs
+      sikmir
+    ];
     changelog = "https://github.com/gopasspw/gopass/blob/v${version}/CHANGELOG.md";
 
     longDescription = ''

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -10,7 +10,9 @@
   xclip,
   wl-clipboard,
   passAlias ? false,
+  testers,
   nix-update-script,
+  gopass,
 }:
 
 buildGoModule rec {
@@ -68,6 +70,10 @@ buildGoModule rec {
   '';
   passthru = {
     inherit wrapperPath;
+
+    tests.version = testers.testVersion {
+      package = gopass;
+    };
 
     updateScript = nix-update-script { };
   };

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -10,6 +10,7 @@
   xclip,
   wl-clipboard,
   passAlias ? false,
+  apple-sdk_14,
   testers,
   nix-update-script,
   gopass,
@@ -17,21 +18,26 @@
 
 buildGoModule rec {
   pname = "gopass";
-  version = "1.15.14";
+  version = "1.15.15";
 
   nativeBuildInputs = [
     installShellFiles
     makeWrapper
   ];
 
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    # For ScreenCaptureKit.h, see https://github.com/NixOS/nixpkgs/pull/358760#discussion_r1858327365
+    apple-sdk_14
+  ];
+
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "gopass";
     rev = "v${version}";
-    hash = "sha256-3oXdHjW3svGfOEoikEeGm4oU9j+7IBOHw5KH7CCV/uw=";
+    hash = "sha256-GL0vnrNz9vcdybubYIjiK0tDH3L4lNWNo+rAAWv7d8o=";
   };
 
-  vendorHash = "sha256-GeppWyIWE8kYIqhRf1iHksWksdjbIzy96rRpx+qQ3L0=";
+  vendorHash = "sha256-dDy7eQe/JtAsB+cPONiqUwcCsbisCLzY/5YQaH9w2Yg=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -10,6 +10,7 @@
   xclip,
   wl-clipboard,
   passAlias ? false,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -67,6 +68,8 @@ buildGoModule rec {
   '';
   passthru = {
     inherit wrapperPath;
+
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/gopasspw/gopass/releases/tag/v1.15.15

Related projects are already updated https://github.com/NixOS/nixpkgs/pull/358760, https://github.com/NixOS/nixpkgs/pull/358876
And nixpkgs-update skipped because of the title matched with one of above PRs. https://nixpkgs-update-logs.nix-community.org/gopass/2024-11-25.log

```
gopass 1.15.14 -> 1.15.15 https://github.com/gopasspw/gopass/releases
attrpath: gopass
Checking auto update branch...
No auto update branch exists
There might already be an open PR for this update:
- gopass-jsonapi: 1.15.14 -> 1.15.15
  URL "https://api.github.com/repos/NixOS/nixpkgs/issues/358760"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
