### PR TITLE
zfs: warnIf kernel is not LTS, add LTS flag to kernels

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -133,3 +133,8 @@ This section was moved to the [Nixpkgs manual](https://nixos.org/nixpkgs/manual#
 It's a common issue that the latest stable version of ZFS doesn't support the latest
 available Linux kernel. It is recommended to use the latest available LTS that's compatible
 with ZFS. Usually this is the default kernel provided by nixpkgs (i.e. `pkgs.linuxPackages`).
+
+:::{.note}
+Using non-LTS releases with ZFS is likely to leave you in a situation where you are unable to update because it doesn't support any up-to-date kernel.
+NixOS will show an eval warning which further elaborates this issue aswell as how to turn the warning off should you choose to ignore it.
+:::

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -227,9 +227,22 @@ in
       modulePackage = lib.mkOption {
         internal = true; # It is supposed to be selected automatically, but can be overridden by expert users.
         default = selectModulePackage cfgZfs.package;
+        apply = pkg: pkg.override { inherit (cfgZfs) allowNonLTSKernels; };
         type = lib.types.package;
         description = "Configured ZFS kernel module package.";
       };
+
+      allowNonLTSKernels = lib.mkEnableOption ''
+        usage of ZFS with non-LTS kernels that are likely to become
+        incompatible, preventing you from updating the system until you switch
+        to an LTS kernel.
+
+        Please see the evaluation warning of the ZFS package for more
+        information. If you have never seen such a warning, this option very
+        likely doesn't apply to you.
+
+        This option suppresses the warning in case you chose to ignore it.
+      '';
 
       enabled = lib.mkOption {
         readOnly = true;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -63,6 +63,7 @@ lib.makeOverridable ({ # The kernel source tarball.
 , ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name != "pc"
 , extraMeta ? {}
 
+, isLTS      ? false
 , isZen      ? false
 , isLibre    ? false
 , isHardened ? false
@@ -234,7 +235,7 @@ kernel.overrideAttrs (finalAttrs: previousAttrs: {
 
   passthru = previousAttrs.passthru or { } // basicArgs // {
     features = kernelFeatures;
-    inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isZen isHardened isLibre;
+    inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isLTS isZen isHardened isLibre;
     isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
 
     # Adds dependencies needed to edit the config:

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -1,34 +1,42 @@
 {
     "testing": {
         "version": "6.13-rc1",
-        "hash": "sha256:0k3fj9wia9z0pv0vn3hzfzsrbp0lc84yjmww63ygac0fdvkml6l5"
+        "hash": "sha256:0k3fj9wia9z0pv0vn3hzfzsrbp0lc84yjmww63ygac0fdvkml6l5",
+        "lts": false
     },
     "6.1": {
         "version": "6.1.119",
-        "hash": "sha256:0y1j8bz99d5vkxklzpwhns5r77lpz2prszf6whfahi58s0wszkdf"
+        "hash": "sha256:0y1j8bz99d5vkxklzpwhns5r77lpz2prszf6whfahi58s0wszkdf",
+        "lts": true
     },
     "5.15": {
         "version": "5.15.173",
-        "hash": "sha256:1a3x3ld6g7ny0hdfqfvj5j2i5sx5l5p236pdnsr0icn9ri3jljwa"
+        "hash": "sha256:1a3x3ld6g7ny0hdfqfvj5j2i5sx5l5p236pdnsr0icn9ri3jljwa",
+        "lts": true
     },
     "5.10": {
         "version": "5.10.230",
-        "hash": "sha256:0isbb0ixqg4yzlh3lmdvnax4m1ikf2q4wk0b9vgqc63p7gpm066d"
+        "hash": "sha256:0isbb0ixqg4yzlh3lmdvnax4m1ikf2q4wk0b9vgqc63p7gpm066d",
+        "lts": true
     },
     "5.4": {
         "version": "5.4.286",
-        "hash": "sha256:0z48n7vahg318bgkccy8xqgl87vfb8zmn995cqh7z38fvzrm81qq"
+        "hash": "sha256:0z48n7vahg318bgkccy8xqgl87vfb8zmn995cqh7z38fvzrm81qq",
+        "lts": true
     },
     "6.6": {
         "version": "6.6.63",
-        "hash": "sha256:0d8q0vwv3lcix3wiq2n53rir3h298flg2l0ghpify4rlh2s4l1fi"
+        "hash": "sha256:0d8q0vwv3lcix3wiq2n53rir3h298flg2l0ghpify4rlh2s4l1fi",
+        "lts": true
     },
     "6.11": {
         "version": "6.11.11",
-        "hash": "sha256:1z2913y38clnlmhvwj49h7p4pic24s4d8np7nmd4lk7m2xz8w532"
+        "hash": "sha256:1z2913y38clnlmhvwj49h7p4pic24s4d8np7nmd4lk7m2xz8w532",
+        "lts": false
     },
     "6.12": {
         "version": "6.12.3",
-        "hash": "sha256:1bnycpkzcd6qdz4m5rx00wvkh9hs50q8c4aa93mg2l3xfz60k668"
+        "hash": "sha256:1bnycpkzcd6qdz4m5rx00wvkh9hs50q8c4aa93mg2l3xfz60k668",
+        "lts": false
     }
 }

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -28,6 +28,8 @@ lib.overrideDerivation (buildLinux (args // {
     efiBootStub = false;
   } // (args.features or {});
 
+  isLTS = true;
+
   extraMeta = if (rpiVersion < 3) then {
     platforms = with lib.platforms; arm;
     hydraPlatforms = [];

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -39,6 +39,8 @@ in buildLinux (args // {
     RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
   } // structuredExtraConfig;
 
+  isLTS = true;
+
   extraMeta = extraMeta // {
     inherit branch;
   };

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -40,6 +40,8 @@ in buildLinux (args // {
     RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
   } // structuredExtraConfig;
 
+  isLTS = true;
+
   extraMeta = extraMeta // {
     inherit branch;
   };

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
@@ -36,6 +36,8 @@ in buildLinux (args // {
     RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
   } // structuredExtraConfig;
 
+  isLTS = true;
+
   extraMeta = extraMeta // {
     inherit branch;
   };

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -40,6 +40,8 @@ in buildLinux (args // {
     RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
   } // structuredExtraConfig;
 
+  isLTS = true;
+
   extraMeta = extraMeta // {
     inherit branch;
   };

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -40,6 +40,8 @@ in buildLinux (args // {
     RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
   } // structuredExtraConfig;
 
+  isLTs = true;
+
   extraMeta = extraMeta // {
     inherit branch;
   };

--- a/pkgs/os-specific/linux/kernel/mainline.nix
+++ b/pkgs/os-specific/linux/kernel/mainline.nix
@@ -22,6 +22,7 @@ let
 
   args' = (builtins.removeAttrs args ["branch"]) // {
     inherit src version;
+    isLTS = thisKernel.lts;
 
     modDirVersion = lib.versions.pad 3 version;
     extraMeta.branch = branch;

--- a/pkgs/os-specific/linux/kernel/update-mainline.py
+++ b/pkgs/os-specific/linux/kernel/update-mainline.py
@@ -152,6 +152,7 @@ def main():
         all_kernels[branch] = {
             "version": kernel.version,
             "hash": get_hash(kernel),
+            "lts": kernel.nature == KernelNature.LONGTERM,
         }
 
         with VERSIONS_FILE.open("w") as fd:

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -16,6 +16,7 @@ let
     lts = {
       version = "6.6.63";
       hash = "sha256-P4B6r3p+Buu1Hf+RQsw5h2oUANVvQvQ4e/2gQcZ0vKw=";
+      isLTS = true;
     };
     main = {
       version = "6.11.10";
@@ -28,6 +29,7 @@ let
       version,
       suffix ? "xanmod1",
       hash,
+      isLTS ? false,
     }:
     buildLinux (
       args
@@ -69,6 +71,8 @@ let
           RCU_BOOST_DELAY = freeform "0";
           RCU_EXP_KTHREAD = yes;
         };
+
+        inherit isLTS;
 
         extraMeta = {
           branch = lib.versions.majorMinor version;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -311,7 +311,7 @@ in {
     inherit (kernel) stdenv; # in particular, use the same compiler by default
 
     # to help determine module compatibility
-    inherit (kernel) isZen isHardened isLibre;
+    inherit (kernel) isLTS isZen isHardened isLibre;
     inherit (kernel) kernelOlder kernelAtLeast;
     # Obsolete aliases (these packages do not depend on the kernel).
     inherit (pkgs) odp-dpdk pktgen; # added 2018-05


### PR DESCRIPTION
Please see the individual commit messages.

This is based on https://github.com/NixOS/nixpkgs/pull/361159 as to not cause conflicts with it.

If the kernel maintainers give their ACK for the kernel part, we can merge it before the next kernel update in a separate PR should the ZFS part take longer. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
