### PR TITLE
julia.withPackages: add juliaCpuTarget option

### DIFF
--- a/doc/languages-frameworks/julia.section.md
+++ b/doc/languages-frameworks/julia.section.md
@@ -67,3 +67,14 @@ nix-shell -p 'julia.withPackages ["Plots"]' --run julia
 
   This normally points at a special augmented version of the Julia [General packages registry](https://github.com/JuliaRegistries/General).
   If you want to use a bleeding-edge version to pick up the latest package updates, you can plug in a later revision than the one in Nixpkgs.
+
+* `juliaCpuTarget`: Allows you to set `JULIA_CPU_TARGET` when precompiling. Has no effect if `precompile=false`.
+
+  You may want to use this if you're building a Julia depot that will end up in a Nix cache and used on machines with
+  different CPUs.
+
+  Why? Julia will detect the CPU microarchitecture of the build machine and include this information in the precompiled
+  `*.ji` files. Starting in 1.10 Julia became more strict about checking the CPU target compatibility, so it may reject
+  your precompiled files if they were compiled on a different machine.
+  A good option to provide wide compatibility is to set this to `"generic"`, although this may reduce performance.
+  You can also set a semicolon-separated list of multiple different targets. See the Julia documentation for details.

--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -1,13 +1,14 @@
-{ lib
-, callPackage
-, runCommand
+{ callPackage
 , fetchgit
 , fontconfig
 , git
+, lib
 , makeWrapper
+, python3
+, runCommand
+, system
 , writeText
 , writeTextFile
-, python3
 
 # Artifacts dependencies
 , fetchurl
@@ -23,18 +24,18 @@
 
 # Other overridable arguments
 , extraLibs ? []
-, precompile ? true
-, setDefaultDepot ? true
+, juliaCpuTarget ? null
+, makeTransitiveDependenciesImportable ? false # Used to support symbol indexing
 , makeWrapperArgs ? ""
 , packageOverrides ? {}
-, makeTransitiveDependenciesImportable ? false # Used to support symbol indexing
+, precompile ? true
+, setDefaultDepot ? true
 }:
 
 packageNames:
 
 let
   util = callPackage ./util.nix {};
-
 
   # Some Julia packages require access to Python. Provide a Nixpkgs version so it
   # doesn't try to install its own.
@@ -152,7 +153,7 @@ let
   # Build a Julia project and depot. The project contains Project.toml/Manifest.toml, while the
   # depot contains package build products (including the precompiled libraries, if precompile=true)
   projectAndDepot = callPackage ./depot.nix {
-    inherit closureYaml extraLibs overridesToml packageImplications precompile;
+    inherit closureYaml extraLibs juliaCpuTarget overridesToml packageImplications precompile;
     julia = juliaWrapped;
     registry = minimalRegistry;
     packageNames = if makeTransitiveDependenciesImportable

--- a/pkgs/development/julia-modules/depot.nix
+++ b/pkgs/development/julia-modules/depot.nix
@@ -9,17 +9,18 @@
 
 , closureYaml
 , extraLibs
+, juliaCpuTarget
 , overridesToml
-, packageNames
 , packageImplications
+, packageNames
 , precompile
 , registry
 }:
 
 runCommand "julia-depot" {
-    nativeBuildInputs = [curl git julia (python3.withPackages (ps: with ps; [pyyaml]))] ++ extraLibs;
-    inherit precompile registry;
-  } ''
+  nativeBuildInputs = [curl git julia (python3.withPackages (ps: with ps; [pyyaml]))] ++ extraLibs;
+  inherit precompile registry;
+} (''
   export HOME=$(pwd)
 
   echo "Building Julia depot and project with the following inputs"
@@ -42,7 +43,9 @@ runCommand "julia-depot" {
 
   # Only precompile if configured to below
   export JULIA_PKG_PRECOMPILE_AUTO=0
-
+'' + lib.optionalString (juliaCpuTarget != null) ''
+  export JULIA_CPU_TARGET="${juliaCpuTarget}"
+'' + ''
   # Prevent a warning where Julia tries to download package server info
   export JULIA_PKG_SERVER=""
 
@@ -84,6 +87,10 @@ runCommand "julia-depot" {
       Pkg.instantiate()
 
       if "precompile" in keys(ENV) && ENV["precompile"] != "0" && ENV["precompile"] != ""
+        if isdefined(Sys, :CPU_NAME)
+          println("Precompiling with CPU_NAME = " * Sys.CPU_NAME)
+        end
+
         Pkg.precompile()
       end
     end
@@ -91,4 +98,4 @@ runCommand "julia-depot" {
     # Remove the registry to save space
     Pkg.Registry.rm("General")
   '
-''
+'')


### PR DESCRIPTION
Copying from the documentation I added for this feature:

* `juliaCpuTarget`: Allows you to set `JULIA_CPU_TARGET` when precompiling. Has no effect if `precompile=false`.

  You may want to use this if you're building a Julia depot that will end up in a Nix cache and used on machines with
  different CPUs.

  Why? Julia will detect the CPU microarchitecture of the build machine and include this information in the precompiled
  `*.ji` files. Starting in 1.10 Julia became more strict about checking the CPU target compatibility, so it may reject
  your precompiled files if they were compiled on a different machine.
  A good option to provide wide compatibility is to set this to `"generic"`, although this may reduce performance.
  You can also set a semicolon-separated list of multiple different targets. See the Julia documentation for details.


## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
