### PR TITLE
got: 0.106 -> 0.108, format, use nix-update-script, fix darwin build

### DIFF
--- a/pkgs/by-name/go/got/package.nix
+++ b/pkgs/by-name/go/got/package.nix
@@ -1,29 +1,34 @@
-{ lib
-, stdenv
-, fetchurl
-, pkg-config
-, libressl
-, libbsd
-, libevent
-, libuuid
-, libossp_uuid
-, libmd
-, zlib
-, ncurses
-, bison
-, autoPatchelfHook
-, testers
-, signify
-, overrideSDK
-, withSsh ? true, openssh
-# Default editor to use when neither VISUAL nor EDITOR are defined
-, defaultEditor ? null
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libressl,
+  libbsd,
+  libevent,
+  libuuid,
+  libossp_uuid,
+  libmd,
+  zlib,
+  ncurses,
+  bison,
+  autoPatchelfHook,
+  testers,
+  signify,
+  overrideSDK,
+  nix-update-script,
+  withSsh ? true,
+  openssh,
+  # Default editor to use when neither VISUAL nor EDITOR are defined
+  defaultEditor ? null,
 }:
 
 let
-  stdenv' = if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-    then overrideSDK stdenv "11.0"
-    else stdenv;
+  stdenv' =
+    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
+      overrideSDK stdenv "11.0"
+    else
+      stdenv;
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "got";
@@ -34,11 +39,20 @@ stdenv'.mkDerivation (finalAttrs: {
     hash = "sha256-MHnXQsElBH3jOd2SPXXQuWCZWjpLVn7QjvNtESvbB8w=";
   };
 
-  nativeBuildInputs = [ pkg-config bison ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    pkg-config
+    bison
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = [ libressl libbsd libevent libuuid libmd zlib ncurses ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ libossp_uuid ];
+  buildInputs = [
+    libressl
+    libbsd
+    libevent
+    libuuid
+    libmd
+    zlib
+    ncurses
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libossp_uuid ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # The configure script assumes dependencies on Darwin are installed via
@@ -48,22 +62,27 @@ stdenv'.mkDerivation (finalAttrs: {
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (
-  lib.optionals (defaultEditor != null) [
-    ''-DGOT_DEFAULT_EDITOR="${lib.getExe defaultEditor}"''
-  ] ++ lib.optionals withSsh [
-    ''-DGOT_DIAL_PATH_SSH="${lib.getExe openssh}"''
-    ''-DGOT_TAG_PATH_SSH_KEYGEN="${lib.getExe' openssh "ssh-keygen"}"''
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    ''-DGOT_TAG_PATH_SIGNIFY="${lib.getExe signify}"''
-  ] ++ lib.optionals stdenv.cc.isClang [
-    "-Wno-error=implicit-function-declaration"
-    "-Wno-error=int-conversion"
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # error: conflicting types for 'strmode'
-    "-DHAVE_STRMODE=1"
-    # Undefined symbols for architecture arm64: "_bsd_getopt"
-    "-include getopt.h"
-  ]);
+    lib.optionals (defaultEditor != null) [
+      ''-DGOT_DEFAULT_EDITOR="${lib.getExe defaultEditor}"''
+    ]
+    ++ lib.optionals withSsh [
+      ''-DGOT_DIAL_PATH_SSH="${lib.getExe openssh}"''
+      ''-DGOT_TAG_PATH_SSH_KEYGEN="${lib.getExe' openssh "ssh-keygen"}"''
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      ''-DGOT_TAG_PATH_SIGNIFY="${lib.getExe signify}"''
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=int-conversion"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # error: conflicting types for 'strmode'
+      "-DHAVE_STRMODE=1"
+      # Undefined symbols for architecture arm64: "_bsd_getopt"
+      "-include getopt.h"
+    ]
+  );
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
@@ -83,7 +102,10 @@ stdenv'.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gameoftrees.org";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ abbe afh ];
+    maintainers = with lib.maintainers; [
+      abbe
+      afh
+    ];
     mainProgram = "got";
     platforms = with lib.platforms; darwin ++ linux;
   };

--- a/pkgs/by-name/go/got/package.nix
+++ b/pkgs/by-name/go/got/package.nix
@@ -15,7 +15,7 @@
   autoPatchelfHook,
   testers,
   signify,
-  overrideSDK,
+  apple-sdk_15,
   nix-update-script,
   withSsh ? true,
   openssh,
@@ -23,20 +23,13 @@
   defaultEditor ? null,
 }:
 
-let
-  stdenv' =
-    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
-      overrideSDK stdenv "11.0"
-    else
-      stdenv;
-in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "got";
-  version = "0.106";
+  version = "0.108";
 
   src = fetchurl {
     url = "https://gameoftrees.org/releases/portable/got-portable-${finalAttrs.version}.tar.gz";
-    hash = "sha256-MHnXQsElBH3jOd2SPXXQuWCZWjpLVn7QjvNtESvbB8w=";
+    hash = "sha256-bI0yCt01h65HwG2jLUH+5Ah+1mGTG6ZNxt53v0Mr0+I=";
   };
 
   nativeBuildInputs = [
@@ -44,15 +37,20 @@ stdenv'.mkDerivation (finalAttrs: {
     bison
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = [
-    libressl
-    libbsd
-    libevent
-    libuuid
-    libmd
-    zlib
-    ncurses
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libossp_uuid ];
+  buildInputs =
+    [
+      libressl
+      libbsd
+      libevent
+      libuuid
+      libmd
+      zlib
+      ncurses
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libossp_uuid
+      apple-sdk_15
+    ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # The configure script assumes dependencies on Darwin are installed via

--- a/pkgs/by-name/go/got/package.nix
+++ b/pkgs/by-name/go/got/package.nix
@@ -84,8 +84,13 @@ stdenv'.mkDerivation (finalAttrs: {
     ]
   );
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--url=https://github.com/ThomasAdam/got-portable" ];
+    };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Update to 0.108
* Format using [nixfmt](https://github.com/NixOS/nixfmt)
* Use `nix-update-script` for automated updates using [r-ryantm](https://github.com/r-ryantm)
* Fix darwin build by using `apple-sdk_15` as a buildInput instead of using `overrideSDK`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
