### PR TITLE
bombsquad: use the wayback machine for stable links

### DIFF
--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -9,7 +9,7 @@
   curl,
   gnugrep,
   libgcc,
-  makeWrapper,
+  makeBinaryWrapper,
   makeDesktopItem,
   autoPatchelfHook,
   copyDesktopItems,
@@ -22,38 +22,44 @@ let
     {
       x86_64-linux = {
         name = "BombSquad_Linux_x86_64";
-        hash = "sha256-aujLYzFcKaW0ff7sRdyJ6SvSQowafWVbmwycQfDQUYY=";
+        hash = "sha256-ICjaNZSCUbslB5pELbI4e+1zXWrZzkCkv69jLRx4dr0=";
       };
       aarch-64-linux = {
         name = "BombSquad_Linux_Arm64";
-        hash = "sha256-pPP7QZzToTOQtSxzF7Q3ZzlDjUjQWMBM/y79d6Yf38I=";
+        hash = "sha256-/m0SOQbHssk0CqZJPRLK9YKphup3dtMqkbWGzqcF0+g=";
       };
     }
     .${stdenv.targetPlatform.system} or (throw "${stdenv.targetPlatform.system} is unsupported.");
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "bombsquad";
-  version = "1.7.37";
-  sourceRoot = ".";
-  src = fetchurl {
-    url = "https://files.ballistica.net/bombsquad/builds/${archive.name}_${finalAttrs.version}.tar.gz";
-    inherit (archive) hash;
-  };
 
   bombsquadIcon = fetchurl {
     url = "https://files.ballistica.net/bombsquad/promo/BombSquadIcon.png";
     hash = "sha256-MfOvjVmjhLejrJmdLo/goAM9DTGubnYGhlN6uF2GugA=";
   };
 
-  nativeBuildInputs = [
-    python312
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bombsquad";
+  version = "1.7.37";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20240825230506if_/https://files.ballistica.net/bombsquad/builds/${archive.name}_${finalAttrs.version}.tar.gz";
+    inherit (archive) hash;
+  };
+
+  sourceRoot = "${archive.name}_${finalAttrs.version}";
+
+  buildInputs = [
     SDL2
+    libgcc
     libvorbis
     openal
-    libgcc
-    makeWrapper
+    python312
+  ];
+
+  nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
+    makeBinaryWrapper
   ];
 
   desktopItems = [
@@ -61,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       name = "bombsquad";
       genericName = "bombsquad";
       desktopName = "BombSquad";
+
       icon = "bombsquad";
       exec = "bombsquad";
       comment = "An explosive arcade-style party game.";
@@ -71,17 +78,16 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    base=${archive.name}_${finalAttrs.version}
+    mkdir -p $out/bin $out/libexec $out/share/bombsquad/ba_data
 
-    install -m755 -D $base/bombsquad $out/bin/bombsquad
-    install -dm755 $base/ba_data $out/usr/share/bombsquad/ba_data
-    cp -r $base/ba_data $out/usr/share/bombsquad/
+    install -Dm555 -t $out/libexec ${finalAttrs.meta.mainProgram}
+    cp -r ba_data $out/share/bombsquad
 
-    wrapProgram "$out/bin/bombsquad" \
+    makeWrapper "$out/libexec/${finalAttrs.meta.mainProgram}" "$out/bin/${finalAttrs.meta.mainProgram}" \
       --add-flags ${lib.escapeShellArg commandLineArgs} \
-      --add-flags "-d $out/usr/share/bombsquad"
+      --add-flags "-d $out/share/bombsquad"
 
-    install -Dm755 ${finalAttrs.bombsquadIcon} $out/usr/share/icons/hicolor/32x32/apps/bombsquad.png
+    install -Dm755 ${bombsquadIcon} $out/share/icons/hicolor/1024x1024/apps/bombsquad.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
Upstream keeps making changes to the archives without bumping the version, so instead go via the wayback machine for stable links until upstream addresses it.

Furthermore, a number of other fixes:

1. the required host libraries must be in buildInputs and not nativeBuildInputs
2. don't write anything into $out/usr/share but use $out/share instead
3. the icon isn't a proper attribute when using stdenv.mkDerivation so move that out
4. use makeBinaryWrapper instead of the shell variant and put the actual binary in $out/libexec which means we get a proper binary name without "-wrapped"

Ref: #360201


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
