### PR TITLE
python312Packages.pytorch-pfn-extras: 0.7.7 -> 0.8.1; fix build

### DIFF
--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -16,21 +17,18 @@
   onnx,
   pytestCheckHook,
   torchvision,
-
-  pythonAtLeast,
-  stdenv,
 }:
 
 buildPythonPackage rec {
   pname = "pytorch-pfn-extras";
-  version = "0.7.7";
+  version = "0.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pfnet";
     repo = "pytorch-pfn-extras";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0+ltkm7OH18hlpHYyZCmy1rRleF52IM2BjLoW44tJUY=";
+    hash = "sha256-6KHVsUHN2KDKAaMdhBpZgTq0XILWUsHJPgeRD0m9m20=";
   };
 
   build-system = [ setuptools ];
@@ -52,9 +50,6 @@ buildPythonPackage rec {
     # Requires CUDA access which is not possible in the nix environment.
     "-m 'not gpu and not mpi'"
     "-Wignore::DeprecationWarning"
-
-    # FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly...
-    "-Wignore::FutureWarning"
   ];
 
   pythonImportsCheck = [ "pytorch_pfn_extras" ];
@@ -90,11 +85,10 @@ buildPythonPackage rec {
 
       # RuntimeError: No Op registered for Gradient with domain_version of 9
       "tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.12") [
-      # RuntimeError: Dynamo is not supported on Python 3.12+
+
+      # torch._dynamo.exc.BackendCompilerFailed: backend='compiler_fn' raised:
+      # AttributeError: module 'torch.fx.experimental.proxy_tensor' has no attribute 'maybe_disable_fake_tensor_mode'
       "tests/pytorch_pfn_extras_tests/dynamo_tests/test_compile.py"
-      "tests/pytorch_pfn_extras_tests/test_ops/test_register.py"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       # torch.distributed is not available on darwin


### PR DESCRIPTION
## Things done

Changelog: https://github.com/pfnet/pytorch-pfn-extras/releases/tag/v0.8.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
