### PR TITLE
lib.packagesFromDirectoryRecursive: refactor (v2)

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -364,13 +364,14 @@ in
       ...
     }:
     let
+      inherit (lib) concatMapAttrs removeSuffix;
       inherit (lib.path) append;
       defaultPath = append directory "package.nix";
     in
     if pathExists defaultPath then
       # if `${directory}/package.nix` exists, call it directly
       callPackage defaultPath {}
-    else lib.concatMapAttrs (name: type:
+    else concatMapAttrs (name: type:
       # otherwise, for each directory entry
       let path = append directory name; in
       if type == "directory" then {
@@ -381,7 +382,7 @@ in
         };
       } else if type == "regular" && hasSuffix ".nix" name then {
         # call .nix files
-        "${lib.removeSuffix ".nix" name}" = callPackage path {};
+        "${removeSuffix ".nix" name}" = callPackage path {};
       } else if type == "regular" then {
         # ignore non-nix files
       } else throw ''

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -18,7 +18,10 @@ let
     ;
 
   inherit (lib.filesystem)
+    pathIsDirectory
+    pathIsRegularFile
     pathType
+    packagesFromDirectoryRecursive
     ;
 
   inherit (lib.strings)
@@ -361,51 +364,28 @@ in
       ...
     }:
     let
-      # Determine if a directory entry from `readDir` indicates a package or
-      # directory of packages.
-      directoryEntryIsPackage = basename: type:
-        type == "directory" || hasSuffix ".nix" basename;
-
-      # List directory entries that indicate packages in the given `path`.
-      packageDirectoryEntries = path:
-        filterAttrs directoryEntryIsPackage (readDir path);
-
-      # Transform a directory entry (a `basename` and `type` pair) into a
-      # package.
-      directoryEntryToAttrPair = subdirectory: basename: type:
-        let
-          path = subdirectory + "/${basename}";
-        in
-        if type == "regular"
-        then
-        {
-          name = removeSuffix ".nix" basename;
-          value = callPackage path { };
-        }
-        else
-        if type == "directory"
-        then
-        {
-          name = basename;
-          value = packagesFromDirectory path;
-        }
-        else
-        throw
-          ''
-            lib.filesystem.packagesFromDirectoryRecursive: Unsupported file type ${type} at path ${toString subdirectory}
-          '';
-
-      # Transform a directory into a package (if there's a `package.nix`) or
-      # set of packages (otherwise).
-      packagesFromDirectory = path:
-        let
-          defaultPackagePath = path + "/package.nix";
-        in
-        if pathExists defaultPackagePath
-        then callPackage defaultPackagePath { }
-        else mapAttrs'
-          (directoryEntryToAttrPair path)
-          (packageDirectoryEntries path);
+      inherit (lib.path) append;
+      defaultPath = append directory "package.nix";
     in
-    packagesFromDirectory directory;
+    if pathExists defaultPath then
+      # if `${directory}/package.nix` exists, call it directly
+      callPackage defaultPath {}
+    else lib.concatMapAttrs (name: type:
+      # otherwise, for each directory entry
+      let path = append directory name; in
+      if type == "directory" then {
+        # recurse into directories
+        "${name}" = packagesFromDirectoryRecursive {
+          inherit callPackage;
+          directory = path;
+        };
+      } else if type == "regular" && hasSuffix ".nix" name then {
+        # call .nix files
+        "${lib.removeSuffix ".nix" name}" = callPackage path {};
+      } else if type == "regular" then {
+        # ignore non-nix files
+      } else throw ''
+        lib.filesystem.packagesFromDirectoryRecursive: Unsupported file type ${type} at path ${toString path}
+      ''
+    ) (builtins.readDir directory);
 }


### PR DESCRIPTION
Second go at #359941

An assertion was too restrictive and broke the installer's tests, due to `directory` being a symlink.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS test](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) `installer`
  - [x] `nix-instantiate --eval --strict lib/tests/misc.nix`
  - [x] `nix-build lib/tests/release.nix`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
