### PR TITLE
luna-base: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2633,6 +2633,12 @@
     github = "beardhatcode";
     githubId = 662538;
   };
+  beaudan = {
+    name = "Beaudan Brown";
+    email = "beaudan.brown@gmail.com";
+    github = "BeaudanBrown";
+    githubId = 43770694;
+  };
   beeb = {
     name = "Valentin Bersier";
     email = "hi@beeb.li";

--- a/pkgs/by-name/lu/luna-base/package.nix
+++ b/pkgs/by-name/lu/luna-base/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  fetchFromGitHub,
+  fftw,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "luna-base";
+  version = "1.0.0";
+  enableParallelBuilding = true;
+
+  src = fetchFromGitHub {
+    owner = "remnrem";
+    repo = "luna-base";
+    rev = "v${version}";
+    hash = "sha256-IWftBR1rU5yejdmngg6eFrLe/Pyfq/Qok/fq/cXyKX8=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    fftw
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 luna destrat behead tocol -t $out/bin
+    find . -name '*.h' -exec install -Dm644 {} $out/include/{} \;
+
+    # These do not have .h extensions
+    mkdir -p $out/include/stats
+    find stats/Eigen/ -maxdepth 1 -type f -exec cp {} $out/include/stats/Eigen/ \;
+
+    mkdir -p $out/lib
+    cp *.a *.so *.o $out/lib/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Library supporting large-scale objective studies of sleep";
+    homepage = "https://zzz.bwh.harvard.edu/luna";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ beaudan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "luna";
+  };
+}


### PR DESCRIPTION
Add the base binary for Luna, an open-source C/C++ software package for manipulating and analyzing polysomnographic recordings, with a focus on the sleep EEG.
https://zzz.bwh.harvard.edu/luna/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
