### PR TITLE
python312Packages.tensordict: disable flaky test_map_iter_interrupt_early on all platforms

### DIFF
--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -70,13 +70,8 @@ buildPythonPackage rec {
       # +  where tensor(False) = <built-in method all of Tensor object at 0x7ffe49bf87d0>()
       "test_mp"
 
-      # torch._dynamo.exc.BackendCompilerFailed
-      # Requires a more recent version of triton
-      # Re-enable when https://github.com/NixOS/nixpkgs/pull/328247 is merged
+      # torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: to_module requires TORCHDYNAMO_INLINE_INBUILT_NN_MODULES to be set.
       "test_functional"
-      "test_linear"
-      "test_seq"
-      "test_seq_lmbda"
     ]
     ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
       # RuntimeError: internal error

--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -72,6 +72,9 @@ buildPythonPackage rec {
 
       # torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: to_module requires TORCHDYNAMO_INLINE_INBUILT_NN_MODULES to be set.
       "test_functional"
+
+      # hangs forever on some CPUs
+      "test_map_iter_interrupt_early"
     ]
     ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
       # RuntimeError: internal error
@@ -81,9 +84,6 @@ buildPythonPackage rec {
 
       # _queue.Empty errors in multiprocessing tests
       "test_isend"
-
-      # hangs forever
-      "test_map_iter_interrupt_early"
     ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -167,6 +167,10 @@ buildPythonPackage rec {
     # assert torch.get_num_threads() == max(1, init_threads - 3)
     # AssertionError: assert 23 == 21
     "test_auto_num_threads"
+
+    # Flaky (hangs indefinitely on some CPUs)
+    "test_gae_multidim"
+    "test_gae_param_as_tensor"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

- **python312Packages.tensordict: enable now succeeding tests**
- **python312Packages.tensordict: disable flaky test_map_iter_interrupt_early on all platforms**

cc @mweinelt

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
