### PR TITLE
buildFHSEnv: fix cross compilation

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -5,7 +5,7 @@
 , writeText
 , writeShellScriptBin
 , pkgs
-, pkgsi686Linux
+, pkgsHostTarget
 }:
 
 { profile ? ""
@@ -36,6 +36,10 @@
 # /lib will link to /lib64
 
 let
+  # The splicing code does not handle `pkgsi686Linux` well, so we have to be
+  # explicit about which package set it's coming from.
+  inherit (pkgsHostTarget) pkgsi686Linux;
+
   name = if (args ? pname && args ? version)
     then "${args.pname}-${args.version}"
     else args.name;
@@ -212,7 +216,7 @@ let
         ln -fsr $d/glib-2.0/schemas/*.xml $out/usr/share/glib-2.0/schemas
         ln -fsr $d/glib-2.0/schemas/*.gschema.override $out/usr/share/glib-2.0/schemas
       done
-      ${pkgs.glib.dev}/bin/glib-compile-schemas $out/usr/share/glib-2.0/schemas
+      ${pkgs.pkgsBuildBuild.glib.dev}/bin/glib-compile-schemas $out/usr/share/glib-2.0/schemas
     fi
 
     ${extraBuildCommands}

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -4,7 +4,7 @@
 , runCommandLocal
 , writeShellScript
 , glibc
-, pkgsi686Linux
+, pkgsHostTarget
 , runCommandCC
 , coreutils
 , bubblewrap
@@ -41,6 +41,10 @@ let
     ;
 
   inherit (lib.attrsets) removeAttrs;
+
+  # The splicing code does not handle `pkgsi686Linux` well, so we have to be
+  # explicit about which package set it's coming from.
+  inherit (pkgsHostTarget) pkgsi686Linux;
 
   name = args.name or "${args.pname}-${args.version}";
   executableName = args.pname or args.name;


### PR DESCRIPTION
In particular, steam aarch64-linux -> x86_64-linux cross did not compile before:
```nix
nix build --impure --expr '(import ./. { localSystem.system = "aarch64-linux"; crossSystem.system = "x86_64-linux"; config.allowUnfree = true; }).steam'
```

Note that there is also a fix pending for the splicing issue being worked around as part of this PR, see #360602.

Also note that this does not yet produce a _working_ steam FHS env, #360552 still needs to be resolved.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
