### PR TITLE
comictagger: init at 1.5.5

### DIFF
--- a/pkgs/by-name/co/comictagger/package.nix
+++ b/pkgs/by-name/co/comictagger/package.nix
@@ -1,0 +1,93 @@
+{
+  fetchPypi,
+  imagemagick,
+  lib,
+  nix-update-script,
+  python3Packages,
+  qt5,
+  stdenvNoCC,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "comictagger";
+  version = "1.5.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-f/SS6mo5zIcNBN/FRMhRPMNOeB1BIqBhsAogjsmdjB0=";
+  };
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    versionCheckHook
+    imagemagick
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    importlib-metadata
+    natsort
+    pathvalidate
+    pillow
+    py7zr
+    pycountry
+    pyicu
+    pyqt5
+    requests
+    text2digits
+    thefuzz
+    typing-extensions
+    unrar2-cffi # drop this when updating ComicTagger to version 1.6.0
+    wordninja
+  ];
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [ qt5.qtwayland ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Seven7zipArchiver test fails: Error reading in raw CIX!
+    "test_copy_from_archive"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  dontWrapQtApps = true;
+
+  postInstall = ''
+    for size in 16 32 48 64 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      magick convert -resize "$size"x"$size" comictaggerlib/graphics/app.png $out/share/icons/hicolor/"$size"x"$size"/apps/ComicTagger.png
+    done
+    install -D --mode=0644 --target-directory=$out/share/applications/ desktop-integration/linux/ComicTagger.desktop
+    substituteInPlace $out/share/applications/ComicTagger.desktop \
+      --replace-fail "Exec=%%CTSCRIPT%% %F" "Exec=comictagger %F" \
+      --replace-fail "Icon=/usr/local/share/comictagger/app.png" "Icon=ComicTagger"
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "Multi-platform app for writing metadata to digital comics";
+    homepage = "https://github.com/comictagger/comictagger";
+    changelog = "https://github.com/comictagger/comictagger/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; darwin ++ linux ++ windows;
+    broken = !stdenvNoCC.hostPlatform.isLinux; # Not tested on other platforms.
+    maintainers = with lib.maintainers; [ jwillikers ];
+    mainProgram = "comictagger";
+  };
+}

--- a/pkgs/development/python-modules/unrar2-cffi/default.nix
+++ b/pkgs/development/python-modules/unrar2-cffi/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  cffi,
+  fetchPypi,
+  lib,
+  nix-update-script,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "unrar2-cffi";
+  version = "0.4.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "unrar2_cffi";
+    hash = "sha256-P+MXSmoMiIkk42MEYoJq9Okd1JTVwEPLCjGGXrnpyDM=";
+  };
+
+  build-system = [
+    cffi
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    rm -r unrar
+  '';
+
+  pythonImportsCheck = [
+    "unrar.cffi"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Read RAR file from python -- cffi edition";
+    homepage = "https://github.com/noaione/unrar2-cffi";
+    changelog = "https://github.com/noaione/unrar2-cffi/releases/tag/v${version}";
+    license = with lib; [
+      licenses.asl20
+      licenses.unfreeRedistributable # for including unrar
+    ];
+    maintainers = [ lib.maintainers.jwillikers ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18535,6 +18535,8 @@ self: super: with self; {
 
   unpaddedbase64 = callPackage ../development/python-modules/unpaddedbase64 { };
 
+  unrar2-cffi = callPackage ../development/python-modules/unrar2-cffi { };
+
   unrardll = callPackage ../development/python-modules/unrardll { };
 
   unrpa = callPackage ../development/python-modules/unrpa { };


### PR DESCRIPTION
Add [ComicTagger](https://github.com/comictagger/comictagger) version 1.5.5.

Fixes #183011.

Supersedes #194502.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
