### PR TITLE
podman-desktop: 1.13.2 -> 1.15.0

### DIFF
--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -3,9 +3,9 @@
 , fetchFromGitHub
 , makeWrapper
 , copyDesktopItems
-, electron
+, electron_33
 , nodejs
-, pnpm
+, pnpm_9
 , makeDesktopItem
 , autoSignDarwinBinariesHook
 , nix-update-script
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.13.2";
+  version = "1.14.1";
 
   passthru.updateScript = nix-update-script { };
 
@@ -21,12 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-07lf9jy22JUT+Vc5y9Tu1nkWaXU5RTdu3GibcvQsSs8=";
+    sha256 = "sha256-/aL6WZvUr2FAxR5L/gceMX/5PIYvOj/yiBbjZvP9rok=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-LPsNRd1c/cQeyBn3LZKnKeAsZ981sOkLYTnXIZL82LA=";
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src patches;
+    hash = "sha256-f7LDfKMPaVRtgvZLFz2JePXd45JBdBCNQR/Ch6VaBKU=";
   };
 
   patches = [
@@ -35,10 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    for file in packages/main/src/tray-animate-icon.ts packages/main/src/plugin/certificates.ts; do
-      substituteInPlace "$file" \
-        --replace-fail 'process.resourcesPath' "'$out/share/lib/podman-desktop/resources'"
-    done
+    substituteInPlace 'packages/main/src/plugin/certificates.ts' \
+      --replace-fail 'process.resourcesPath' "'$out/share/lib/podman-desktop/resources'"
     substituteInPlace "extensions/podman/packages/extension/src/util.ts" \
       --replace-fail '(process as any).resourcesPath' "'$out/share/lib/podman-desktop/resources'"
   '';
@@ -46,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
-    makeWrapper nodejs pnpm.configHook
+    makeWrapper nodejs pnpm_9.configHook
   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -56,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    cp -r ${electron.dist} electron-dist
+    cp -r ${electron_33.dist} electron-dist
     chmod -R u+w electron-dist
 
     pnpm build
@@ -64,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
       --dir \
       --config .electron-builder.config.cjs \
       -c.electronDist=electron-dist \
-      -c.electronVersion=${electron.version}
+      -c.electronVersion=${electron_33.version}
 
     runHook postBuild
   '';
@@ -84,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 
-    makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
+    makeWrapper '${electron_33}/bin/electron' "$out/bin/podman-desktop" \
       --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
@@ -113,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/containers/podman-desktop/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ booxter panda2134 ];
-    inherit (electron.meta) platforms;
+    inherit (electron_33.meta) platforms;
     mainProgram = "podman-desktop";
   };
 })

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.14.1";
+  version = "1.15.0";
 
   passthru.updateScript = nix-update-script { };
 
@@ -21,12 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-/aL6WZvUr2FAxR5L/gceMX/5PIYvOj/yiBbjZvP9rok=";
+    sha256 = "sha256-pewLcukPTXijEP11i2ah8F17N3Rav8UyHrpCu9fUScg=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src patches;
-    hash = "sha256-f7LDfKMPaVRtgvZLFz2JePXd45JBdBCNQR/Ch6VaBKU=";
+    hash = "sha256-EzkAcd84JEBq6eDkh9XCGfCyeo5r2vpZSIvb2hqpsBU=";
   };
 
   patches = [

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -43,9 +43,14 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'process.resourcesPath' "'$out/share/lib/podman-desktop/resources'"
     substituteInPlace "extensions/podman/packages/extension/src/util.ts" \
       --replace-fail '(process as any).resourcesPath' "'$out/share/lib/podman-desktop/resources'"
+    substituteInPlace 'package.json' \
+      --replace-fail 'playwright install' 'true'
   '';
 
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+  };
 
   nativeBuildInputs = [
     makeWrapper nodejs pnpm_9.configHook

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -20,12 +20,16 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman-desktop";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-pewLcukPTXijEP11i2ah8F17N3Rav8UyHrpCu9fUScg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pewLcukPTXijEP11i2ah8F17N3Rav8UyHrpCu9fUScg=";
   };
 
+  prePnpmInstall = ''
+    pnpm config set dedupe-peer-dependants false
+  '';
+
   pnpmDeps = pnpm_9.fetchDeps {
-    inherit (finalAttrs) pname version src patches;
+    inherit (finalAttrs) pname version src patches prePnpmInstall;
     hash = "sha256-EzkAcd84JEBq6eDkh9XCGfCyeo5r2vpZSIvb2hqpsBU=";
   };
 
@@ -41,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '(process as any).resourcesPath' "'$out/share/lib/podman-desktop/resources'"
   '';
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
     makeWrapper nodejs pnpm_9.configHook


### PR DESCRIPTION
Diff: https://github.com/podman-desktop/podman-desktop/compare/v1.13.2...v1.15.0

Update postPatch with https://github.com/podman-desktop/podman-desktop/commit/8af3761b41f051933726b187617d14227ab0f0b8

This PR aims to fix [failure in nixpkgs-update](https://nixpkgs-update-logs.nix-community.org/podman-desktop/2024-11-26.log)

```
patching file extensions/podman/packages/extension/package.json
substituteStream() in derivation podman-desktop-1.14.1: ERROR: pattern process.resourcesPath doesn't match anything in file 'packages/main/src/tray-animate-icon.ts'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
