### PR TITLE
treewide: remove unused {lib,}clang from more build closures

### DIFF
--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -10,7 +10,6 @@
 , zlib
 , protobuf
 , openssl
-, libclang
 , libcxx
 , rocksdb_8_3
 , rustfmt
@@ -75,7 +74,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config protobuf rustfmt perl rustPlatform.bindgenHook ];
   buildInputs =
-    [ openssl zlib libclang hidapi ] ++ (lib.optionals stdenv.hostPlatform.isLinux [ udev ])
+    [ openssl zlib hidapi ] ++ (lib.optionals stdenv.hostPlatform.isLinux [ udev ])
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security System Libsystem libcxx ];
   strictDeps = true;
 

--- a/pkgs/by-name/mc/mchprs/package.nix
+++ b/pkgs/by-name/mc/mchprs/package.nix
@@ -7,7 +7,6 @@
   sqlite,
   zlib,
   stdenv,
-  clang,
   darwin,
 }:
 
@@ -31,7 +30,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    clang
     rustPlatform.bindgenHook
   ];
 

--- a/pkgs/by-name/st/stratovirt/package.nix
+++ b/pkgs/by-name/st/stratovirt/package.nix
@@ -1,6 +1,6 @@
 { lib, rustPlatform, fetchgit
 , pkg-config, pixman, libcap_ng, cyrus_sasl
-, libpulseaudio, libclang, gtk3, libusbgx, alsa-lib
+, libpulseaudio, gtk3, libusbgx, alsa-lib
 , linuxHeaders, libseccomp
 }:
 
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     gtk3
     libusbgx
     alsa-lib
-    libclang
     linuxHeaders
     libseccomp
   ];

--- a/pkgs/by-name/tp/tplay/package.nix
+++ b/pkgs/by-name/tp/tplay/package.nix
@@ -7,7 +7,6 @@
   ffmpeg,
   openssl,
   alsa-lib,
-  libclang,
   opencv,
   makeWrapper,
 }:
@@ -42,7 +41,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     openssl.dev
     alsa-lib.dev
-    (lib.getLib libclang)
     ffmpeg.dev
     opencv
   ];

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  clang,
   cmake,
   copyDesktopItems,
   curl,
@@ -122,7 +121,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs =
     [
-      clang
       cmake
       copyDesktopItems
       curl


### PR DESCRIPTION
follow-up to #360711, which seemed to miss oddly many of these? there were like 3x as many as that PR would suggest

```sh
rg -C 3 'bindgenHook|clang' $(rg -l 'bindgenHook' $(rg -l 'clang' --sort=path) --sort=path) --sort=path
```

`ripasso-cursive`, `zed-editor` and `mchprs` are simple Rust packages with the exact same change as the previous PR

the above query also gives a couple more packagese: `stratovirt`, `solana-validator`, `materialize`, and `tplay` all have `buildInputs = [ libclang ];`, which also seemed unnecessary.

i didn't test these packages' functionality, but they *build* just fine. all except `materialize` that is, which took long enough that i just gave up. usually, the crates that are dependent on `clang` would be earlier on in the dependency graph. hope someone else can build and verify this package still workse.

the query would suggest `tplay` and `gyroflow` should have the same `clang`-removal surgery. this is not the case, since they depend on `opencv` which [requires `clang` as a binary](https://github.com/twistedfall/opencv-rust/blob/7b97b9f988e93545f528ec7f2945de93d5dbac6c/binding-generator/src/generator.rs#L364).

`parinfer-rust` also looks like it should get the same treatment, but it doesn't like that either. this is the error i get

>  ```
>  ./include/emacs-module.h:23:10: fatal error: 'stdint.h' file not found
>  ./include/emacs-module.h:23:10: fatal error: 'stdint.h' file not found, err: true
>  thread 'main' panicked at /build/parinfer-rust-0.4.3-vendor.tar.gz/emacs_module/build.rs:12:10:
>  called `Result::unwrap()` on an `Err` value: ()
>  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
>  ```

and besides those three, i don't think there are any other packages covered by this?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (6/7)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
