### PR TITLE
nixos/lib/make-btrfs-fs: use unshare on Linux

### DIFF
--- a/nixos/lib/make-btrfs-fs.nix
+++ b/nixos/lib/make-btrfs-fs.nix
@@ -19,10 +19,14 @@
   btrfs-progs,
   libfaketime,
   fakeroot,
+  util-linux,
 }:
 
 let
   sdClosureInfo = pkgs.buildPackages.closureInfo { rootPaths = storePaths; };
+
+  becomeRootPkg = if pkgs.stdenv.buildPlatform.isLinux then util-linux else fakeroot;
+  becomeRoot = if pkgs.stdenv.buildPlatform.isLinux then "unshare -r" else "fakeroot";
 in
 pkgs.stdenv.mkDerivation {
   name = "btrfs-fs.img${lib.optionalString compressImage ".zst"}";
@@ -30,7 +34,7 @@ pkgs.stdenv.mkDerivation {
   nativeBuildInputs = [
     btrfs-progs
     libfaketime
-    fakeroot
+    becomeRootPkg
   ] ++ lib.optional compressImage zstd;
 
   buildCommand = ''
@@ -57,7 +61,7 @@ pkgs.stdenv.mkDerivation {
     cp ${sdClosureInfo}/registration ./rootImage/nix-path-registration
 
     touch $img
-    faketime -f "1970-01-01 00:00:01" fakeroot mkfs.btrfs -L ${volumeLabel} -U ${uuid} -r ./rootImage --shrink $img
+    faketime -f "1970-01-01 00:00:01" ${becomeRoot} mkfs.btrfs -L ${volumeLabel} -U ${uuid} -r ./rootImage --shrink $img
 
     if ! btrfs check $img; then
       echo "--- 'btrfs check' failed for BTRFS image ---"


### PR DESCRIPTION
The unshare usage fixes issue where mkfs.btrfs is able to bypass fakeroot and thus read the original owner. The effect is that files on the created file-system then have invalid owner (user id 1000). It might be that this affects only build hosts using BTRFS as root FS.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
