### PR TITLE
Revert "stdenv: `runPhase` returns status"

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1694,7 +1694,6 @@ showPhaseFooter() {
 
 
 runPhase() {
-    local retval=0
     local curPhase="$*"
     if [[ "$curPhase" = unpackPhase && -n "${dontUnpack:-}" ]]; then return; fi
     if [[ "$curPhase" = patchPhase && -n "${dontPatch:-}" ]]; then return; fi
@@ -1713,9 +1712,8 @@ runPhase() {
     startTime=$(date +"%s")
 
     # Evaluate the variable named $curPhase if it exists, otherwise the
-    # function named $curPhase. Trap errors in subshell to set non-zero retval.
-    trap 'retval=1; trap - ERR' ERR
-    eval "set -o errtrace; ${!curPhase:-$curPhase}"
+    # function named $curPhase.
+    eval "${!curPhase:-$curPhase}"
 
     endTime=$(date +"%s")
 
@@ -1727,8 +1725,6 @@ runPhase() {
 
         cd -- "${sourceRoot:-.}"
     fi
-
-    return $retval
 }
 
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#330751

Breaks the build of systemdMinimal and can be reapplied once this is sorted out.