### PR TITLE
ci: add Nixpkgs lib-tests workflow

### DIFF
--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -1,0 +1,30 @@
+name: "Building Nixpkgs lib-tests"
+
+permissions:
+  contents: read
+
+on:
+  pull_request_target:
+    paths:
+      - 'lib/**'
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  nixpkgs-lib-tests:
+    name: nixpkgs-lib-tests
+    runs-on: ubuntu-latest
+    needs: get-merge-commit
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: needs.get-merge-commit.outputs.mergedSha
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          # explicitly enable sandbox
+          extra_nix_config: sandbox = true
+      - name: Building Nixpkgs lib-tests
+        run: |
+          nix-build --arg pkgs "(import ./ci/. {}).pkgs" ./lib/tests/release.nix


### PR DESCRIPTION
Ofborg also does this.

https://github.com/JohnRTitor/nixpkgs/pull/1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
