### PR TITLE
ibm-plex: add sans-sc family

### DIFF
--- a/pkgs/by-name/ib/ibm-plex/hashes.nix
+++ b/pkgs/by-name/ib/ibm-plex/hashes.nix
@@ -6,6 +6,7 @@
   "sans-devanagari" = "sha256-K57OVqcH5r9tZx8NFEoz1P3xpUooqpF7xxJzNmnObwE=";
   "sans-thai" = "sha256-JZVbvZdj+IfBthiqivOXHrvAUe392M9ECGsiJkm0saE=";
   "sans-thai-looped" = "sha256-cry/Ctwt1bsrdbvWkJIYWLjsvV6a1lLFsT85znqERnw=";
+  "sans-sc" = "sha256-Q3cEVlR/UkNZaGIhNMIdojId6fHmAsZdLwMsKq1zLRY=";
   "sans-tc" = "sha256-kZvzSK6fEjfVMR4kxC4lxtD7GskqvJZx8BBJVT4T9MU=";
   "sans-kr" = "sha256-FsHxMvLlI4yylgG96DOZIdW2DYpk7I+c5QgkVIkNZIE=";
   "sans-jp" = "sha256-hUl/SSkN6q3pDTtrY2mJepw3ljhhLJskGbxfsTl9TuI=";

--- a/pkgs/by-name/ib/ibm-plex/update.sh
+++ b/pkgs/by-name/ib/ibm-plex/update.sh
@@ -11,6 +11,7 @@ families=(
     "sans-devanagari"
     "sans-thai"
     "sans-thai-looped"
+    "sans-sc"
     "sans-tc"
     "sans-kr"
     "sans-jp"


### PR DESCRIPTION
https://github.com/IBM/plex/releases/tag/%40ibm%2Fplex-sans-sc%401.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
