### PR TITLE
nerd-fonts: correct typos in descriptions

### DIFF
--- a/pkgs/data/fonts/nerd-fonts/manifests/fonts.json
+++ b/pkgs/data/fonts/nerd-fonts/manifests/fonts.json
@@ -97,7 +97,7 @@
   },
   {
     "caskName": "comic-shanns-mono",
-    "description": "The very typeface you\u2019ve been trained to recognize since childhood",
+    "description": "The very typeface you’ve been trained to recognize since childhood",
     "folderName": "ComicShannsMono",
     "licenseId": "MIT",
     "patchedName": "ComicShannsMono",
@@ -217,7 +217,7 @@
   },
   {
     "caskName": "hack",
-    "description": "Dotted zero, short descenders, expands upon work done for Bitstream Vera &amp; DejaVu, legible at common sizes",
+    "description": "Dotted zero, short descenders, expands upon work done for Bitstream Vera & DejaVu, legible at common sizes",
     "folderName": "Hack",
     "licenseId": "Bitstream-Vera AND MIT",
     "patchedName": "Hack",
@@ -281,7 +281,7 @@
   },
   {
     "caskName": "intone-mono",
-    "description": "Expressive monospaced font family that\u2019s built with clarity, legibility, and the needs of developers in mind",
+    "description": "Expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind",
     "folderName": "IntelOneMono",
     "licenseId": "OFL-1.1-RFN",
     "patchedName": "IntoneMono",
@@ -377,7 +377,7 @@
   },
   {
     "caskName": "monoid",
-    "description": "Ligatures, distinguishable glyphs with short ascenders &amp; descenders, large operators &amp; punctuation",
+    "description": "Ligatures, distinguishable glyphs with short ascenders & descenders, large operators & punctuation",
     "folderName": "Monoid",
     "licenseId": "MIT OR OFL-1.1-no-RFN",
     "patchedName": "Monoid",
@@ -513,7 +513,7 @@
   },
   {
     "caskName": "ubuntu-mono",
-    "description": "Dotted zeros, used the `n`, `o`, `H` &amp; `O` Latin characters as a base for design",
+    "description": "Dotted zeros, used the `n`, `o`, `H` & `O` Latin characters as a base for design",
     "folderName": "UbuntuMono",
     "licenseId": "LicenseRef-UbuntuFont",
     "patchedName": "UbuntuMono",

--- a/pkgs/data/fonts/nerd-fonts/update.py
+++ b/pkgs/data/fonts/nerd-fonts/update.py
@@ -3,6 +3,7 @@
 import os
 import urllib.request as ureq
 import json
+import html
 
 if not all(
     f"UPDATE_NIX_{v}" in os.environ
@@ -28,12 +29,12 @@ def fetchjson(url):
 
 def storejson(path, obj):
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(obj, f, indent=2)
+        json.dump(obj, f, indent=2, ensure_ascii=False)
         # Needed to satisfy EditorConfig's rules
         f.write('\n')
 
 def slicedict(d, ks):
-    return {k: d[k] for k in ks}
+    return {k: html.unescape(d[k]) for k in ks}
 
 os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), "manifests"))
 


### PR DESCRIPTION
Characters such as `&` and `'` were encoded as `&amp;` and `\u2019`. This fixes that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
