### PR TITLE
nixos/victoriametrics: the prometheusConfig option isn't null by default

### DIFF
--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -139,7 +139,7 @@ in
       serviceConfig = {
         ExecStart = lib.escapeShellArgs (
           startCLIList
-          ++ lib.optionals (cfg.prometheusConfig != null) [ "-promscrape.config=${prometheusConfigYml}" ]
+          ++ lib.optionals (cfg.prometheusConfig != {}) [ "-promscrape.config=${prometheusConfigYml}" ]
         );
 
         DynamicUser = true;

--- a/nixos/modules/services/monitoring/vmagent.nix
+++ b/nixos/modules/services/monitoring/vmagent.nix
@@ -115,7 +115,7 @@ in {
         CacheDirectory = "vmagent";
         ExecStart = lib.escapeShellArgs (
           startCLIList
-          ++ lib.optionals (cfg.prometheusConfig != null) ["-promscrape.config=${prometheusConfigYml}"]
+          ++ lib.optionals (cfg.prometheusConfig != {}) ["-promscrape.config=${prometheusConfigYml}"]
         );
         LoadCredential = lib.optional (cfg.remoteWrite.basicAuthPasswordFile != null) [
           "remote_write_basic_auth_password:${cfg.remoteWrite.basicAuthPasswordFile}"

--- a/nixos/tests/victoriametrics/default.nix
+++ b/nixos/tests/victoriametrics/default.nix
@@ -7,4 +7,5 @@
 {
   remote-write = import ./remote-write.nix { inherit system pkgs; };
   vmalert = import ./vmalert.nix { inherit system pkgs; };
+  external-promscrape-config = import ./external-promscrape-config.nix { inherit system pkgs; };
 }

--- a/nixos/tests/victoriametrics/external-promscrape-config.nix
+++ b/nixos/tests/victoriametrics/external-promscrape-config.nix
@@ -1,0 +1,82 @@
+import ../make-test-python.nix (
+  {
+    lib,
+    pkgs,
+    ...
+  }:
+  let
+    nodeExporterPort = 9100;
+    promscrapeConfig = {
+      global = {
+        scrape_interval = "2s";
+      };
+      scrape_configs = [
+        {
+          job_name = "node";
+          static_configs = [
+            {
+              targets = [
+                "node:${toString nodeExporterPort}"
+              ];
+            }
+          ];
+        }
+      ];
+    };
+    settingsFormat = pkgs.formats.yaml { };
+    promscrapeConfigYaml = settingsFormat.generate "prometheusConfig.yaml" promscrapeConfig;
+  in
+  {
+    name = "victoriametrics-external-promscrape-config";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [
+        ryan4yin
+      ];
+    };
+
+    nodes = {
+      victoriametrics =
+        {
+          config,
+          pkgs,
+          ...
+        }:
+        {
+          environment.systemPackages = [ pkgs.jq ];
+          networking.firewall.allowedTCPPorts = [ 8428 ];
+          services.victoriametrics = {
+            enable = true;
+            extraOptions = [
+              "-promscrape.config=${toString promscrapeConfigYaml}"
+            ];
+          };
+        };
+
+      node =
+        { ... }:
+        {
+          services.prometheus.exporters.node = {
+            enable = true;
+            openFirewall = true;
+          };
+        };
+    };
+
+    testScript = ''
+      node.wait_for_unit("prometheus-node-exporter")
+      node.wait_for_open_port(${toString nodeExporterPort})
+
+      victoriametrics.wait_for_unit("victoriametrics")
+      victoriametrics.wait_for_open_port(8428)
+
+
+      promscrape_config = victoriametrics.succeed("journalctl -u victoriametrics -o cat | grep 'promscrape.config'")
+      assert '${toString promscrapeConfigYaml}' in promscrape_config
+
+      victoriametrics.wait_until_succeeds(
+        "curl -sf 'http://localhost:8428/api/v1/query?query=node_exporter_build_info\{instance=\"node:9100\"\}' | "
+        + "jq '.data.result[0].value[1]' | grep '\"1\"'"
+      )
+    '';
+  }
+)


### PR DESCRIPTION
Fix the problem introduced by #350737 & #353950: Since `prometheusConfig` defaults to `{}`, the check `cfg.prometheusConfig != null` always passes, which prevents the custom `-promscrape.config=xxx` from working.

Related to https://github.com/NixOS/nixpkgs/pull/350737#issuecomment-2515169901

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
