### PR TITLE
deepin: do not install infrequently used apps by default

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -52,7 +52,6 @@ in
       services.deepin.dde-daemon.enable = mkForce true;
       services.deepin.dde-api.enable = mkForce true;
       services.deepin.app-services.enable = mkForce true;
-      services.deepin.deepin-anything.enable = mkDefault true;
 
       services.colord.enable = mkDefault true;
       services.accounts-daemon.enable = mkDefault true;
@@ -161,37 +160,28 @@ in
             dde-control-center
             dde-network-core
             dde-clipboard
-            dde-calendar
             dde-polkit-agent
             dpa-ext-gnomekeyring
             deepin-desktop-schemas
-            deepin-terminal
             deepin-kwin
             dde-session
             dde-widgets
             dde-appearance
             dde-application-manager
             deepin-service-manager
-            dde-grand-search
             dde-api-proxy
             dde-tray-loader
           ];
           optionalPackages = [
+            dde-calendar
+            dde-grand-search
+            deepin-terminal
             onboard # dde-dock plugin
             deepin-calculator
             deepin-compressor
             deepin-editor
-            deepin-picker
-            deepin-draw
-            deepin-music
-            deepin-movie-reborn
             deepin-system-monitor
             deepin-shortcut-viewer
-            # freeimage has knownVulnerabilties, don't install packages using freeiamge by default
-            # deepin-album
-            # deepin-camera
-            # deepin-image-viewer
-            # deepin-screen-recorder
           ];
         in
         requiredPackages


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1.  do not install deepin-draw/deepin-picker/deepin-music/deepin-movie-reborn by default when enable deepin desktop environment 
2. move  dde-calendar/dde-grand-search/deepin-terminal to `optionalPackages ` 
3. deepin-anything only provides file search support for dde-grand-search and is not needed by the file manager. It is not necessary to enable it by default


deepin-draw/deepin-picker are rarely used by most users, so they are no longer pre-installed to reduce disk usage. deepin users can install them manually using `environment.systemPackages = [ deepin.deepin-draw ]`

deepin-movie-reborn has poor stability and crashes when playing videos. I will mark it broken later.
deepin's multimedia application is very slow in adapting to new versions of dependencies (such as ffmpeg, icu, etc.), and the processing of PRs from external contributors is also very slow, and there may be no response for a year. I don't want to waste time on these applications

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
