### PR TITLE
super-slicer: fix build for GCC 14

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -91,7 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # required for GCC 14
-  postPatch = ''
+  # (not applicable to super-slicer fork)
+  postPatch = lib.optionalString (finalAttrs.pname == "prusa-slicer") ''
     substituteInPlace src/libslic3r/Arrange/Core/DataStoreTraits.hpp \
       --replace-fail \
       "WritableDataStoreTraits<ArrItem>::template set" \

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -62,6 +62,11 @@ let
 
       substituteInPlace src/libslic3r/CMakeLists.txt \
         --replace "libexpat" "EXPAT::EXPAT"
+
+      # fixes GCC 14 error
+      substituteInPlace src/libslic3r/MeshBoolean.cpp \
+        --replace-fail 'auto &face' 'auto face' \
+        --replace-fail 'auto &vi' 'auto vi'
     '';
 
     # We don't need PS overrides anymore, and gcode-viewer is embedded in the binary.


### PR DESCRIPTION
Regression from #359083, #356812

cc @bendlas 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).