### PR TITLE
mixxx: fix source hash

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -63,7 +63,7 @@ mkDerivation rec {
     owner = "mixxxdj";
     repo = "mixxx";
     rev = version;
-    hash = "sha256-foY4K1rSth0GUjM1xpctI3fpavVjGoPMnRN2tT4Lsqg=";
+    hash = "sha256-YfpFRLosIIND+HnZN+76ZY0dQqEJaFkWZS84gZOCdfc=";
   };
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook3 ];


### PR DESCRIPTION
Upstream must have sneakily replaced the tagged version.
Or... the previous update was somehow done incorrectly, as ofborg almost immediately observed the hash mismatch.

Fixes #361702

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).