### PR TITLE
x264: generate version number during `configurePhase`

### DIFF
--- a/pkgs/by-name/x2/x264/package.nix
+++ b/pkgs/by-name/x2/x264/package.nix
@@ -6,67 +6,95 @@
   enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation {
-  pname = "x264";
-  version = "0-unstable-2025-01-03";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    versionParts = lib.strings.splitString " " finalAttrs.version;
 
-  src = fetchFromGitLab {
-    domain = "code.videolan.org";
-    owner = "videolan";
-    repo = "x264";
-    rev = "373697b467f7cd0af88f1e9e32d4f10540df4687";
-    hash = "sha256-WWtS/UfKA4i1yakHErUnyT/3/+Wy2H5F0U0CmxW4ick=";
-  };
+    versionNumberParts = lib.strings.splitString "." (lib.lists.head versionParts);
+    # X264_BUILD in x264_config.h
+    apiVersion = lib.lists.elemAt versionNumberParts 1;
+    # X264_REV in x264_config.h
+    numCommits = lib.lists.last versionNumberParts;
 
-  patches = [
-    # Upstream ./configure greps for (-mcpu|-march|-mfpu) in CFLAGS, which in nix
-    # is put in the cc wrapper anyway.
-    ./disable-arm-neon-default.patch
-  ];
+    gitRevision = lib.lists.last versionParts;
+  in
+  {
+    pname = "x264";
+    # X264_POINTVER in x264_config.h
+    version = "0.164.3204 373697b";
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace Makefile --replace-fail \
-      '$(if $(STRIP), $(STRIP) -x $@)' '$(if $(STRIP), $(STRIP) -S $@)'
-  '';
+    src = fetchFromGitLab {
+      domain = "code.videolan.org";
+      owner = "videolan";
+      repo = "x264";
+      rev = gitRevision;
+      hash = "sha256-WWtS/UfKA4i1yakHErUnyT/3/+Wy2H5F0U0CmxW4ick=";
+    };
 
-  enableParallelBuilding = true;
+    patches = [
+      # Upstream ./configure greps for (-mcpu|-march|-mfpu) in CFLAGS, which in nix
+      # is put in the cc wrapper anyway.
+      ./disable-arm-neon-default.patch
+    ];
 
-  outputs = [
-    "out"
-    "lib"
-    "dev"
-  ];
-
-  preConfigure =
-    lib.optionalString stdenv.hostPlatform.isx86 ''
-      # `AS' is set to the binutils assembler, but we need nasm
-      unset AS
-    ''
-    + lib.optionalString stdenv.hostPlatform.isAarch ''
-      export AS=$CC
+    postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace Makefile --replace-fail \
+        '$(if $(STRIP), $(STRIP) -x $@)' '$(if $(STRIP), $(STRIP) -S $@)'
     '';
 
-  configureFlags =
-    lib.optional enableShared "--enable-shared"
-    ++ lib.optional (!stdenv.hostPlatform.isi686) "--enable-pic"
-    ++ lib.optional (
-      stdenv.buildPlatform != stdenv.hostPlatform
-    ) "--cross-prefix=${stdenv.cc.targetPrefix}";
+    enableParallelBuilding = true;
 
-  makeFlags = [
-    "BASHCOMPLETIONSDIR=$(out)/share/bash-completion/completions"
-    "install-bashcompletion"
-    "install-lib-shared"
-  ];
+    outputs = [
+      "out"
+      "lib"
+      "dev"
+    ];
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isx86 nasm;
+    preConfigure =
+      lib.optionalString stdenv.hostPlatform.isx86 ''
+        # `AS' is set to the binutils assembler, but we need nasm
+        unset AS
+      ''
+      + lib.optionalString stdenv.hostPlatform.isAarch ''
+        export AS=$CC
+      '';
 
-  meta = with lib; {
-    description = "Library for encoding H264/AVC video streams";
-    mainProgram = "x264";
-    homepage = "http://www.videolan.org/developers/x264.html";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix ++ platforms.windows;
-    maintainers = [ ];
-  };
-}
+    configureFlags =
+      lib.optional enableShared "--enable-shared"
+      ++ lib.optional (!stdenv.hostPlatform.isi686) "--enable-pic"
+      ++ lib.optional (
+        stdenv.buildPlatform != stdenv.hostPlatform
+      ) "--cross-prefix=${stdenv.cc.targetPrefix}";
+
+    postConfigure = ''
+      substituteInPlace x264_config.h --replace-fail \
+        "X264_VERSION \"\"" "X264_VERSION \" r${numCommits} ${gitRevision}\""
+
+      substituteInPlace x264_config.h --replace-fail \
+        "X264_POINTVER \"0.${apiVersion}.x\"" "X264_POINTVER \"${finalAttrs.version}\""
+
+      cat << EOF >> x264_config.h
+      #define X264_REV ${numCommits}
+      #define X264_REV_DIFF 0
+      EOF
+    '';
+
+    makeFlags = [
+      "BASHCOMPLETIONSDIR=$(out)/share/bash-completion/completions"
+      "install-bashcompletion"
+      "install-lib-shared"
+    ];
+
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isx86 nasm;
+
+    meta = with lib; {
+      description = "Library for encoding H264/AVC video streams";
+      mainProgram = "x264";
+      homepage = "http://www.videolan.org/developers/x264.html";
+      license = licenses.gpl2Plus;
+      platforms = platforms.unix ++ platforms.windows;
+      maintainers = [ ];
+    };
+  }
+)

--- a/pkgs/by-name/x2/x264/package.nix
+++ b/pkgs/by-name/x2/x264/package.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation {
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace Makefile --replace '$(if $(STRIP), $(STRIP) -x $@)' '$(if $(STRIP), $(STRIP) -S $@)'
+    substituteInPlace Makefile --replace-fail \
+      '$(if $(STRIP), $(STRIP) -x $@)' '$(if $(STRIP), $(STRIP) -S $@)'
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
x264's configure script runs a shell script to populate version info in x264_config.h. The version number is used in various places, including `x264 --version` and `x264 --help`. If Git is not present, a hardcoded version based on the current API version is used instead.

Update the derivation to patch x264_config.h during `configurePhase` based on the package version. This allows x264 to be built with version info without depending on Git.

Before:

```
$ x264 --version
x264 0.164.x
built on Jan  1 1980, clang: 16.0.6
x264 configuration: --chroma-format=all
libx264 configuration: --chroma-format=all
x264 license: GPL version 2 or later

$ x264 --help | head -n 1
x264 core:164
```

Git (`leaveDotGit` + `git` in `nativeBuildInputs`):

```
$ x264 --version
x264 0.164.3108 31e19f9
built on Jan  1 1980, clang: 16.0.6
x264 configuration: --chroma-format=all
libx264 configuration: --chroma-format=all
x264 license: GPL version 2 or later

$ x264 --help | head -n 1
x264 core:164 r3108 31e19f9
```

After:

```
$ x264 --version
x264 0.164.3108 31e19f9
built on Jan  1 1980, clang: 16.0.6
x264 configuration: --chroma-format=all
libx264 configuration: --chroma-format=all
x264 license: GPL version 2 or later

$ x264 --help | head -n 1
x264 core:164 r3108 31e19f9
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
