### PR TITLE
ci/eval: Also count added packages as rebuilds

### DIFF
--- a/ci/eval/compare.jq
+++ b/ci/eval/compare.jq
@@ -109,11 +109,23 @@ def diff($before; $after):
 | ($after[0] | expand_system) as $after
 | .attrdiff = diff($before; $after)
 | .rebuildsByKernel = (
-  .attrdiff.changed
-  | map({
-    key: .,
-    value: diff($before."\(.)"; $after."\(.)").changed
-  })
+  [
+    (
+      .attrdiff.changed[]
+      | {
+        key: .,
+        value: diff($before."\(.)"; $after."\(.)").changed
+      }
+    )
+    ,
+    (
+      .attrdiff.added[]
+      | {
+        key: .,
+        value: ($after."\(.)" | keys)
+      }
+    )
+  ]
   | from_entries
   | transpose
 )


### PR DESCRIPTION
This is also what ofborg does, discovered by @FliegendeWurst after https://github.com/NixOS/nixpkgs/pull/359704

## Things done
- [x] Tested: https://github.com/tweag/nixpkgs/pull/106#event-15499084817

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
