### PR TITLE
nixos/ananicy: fix eval when hardened kernel is used with ananicy-cpp

### DIFF
--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -22,7 +22,7 @@ let
   # Ananicy-CPP with BPF is not supported on hardened kernels https://github.com/NixOS/nixpkgs/issues/327382
   finalPackage =
     if (servicename == "ananicy-cpp" && config.boot.kernelPackages.isHardened) then
-      (cfg.package { withBpf = false; })
+      (cfg.package.override { withBpf = false; })
     else
       cfg.package;
 in


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/360957

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - With my own configuration (https://github.com/JohnRTitor/nix-conf/commit/d5b1cfa026137cb16637cf82e4e39e33d542560e)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
