### PR TITLE
rubyPackages.rexml: 3.3.6 -> 3.3.9

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -3148,10 +3148,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ik3in0957l9s6iwdm3nsk4za072cj27riiqgpx6zzcd22flbw3s";
+      sha256 = "1j9p66pmfgxnzp76ksssyfyqqrg7281dyi3xyknl3wwraaw7a66p";
       type = "gem";
     };
-    version = "3.3.6";
+    version = "3.3.9";
   };
   rmagick = {
     dependencies = ["observer" "pkg-config"];


### PR DESCRIPTION
Fixes CVE-2024-49761 (only impacts Ruby 3.1).

Changes:
https://github.com/ruby/rexml/releases/tag/v3.3.9
https://github.com/ruby/rexml/releases/tag/v3.3.8
https://github.com/ruby/rexml/releases/tag/v3.3.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 361513`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 196 packages built:</summary>
  <ul>
    <li>rubocop</li>
    <li>rubyPackages.cocoapods-dependencies</li>
    <li>rubyPackages.github-pages</li>
    <li>rubyPackages.jekyll</li>
    <li>rubyPackages.jekyll-archives</li>
    <li>rubyPackages.jekyll-avatar</li>
    <li>rubyPackages.jekyll-commonmark-ghpages</li>
    <li>rubyPackages.jekyll-compose</li>
    <li>rubyPackages.jekyll-default-layout</li>
    <li>rubyPackages.jekyll-favicon</li>
    <li>rubyPackages.jekyll-feed</li>
    <li>rubyPackages.jekyll-github-metadata</li>
    <li>rubyPackages.jekyll-include-cache</li>
    <li>rubyPackages.jekyll-mentions</li>
    <li>rubyPackages.jekyll-optional-front-matter</li>
    <li>rubyPackages.jekyll-readme-index</li>
    <li>rubyPackages.jekyll-redirect-from</li>
    <li>rubyPackages.jekyll-relative-links</li>
    <li>rubyPackages.jekyll-remote-theme</li>
    <li>rubyPackages.jekyll-seo-tag</li>
    <li>rubyPackages.jekyll-sitemap</li>
    <li>rubyPackages.jekyll-spaceship</li>
    <li>rubyPackages.jekyll-theme-architect</li>
    <li>rubyPackages.jekyll-theme-cayman</li>
    <li>rubyPackages.jekyll-theme-dinky</li>
    <li>rubyPackages.jekyll-theme-hacker</li>
    <li>rubyPackages.jekyll-theme-leap-day</li>
    <li>rubyPackages.jekyll-theme-merlot</li>
    <li>rubyPackages.jekyll-theme-midnight</li>
    <li>rubyPackages.jekyll-theme-minimal</li>
    <li>rubyPackages.jekyll-theme-modernist</li>
    <li>rubyPackages.jekyll-theme-primer</li>
    <li>rubyPackages.jekyll-theme-slate</li>
    <li>rubyPackages.jekyll-theme-tactile</li>
    <li>rubyPackages.jekyll-theme-time-machine</li>
    <li>rubyPackages.jekyll-titles-from-headings</li>
    <li>rubyPackages.jekyll-webmention_io</li>
    <li>rubyPackages.jemoji</li>
    <li>rubyPackages.kramdown</li>
    <li>rubyPackages.kramdown-parser-gfm</li>
    <li>rubyPackages.kramdown-rfc2629</li>
    <li>rubyPackages.minima</li>
    <li>rubyPackages.rexml</li>
    <li>rubyPackages.rubocop-performance</li>
    <li>rubyPackages.ruby-graphviz</li>
    <li>rubyPackages.solargraph</li>
    <li>rubyPackages.standard</li>
    <li>rubyPackages.standard-custom</li>
    <li>rubyPackages.standard-performance</li>
    <li>rubyPackages_3_1.cocoapods-dependencies</li>
    <li>rubyPackages_3_1.github-pages</li>
    <li>rubyPackages_3_1.jekyll</li>
    <li>rubyPackages_3_1.jekyll-archives</li>
    <li>rubyPackages_3_1.jekyll-avatar</li>
    <li>rubyPackages_3_1.jekyll-commonmark-ghpages</li>
    <li>rubyPackages_3_1.jekyll-compose</li>
    <li>rubyPackages_3_1.jekyll-default-layout</li>
    <li>rubyPackages_3_1.jekyll-favicon</li>
    <li>rubyPackages_3_1.jekyll-feed</li>
    <li>rubyPackages_3_1.jekyll-github-metadata</li>
    <li>rubyPackages_3_1.jekyll-include-cache</li>
    <li>rubyPackages_3_1.jekyll-mentions</li>
    <li>rubyPackages_3_1.jekyll-optional-front-matter</li>
    <li>rubyPackages_3_1.jekyll-readme-index</li>
    <li>rubyPackages_3_1.jekyll-redirect-from</li>
    <li>rubyPackages_3_1.jekyll-relative-links</li>
    <li>rubyPackages_3_1.jekyll-remote-theme</li>
    <li>rubyPackages_3_1.jekyll-seo-tag</li>
    <li>rubyPackages_3_1.jekyll-sitemap</li>
    <li>rubyPackages_3_1.jekyll-spaceship</li>
    <li>rubyPackages_3_1.jekyll-theme-architect</li>
    <li>rubyPackages_3_1.jekyll-theme-cayman</li>
    <li>rubyPackages_3_1.jekyll-theme-dinky</li>
    <li>rubyPackages_3_1.jekyll-theme-hacker</li>
    <li>rubyPackages_3_1.jekyll-theme-leap-day</li>
    <li>rubyPackages_3_1.jekyll-theme-merlot</li>
    <li>rubyPackages_3_1.jekyll-theme-midnight</li>
    <li>rubyPackages_3_1.jekyll-theme-minimal</li>
    <li>rubyPackages_3_1.jekyll-theme-modernist</li>
    <li>rubyPackages_3_1.jekyll-theme-primer</li>
    <li>rubyPackages_3_1.jekyll-theme-slate</li>
    <li>rubyPackages_3_1.jekyll-theme-tactile</li>
    <li>rubyPackages_3_1.jekyll-theme-time-machine</li>
    <li>rubyPackages_3_1.jekyll-titles-from-headings</li>
    <li>rubyPackages_3_1.jekyll-webmention_io</li>
    <li>rubyPackages_3_1.jemoji</li>
    <li>rubyPackages_3_1.kramdown</li>
    <li>rubyPackages_3_1.kramdown-parser-gfm</li>
    <li>rubyPackages_3_1.kramdown-rfc2629</li>
    <li>rubyPackages_3_1.minima</li>
    <li>rubyPackages_3_1.rexml</li>
    <li>rubyPackages_3_1.rubocop</li>
    <li>rubyPackages_3_1.rubocop-performance</li>
    <li>rubyPackages_3_1.ruby-graphviz</li>
    <li>rubyPackages_3_1.solargraph</li>
    <li>rubyPackages_3_1.standard</li>
    <li>rubyPackages_3_1.standard-custom</li>
    <li>rubyPackages_3_1.standard-performance</li>
    <li>rubyPackages_3_2.cocoapods-dependencies</li>
    <li>rubyPackages_3_2.github-pages</li>
    <li>rubyPackages_3_2.jekyll</li>
    <li>rubyPackages_3_2.jekyll-archives</li>
    <li>rubyPackages_3_2.jekyll-avatar</li>
    <li>rubyPackages_3_2.jekyll-commonmark-ghpages</li>
    <li>rubyPackages_3_2.jekyll-compose</li>
    <li>rubyPackages_3_2.jekyll-default-layout</li>
    <li>rubyPackages_3_2.jekyll-favicon</li>
    <li>rubyPackages_3_2.jekyll-feed</li>
    <li>rubyPackages_3_2.jekyll-github-metadata</li>
    <li>rubyPackages_3_2.jekyll-include-cache</li>
    <li>rubyPackages_3_2.jekyll-mentions</li>
    <li>rubyPackages_3_2.jekyll-optional-front-matter</li>
    <li>rubyPackages_3_2.jekyll-readme-index</li>
    <li>rubyPackages_3_2.jekyll-redirect-from</li>
    <li>rubyPackages_3_2.jekyll-relative-links</li>
    <li>rubyPackages_3_2.jekyll-remote-theme</li>
    <li>rubyPackages_3_2.jekyll-seo-tag</li>
    <li>rubyPackages_3_2.jekyll-sitemap</li>
    <li>rubyPackages_3_2.jekyll-spaceship</li>
    <li>rubyPackages_3_2.jekyll-theme-architect</li>
    <li>rubyPackages_3_2.jekyll-theme-cayman</li>
    <li>rubyPackages_3_2.jekyll-theme-dinky</li>
    <li>rubyPackages_3_2.jekyll-theme-hacker</li>
    <li>rubyPackages_3_2.jekyll-theme-leap-day</li>
    <li>rubyPackages_3_2.jekyll-theme-merlot</li>
    <li>rubyPackages_3_2.jekyll-theme-midnight</li>
    <li>rubyPackages_3_2.jekyll-theme-minimal</li>
    <li>rubyPackages_3_2.jekyll-theme-modernist</li>
    <li>rubyPackages_3_2.jekyll-theme-primer</li>
    <li>rubyPackages_3_2.jekyll-theme-slate</li>
    <li>rubyPackages_3_2.jekyll-theme-tactile</li>
    <li>rubyPackages_3_2.jekyll-theme-time-machine</li>
    <li>rubyPackages_3_2.jekyll-titles-from-headings</li>
    <li>rubyPackages_3_2.jekyll-webmention_io</li>
    <li>rubyPackages_3_2.jemoji</li>
    <li>rubyPackages_3_2.kramdown</li>
    <li>rubyPackages_3_2.kramdown-parser-gfm</li>
    <li>rubyPackages_3_2.kramdown-rfc2629</li>
    <li>rubyPackages_3_2.minima</li>
    <li>rubyPackages_3_2.rexml</li>
    <li>rubyPackages_3_2.rubocop</li>
    <li>rubyPackages_3_2.rubocop-performance</li>
    <li>rubyPackages_3_2.ruby-graphviz</li>
    <li>rubyPackages_3_2.solargraph</li>
    <li>rubyPackages_3_2.standard</li>
    <li>rubyPackages_3_2.standard-custom</li>
    <li>rubyPackages_3_2.standard-performance</li>
    <li>rubyPackages_3_4.cocoapods-dependencies</li>
    <li>rubyPackages_3_4.github-pages</li>
    <li>rubyPackages_3_4.jekyll</li>
    <li>rubyPackages_3_4.jekyll-archives</li>
    <li>rubyPackages_3_4.jekyll-avatar</li>
    <li>rubyPackages_3_4.jekyll-commonmark-ghpages</li>
    <li>rubyPackages_3_4.jekyll-compose</li>
    <li>rubyPackages_3_4.jekyll-default-layout</li>
    <li>rubyPackages_3_4.jekyll-favicon</li>
    <li>rubyPackages_3_4.jekyll-feed</li>
    <li>rubyPackages_3_4.jekyll-github-metadata</li>
    <li>rubyPackages_3_4.jekyll-include-cache</li>
    <li>rubyPackages_3_4.jekyll-mentions</li>
    <li>rubyPackages_3_4.jekyll-optional-front-matter</li>
    <li>rubyPackages_3_4.jekyll-readme-index</li>
    <li>rubyPackages_3_4.jekyll-redirect-from</li>
    <li>rubyPackages_3_4.jekyll-relative-links</li>
    <li>rubyPackages_3_4.jekyll-remote-theme</li>
    <li>rubyPackages_3_4.jekyll-seo-tag</li>
    <li>rubyPackages_3_4.jekyll-sitemap</li>
    <li>rubyPackages_3_4.jekyll-spaceship</li>
    <li>rubyPackages_3_4.jekyll-theme-architect</li>
    <li>rubyPackages_3_4.jekyll-theme-cayman</li>
    <li>rubyPackages_3_4.jekyll-theme-dinky</li>
    <li>rubyPackages_3_4.jekyll-theme-hacker</li>
    <li>rubyPackages_3_4.jekyll-theme-leap-day</li>
    <li>rubyPackages_3_4.jekyll-theme-merlot</li>
    <li>rubyPackages_3_4.jekyll-theme-midnight</li>
    <li>rubyPackages_3_4.jekyll-theme-minimal</li>
    <li>rubyPackages_3_4.jekyll-theme-modernist</li>
    <li>rubyPackages_3_4.jekyll-theme-primer</li>
    <li>rubyPackages_3_4.jekyll-theme-slate</li>
    <li>rubyPackages_3_4.jekyll-theme-tactile</li>
    <li>rubyPackages_3_4.jekyll-theme-time-machine</li>
    <li>rubyPackages_3_4.jekyll-titles-from-headings</li>
    <li>rubyPackages_3_4.jekyll-webmention_io</li>
    <li>rubyPackages_3_4.jemoji</li>
    <li>rubyPackages_3_4.kramdown</li>
    <li>rubyPackages_3_4.kramdown-parser-gfm</li>
    <li>rubyPackages_3_4.kramdown-rfc2629</li>
    <li>rubyPackages_3_4.minima</li>
    <li>rubyPackages_3_4.rexml</li>
    <li>rubyPackages_3_4.rubocop</li>
    <li>rubyPackages_3_4.rubocop-performance</li>
    <li>rubyPackages_3_4.ruby-graphviz</li>
    <li>rubyPackages_3_4.solargraph</li>
    <li>rubyPackages_3_4.standard</li>
    <li>rubyPackages_3_4.standard-custom</li>
    <li>rubyPackages_3_4.standard-performance</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
