### PR TITLE
ytdl-sub: relax yt-dlp dependency

### DIFF
--- a/pkgs/by-name/yt/ytdl-sub/package.nix
+++ b/pkgs/by-name/yt/ytdl-sub/package.nix
@@ -15,6 +15,10 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-YMki+1rC726RtbZceoVbcpk/Gi3F81xxERQjpqLjn+A=";
   };
 
+  pythonRelaxDeps = [
+    "yt-dlp"
+  ];
+
   build-system = with python3Packages; [
     setuptools
     wheel


### PR DESCRIPTION
Fixes #361692

not tested, but it should work

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).