### PR TITLE
CONTRIBUTING.md: Add info about PR labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -690,6 +690,9 @@ Ask them nicely whether they still intend to review your PR and find yourself an
 
 - Improve skimmability: use a simple descriptive PR title (details go in commit titles) outlining _what_ is done and _why_.
 - Improve discoverability: apply all relevant labels, tick all relevant PR body checkboxes.
+- Add labels:
+  - If your PR needs a review, add the `needs_reviewer` label
+  - If your PR already has an approving review and is ready to be merged, add the `needs_merger` label
 - Wait. Reviewers frequently browse open PRs and may happen to run across yours and take a look.
 - Get non-committers to review/approve. Many committers filter open PRs for low-hanging fruit that are already been reviewed.
 - [@-mention](https://github.blog/news-insights/mention-somebody-they-re-notified/) someone and ask them nicely


### PR DESCRIPTION
I had to stumble across the [needs_reviewer](https://github.com/NixOS/nixpkgs/labels/needs_reviewer) and [needs_merger](https://github.com/NixOS/nixpkgs/labels/needs_merger) labels but it seems they're actively used, so put them in the docs about how to get a PR merged.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
