### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
-  "sha256": "0l3b9jr5ydzqgvd10j12imc9jqb6jv5v2bdi1gyy5cwkwplfay67"
+  "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
+  "sha256": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
 }


### PR DESCRIPTION
From the nixpkgs-unstable channel: https://hydra.nixos.org/eval/1810238#tabs-inputs

Needed for https://github.com/NixOS/nixpkgs/pull/322537

Ran `ci/update-pinned-nixpkgs.sh`, which updated it to the version from this nixpkgs-unstable Hydra eval: https://hydra.nixos.org/eval/1810238#tabs-inputs

Includes https://github.com/NixOS/nixpkgs/pull/359904, ping @NixOS/nix-formatting 

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
