### PR TITLE
testers.hasPkgConfigModules: Shorten derivation name

### DIFF
--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -1,10 +1,20 @@
 # Static arguments
 { lib, runCommand, pkg-config }:
 
+let
+  genTestName = moduleNames:
+    # An overly long name made the progress bar weird and distraction, and same
+    # for the build log prefix.
+    if lib.length moduleNames > 1 then
+      "modules"
+    else
+      lib.head moduleNames;
+in
+
 # Tester arguments
 { package,
   moduleNames ? package.meta.pkgConfigModules,
-  testName ? "check-pkg-config-${lib.concatStringsSep "-" moduleNames}",
+  testName ? "check-pkg-config-${genTestName moduleNames}",
   version ? package.version or null,
   versionCheck ? false,
 }:

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -1,20 +1,10 @@
 # Static arguments
 { lib, runCommand, pkg-config }:
 
-let
-  genTestName = moduleNames:
-    # An overly long name made the progress bar weird and distraction, and same
-    # for the build log prefix.
-    if lib.length moduleNames > 1 then
-      "modules"
-    else
-      lib.head moduleNames;
-in
-
 # Tester arguments
 { package,
   moduleNames ? package.meta.pkgConfigModules,
-  testName ? "check-pkg-config-${genTestName moduleNames}",
+  testName ? "check-pkg-config-${package.pname or package.name}",
   version ? package.version or null,
   versionCheck ? false,
 }:


### PR DESCRIPTION
Overly long names are annoying, and grab attention that these tests usually don't need.
Keep it short and sweet.

This changes a behavior introduced in af60e68744fc34d61766d1bf0b58fc0cc6aa11de. I don't think anything depends on it.
cc @sternenseemann 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
