### PR TITLE
tonelib-gfx: 4.8.5 -> 4.8.7

### DIFF
--- a/pkgs/by-name/to/tonelib-gfx/package.nix
+++ b/pkgs/by-name/to/tonelib-gfx/package.nix
@@ -17,11 +17,21 @@
 
 stdenv.mkDerivation rec {
   pname = "tonelib-gfx";
-  version = "4.8.5";
+  version = "4.8.7";
 
+  # It's hard to find out when a release happens and what version that release is,
+  #  without visiting the site directly.
+  #
+  # The following command can retrieve the latest released version.
+  # curl --silent https://tonelib.net/downloads.html | \
+  #     grep -P 'ToneLib GFX</h3' -A3 | \
+  #     sed -nE 's/^.*Version: ([0-9.]+).*/\1/p'
+  #
+  # The following command gives us the URL for the latest release without intermediate redirects.
+  # curl --head 'https://www.tonelib.net/download.php?id=gfx&os=lnx'
   src = fetchurl {
-    url = "https://tonelib.vip/download/24-10-03/ToneLib-GFX-amd64.deb";
-    hash = "sha256-RG5rliF4/9LDd07i5dSFQzTGPqyF6UmTfatKb59LZA4=";
+    url = "https://tonelib.vip/download/24-10-24/ToneLib-GFX-amd64.deb";
+    hash = "sha256-2ao6tTRbPMpE2Y/7/gwQN3G5Z6Uu+SQel9o1ejwD9v4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bump version to `4.8.7`

Added comment with information about fetching the latest version and release link since this can be hard to find without visiting the download page or turning on in-application version upgrades (which wouldn't work for NixOS anyways)



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
