### PR TITLE
google-lighthouse: init at 12.3.0

### DIFF
--- a/pkgs/by-name/go/google-lighthouse/package.nix
+++ b/pkgs/by-name/go/google-lighthouse/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  chromium, # Can be overwritten to be (potentially) any Chromium implementation
+  fetchFromGitHub,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  yarnInstallHook,
+  nodejs,
+  makeWrapper,
+}:
+stdenv.mkDerivation rec {
+  pname = "google-lighthouse";
+  version = "12.3.0";
+
+  src = fetchFromGitHub {
+    owner = "GoogleChrome";
+    repo = "lighthouse";
+    tag = "v${version}";
+    hash = "sha256-q/5P/b47RpIwaNCLT30NXg7S8W56v9Z/QDOzJMDgQOo=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-a4LLrxg0TpQ3QNaMg3OVFTukdCmlOCJjTUt3paddaTM=";
+  };
+
+  yarnBuildScript = "build-report";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    chromium
+    nodejs
+  ];
+
+  postCheck = ''
+    yarn unit
+    yarn test-clients
+    yarn test-docs
+    yarn test-treemap
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/lighthouse" \
+      --set CHROME_PATH ${lib.getExe chromium}
+  '';
+
+  doDist = false;
+  meta = {
+    description = "Automated auditing, performance metrics, and best practices for the web";
+    homepage = "https://developer.chrome.com/docs/lighthouse/overview";
+    license = lib.licenses.asl20;
+    mainProgram = "lighthouse";
+    maintainers = with lib.maintainers; [ theCapypara ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds Google's Lighthouse NodeJS CLI. As a browser `chromium` is used by default, but this can be overwritten.

Closes #187747

Homepage: https://developer.chrome.com/docs/lighthouse/overview
Source: https://github.com/GoogleChrome/lighthouse/tree/main

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
