### PR TITLE
chocolate-doom: 3.0.1 -> 3.1.0; adopt; modernize

### DIFF
--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, autoreconfHook, pkg-config, SDL2, SDL2_mixer, SDL2_net
-, fetchFromGitHub, fetchpatch, python3 }:
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  pkg-config,
+  SDL2,
+  SDL2_mixer,
+  SDL2_net,
+  fetchFromGitHub,
+  fetchpatch,
+  python3,
+}:
 
 stdenv.mkDerivation rec {
   pname = "chocolate-doom";
@@ -22,7 +32,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   postPatch = ''
     sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
@@ -35,7 +48,11 @@ stdenv.mkDerivation rec {
     # for documentation
     python3
   ];
-  buildInputs = [ SDL2 SDL2_mixer SDL2_net ];
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    SDL2_net
+  ];
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "chocolate-doom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    hydraPlatforms = lib.platforms.linux; # darwin times out
     maintainers = with lib.maintainers; [ Gliczy ];
   };
 })

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://www.chocolate-doom.org";
     description = "Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s";
+    mainProgram = "chocolate-doom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     hydraPlatforms = lib.platforms.linux; # darwin times out

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  libpng,
+  libsamplerate,
   pkg-config,
   python3,
   SDL2,
@@ -33,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    libpng
+    libsamplerate
     SDL2
     SDL2_mixer
     SDL2_net

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.chocolate-doom.org";
+    changelog = "https://github.com/chocolate-doom/chocolate-doom/releases/tag/chocolate-doom-${finalAttrs.version}";
     description = "Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s";
     mainProgram = "chocolate-doom";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     hydraPlatforms = lib.platforms.linux; # darwin times out
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ Gliczy ];
   };
 })

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -1,25 +1,25 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
   autoreconfHook,
   pkg-config,
+  python3,
   SDL2,
   SDL2_mixer,
   SDL2_net,
-  fetchFromGitHub,
   fetchpatch,
-  python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chocolate-doom";
   version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "chocolate-doom";
-    repo = pname;
-    rev = "${pname}-${version}";
-    sha256 = "1zlcqhd49c5n8vaahgaqrc2y10z86xng51sbd82xm3rk2dly25jp";
+    repo = "chocolate-doom";
+    rev = "refs/tags/chocolate-doom-${finalAttrs.version}";
+    hash = "sha256-VxbhaRMzj9oFakuH8mw36IPgBctYPajURrawRBrEjP4=";
   };
 
   patches = [
@@ -30,11 +30,6 @@ stdenv.mkDerivation rec {
       url = "https://github.com/chocolate-doom/chocolate-doom/commit/a8fd4b1f563d24d4296c3e8225c8404e2724d4c2.patch";
       sha256 = "1dmbygn952sy5n8qqp0asg11pmygwgygl17lrj7i0fxa0nrhixhj";
     })
-  ];
-
-  outputs = [
-    "out"
-    "man"
   ];
 
   postPatch = ''
@@ -48,12 +43,21 @@ stdenv.mkDerivation rec {
     # for documentation
     python3
   ];
+
   buildInputs = [
     SDL2
     SDL2_mixer
     SDL2_net
   ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
   enableParallelBuilding = true;
+
+  strictDeps = true;
 
   meta = {
     homepage = "http://chocolate-doom.org/";
@@ -63,4 +67,4 @@ stdenv.mkDerivation rec {
     hydraPlatforms = lib.platforms.linux; # darwin times out
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   meta = {
-    homepage = "http://chocolate-doom.org/";
+    homepage = "https://www.chocolate-doom.org";
     description = "Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ch/chocolate-doom/package.nix
+++ b/pkgs/by-name/ch/chocolate-doom/package.nix
@@ -8,32 +8,20 @@
   SDL2,
   SDL2_mixer,
   SDL2_net,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "chocolate-doom";
-  version = "3.0.1";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "chocolate-doom";
     repo = "chocolate-doom";
     rev = "refs/tags/chocolate-doom-${finalAttrs.version}";
-    hash = "sha256-VxbhaRMzj9oFakuH8mw36IPgBctYPajURrawRBrEjP4=";
+    hash = "sha256-yDPfqCuzRbDhOQisIDAGo2bmmMjT+0lds5xc9C2pqoU=";
   };
 
-  patches = [
-    # Pull upstream patch to fix builx against gcc-10:
-    #   https://github.com/chocolate-doom/chocolate-doom/pull/1257
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/chocolate-doom/chocolate-doom/commit/a8fd4b1f563d24d4296c3e8225c8404e2724d4c2.patch";
-      sha256 = "1dmbygn952sy5n8qqp0asg11pmygwgygl17lrj7i0fxa0nrhixhj";
-    })
-  ];
-
   postPatch = ''
-    sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
     patchShebangs --build man/{simplecpp,docgen}
   '';
 


### PR DESCRIPTION
https://github.com/chocolate-doom/chocolate-doom/releases/tag/chocolate-doom-3.1.0

I removed `hydraPlatforms`, but I do not have a `darwin` machine to test if it builds, I will revert this if CI fails.

I also updated the url, as it was outdated, used `http` and was leading nowhere.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
