### PR TITLE
coredns: assign an optional priority variable to externalPlugins

### DIFF
--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -11,11 +11,11 @@
 let
   attrsToPlugins = attrs:
     let
-        sortedAttrs = lib.sort (a: b: (a.priority or 1) > (b.priority or 1)) attrs;
+        sortedAttrs = lib.sort (a: b: (a.priority or 0) > (b.priority or 0)) attrs;
     in
-        builtins.map ({name, repo, version, priority ? 1}: "${toString priority}i${name}:${repo}") sortedAttrs;
+        builtins.map ({name, repo, version, priority ? 0}: "${toString priority}i${name}:${repo}") sortedAttrs;
   attrsToSources = attrs:
-    builtins.map ({name, repo, version, priority ? 1}: "${repo}@${version}") attrs;
+    builtins.map ({name, repo, version, priority ? 0}: "${repo}@${version}") attrs;
 in buildGoModule rec {
   pname = "coredns";
   version = "1.11.3";
@@ -34,8 +34,16 @@ in buildGoModule rec {
   outputs = [ "out" "man" ];
 
   # Override the go-modules fetcher derivation to fetch plugins
+  # If a priority is set, the plugin will be inserted at that line number in the plugin.cfg
+  # otherwise it will be appended to the end of the file
   modBuildPhase = ''
-    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do sed -i "$plugin" plugin.cfg; done
+    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do
+      if [[ "$plugin" == 0i* ]]; then
+        echo "''${plugin:2}" >> plugin.cfg
+      else
+        sed -i "$plugin" plugin.cfg
+      fi
+    done
     for src in ${builtins.toString (attrsToSources externalPlugins)}; do go get $src; done
     GOOS= GOARCH= go generate
     go mod vendor

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -10,7 +10,10 @@
 
 let
   attrsToPlugins = attrs:
-    builtins.map ({name, repo, version, priority ? 1}: "${toString priority}i${name}:${repo}") attrs;
+    let
+        sortedAttrs = lib.sort (a: b: (a.priority or 1) > (b.priority or 1)) attrs;
+    in
+        builtins.map ({name, repo, version, priority ? 1}: "${toString priority}i${name}:${repo}") sortedAttrs;
   attrsToSources = attrs:
     builtins.map ({name, repo, version, priority ? 1}: "${repo}@${version}") attrs;
 in buildGoModule rec {

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -10,9 +10,9 @@
 
 let
   attrsToPlugins = attrs:
-    builtins.map ({name, repo, version}: "${name}:${repo}") attrs;
+    builtins.map ({name, repo, version, priority ? 1}: "${toString priority}i${name}:${repo}") attrs;
   attrsToSources = attrs:
-    builtins.map ({name, repo, version}: "${repo}@${version}") attrs;
+    builtins.map ({name, repo, version, priority ? 1}: "${repo}@${version}") attrs;
 in buildGoModule rec {
   pname = "coredns";
   version = "1.11.3";
@@ -32,7 +32,7 @@ in buildGoModule rec {
 
   # Override the go-modules fetcher derivation to fetch plugins
   modBuildPhase = ''
-    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do echo $plugin >> plugin.cfg; done
+    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do sed -i "$plugin" plugin.cfg; done
     for src in ${builtins.toString (attrsToSources externalPlugins)}; do go get $src; done
     GOOS= GOARCH= go generate
     go mod vendor


### PR DESCRIPTION
In CoreDNS, the order in which plugins are executed is based on their position in the `plugin.cfg` file, the higher the position in the list, the higher the priority.
Right now, all newly added externalPlugins are put at the bottom of `plugin.cfg`, which gives them the lowest priority. This means that in the following example the `tailscale` plugin will never be executed, as `forward` has priority.

```
  services.coredns = {
    enable = true;

    package = coredns.override {
      externalPlugins = [
        {
          name = "tailscale";
          repo = "github.com/damomurf/coredns-tailscale";
          version = "d42c032feb511709cc51c9e22037561073ecbe26";
        }
      ];
      vendorHash = "sha256-1H7acpFcnIks9x2oKTV630EN/TPmdG3M1O2qo0/EY6k=";
    };

    config = ''
      example.com {
        tailscale example.com {
          fallthrough
        }
        forward . 1.1.1.1
        log
        errors
        debug
      }
    '';
  };

``` 


The proposed change adds an optional variable `priority` to externalPlugins that allows to choose the exact position in the config.cfg file in which we want the new plugin to be. By default this is the top of the file. 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
