### PR TITLE
nixos/librenms: enableLocalBilling + memory limit for cronjobs

### DIFF
--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -116,7 +116,7 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Enables (distributed pollers)[https://docs.librenms.org/Extensions/Distributed-Poller/]
+        Enables [distributed pollers](https://docs.librenms.org/Extensions/Distributed-Poller/)
         for this LibreNMS instance. This will enable a local `rrdcached` and `memcached` server.
 
         To use this feature, make sure to configure your firewall that the distributed pollers
@@ -129,7 +129,7 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Configure this LibreNMS instance as a (distributed poller)[https://docs.librenms.org/Extensions/Distributed-Poller/].
+          Configure this LibreNMS instance as a [distributed poller](https://docs.librenms.org/Extensions/Distributed-Poller/).
           This will disable all web features and just configure the poller features.
           Use the `mysql` database of your main LibreNMS instance in the database settings.
         '';

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -14,6 +14,7 @@ let
     log_errors = on
     post_max_size = 100M
     upload_max_filesize = 100M
+    memory_limit = ${toString cfg.settings.php_memory_limit}M
     date.timezone = "${config.time.timeZone}"
   '';
   phpIni = pkgs.runCommand "php.ini"
@@ -375,6 +376,9 @@ in
 
       # enable fast ping by default
       "ping_rrd_step" = 60;
+
+      # set default memory limit to 1G
+      "php_memory_limit" = lib.mkDefault 1024;
 
       # one minute polling
       "rrd.step" = if cfg.enableOneMinutePolling then 60 else 300;

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -678,5 +678,5 @@ in
 
   };
 
-  meta.maintainers = lib.teams.wdz.members;
+  meta.maintainers = with lib.maintainers; [ netali ] ++ lib.teams.wdz.members;
 }


### PR DESCRIPTION
This PR does the following things:
- Adds a new `enableLocalBilling` option to the LibreNMS module to disable billing on some nodes in a distributed poller setup
  - Set to `true` as default to not break downwards compatibility
- Sets a default for the `php_memory_limit` LibreNMS setting and also uses this setting for the cronjobs
- Fixes some links in the Markdown docs for some options
- Adds me to the module maintainers (I have initially written this module)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
