### PR TITLE
python312Packages.mtcnn: 0.1.1 -> 1.0.0; fix build

### DIFF
--- a/pkgs/development/python-modules/mtcnn/default.nix
+++ b/pkgs/development/python-modules/mtcnn/default.nix
@@ -2,50 +2,55 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  opencv-python,
-  pytestCheckHook,
-  pythonOlder,
+
+  # build-system
   setuptools,
-  tensorflow,
+
+  # dependencies
+  joblib,
+  keras,
+  lz4,
+  pythonAtLeast,
+  distutils,
+
+  # tests
+  pytestCheckHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "mtcnn";
-  version = "0.1.1";
+  version = "1.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ipazc";
     repo = "mtcnn";
-    # No tags / releases; using commit: https://github.com/ipazc/mtcnn/commit/3208d443a8f01d317c65d7c97a03bc0a6143c41d
-    rev = "3208d443a8f01d317c65d7c97a03bc0a6143c41d";
-    hash = "sha256-GXUrLJ5XD6V2hT/gjyYSuh/CMMw2xIXKBsYFvQmbLYs=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-gp+jfa1arD3PpJpuRFKIUznV0Lyjt3DPn/HHUviDXhk=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "setup, setuptools" "setup, find_packages"\
-      --replace-fail "setuptools.find_packages" "find_packages"\
-      --replace-fail "keras>=2.0.0" ""\
-      --replace-fail "tests_require=['nose']," ""
-  '';
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    opencv-python
-    tensorflow
-  ];
+  dependencies =
+    [
+      joblib
+      lz4
+    ]
+    ++ lib.optionals (pythonAtLeast "3.12") [
+      distutils
+    ];
 
   pythonImportsCheck = [ "mtcnn" ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    keras
+    pytestCheckHook
+  ];
 
   meta = {
     description = "MTCNN face detection implementation for TensorFlow";
     homepage = "https://github.com/ipazc/mtcnn";
+    changelog = "https://github.com/ipazc/mtcnn/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ derdennisop ];
   };

--- a/pkgs/development/python-modules/retinaface/default.nix
+++ b/pkgs/development/python-modules/retinaface/default.nix
@@ -2,14 +2,21 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  gdown,
-  numpy,
-  opencv4,
-  pillow,
-  pytestCheckHook,
-  pythonOlder,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  gdown,
+  keras,
+  numpy,
+  opencv-python,
+  pillow,
   tensorflow,
+  tf-keras,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -17,21 +24,12 @@ buildPythonPackage rec {
   version = "0.0.17";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "serengil";
     repo = "retinaface";
     rev = "refs/tags/v${version}";
     hash = "sha256-0s1CSGlK2bF1F2V/IuG2ZqD7CkNfHGvp1M5C3zDnuKs=";
   };
-
-  postPatch = ''
-    # prevent collisions
-    substituteInPlace setup.py \
-      --replace-fail "data_files=[(\"\", [\"README.md\", \"requirements.txt\", \"package_info.json\"])]," "" \
-      --replace-fail "install_requires=requirements," ""
-  '';
 
   # requires internet connection
   disabledTestPaths = [
@@ -44,10 +42,12 @@ buildPythonPackage rec {
 
   dependencies = [
     gdown
+    keras
     numpy
-    opencv4
+    opencv-python
     pillow
     tensorflow
+    tf-keras
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
## Things done

This PR fixes both `mtcnn` and `retinaface`.

Changelog: https://github.com/ipazc/mtcnn/releases/tag/v1.0.0

cc @derdennisop

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
