### PR TITLE
ci: init get-merge-commit workflow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -16,53 +16,29 @@ permissions:
   contents: read
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   attrs:
     name: Attributes
     runs-on: ubuntu-latest
+    needs: get-merge-commit
     outputs:
-      mergedSha: ${{ steps.merged.outputs.mergedSha }}
+      mergedSha: ${{ needs.get-merge-commit.outputs.mergedSha }}
       baseSha: ${{ steps.baseSha.outputs.baseSha }}
       systems: ${{ steps.systems.outputs.systems }}
     steps:
-      # Important: Because of `pull_request_target`, this doesn't check out the PR,
-      # but rather the base branch of the PR, which is needed so we don't run untrusted code
-      - name: Check out the ci directory of the base branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: base
-          sparse-checkout: ci
-      - name: Check if the PR can be merged and get the test merge commit
-        id: merged
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_EVENT: ${{ github.event_name }}
-        run: |
-          case "$GH_EVENT" in
-            push)
-              echo "mergedSha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-              ;;
-            pull_request_target)
-              if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
-                echo "Checking the merge commit $mergedSha"
-                echo "mergedSha=$mergedSha" >> "$GITHUB_OUTPUT"
-              else
-                # Skipping so that no notifications are sent
-                echo "Skipping the rest..."
-              fi
-              ;;
-          esac
-          rm -rf base
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         # Add this to _all_ subsequent steps to skip them
-        if: steps.merged.outputs.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         with:
-          ref: ${{ steps.merged.outputs.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           fetch-depth: 2
           path: nixpkgs
 
       - name: Determine base commit
-        if: github.event_name == 'pull_request_target' && steps.merged.outputs.mergedSha
+        if: github.event_name == 'pull_request_target' && needs.get-merge-commit.outputs.mergedSha
         id: baseSha
         run: |
           baseSha=$(git -C nixpkgs rev-parse HEAD^1)
@@ -70,18 +46,18 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
-        if: steps.merged.outputs.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
 
       - name: Evaluate the list of all attributes and get the systems matrix
         id: systems
-        if: steps.merged.outputs.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         run: |
           nix-build nixpkgs/ci -A eval.attrpathsSuperset
           echo "systems=$(<result/systems.json)" >> "$GITHUB_OUTPUT"
 
       - name: Upload the list of all attributes
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: steps.merged.outputs.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         with:
           name: paths
           path: result/*

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -1,0 +1,43 @@
+name: Get merge commit
+
+on:
+  workflow_call:
+    outputs:
+      mergedSha:
+        description: "The merge commit SHA"
+        value: ${{ jobs.resolve-merge-commit.outputs.mergedSha }}
+
+# We need a token to query the API, but it doesn't need any special permissions
+permissions: {}
+
+jobs:
+  resolve-merge-commit:
+    runs-on: ubuntu-latest
+    outputs:
+      mergedSha: ${{ steps.merged.outputs.mergedSha }}
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        path: base
+        sparse-checkout: ci
+    - name: Check if the PR can be merged and get the test merge commit
+      id: merged
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_EVENT: ${{ github.event_name }}
+      run: |
+        case "$GH_EVENT" in
+          push)
+            echo "mergedSha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            ;;
+          pull_request_target)
+            if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
+              echo "Checking the merge commit $mergedSha"
+              echo "mergedSha=$mergedSha" >> "$GITHUB_OUTPUT"
+            else
+              # Skipping so that no notifications are sent
+              echo "Skipping the rest..."
+            fi
+            ;;
+        esac
+        rm -rf base

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -19,46 +19,34 @@ permissions: {}
 # There is a feature request for suppressing notifications on concurrency-canceled runs: https://github.com/orgs/community/discussions/13015
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   check:
     name: nixpkgs-vet
     # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases.
     runs-on: ubuntu-latest
     # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
+    needs: get-merge-commit
     steps:
-      # This checks out the base branch because of pull_request_target
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: base
-          sparse-checkout: ci
-      - name: Resolving the merge commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
-            echo "Checking the merge commit $mergedSha"
-            echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
-          else
-            echo "Skipping the rest..."
-          fi
-          rm -rf base
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         with:
           # pull_request_target checks out the base branch by default
-          ref: ${{ env.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           # Fetches the merge commit and its parents
           fetch-depth: 2
       - name: Checking out base branch
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         run: |
           base=$(mktemp -d)
           git worktree add "$base" "$(git rev-parse HEAD^1)"
           echo "base=$base" >> "$GITHUB_ENV"
       - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
       - name: Fetching the pinned tool
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         # Update the pinned version using ci/nixpkgs-vet/update-pinned-tool.sh
         run: |
           # The pinned version of the tooling to use.
@@ -71,7 +59,7 @@ jobs:
           # Adds a result symlink as a GC root.
           nix-store --realise "$toolPath" --add-root result
       - name: Running nixpkgs-vet
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         env:
           # Force terminal colors to be enabled. The library that `nixpkgs-vet` uses respects https://bixense.com/clicolors/
           CLICOLOR_FORCE: 1

--- a/ci/README.md
+++ b/ci/README.md
@@ -58,7 +58,7 @@ Exit codes:
 
 ### Usage
 
-This script can be used in GitHub Actions workflows as follows:
+This script is implemented as a reusable GitHub Actions workflow, and can be used as follows:
 
 ```yaml
 on: pull_request_target
@@ -67,32 +67,19 @@ on: pull_request_target
 permissions: {}
 
 jobs:
+  get-merge-commit:
+    # use the relative path of the get-merge-commit workflow yaml here
+    uses: ./.github/workflows/get-merge-commit.yml
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: get-merge-commit
     steps:
-      # Important: Because of `pull_request_target`, this doesn't check out the PR,
-      # but rather the base branch of the PR, which is needed so we don't run untrusted code
-      - uses: actions/checkout@<VERSION>
-        with:
-          path: base
-          sparse-checkout: ci
-      - name: Resolving the merge commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
-            echo "Checking the merge commit $mergedSha"
-            echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
-          else
-            # Skipping so that no notifications are sent
-            echo "Skipping the rest..."
-          fi
-          rm -rf base
       - uses: actions/checkout@<VERSION>
         # Add this to _all_ subsequent steps to skip them
-        if: env.mergedSha
+        if: needs.get-merge-commit.outputs.mergedSha
         with:
-          ref: ${{ env.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
       - ...
 ```


### PR DESCRIPTION
Since we are preferring to use [get-merge-commit.sh](https://github.com/NixOS/nixpkgs/blob/4c9ca53890654b5e2fbb22ab8feb1842d81e01c1/ci/get-merge-commit.sh) to resolve the merge commit, let's make it a reusable workflow so we can use it in other actions (ie, in https://github.com/NixOS/nixpkgs/pull/361447)

Tested at https://github.com/JohnRTitor/nixpkgs/pull/2

