### PR TITLE
[Backport 24.11] Updates from #359215

### DIFF
--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -5,7 +5,7 @@
 , pkg-config
 , openssl
 , nixVersions
-, nixPackage ? nixVersions.nix_2_18
+, nixPackage ? nixVersions.stable
 , darwin
 }:
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2892,12 +2892,6 @@ self: super: {
   # 2024-03-17: broken
   vaultenv = dontDistribute super.vaultenv;
 
-  # Support base16 1.0
-  nix-serve-ng = appendPatch (fetchpatch {
-    url = "https://github.com/aristanetworks/nix-serve-ng/commit/4d9eacfcf753acbcfa0f513bec725e9017076270.patch";
-    hash = "sha256-zugyUpEq/iVkxghrvguL95+lJDEpE8MLvZivken0p24=";
-  }) super.nix-serve-ng;
-
   # 2024-01-24: support optparse-applicative 0.18
   niv = appendPatches [
     (fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -350,17 +350,23 @@ self: super: builtins.intersectAttrs super {
   # Add necessary reference to gtk3 package
   gi-dbusmenugtk3 = addPkgconfigDepend pkgs.gtk3 super.gi-dbusmenugtk3;
 
-  # Doesn't declare boost dependency
-  nix-serve-ng = (overrideSrc {
-    version = "1.0.0-unstable-2023-12-18";
+  nix-serve-ng = (overrideCabal (old: {
     src = pkgs.fetchFromGitHub {
       repo = "nix-serve-ng";
       owner = "aristanetworks";
-      rev = "21e65cb4c62b5c9e3acc11c3c5e8197248fa46a4";
-      hash = "sha256-qseX+/8drgwxOb1I3LKqBYMkmyeI5d5gmHqbZccR660=";
+      rev = "578ad85b3096d99b25cae0a73c03df4e82f587c7";
+      hash = "sha256-2LPx4iRJonX4gtd3r73DBM/ZhN/hKu1lb/MHOav8c5s=";
     };
-  } (addPkgconfigDepend pkgs.boost.dev super.nix-serve-ng)).override {
-      nix = pkgs.nixVersions.nix_2_18;
+    version = "1.0.0-unstable-2024-10-01";
+    #editedCabalFile = null;
+    # Doesn't declare boost dependency
+    pkg-configDepends = (old.pkg-configDepends or []) ++ [ pkgs.boost.dev ];
+    patches = (old.patches or []) ++ [
+      # Part of https://github.com/aristanetworks/nix-serve-ng/pull/40
+      ./patches/nix-serve-ng-nix.2.24.patch
+    ];
+  }) super.nix-serve-ng).override {
+    nix = pkgs.nixVersions.nix_2_24;
   };
 
   # These packages try to access the network.

--- a/pkgs/development/haskell-modules/patches/nix-serve-ng-nix.2.24.patch
+++ b/pkgs/development/haskell-modules/patches/nix-serve-ng-nix.2.24.patch
@@ -1,0 +1,55 @@
+From 97cb18bee646a23bd08e3959d6544e703e0bb862 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Tue, 26 Nov 2024 08:39:30 +0100
+Subject: [PATCH] fix build against nix 2.24
+
+---
+ cbits/nix.cpp      | 6 +++---
+ nix-serve-ng.cabal | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cbits/nix.cpp b/cbits/nix.cpp
+index 8872af1..6305001 100644
+--- a/cbits/nix.cpp
++++ b/cbits/nix.cpp
+@@ -1,6 +1,7 @@
+ #include <cstddef>
+ #include <cstdlib>
+ #include <nix/store-api.hh>
++#include <nix/shared.hh>
+ #include <nix/log-store.hh>
+ #include "nix.hh"
+
+@@ -14,8 +15,7 @@ static ref<Store> getStore()
+     static std::shared_ptr<Store> _store;
+
+     if (!_store) {
+-        initLibStore();
+-        loadConfFile();
++        initLibStore(true);
+
+         _store = openStore();
+     }
+@@ -120,7 +120,7 @@ void queryPathInfo
+         output->deriver = emptyString;
+     };
+
+-    copyString(validPathInfo->narHash.to_string(Base32, true), &output->narHash);
++    copyString(validPathInfo->narHash.to_string(nix::HashFormat::Nix32, true), &output->narHash);
+
+     output->narSize = validPathInfo->narSize;
+
+diff --git a/nix-serve-ng.cabal b/nix-serve-ng.cabal
+index 9298f9a..8443b04 100644
+--- a/nix-serve-ng.cabal
++++ b/nix-serve-ng.cabal
+@@ -36,7 +36,7 @@ executable nix-serve
+     cxx-sources:      cbits/nix.cpp
+                     , cbits/nix.hh
+
+-    cxx-options:      -std=c++17
++    cxx-options:      -std=c++20
+
+     build-depends:    base < 5
+                     , base16 >= 1.0
+


### PR DESCRIPTION
## Motivation

These packages are the last packages that would be affected by Nix 2.18 EOL next month.
I did not backport the removal of 2.18, because I'm not sure what's the best thing to do about that in terms of errors or warnings.

- Partial backport of https://github.com/NixOS/nixpkgs/pull/359215

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
