### PR TITLE
gImageReader: 3.4.2 -> unstable-2025-06-04, add support for Qt

### DIFF
--- a/pkgs/by-name/gi/gImageReader/package.nix
+++ b/pkgs/by-name/gi/gImageReader/package.nix
@@ -17,6 +17,8 @@
   json-glib,
   ninja,
   python3,
+  doxygen,
+  enchant,
 
   # Gtk deps
   # upstream gImagereader supports Qt too
@@ -28,21 +30,24 @@
   gtkspell3,
   gtkspellmm,
   cairomm,
+  kdePackages,
+  qt6Packages,
+  withQt6 ? false,
+  wrapQtAppsHook ? null,
 }:
 
 let
-  variant = "gtk";
   pythonEnv = python3.withPackages (ps: with ps; [ pygobject3 ]);
 in
 stdenv.mkDerivation rec {
   pname = "gImageReader";
-  version = "3.4.2";
+  version = "5aff249fdc119caa1464af9405259799b4f69d8b";
 
   src = fetchFromGitHub {
     owner = "manisandro";
     repo = "gImageReader";
-    rev = "v${version}";
-    sha256 = "sha256-yBkVeufRRoSAc20/8mV39widBPloHFz12K7B4Y9xiWg=";
+    rev = "${version}";
+    sha256 = "sha256-xS63iGY1yf0NEnGuss0sme1vSYd2L3sOUd/g8yyPn1k=";
   };
 
   nativeBuildInputs = [
@@ -51,40 +56,52 @@ stdenv.mkDerivation rec {
     intltool
     pkg-config
     pythonEnv
-
-    # Gtk specific
-    wrapGAppsHook3
+    enchant
     gobject-introspection
-  ];
+    wrapGAppsHook3
+  ] ++ lib.optionals withQt6 [ qt6Packages.wrapQtAppsHook ];
 
-  buildInputs = [
-    libxmlxx3
-    libzip
-    libuuid
-    sane-backends
-    podofo
-    libjpeg
-    djvulibre
-    tesseract
-    poppler
+  buildInputs =
+    [
+      libxmlxx3
+      libzip
+      libuuid
+      sane-backends
+      podofo
+      libjpeg
+      djvulibre
+      tesseract
+      poppler
+      doxygen
+      cairomm
+      gtkmm3
+      gtksourceview3
+      gtksourceviewmm
+      gtkspell3
+      gtkspellmm
+      json-glib
+    ]
+    ++ lib.optionals withQt6 (
+      with qt6Packages;
+      [
+        kdePackages.poppler
+        qtbase
+        qtspell
+        qttools
+        quazip
+      ]
+    );
 
-    # Gtk specific
-    gtkmm3
-    gtkspell3
-    gtkspellmm
-    gtksourceview3
-    gtksourceviewmm
-    cairomm
-    json-glib
-  ];
-
-  # interface type can be where <type> is either gtk, qt5, qt4
-  cmakeFlags = [ "-DINTERFACE_TYPE=${variant}" ];
+  # interface type can be where <type> is either gtk, qt6
+  cmakeFlags = [
+    "-DINTERFACE_TYPE=gtk"
+  ] ++ lib.optionals withQt6 [ "-DINTERFACE_TYPE=qt6 -DQT_VER=6" ];
 
   meta = with lib; {
     description = "Simple Gtk/Qt front-end to tesseract-ocr";
-    mainProgram = "gimagereader-gtk";
+    mainProgram = if withQt6 then "gImageReader-qt6" else "gImageReader";
     homepage = "https://github.com/manisandro/gImageReader";
+    changelog = "https://github.com/manisandro/gImageReader/blob/${version}/NEWS";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ teto ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12311,6 +12311,10 @@ with pkgs;
   geany = callPackage ../applications/editors/geany { };
   geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
 
+  gImageReader-qt = qt6Packages.callPackage ../by-name/gi/gImageReader/package.nix {
+    withQt6 = true;
+  };
+
   gnuradio = callPackage ../applications/radio/gnuradio/wrapper.nix {
     unwrapped = callPackage ../applications/radio/gnuradio {
       python = python311;


### PR DESCRIPTION
Now that [qtspell](https://github.com/NixOS/nixpkgs/pull/258143) was added it's possible to build gImageReader with qt6 (and probably qt5 also).

diff: https://github.com/manisandro/gImageReader/compare/v3.4.2...af9e94e0714337d74e9fe1f21db7e3b1531852de

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
