### PR TITLE
chromium,chromedriver: 131.0.6778.85 -> 131.0.6778.108

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "131.0.6778.85",
+    "version": "131.0.6778.108",
     "chromedriver": {
-      "hash_darwin": "sha256-li9wQkcgh5ORPu2kjdyfwvvuykRz1gTL3b8UVQs+MY4=",
-      "hash_darwin_aarch64": "sha256-r/C6QpmkVzovLJKfMTjUome9nL5WoEvPGRFB+AJJFqk="
+      "hash_darwin": "sha256-X0kzihCQsICn5SRdU+THdthov0EPxsmMcrm6YJ6hMhs=",
+      "hash_darwin_aarch64": "sha256-3Qdj44cZD4wQTzkBx47ZCfqHE2HckkLuqYKpJxxfESk="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d",
-        "hash": "sha256-fREToEHVbTD0IVGx/sn7csSju4BYajWZ+LDCiKWV4cI=",
+        "rev": "3b014839fbc4fb688b2f5af512d6ce312ad208b1",
+        "hash": "sha256-ypzu3LveMFcOFm7+JlaERjzs3SK/n9+sfm5wOKB8/zw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -120,8 +120,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "7e742cac42c29a14ab7f54b134b2f17592711267",
-        "hash": "sha256-K2gwKNwonzCIu4hnlYuOaYyKaRV11hwDzF4oykiKsl0="
+        "rev": "740d2502dbbd719a76c5a8d3fb4dac1b5363f42e",
+        "hash": "sha256-R41YVv4uWCU6SsACXPRppeCDguTs+/NVJckvMGGTgJE="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -600,8 +600,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "94631d9b9a10697325589e1642af63a0137cac94",
-        "hash": "sha256-SKKLOxjimQWt8W+Q3wlCJaUC/lxw6EIZDFBuVQKmnVY="
+        "rev": "f14f6b1ab7cf544c0190074488d17821281cfa4d",
+        "hash": "sha256-0p57otDuIShl6MngYs22XA1QYxptDVa3vCwJsH59H34="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -725,8 +725,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "8445abdf8069cadcbd134369b70d0ebd436ef477",
-        "hash": "sha256-EitEjXNtm0gB9wtAwIYHBHkU7paHg5zvsTz171hRmK4="
+        "rev": "79aff54b0fa9238ce3518dd9eaf9610cd6f22e82",
+        "hash": "sha256-xkMnUduSG88EWiwq6PITN0KgAKjFd4QOis3dgxedK30="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -760,8 +760,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "bd2671b973062afc614b852ec190524b80aaef8a",
-        "hash": "sha256-uq0CE7Chqzy2d+iifC3hV9RTnDVinpwjl1pOzyNGbSo="
+        "rev": "e38771cb283b9689683c5ac0b5831dd89f8ec690",
+        "hash": "sha256-csSDnepYxil0R3PD/LVxW7JBcasOKG4l6q6vj8zHV/I="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2024/12/stable-channel-update-for-desktop.html

This update includes 4 security fixes.

CVEs:
CVE-2024-12053

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
