### PR TITLE
fishPlugins: init multiple fish shell plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6025,6 +6025,12 @@
     name = "Will Dietz";
     keys = [ { fingerprint = "389A 78CB CD88 5E0C 4701  DEB9 FD42 C7D0 D414 94C8"; } ];
   };
+  dudeofawesome = {
+    email = "tourist-04.iced@icloud.com";
+    github = "dudeofawesome";
+    githubId = 1683595;
+    name = "Louis Orleans";
+  };
   dudymas = {
     email = "jeremy.white@cloudposse.com";
     github = "dudymas";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -72,6 +72,8 @@ lib.makeScope newScope (self: with self; {
 
   sdkman-for-fish = callPackage ./sdkman-for-fish.nix { };
 
+  shell-integrations = callPackage ./shell-integrations.nix { };
+
   spark = callPackage ./spark.nix { };
 
   sponge = callPackage ./sponge.nix { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -56,6 +56,8 @@ lib.makeScope newScope (self: with self; {
 
   node-version = callPackage ./node-version.nix { };
 
+  nvm = callPackage ./nvm.nix { };
+
   pisces = callPackage ./pisces.nix { };
 
   plugin-git = callPackage ./plugin-git.nix { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -52,6 +52,8 @@ lib.makeScope newScope (self: with self; {
 
   hydro = callPackage ./hydro.nix { };
 
+  node-binpath = callPackage ./node-binpath.nix { };
+
   pisces = callPackage ./pisces.nix { };
 
   plugin-git = callPackage ./plugin-git.nix { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -19,6 +19,8 @@ lib.makeScope newScope (self: with self; {
 
   done = callPackage ./done.nix { };
 
+  editor-updater = callPackage ./editor-updater.nix { };
+
   fifc = callPackage ./fifc.nix { };
 
   fish-bd = callPackage ./fish-bd.nix { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -58,6 +58,8 @@ lib.makeScope newScope (self: with self; {
 
   nvm = callPackage ./nvm.nix { };
 
+  osx = callPackage ./osx.nix { };
+
   pisces = callPackage ./pisces.nix { };
 
   plugin-git = callPackage ./plugin-git.nix { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -54,6 +54,8 @@ lib.makeScope newScope (self: with self; {
 
   node-binpath = callPackage ./node-binpath.nix { };
 
+  node-version = callPackage ./node-version.nix { };
+
   pisces = callPackage ./pisces.nix { };
 
   plugin-git = callPackage ./plugin-git.nix { };

--- a/pkgs/shells/fish/plugins/editor-updater.nix
+++ b/pkgs/shells/fish/plugins/editor-updater.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+buildFishPlugin rec {
+  pname = "editor-updater";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dudeofawesome";
+    repo = "fish-plugin-${pname}";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-cS95OGrq0u9/VS19wTpzx/d8nMZqzxZt7Lzj0M/9Yp0=";
+  };
+
+  meta = {
+    description = "Fish shell plugin to set EDITOR in an IDE's integrated terminal";
+    homepage = "https://github.com/${src.owner}/${src.repo}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+}

--- a/pkgs/shells/fish/plugins/node-binpath.nix
+++ b/pkgs/shells/fish/plugins/node-binpath.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+buildFishPlugin rec {
+  pname = "node-binpath";
+  version = "0-unstable-2023-08-23";
+
+  src = fetchFromGitHub {
+    owner = "oh-my-fish";
+    repo = "plugin-${pname}";
+    rev = "70ecbe7be606b1b26bfd1a11e074bc92fe65550c";
+    hash = "sha256-Hkm9dhTC9lf2sviTIEBa56nayHgNVg8NOIvYg6EslH0=";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Automatically add node_modules binaries to PATH";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+}

--- a/pkgs/shells/fish/plugins/node-version.nix
+++ b/pkgs/shells/fish/plugins/node-version.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  gitUpdater,
+  fishtape_3,
+}:
+
+buildFishPlugin rec {
+  pname = "node-version";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "dudeofawesome";
+    repo = "fish-plugin-${pname}";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WD7Kgn2WIg4jBIvN/nFGx5Qeo2JkL2o74e4+HJKi8y8=";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Change Node versions based on a Node Version File";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  checkPlugins = [ fishtape_3 ];
+  checkPhase = ''
+    fishtape test/*.test.fish
+  '';
+}

--- a/pkgs/shells/fish/plugins/nvm.nix
+++ b/pkgs/shells/fish/plugins/nvm.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  gitUpdater,
+  fishtape_3,
+}:
+
+buildFishPlugin rec {
+  pname = "nvm";
+  version = "2.2.16";
+
+  src = fetchFromGitHub {
+    owner = "jorgebucaran";
+    repo = "${pname}.fish";
+    rev = "refs/tags/${version}";
+    hash = "sha256-GTEkCm+OtxMS3zJI5gnFvvObkrpepq1349/LcEPQRDo=";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Node.js version manager crafted just for Fish";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
+
+  checkPlugins = [ fishtape_3 ];
+  checkPhase = ''
+    fishtape tests/*.fish
+  '';
+}

--- a/pkgs/shells/fish/plugins/osx.nix
+++ b/pkgs/shells/fish/plugins/osx.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+buildFishPlugin rec {
+  pname = "osx";
+  version = "0-unstable-2019-01-14";
+
+  src = fetchFromGitHub {
+    owner = "oh-my-fish";
+    repo = "plugin-${pname}";
+    rev = "27039b251201ec2e70d8e8052cbc59fa0ac3b3cd";
+    hash = "sha256-jSUIk3ewM6QnfoAtp16l96N1TlX6vR0d99dvEH53Xgw=";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Integration with macOS Finder, iTunes, and more";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+}

--- a/pkgs/shells/fish/plugins/shell-integrations.nix
+++ b/pkgs/shells/fish/plugins/shell-integrations.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+buildFishPlugin rec {
+  pname = "shell-integrations";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "dudeofawesome";
+    repo = "fish-plugin-${pname}";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fvtimmdxFDA+MQkZODMMQTnH7ICVHtsofPSk0fl7nm0=";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Loads a number of shell integrations when available";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+  };
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+}


### PR DESCRIPTION
Adding several fish shell plugins:
- [editor-updater](https://github.com/dudeofawesome/fish-plugin-editor-updater)
- [node-binpath](https://github.com/oh-my-fish/plugin-node-binpath)
- [node-version](https://github.com/dudeofawesome/fish-plugin-node-version)
- [nvm](https://github.com/jorgebucaran/nvm.fish)
- [osx](https://github.com/oh-my-fish/plugin-osx)
- [shell-integrations](https://github.com/dudeofawesome/fish-plugin-shell-integrations)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
