### PR TITLE
ci: eval for pkgsStatic

### DIFF
--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -5,8 +5,8 @@ The code in this directory is used by the [eval.yml](../../.github/workflows/eva
 Furthermore it also allows local evaluation using
 ```
 nix-build ci -A eval.full \
-  --max-jobs 4
-  --cores 2
+  --max-jobs 4 \
+  --cores 2 \
   --arg chunkSize 10000
 ```
 

--- a/ci/supportedSystems.nix
+++ b/ci/supportedSystems.nix
@@ -1,6 +1,11 @@
 [
-  "aarch64-linux"
   "aarch64-darwin"
-  "x86_64-linux"
+  "aarch64-linux"
   "x86_64-darwin"
+  "x86_64-linux"
+
+  # The only thing "supported" here is preventing eval failures
+  # "x86_64-cygwin"
+  # "x86_64-freebsd"
+  "x86_64-musl"
 ]

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -57,6 +57,7 @@ let
     pkgs_i686_freebsd = packageSet' { system = "i686-freebsd"; };
     pkgs_i686_cygwin = packageSet' { system = "i686-cygwin"; };
     pkgs_x86_64_cygwin = packageSet' { system = "x86_64-cygwin"; };
+    pkgs_x86_64_musl = packageSet' { config = "x86_64-unknown-linux-musl"; isStatic = true; };
 
     in system:
       if system == "x86_64-linux" then pkgs_x86_64_linux
@@ -71,6 +72,7 @@ let
       else if system == "i686-freebsd" then pkgs_i686_freebsd
       else if system == "i686-cygwin" then pkgs_i686_cygwin
       else if system == "x86_64-cygwin" then pkgs_x86_64_cygwin
+      else if system == "x86_64-musl" then pkgs_x86_64_musl
       else abort "unsupported system type: ${system}";
 
   pkgsFor = pkgsForCross null;


### PR DESCRIPTION
Now that eval is running nicely in Github Actions, I wonder whether it would be possible to add more systems - just to make sure eval is not [easily broken](https://github.com/NixOS/nixpkgs/pull/361265)?

Since [RFC46](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md) is not really much help to figure out which platforms to do this on, I went grepping:

```
grep -ohrIE '(Platform|cc|stdenv|bintools)\.(is|use)[^ .]+\b' . | sed -e 's/^.*\.//g' | sort | uniq | xargs -I {} sh -c 'echo -n "{} "; grep -Ir "\b{}\b" . | wc -l'
```

The idea is: The more conditionals a platform uses in nixpkgs, the more useful an eval CI check is. I ran the numbers and cut off everything below 50 hits.

conditional | n |  eval
-- | -- | --
isDarwin | 6366 | :heavy_check_mark: :heavy_check_mark: 
isLinux | 2420 | :heavy_check_mark: :heavy_check_mark: 
isAarch64 | 689 | :heavy_check_mark: :heavy_check_mark: 
isClang | 458 | :heavy_check_mark: :heavy_check_mark: 
isStatic | 436 |  
isx86_64 | 364 | :heavy_check_mark: :heavy_check_mark: 
isMusl | 252 |  
isGNU | 186 | :heavy_check_mark: :heavy_check_mark: 
isWindows | 176 |  
isx86 | 134 | :heavy_check_mark: :heavy_check_mark: 
isFreeBSD | 128 |  
useLLVM | 118 |  
is64bit | 103 | :heavy_check_mark: :heavy_check_mark: :heavy_check_mark: :heavy_check_mark: 
isAarch32 | 93 |  
isi686 | 92 |  
isMinGW | 86 |  
isCygwin | 71 |  
is32bit | 64 |  
isAarch | 55 | :heavy_check_mark: :heavy_check_mark: 
isGhcjs | 50 |  

My conclusion: pkgsStatic on x86_64-linux, which covers both `isStatic` and `isMusl` is the next logical target. Especially, because eval currently succeeds as well.

I also tried x86_64-freebsd, which would give us `isFreeBSD` and `useLLVM` and x86_64-cygwin, which would give us `isWindows` and `isCygwin`. Both failed eval right now.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
