### PR TITLE
writableDirWrapper: init

### DIFF
--- a/pkgs/by-name/wr/writableDirWrapper/package.nix
+++ b/pkgs/by-name/wr/writableDirWrapper/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  writeShellApplication,
+  xorg,
+  makeSetupHook,
+
+  makeWrapper,
+}:
+makeSetupHook {
+  name = "writable-dir-wrapper";
+
+  propagatedBuildInputs = [
+    makeWrapper
+  ];
+
+  substitutions = {
+    lndir = lib.getExe xorg.lndir;
+  };
+
+} ./wrapper.sh
+
+/**
+  A wrapper for programs that require a writable directory to function, typically
+  games or proprietary software that expect read-only resources to be placed alongside
+  config files and state files (e.g. logs).
+
+  # Inputs
+
+  *`options`* (Attribute set)
+
+  : Set of options for the wrapper.
+
+    `name` (String)
+
+    : File name of the wrapper.
+
+   `version` (String, _optional_)
+
+    : Version of the underlying program. When set, version checks will be enabled and existing links will be recreated if they belong to a different version.
+
+    `path` (String)
+
+    : Path of the directory that would hold the linked data.
+
+    `links` (List of attrsets, _optional_)
+
+    : List of links from a source directory to a directory relative to the output path.
+
+      `src` (String)
+
+      : Source directory of the link, usually from the Nix store.
+
+      `dst` (String, _optional_)
+
+      : Destination directory of the link.
+
+      : _Default:_ the output path.
+
+    `postLink` (String, _optional_)
+
+    : Command to run after (re-)linking. Since links are first created in a temporary directory, `postLink` can be used to remove or add files that will be copied to the output path (for example, when some files need to be excluded from the linked result).
+
+    `exec` (String)
+
+    : Command to run.
+
+    `flags` (List of strings, _optional_)
+
+    : The list of flags given to the command. ***Unescaped and can refer to Bash variables and perform shell substitutions.***
+
+  # Type
+
+  ```
+  writableDirWrapper ::
+    {
+      name :: String;
+      version? :: String;
+      path :: String;
+      links? :: [{ src :: String; dst? :: String }];
+      postLink? :: String;
+      exec :: String
+    } -> Derivation
+  ```
+
+  # Examples
+  :::{.example}
+  ## `pkgs.writableDirWrapper` usage example
+
+  ```nix
+  {
+    writableDirWrapper,
+    hello,
+  }:
+  writableDirWrapper {
+    name = "writable-hello";
+    links = [
+      {
+        src = hello;
+        dst = "hello";
+      }
+    ];
+    postLink = ''
+      echo "Hello world!" | base64 > hello.txt
+    '';
+    exec = ''
+      ./hello/bin/hello --greeting=$(<"hello.txt")
+    '';
+  }
+  ```
+
+  When built and run, this should output:
+  ```console
+  SGVsbG8gd29ybGQhCg==
+  ```
+  :::
+*/

--- a/pkgs/by-name/wr/writableDirWrapper/wrapper.sh
+++ b/pkgs/by-name/wr/writableDirWrapper/wrapper.sh
@@ -1,0 +1,129 @@
+# makeWritableDirWrapper EXECUTABLE OUT_PATH DIR ARGS
+
+# ARGS:
+# --dont-track-version               : don't relink when version mismatches
+#
+# --post-link-run      COMMAND       : run command after linking
+#
+# --link               SRC DST       : link SRC to DST
+
+makeWritableDirWrapper() {
+  local original="$1"; shift
+  local wrapper="$1"; shift
+  local dir="$1"; shift
+  local postLinkRun dontTrackVersion
+  local -A links
+
+  local makeWrapperParams=("$original" "$wrapper")
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --post-link-run)
+        postLinkRun="$2"; shift
+        ;;
+      --dont-track-version)
+        dontTrackVersion=true
+        ;;
+      --link)
+        src="$2"; shift
+        dst="$2"; shift
+        links["$src"]="$dst"
+        ;;
+      *) makeWrapperParams+=("$1") ;;
+    esac
+    shift
+  done
+
+  local fragment=$(mktemp)
+
+  local unlinkCommands=()
+  local linkCommands=()
+  for src in "${!links[@]}"; do
+    dst=${links[$src]}
+    unlinkCommands+=("[[ -d \"$dir/$dst\" ]] && find \"$dir/$dst\" -type l -lname '$src' -delete;")
+    linkCommands+=(
+      "mkdir -p './$dst';"
+      "@lndir@ -silent '$src' './$dst';"
+    )
+  done
+
+
+  {
+    cat <<EOF
+unlink() {
+  echo 'Removing existing file links'
+  ${unlinkCommands[@]}
+}
+
+link() {
+  echo 'Linking files'
+  mkdir -p "$dir"
+EOF
+
+    if [[ -z "$dontTrackVersion" ]]; then
+      echo "  echo '$version' > \"$dir/.$pname.version\""
+    fi
+
+    # In case that postLink needs to remove some links to avoid conflict,
+    # we first link everything into a temporary directory then move over
+    cat <<EOF
+  (
+    cd \$(mktemp -d)
+    ${linkCommands[@]}
+    $postLinkRun
+    cp -a ./. -t "$dir"
+  )
+}
+
+relink() {
+  [[ -d "$dir" ]] && unlink
+  link
+}
+
+declare manuallyRelink
+for arg in "\$@"; do
+  case "\$arg" in
+    --relink-files) manuallyRelink=true ;;
+    *) args+=("\$arg") ;; # Passthrough all other args
+  esac
+done
+set -- "\${args[@]}"
+
+if [[ -n "\$manuallyRelink" ]]; then
+  echo "Manually relinking files"; relink
+elif [[ ! -d "$dir" ]]; then
+  echo "Directory $dir not found. Linking files..."; relink
+EOF
+
+    if [[ -z "$dontTrackVersion" ]]; then
+      cat <<EOF
+elif [[ ! -e "$dir/.$name.version" ]]; then
+  echo "Version file not found. Relinking files just to be safe..."; relink
+elif [[ '$version' != "\$(<"$dir/.$pname.version")" ]]; then
+  echo "Current version is not the same as the newest version ($version). Relinking files"; relink
+EOF
+    fi
+
+    echo "fi"
+  } >> "$fragment"
+
+  makeWrapper "${makeWrapperParams[@]}"
+
+  # Inject after the shebang
+  sed -i "1r $fragment" "$wrapper"
+}
+
+# Syntax: wrapProgramInWritableDir <PROGRAM> <DIRECTORY> <MAKE-WRAPPER FLAGS...>
+wrapProgramInWritableDir() {
+    local prog="$1"
+    local dir="$2"
+    local hidden
+
+    assertExecutable "$prog"
+
+    hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+    while [ -e "$hidden" ]; do
+      hidden="${hidden}_"
+    done
+    mv "$prog" "$hidden"
+    makeWritableDirWrapper "$hidden" "$prog" "$dir" --inherit-argv0 "${@:3}"
+}


### PR DESCRIPTION
An unfortunate fact of life is that some packages (mostly video games) *really* want a writable state directory that also has all assets and resources in it. This helper creates a wrapper script that helps in automatically linking resources and updating the links when versions are updated, while keeping config files and other state files intact.

Dependents:
* https://github.com/NixOS/nixpkgs/pull/356578
* https://github.com/NixOS/nixpkgs/pull/357199
* https://github.com/NixOS/nixpkgs/pull/353088

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
