### PR TITLE
sydbox: 3.28.3 -> 3.29.4

### DIFF
--- a/pkgs/by-name/sy/sydbox/package.nix
+++ b/pkgs/by-name/sy/sydbox/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sydbox";
-  version = "3.28.3";
+  version = "3.29.4";
 
   outputs = [
     "out"
@@ -25,10 +25,10 @@ rustPlatform.buildRustPackage rec {
     owner = "Sydbox";
     repo = "sydbox";
     rev = "refs/tags/v${version}";
-    hash = "sha256-9IegNFkOWYt+jdpN0rk4S/qyD/NSPaSqmFnMmCl/3Tk=";
+    hash = "sha256-k7qh375SuonybwgECI9Bl898FFigVxJ4L174AUDxntk=";
   };
 
-  cargoHash = "sha256-6/D//mkPDRW01SCLmQGWwFCClZ84aJUPhleWGVCJaKM=";
+  cargoHash = "sha256-iupVEo7ZEcKfPw3MbZoQqwWw9lKAbcFKeiLy+1DwXHU=";
 
   nativeBuildInputs = [
     mandoc
@@ -45,15 +45,17 @@ rustPlatform.buildRustPackage rec {
     "--skip=fs::tests::test_relative_symlink_resolution"
     # Failed to write C source file!: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
     "--skip=proc::tests::test_proc_set_at_secure_test_32bit_dynamic"
+    # Flakey. May only fail on OfBorg/Hydra
+    # Failed to write C source file!: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
+    "proc::tests::test_proc_set_at_secure_test_32bit_static"
+    # Failed to write C source file!: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
+    "--skip=proc::tests::test_proc_set_at_secure_test_32bit_static_pie"
     # /bin/false: Os { code: 2, kind: NotFound, message: "No such file or directory" }
     "--skip=syd_test"
 
-    # Endlessly stall. Maybe a sandbox issue?
+    # Endlessly stall or use "invalid arguments". Maybe a sandbox issue?
     "--skip=caps"
-    "--skip=landlock::compat::Compatible::set_compatibility"
-    "--skip=landlock::fs::PathBeneath"
-    "--skip=landlock::fs::PathFd"
-    "--skip=landlock::fs::path_beneath_rules"
+    "--skip=landlock"
     "--skip=proc::proc_cmdline"
     "--skip=proc::proc_comm"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
