### PR TITLE
cplex: meta.mainProgram, desktop entry, fix oplide GUI, misc fixes

### DIFF
--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation rec {
       $out/cpoptimizer/bin/x86-64_linux/cpoptimizer\
       $out/bin
 
+    mkdir -p $out/share/doc
+    mv $out/doc $out/share/doc/$name
+
+    mkdir -p $out/share/licenses
+    mv $out/license $out/share/licenses/$name
+
     runHook postInstall
   '';
 
@@ -63,6 +69,8 @@ stdenv.mkDerivation rec {
     libraryPath = lib.makeLibraryPath [ stdenv.cc.cc gtk2 xorg.libXtst ];
   in ''
     runHook preFixup
+
+    rm -r $out/Uninstall
 
     interpreter=${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2
 

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -48,12 +48,17 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin
-    ln -s $out/opl/bin/x86-64_linux/oplrun\
-      $out/opl/bin/x86-64_linux/oplrunjava\
-      $out/opl/oplide/oplide\
-      $out/cplex/bin/x86-64_linux/cplex\
-      $out/cpoptimizer/bin/x86-64_linux/cpoptimizer\
-      $out/bin
+
+    for pgm in \
+      $out/opl/bin/x86-64_linux/oplrun \
+      $out/opl/bin/x86-64_linux/oplrunjava \
+      $out/opl/oplide/oplide \
+      $out/cplex/bin/x86-64_linux/cplex \
+      $out/cpoptimizer/bin/x86-64_linux/cpoptimizer
+    do
+      makeWrapper "$pgm" "$out/bin/$(basename "$pgm")" \
+        --set-default LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive
+    done
 
     mkdir -p $out/share/pixmaps
     ln -s $out/opl/oplide/icon.xpm $out/share/pixmaps/oplide.xpm
@@ -78,20 +83,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  fixupPhase =
-  let
-    libraryPath = lib.makeLibraryPath [ stdenv.cc.cc gtk2 xorg.libXtst ];
-  in ''
+  fixupPhase = ''
     runHook preFixup
 
     rm -r $out/Uninstall
-
-    for pgm in $out/opl/bin/x86-64_linux/oplrun $out/opl/bin/x86-64_linux/oplrunjava $out/opl/oplide/oplide;
-    do
-      wrapProgram $pgm \
-        --prefix LD_LIBRARY_PATH : $out/opl/bin/x86-64_linux:${libraryPath} \
-        --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive;
-    done
 
     runHook postFixup
   '';

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Optimization solver for mathematical programming";
     homepage = "https://www.ibm.com/be-en/marketplace/ibm-ilog-cplex";
+    mainProgram = "cplex";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeWrapper, openjdk, gtk2, xorg, glibcLocales, releasePath ? null }:
+{ lib, stdenv, makeDesktopItem, copyDesktopItems, makeWrapper, openjdk, gtk2, xorg, glibcLocales, releasePath ? null }:
 
 # To use this package, you need to download your own cplex installer from IBM
 # and override the releasePath attribute to point to the location of the file.
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     else
       releasePath;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
   buildInputs = [ openjdk gtk2 xorg.libXtst glibcLocales ];
 
   unpackPhase = "cp $src $name";
@@ -55,6 +55,9 @@ stdenv.mkDerivation rec {
       $out/cpoptimizer/bin/x86-64_linux/cpoptimizer\
       $out/bin
 
+    mkdir -p $out/share/pixmaps
+    ln -s $out/opl/oplide/icon.xpm $out/share/pixmaps/oplide.xpm
+
     mkdir -p $out/share/doc
     mv $out/doc $out/share/doc/$name
 
@@ -63,6 +66,17 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "oplide";
+      desktopName = "IBM ILOG CPLEX Optimization Studio";
+      genericName = "Optimization Software";
+      icon = "oplide";
+      exec = "oplide";
+      categories = [ "Development" "IDE" "Math" "Science" ];
+    })
+  ];
 
   fixupPhase =
   let

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -101,6 +101,21 @@ stdenv.mkDerivation rec {
 
     rm -r $out/Uninstall
 
+    bins=(
+      $out/bin/*
+      $out/cplex/bin/x86-64_linux/cplex
+      $out/cplex/bin/x86-64_linux/cplexamp
+      $out/cpoptimizer/bin/x86-64_linux/cpoptimizer
+      $out/opl/bin/x86-64_linux/oplrun
+      $out/opl/bin/x86-64_linux/oplrunjava
+      $out/opl/oplide/jre/bin/*
+      $out/opl/oplide/oplide
+    )
+
+    find $out -type d -exec chmod 755 {} \;
+    find $out -type f -exec chmod 644 {} \;
+    chmod +111 "''${bins[@]}"
+
     runHook postFixup
   '';
 

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
     else
       releasePath;
 
-  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
-  buildInputs = [ openjdk gtk2 xorg.libXtst glibcLocales ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper openjdk ];
+  buildInputs = [ gtk2 xorg.libXtst glibcLocales ];
 
   unpackPhase = "cp $src $name";
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
      export JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true
-     sh $name LAX_VM ${openjdk}/bin/java -i silent -DLICENSE_ACCEPTED=TRUE -DUSER_INSTALL_DIR=$out
+    sh $name LAX_VM "$(command -v java)" -i silent -DLICENSE_ACCEPTED=TRUE -DUSER_INSTALL_DIR=$out
 
     runHook postBuild
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Set meta.mainProgram
- Fix phase hooks not running
- Move doc and license files to share/doc and share/licenses
- Install desktop entry for oplide
- Fix file permissions (CPLEX installs everything as 755 by default)
- Fix oplide not starting (this is prebuilt eclipse and needs to be wrapped appropriately)
- Use autoPatchelfHook instead of manual patching

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
