### PR TITLE
python3Packages.torchtnt: init at 0.2.4 

### DIFF
--- a/pkgs/development/python-modules/torchtnt/default.nix
+++ b/pkgs/development/python-modules/torchtnt/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "lightweight library for PyTorch training tools and utilities";
+    description = "Lightweight library for PyTorch training tools and utilities";
     homepage = "https://github.com/pytorch/tnt";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nim65s ];

--- a/pkgs/development/python-modules/torchtnt/default.nix
+++ b/pkgs/development/python-modules/torchtnt/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  fsspec,
+  numpy,
+  packaging,
+  psutil,
+  pyre-extensions,
+  tabulate,
+  tensorboard,
+  torch,
+  tqdm,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "torchtnt";
+  version = "0.2.4";
+  pyproject = true;
+
+  # no tag / releases on github
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Js9OcYllr8KT52FYtHKDciBVvPeelNDmfnC12/YcDJs=";
+  };
+
+  # requirements.txt is not included in Pypi archive
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'read_requirements("requirements.txt")' "[]" \
+      --replace-fail 'read_requirements("dev-requirements.txt")' "[]"
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    fsspec
+    numpy
+    packaging
+    psutil
+    pyre-extensions
+    setuptools
+    tabulate
+    tensorboard
+    torch
+    tqdm
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "torchtnt"
+  ];
+
+  # Tests are not included in Pypi archive
+  doCheck = false;
+
+  meta = {
+    description = "lightweight library for PyTorch training tools and utilities";
+    homepage = "https://github.com/pytorch/tnt";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16152,6 +16152,8 @@ self: super: with self; {
 
   torchsummary = callPackage ../development/python-modules/torchsummary { };
 
+  torchtnt = callPackage ../development/python-modules/torchtnt { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix {


### PR DESCRIPTION
This add https://github.com/pytorch/tnt, a "lightweight library for PyTorch training tools and utilities".

While here, this disable a recently failing test breaking torchsnapshot, ref. https://hydra.nixos.org/build/278371025/log/tail cc @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
