### PR TITLE
emacs: allow wrapped emacs to execute itself again

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/wrapper.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.nix
@@ -198,6 +198,8 @@ runCommand
         --subst-var-by bash ${emacs.stdenv.shell} \
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
         --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp" \
+        --subst-var-by wrapperInvocationDirectory "$out/bin/" \
+        --subst-var-by wrapperInvocationName "$progname" \
         --subst-var prog
       chmod +x $out/bin/$progname
       # Create a “NOP” binary wrapper for the pure sake of it becoming a
@@ -222,6 +224,8 @@ runCommand
         --subst-var-by bash ${emacs.stdenv.shell} \
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
         --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp" \
+        --subst-var-by wrapperInvocationDirectory "$out/Applications/Emacs.app/Contents/MacOS/" \
+        --subst-var-by wrapperInvocationName "Emacs" \
         --subst-var-by prog "$emacs/Applications/Emacs.app/Contents/MacOS/Emacs"
       chmod +x $out/Applications/Emacs.app/Contents/MacOS/Emacs
       wrapProgramBinary $out/Applications/Emacs.app/Contents/MacOS/Emacs

--- a/pkgs/applications/editors/emacs/build-support/wrapper.sh
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.sh
@@ -50,4 +50,7 @@ export emacsWithPackages_siteLisp=@wrapperSiteLisp@
 export EMACSNATIVELOADPATH="${newNativeLoadPath[*]}"
 export emacsWithPackages_siteLispNative=@wrapperSiteLispNative@
 
+export emacsWithPackages_invocationDirectory=@wrapperInvocationDirectory@
+export emacsWithPackages_invocationName=@wrapperInvocationName@
+
 exec @prog@ "$@"

--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -39,6 +39,16 @@ least specific (the system profile)"
       (setenv "EMACSNATIVELOADPATH" (when new-env-list
                                 (mapconcat 'identity new-env-list ":"))))))
 
+(let ((wrapper-invocation-directory (getenv "emacsWithPackages_invocationDirectory")))
+  (when wrapper-invocation-directory
+    (setq invocation-directory (file-name-as-directory wrapper-invocation-directory))
+    (setenv "emacsWithPackages_invocationDirectory" nil)))
+
+(let ((wrapper-invocation-name (getenv "emacsWithPackages_invocationName")))
+  (when wrapper-invocation-name
+    (setq invocation-name wrapper-invocation-name)
+    (setenv "emacsWithPackages_invocationName" nil)))
+
 ;;; Set up native-comp load path.
 (when (featurep 'native-compile)
   ;; Append native-comp subdirectories from `NIX_PROFILES'.


### PR DESCRIPTION
fixes #145302 #237855

emacsWithPackages wrapper script/`site-start.el` sanitizes EMACSLOADPATH, to make nested emacs invocations independent of the package set specified in emacsWithPackages. 

But there are valid use cases when one needs to call nested emacs with the same package set. This includes built-in emacs functionality such as `restart-emacs` and async native compilation, and also external packages like `emacs-async` and `esup`. In all of these cases `invocation-directory`/`invocation-name` variables are being used to launch nested emacs.

With this patch these variables will be populated to point to the emacsWithPackages wrapper executable, so that executing `(file-name-concat invocation-directory invocation-name)` will give a fully functional emacs again.

`EMACSLOADPATH` sanitization was introduced by #106486, this behaviour stays unchanged. The reasoning was to be able to run different emacs executables without polluting their EMACSLOADPATH (as described here https://github.com/NixOS/nixpkgs/pull/106486/commits/23d4bfb6661ca57a9e331a2cf4184232d38ac38b). The only change is that invoking itself is again feasible (and that's what emacs actually expects).


## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
