### PR TITLE
Update git-sync 0-unstable-2024-02-15 → 0-unstable-2024-11-30

### DIFF
--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -8,6 +8,7 @@
   gnused,
   makeWrapper,
   inotify-tools,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -50,6 +51,10 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/git-sync-on-inotify \
       --prefix PATH : $wrap_path
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Script to automatically synchronize a git repository";

--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -1,14 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, coreutils, git, gnugrep, gnused, makeWrapper, inotify-tools }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  coreutils,
+  git,
+  gnugrep,
+  gnused,
+  makeWrapper,
+  inotify-tools,
+}:
 
 stdenv.mkDerivation rec {
   pname = "git-sync";
-  version = "0-unstable-2024-02-15";
+  version = "0-unstable-2024-11-30";
 
   src = fetchFromGitHub {
     owner = "simonthum";
     repo = "git-sync";
-    rev = "493b0155fb974b477b6ea623d6e41e13ddad8500";
-    hash = "sha256-hsq+kpB+akjbFKBeHMsP8ibrtygEG2Yf2QW9vFFIano=";
+    rev = "7242291edf543ecc1bb9de8f47086bb69a5cb9f7";
+    hash = "sha256-t1NVgp+ELmTMK0N1fFFJCoKQd8mSYSMAIDG9+kNs3Ok=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -21,12 +31,15 @@ stdenv.mkDerivation rec {
     cp -a contrib/git-* $out/bin/
   '';
 
-  wrapperPath = lib.makeBinPath ([
-    coreutils
-    git
-    gnugrep
-    gnused
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ inotify-tools ]);
+  wrapperPath = lib.makeBinPath (
+    [
+      coreutils
+      git
+      gnugrep
+      gnused
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ inotify-tools ]
+  );
 
   postFixup = ''
     wrap_path="${wrapperPath}":$out/bin


### PR DESCRIPTION
I have updated git-sync to point to the newest release on master.
This includes a fix by me to allow use with whitespace paths.

I additionally added the nix-update-script to auto-update git-sync in the future.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Formatted code with nixfmt before pushing. 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
