### PR TITLE
nixos/kea: fix settings example

### DIFF
--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -115,6 +115,7 @@ in
                 name = "/var/lib/kea/dhcp4.leases";
               };
               subnet4 = [ {
+                id = 1;
                 subnet = "192.0.2.0/24";
                 pools = [ {
                   pool = "192.0.2.100 - 192.0.2.240";
@@ -176,6 +177,7 @@ in
                 name = "/var/lib/kea/dhcp6.leases";
               };
               subnet6 = [ {
+                id = 1;
                 subnet = "2001:db8:1::/64";
                 pools = [ {
                   pool = "2001:db8:1::1-2001:db8:1::ffff";


### PR DESCRIPTION
As of 2.6.0 subnet-ids need to be provided in the setitngs, adding that to the dhcp{4,6}.settings example
See https://gitlab.isc.org/isc-projects/kea/-/wikis/Release-Notes/release-notes-2.6.0

> Removed autogenerated subnet-ids: We removed the deprecated mechanism that automatically assigned subnet IDs if they were not specified explicitly. While this mechanism was somewhat useful for smaller deployments, it caused many issues for larger configurations and there was no viable way to fix those problems. If your deployment still uses auto-generated subnet IDs, there is an easy way to keep the auto-generated subnet IDs: before upgrading to Kea 2.6.0, call the config-get command. The response will have the generated subnet IDs assigned, which you can write down and use in your Kea configuration. If you upgrade before doing so, you need to assign subnet IDs manually. If you have active leases and/or host reservations, make sure your subnet IDs match in the configuration, in the host reservations, and in the leases [#2961 (closed)]. If you have the id field defined in each subnet, your configuration is fine.

This change was not noted in the release notes for 24.11 (2.4.1 > 2.6.1), not sure if it should be added now.

CC @mweinelt 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
