### PR TITLE
dotnetCorePackages.patchNupkgs: fix patchelf usage

### DIFF
--- a/pkgs/development/compilers/dotnet/patch-nupkgs.nix
+++ b/pkgs/development/compilers/dotnet/patch-nupkgs.nix
@@ -51,14 +51,17 @@ writeShellScriptBin "patch-nupkgs" (
       find "$x" -type f -print0 | while IFS= read -rd "" p; do
         if [[ "$p" != *.nix-patched ]] \
           && isELF "$p" \
-          && ${patchelf}/bin/patchelf --print-interpreter "$p" &>/dev/null; then
+          && interpreter=$(${patchelf}/bin/patchelf --print-interpreter "$p") \
+          && [ -n "$interpreter" ]; then
           tmp="$p".$$.nix-patched
           # if this fails to copy then another process must have patched it
           cp --reflink=auto "$p" "$tmp" || continue
           echo "Patchelfing $p as $tmp"
+
           ${patchelf}/bin/patchelf \
             --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
-            "$tmp" ||:
+            "$tmp"
+
           # This makes sure that if the binary requires some specific runtime dependencies, it can find it.
           # This fixes dotnet-built binaries like crossgen2
           ${patchelf}/bin/patchelf \
@@ -69,7 +72,8 @@ writeShellScriptBin "patch-nupkgs" (
             "$tmp"
           ${patchelf}/bin/patchelf \
             --add-rpath "${binaryRPath}" \
-            "$tmp" ||:
+            "$tmp"
+
           mv "$tmp" "$p"
         fi
       done


### PR DESCRIPTION
The check we had implemented in `dotnetCorePackages.patchNupkgs` to detect whether we should `patchelf` a file or not was flawed since `patchelf` doesn't return a non-zero exit code for non-dynamic ELF files.

I've added a check to ensure that the interpreter is actually set before setting the interpreter as it is done in `auto-patchelf`.

Fixes the issues found in #361077.

cc: @NixOS/dotnet

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
