### PR TITLE
ocamlPackages.reason-react: init at 0.15.0

### DIFF
--- a/pkgs/development/ocaml-modules/reason-react/default.nix
+++ b/pkgs/development/ocaml-modules/reason-react/default.nix
@@ -1,0 +1,23 @@
+{
+  buildDunePackage,
+  melange,
+  reason,
+  reason-react-ppx,
+}:
+
+buildDunePackage {
+  pname = "reason-react";
+  inherit (reason-react-ppx) version src;
+  nativeBuildInputs = [
+    reason
+    melange
+  ];
+  buildInputs = [
+    reason-react-ppx
+    melange
+  ];
+  doCheck = true;
+  meta = reason-react-ppx.meta // {
+    description = "Reason bindings for React.js";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-react/ppx.nix
+++ b/pkgs/development/ocaml-modules/reason-react/ppx.nix
@@ -1,0 +1,31 @@
+{
+  buildDunePackage,
+  fetchurl,
+  lib,
+  ppxlib,
+}:
+
+let
+  version = "0.15.0";
+in
+buildDunePackage {
+  pname = "reason-react-ppx";
+  inherit version;
+  minimalOCamlVersion = "4.14";
+  src = fetchurl {
+    url = "https://github.com/reasonml/reason-react/releases/download/${version}/reason-react-${version}.tbz";
+    hash = "sha256-+pPJo/b50vp4pAC/ygI1LHB5O0pDJ1xpcQZOdFP8Q80=";
+  };
+  buildInputs = [
+    ppxlib
+  ];
+  doCheck = false; # Needs to run in reason-react, see default.nix
+  meta = {
+    description = "React.js JSX PPX";
+    homepage = "https://github.com/reasonml/reason-react";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.vog
+    ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1650,6 +1650,10 @@ let
 
     reason-native = lib.recurseIntoAttrs (callPackage ../development/ocaml-modules/reason-native { });
 
+    reason-react = callPackage ../development/ocaml-modules/reason-react { };
+
+    reason-react-ppx = callPackage ../development/ocaml-modules/reason-react/ppx.nix { };
+
     rebez = callPackage ../development/ocaml-modules/rebez { };
 
     reperf = callPackage ../development/ocaml-modules/reperf { };


### PR DESCRIPTION
This is a follow-up on #359923 where OCaml Melange was included. It adds the OCaml Reason-React bindings for using ReactJS from OCaml.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
