### PR TITLE
commitlint-rs: 0.1.12 -> 0.2.2

### DIFF
--- a/pkgs/by-name/co/commitlint-rs/package.nix
+++ b/pkgs/by-name/co/commitlint-rs/package.nix
@@ -1,41 +1,43 @@
 {
-  fetchFromGitHub,
   lib,
+  commitlint-rs,
+  fetchFromGitHub,
   nix-update-script,
   rustPlatform,
   testers,
-  commitlint-rs,
 }:
+
 rustPlatform.buildRustPackage rec {
   pname = "commitlint-rs";
-  version = "0.1.12";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "KeisukeYamashita";
     repo = "commitlint-rs";
-    rev = "v${version}";
-    hash = "sha256-xDEd3jNmqur+ULjXOReolIDiqvpT2tAHj/IbH2op5Po=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-9az7AJ4NXmisRZiCFTdHQBVatgEIdRuKU6ZEKVHEgnQ=";
   };
-  cargoHash = "sha256-SNOy0B1QARfoueMsCjLZhJsGQy2jTSeFC/D1+R/FH4Y=";
+
+  cargoHash = "sha256-6Ur4s8bMSQR9mfh6apsocle6KDIsQ6gzU5luXH7BP7M=";
 
   passthru = {
-    updateScript = nix-update-script { };
     tests.version = testers.testVersion { package = commitlint-rs; };
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Lint commit messages with conventional commit messages";
     homepage = "https://keisukeyamashita.github.io/commitlint-rs";
     changelog = "https://github.com/KeisukeYamashita/commitlint-rs/releases/tag/${src.rev}";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       asl20
     ];
-    mainProgram = "commitlint";
-    platforms = with platforms; unix ++ windows;
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       croissong
       getchoo
     ];
+    mainProgram = "commitlint";
+    platforms = with lib.platforms; unix ++ windows;
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/KeisukeYamashita/commitlint-rs/releases/tag/v0.2.2
Diff: https://github.com/KeisukeYamashita/commitlint-rs/compare/v0.1.12...v0.2.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
