### PR TITLE
nix-prefetch-scripts: add bash to inputs

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,12 +1,14 @@
 { lib, stdenv, makeWrapper, buildEnv
-, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, nix, subversion
+, bash, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, nix, subversion
 }:
 
 let mkPrefetchScript = tool: src: deps:
   stdenv.mkDerivation {
     name = "nix-prefetch-${tool}";
 
+    strictDeps = true;
     nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ bash ];
 
     dontUnpack = true;
 


### PR DESCRIPTION
These scripts depend on bash via `/bin/sh` or `/usr/bin/env bash`.

I believe this change is only required because I enabled `strictDepsByDefault` in my checkout (#178468).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).