### PR TITLE
rubyPackages.rails-html-sanitizer: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -2915,10 +2915,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pm4z853nyz1bhhqr7fzl44alnx4bjachcr6rh6qjj375sfz3sc6";
+      sha256 = "1w6bqm8d3afc66ff6npnsc2d8ky552n6qzwwwc1bh0wz6c8gplp3";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.6.1";
   };
   railties = {
     dependencies = ["actionpack" "activesupport" "irb" "rackup" "rake" "thor" "zeitwerk"];


### PR DESCRIPTION
Fixes CVE-2024-53985, CVE-2024-53986, CVE-2024-53987, CVE-2024-53988 and CVE-2024-53989. https://discuss.rubyonrails.org/t/rails-html-sanitizer-v1-6-1-addresses-multiple-cves/88092

https://github.com/rails/rails-html-sanitizer/releases/tag/v1.6.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 361503`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 44 packages built:</summary>
  <ul>
    <li>rubyPackages.actioncable</li>
    <li>rubyPackages.actionmailbox</li>
    <li>rubyPackages.actionmailer</li>
    <li>rubyPackages.actionpack</li>
    <li>rubyPackages.actiontext</li>
    <li>rubyPackages.actionview</li>
    <li>rubyPackages.activestorage</li>
    <li>rubyPackages.jbuilder</li>
    <li>rubyPackages.rails</li>
    <li>rubyPackages.rails-html-sanitizer</li>
    <li>rubyPackages.railties</li>
    <li>rubyPackages_3_1.actioncable</li>
    <li>rubyPackages_3_1.actionmailbox</li>
    <li>rubyPackages_3_1.actionmailer</li>
    <li>rubyPackages_3_1.actionpack</li>
    <li>rubyPackages_3_1.actiontext</li>
    <li>rubyPackages_3_1.actionview</li>
    <li>rubyPackages_3_1.activestorage</li>
    <li>rubyPackages_3_1.jbuilder</li>
    <li>rubyPackages_3_1.rails</li>
    <li>rubyPackages_3_1.rails-html-sanitizer</li>
    <li>rubyPackages_3_1.railties</li>
    <li>rubyPackages_3_2.actioncable</li>
    <li>rubyPackages_3_2.actionmailbox</li>
    <li>rubyPackages_3_2.actionmailer</li>
    <li>rubyPackages_3_2.actionpack</li>
    <li>rubyPackages_3_2.actiontext</li>
    <li>rubyPackages_3_2.actionview</li>
    <li>rubyPackages_3_2.activestorage</li>
    <li>rubyPackages_3_2.jbuilder</li>
    <li>rubyPackages_3_2.rails</li>
    <li>rubyPackages_3_2.rails-html-sanitizer</li>
    <li>rubyPackages_3_2.railties</li>
    <li>rubyPackages_3_4.actioncable</li>
    <li>rubyPackages_3_4.actionmailbox</li>
    <li>rubyPackages_3_4.actionmailer</li>
    <li>rubyPackages_3_4.actionpack</li>
    <li>rubyPackages_3_4.actiontext</li>
    <li>rubyPackages_3_4.actionview</li>
    <li>rubyPackages_3_4.activestorage</li>
    <li>rubyPackages_3_4.jbuilder</li>
    <li>rubyPackages_3_4.rails</li>
    <li>rubyPackages_3_4.rails-html-sanitizer</li>
    <li>rubyPackages_3_4.railties</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
