### PR TITLE
emulationstation-de: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
+++ b/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
@@ -1,18 +1,12 @@
---- a/resources/systems/unix/es_find_rules.xml	2023-11-22 15:18:15.912747163 -0500
-+++ b/resources/systems/unix/es_find_rules.xml	2023-11-22 15:20:38.628250448 -0500
-@@ -45,6 +45,8 @@
-             <entry>/usr/local/lib/libretro</entry>
-             <!-- NetBSD repository -->
-             <entry>/usr/pkg/lib/libretro</entry>
-+            <!-- NixOS / Nixpkgs -->
+--- a/resources/systems/linux/es_find_rules.xml	2024-09-13 16:19:36.000000000 +0300
++++ b/resources/systems/linux/es_find_rules.xml	2024-11-26 23:08:49.204498848 +0200
+@@ -41,6 +41,9 @@
+             <entry>/usr/lib64/libretro</entry>
+             <!-- Manjaro repository -->
+             <entry>/usr/lib/libretro</entry>
++            <!-- NixOS and Nixpkgs repository -->
 +            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
++            <entry>~/.nix-profile/lib/retroarch/cores</entry>
          </rule>
      </core>
      <emulator name="3DSEN-WINDOWS">
-@@ -1079,4 +1081,4 @@
-             <entry>~/bin/ZEsarUX/zesarux</entry>
-         </rule>
-     </emulator>
--</ruleList>
-\ No newline at end of file
-+</ruleList>

--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -1,30 +1,40 @@
 {
   lib,
   stdenv,
-  cmake,
   fetchzip,
+  fetchpatch,
+  cmake,
   pkg-config,
   alsa-lib,
   curl,
   ffmpeg,
   freeimage,
   freetype,
+  harfbuzz,
+  icu,
   libgit2,
   poppler,
   pugixml,
-  SDL2
+  SDL2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "emulationstation-de";
-  version = "3.0.2";
+  version = "3.1.0";
 
   src = fetchzip {
     url = "https://gitlab.com/es-de/emulationstation-de/-/archive/v${finalAttrs.version}/emulationstation-de-v${finalAttrs.version}.tar.gz";
-    hash = "sha256:RGlXFybbXYx66Hpjp2N3ovK4T5VyS4w0DWRGNvbwugs=";
+    hash = "sha256-v9nOY9T5VOVLBUKoDXqwYa1iYvW42iGA+3kpPUOmHkg=";
   };
 
-  patches = [ ./001-add-nixpkgs-retroarch-cores.patch ];
+  patches = [
+    (fetchpatch {
+      name = "fix-buffer-overflow-detection-with-gcc-fortification";
+      url = "https://gitlab.com/es-de/emulationstation-de/-/commit/41fd33fdc3dacef507b987ed316aec2b0d684317.patch";
+      sha256 = "sha256-LHJ11mtBn8hRU97+Lz9ugPTTGUAxrPz7yvyxqNOAYKY=";
+    })
+    ./001-add-nixpkgs-retroarch-cores.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -37,36 +47,18 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     freeimage
     freetype
+    harfbuzz
+    icu
     libgit2
     poppler
     pugixml
     SDL2
   ];
 
-  installPhase = ''
-    # Binary
-    install -D ../es-de $out/bin/es-de
-
-    # Resources
-    mkdir -p $out/share/es-de/
-    cp -r ../resources/ $out/share/es-de/resources/
-
-    # Desktop file
-    mkdir -p $out/share/applications
-    cp ../es-app/assets/org.es_de.frontend.desktop $out/share/applications/
-
-    # Icon
-    mkdir -p $out/share/icons/hicolor/scalable/apps
-    cp ../es-app/assets/org.es_de.frontend.svg $out/share/icons/hicolor/scalable/apps/
-  '';
-
-  postInstall = ''
-    substituteInPlace $out/share/applications/org.es_de.frontend.desktop \
-      --replace "Exec=es-de" "Exec=$out/bin/es-de"
-  '';
+  cmakeFlags = [ (lib.cmakeBool "APPLICATION_UPDATER" false) ];
 
   meta = {
-    description = "EmulationStation Desktop Edition is a frontend for browsing and launching games from your multi-platform game collection";
+    description = "ES-DE (EmulationStation Desktop Edition) is a frontend for browsing and launching games from your multi-platform collection";
     homepage = "https://es-de.org";
     maintainers = with lib.maintainers; [ ivarmedi ];
     license = lib.licenses.mit;


### PR DESCRIPTION
[Changelog](https://gitlab.com/es-de/emulationstation-de/-/blob/master/CHANGELOG.md)

Commit [41fd33fd](https://gitlab.com/es-de/emulationstation-de/-/commit/41fd33fdc3dacef507b987ed316aec2b0d684317) has been backported to fix a buffer overflow detection by glibc's source fortification ([relevant issue here](https://gitlab.com/es-de/emulationstation-de/-/issues/1754)).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
