### PR TITLE
workflows/eval: Add the eval summary as a comment

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -267,3 +267,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
+
+      - name: Adding comments
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          # Add the eval summary as a comment
+          body="$(jq -r '
+          "## [Eval summary](https://github.com/" + env.GH_REPO + "/actions/runs/" + env.GITHUB_RUN_ID + "?pr=" + env.NUMBER + ")\n\n" +
+          "- Added packages: " + (.attrdiff.added | length | tostring) + "\n" +
+          "- Removed packages: " + (.attrdiff.removed | length | tostring) + "\n" +
+          "- Changed packages: " + (.attrdiff.changed | length | tostring) + "\n" +
+          "- Rebuild Linux: " + (.rebuildCountByKernel.linux | tostring) + "\n" +
+          "- Rebuild Darwin: " + (.rebuildCountByKernel.darwin | tostring)
+          ' <comparison/changed-paths.json)"
+          gh pr comment "$NUMBER" --edit-last --body "$body" || gh pr comment "$NUMBER" --body "$body"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
See it in action https://github.com/azuwis/nixpkgs/pull/9

Make https://github.com/NixOS/nixpkgs/pull/360339 more discoverable.

Will post a comment like:

---

## [Eval summary](https://github.com/azuwis/nixpkgs/actions/runs/12116130895?pr=9)

- Added packages: 0
- Removed packages: 0
- Changed packages: 1
- Rebuild Linux: 1
- Rebuild Darwin: 0

---

Compared to https://github.com/NixOS/nixpkgs/pull/360962:

1) Only post single comment, and update it on subsequent push, reduce noise for long-running pull requests
    See https://github.com/NixOS/nixpkgs/pull/360962#discussion_r1865303075
2) Only summary and link, no details, will not affect GH search results
    See https://github.com/NixOS/nixpkgs/pull/360962#issuecomment-2510730459

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
