### PR TITLE
nixos/tzupdate: make enabled module actually be enabled

### DIFF
--- a/nixos/modules/services/misc/tzupdate.nix
+++ b/nixos/modules/services/misc/tzupdate.nix
@@ -26,11 +26,12 @@ in
     # zone, which is better than silently overriding it.
     time.timeZone = null;
 
-    # We provide a one-shot service which can be manually run. We could
-    # provide a service that runs on startup, but it's tricky to get
-    # a service to run after you have *internet* access.
+    # We provide a one-shot service that runs at startup once network
+    # interfaces are up, but we can’t ensure we actually have Internet access
+    # at that point. It can also be run manually with `systemctl start tzupdate`.
     systemd.services.tzupdate = {
       description = "tzupdate timezone update service";
+      wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       script = ''

--- a/nixos/modules/services/misc/tzupdate.nix
+++ b/nixos/modules/services/misc/tzupdate.nix
@@ -18,6 +18,25 @@ in
         update the timezone.
       '';
     };
+
+    package = lib.mkPackageOption pkgs "tzupdate" { };
+
+    timer.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable the tzupdate timer to update the timezone automatically.
+      '';
+    };
+
+    timer.interval = lib.mkOption {
+      type = lib.types.str;
+      default = "hourly";
+      description = ''
+        The interval at which the tzupdate timer should run. See
+        {manpage}`systemd.time(7)` to understand the format.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -35,7 +54,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       script = ''
-        timezone="$(${lib.getExe pkgs.tzupdate} --print-only)"
+        timezone="$(${lib.getExe cfg.package} --print-only)"
         if [[ -n "$timezone" ]]; then
           echo "Setting timezone to '$timezone'"
           timedatectl set-timezone "$timezone"
@@ -45,6 +64,17 @@ in
       serviceConfig = {
         Type = "oneshot";
       };
+    };
+
+    systemd.timers.tzupdate = {
+      enable = cfg.timer.enable;
+      interval = cfg.timer.interval;
+      timerConfig = {
+        OnStartupSec = "30s";
+        OnCalendar = cfg.timer.interval;
+        Persistent = true;
+      };
+      wantedBy = [ "timers.target" ];
     };
   };
 


### PR DESCRIPTION
Without this fix, when setting `services.tzupdate.enable = true`, the service would never run automatically.

Now, it's actually enabled in systemd and it actually gets executed.

Still, it could be improved with a timer as explained in https://github.com/NixOS/nixpkgs/issues/127984#issuecomment-2512059143, but this makes it at least work out of the box when rebooting the system.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
