### PR TITLE
[release-24.11] GitHub Action eval backports

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -210,7 +210,7 @@ jobs:
             --arg beforeResultDir ./baseResult \
             --arg afterResultDir ./prResult \
             -o comparison
-
+          cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
           # TODO: Request reviews from maintainers for packages whose files are modified in the PR
 
       - name: Upload the combined results

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           # Get the latest eval.yml workflow run for the PR's base commit
           if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
-            -f head_sha="$BASE_SHA" \
+            -f head_sha="$BASE_SHA" -f event=push \
             --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
             || [[ -z "$run" ]]; then
             echo "Could not find an eval.yml workflow run for $BASE_SHA, cannot make comparison"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -237,9 +237,33 @@ jobs:
 
       - name: Tagging pull request
         run: |
+          # Get all currently set rebuild labels
           gh api \
-            --method POST \
-            /repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
-            --input <(jq -c '{ labels: .labels }' comparison/changed-paths.json)
+            /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+            --jq '.[].name | select(startswith("10.rebuild"))' \
+            | sort > before
+
+          # And the labels that should be there
+          jq -r '.labels[]' comparison/changed-paths.json \
+            | sort > after
+
+          # Remove the ones not needed anymore
+          while read -r toRemove; do
+            echo "Removing label $toRemove"
+            gh api \
+              --method DELETE \
+              /repos/"$REPOSITORY"/issues/"$NUMBER"/labels/"$toRemove"
+          done < <(comm -23 before after)
+
+          # And add the ones that aren't set already
+          while read -r toAdd; do
+            echo "Adding label $toAdd"
+            gh api \
+              --method POST \
+              /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+              -f "labels[]=$toAdd"
+          done < <(comm -13 before after)
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -5,7 +5,7 @@
   linkFarm,
   time,
   procps,
-  nix,
+  nixVersions,
   jq,
   sta,
 }:
@@ -28,6 +28,8 @@ let
         ]
       );
     };
+
+  nix = nixVersions.nix_2_24;
 
   supportedSystems = import ../supportedSystems.nix;
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -261,6 +261,11 @@ let
           --slurpfile after ${afterResultDir}/outpaths.json \
           > $out/changed-paths.json
 
+        jq -r '
+        "## Added\n" + (.attrdiff.added | map("- \(. )") | join("\n")) + "\n" +
+        "## Removed\n" + (.attrdiff.removed | map("- \(. )") | join("\n")) + "\n" +
+        "## Changed\n" + (.attrdiff.changed | map("- \(. )") | join("\n")) + "\n"
+        ' < $out/changed-paths.json > $out/step-summary.md
         # TODO: Compare eval stats
       '';
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -50,8 +50,12 @@ let
         export GC_INITIAL_HEAP_SIZE=4g
         command time -v \
           nix-instantiate --eval --strict --json --show-trace \
-          $src/pkgs/top-level/release-attrpaths-superset.nix -A paths \
-          --arg enableWarnings false > $out/paths.json
+            "$src/pkgs/top-level/release-attrpaths-superset.nix" \
+            -A paths \
+            -I "$src" \
+            --option restrict-eval true \
+            --option allow-import-from-derivation false \
+            --arg enableWarnings false > $out/paths.json
         mv "$supportedSystemsPath" $out/systems.json
       '';
 
@@ -84,6 +88,8 @@ let
         set +e
         command time -f "Chunk $myChunk on $system done [%MKB max resident, %Es elapsed] %C" \
           nix-env -f "${nixpkgs}/pkgs/top-level/release-attrpaths-parallel.nix" \
+          --option restrict-eval true \
+          --option allow-import-from-derivation false \
           --query --available \
           --no-name --attr-path --out-path \
           --show-trace \
@@ -93,6 +99,8 @@ let
           --arg systems "[ \"$system\" ]" \
           --arg checkMeta ${lib.boolToString checkMeta} \
           --arg includeBroken ${lib.boolToString includeBroken} \
+          -I ${nixpkgs} \
+          -I ${attrpathFile} \
           > "$outputDir/result/$myChunk"
         exitCode=$?
         set -e

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -261,11 +261,7 @@ let
           --slurpfile after ${afterResultDir}/outpaths.json \
           > $out/changed-paths.json
 
-        jq -r '
-        "## Added\n" + (.attrdiff.added | map("- \(. )") | join("\n")) + "\n" +
-        "## Removed\n" + (.attrdiff.removed | map("- \(. )") | join("\n")) + "\n" +
-        "## Changed\n" + (.attrdiff.changed | map("- \(. )") | join("\n")) + "\n"
-        ' < $out/changed-paths.json > $out/step-summary.md
+        jq -r -f ${./generate-step-summary.jq} < $out/changed-paths.json > $out/step-summary.md
         # TODO: Compare eval stats
       '';
 

--- a/ci/eval/generate-step-summary.jq
+++ b/ci/eval/generate-step-summary.jq
@@ -1,0 +1,14 @@
+def truncate(xs; n):
+  if xs | length > n then xs[:n] + ["..."]
+  else xs
+  end;
+
+def itemize_packages(xs):
+  truncate(xs; 3000) | map("- \(. )") | join("\n");
+
+def section(title; xs):
+  "## " + title + " (" + (xs | length | tostring) + ")\n" + itemize_packages(xs);
+
+section("Added"; .attrdiff.added) + "\n\n" +
+section("Removed"; .attrdiff.removed) + "\n\n" +
+section("Changed"; .attrdiff.changed)

--- a/ci/eval/generate-step-summary.jq
+++ b/ci/eval/generate-step-summary.jq
@@ -4,11 +4,12 @@ def truncate(xs; n):
   end;
 
 def itemize_packages(xs):
-  truncate(xs; 3000) | map("- \(. )") | join("\n");
+  # we truncate the list to stay below the GitHub limit of 1MB per step summary.
+  truncate(xs; 3000) | map("- [\(.)](https://search.nixos.org/packages?channel=unstable&show=\(.)&from=0&size=50&sort=relevance&type=packages&query=\(.))") | join("\n");
 
 def section(title; xs):
-  "## " + title + " (" + (xs | length | tostring) + ")\n" + itemize_packages(xs);
+  "<details> <summary>" + title + " (" + (xs | length | tostring) + ")</summary>\n\n" + itemize_packages(xs) + "</details>";
 
-section("Added"; .attrdiff.added) + "\n\n" +
-section("Removed"; .attrdiff.removed) + "\n\n" +
-section("Changed"; .attrdiff.changed)
+section("Added packages"; .attrdiff.added) + "\n\n" +
+section("Removed packages"; .attrdiff.removed) + "\n\n" +
+section("Changed packages"; .attrdiff.changed)


### PR DESCRIPTION
Backports these PRs:
- https://github.com/NixOS/nixpkgs/pull/357805
- https://github.com/NixOS/nixpkgs/pull/360225
- https://github.com/NixOS/nixpkgs/pull/360274
- https://github.com/NixOS/nixpkgs/pull/360277
- https://github.com/NixOS/nixpkgs/pull/360339

No other PRs need to be backported to get the GitHub Action eval in sync on master and release-24.11.

Ping @Mic92 @TheGiraffe3 @drupol @itepastra @azuwis 

## Things done

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
