### PR TITLE
zabbix60: 6.0.26 -> 6.0.36, zabbix64: 6.4.15 -> 6.4.20

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -10,8 +10,8 @@ generic: {
     vendorHash = null;
   };
   v60 = generic {
-    version = "6.0.26";
-    hash = "sha256-MIOKe5hqfDecB1oWZKzbFmJCsQLuAGtp21l2WxxVG+g=";
+    version = "6.0.36";
+    hash = "sha256-Ne0OY6NGzTYOn3sDVd+5tfawBu5VBjxNRtlxasubGCk=";
     vendorHash = null;
   };
 

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -5,8 +5,8 @@ generic: {
     vendorHash = null;
   };
   v64 = generic {
-    version = "6.4.15";
-    hash = "sha256-CtmNCuzDVchijinWcop3lGUTVGS2JbiQCbmusyXBQvY=";
+    version = "6.4.20";
+    hash = "sha256-tFsg2Jq8Uaa5YULGUu1kXLkxyJuA3YGeSfJ4DPfOHkk=";
     vendorHash = null;
   };
   v60 = generic {


### PR DESCRIPTION
Fixes CVE-2024-42327 / https://support.zabbix.com/browse/ZBX-25623

Changes 6.0.x:
https://www.zabbix.com/rn/rn6.0.36
https://www.zabbix.com/rn/rn6.0.35
https://www.zabbix.com/rn/rn6.0.34
https://www.zabbix.com/rn/rn6.0.33
https://www.zabbix.com/rn/rn6.0.32
https://www.zabbix.com/rn/rn6.0.31
https://www.zabbix.com/rn/rn6.0.30
https://www.zabbix.com/rn/rn6.0.29
https://www.zabbix.com/rn/rn6.0.28
https://www.zabbix.com/rn/rn6.0.27

Changes 6.4.x:
https://www.zabbix.com/rn/rn6.4.20
https://www.zabbix.com/rn/rn6.4.19
https://www.zabbix.com/rn/rn6.4.18
https://www.zabbix.com/rn/rn6.4.17
https://www.zabbix.com/rn/rn6.4.16

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 361882`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 16 packages built:</summary>
  <ul>
    <li>zabbix.agent</li>
    <li>zabbix.agent2</li>
    <li>zabbix.proxy-mysql</li>
    <li>zabbix.proxy-pgsql</li>
    <li>zabbix.proxy-sqlite</li>
    <li>zabbix.server</li>
    <li>zabbix.server-mysql</li>
    <li>zabbix.web</li>
    <li>zabbix64.agent</li>
    <li>zabbix64.agent2</li>
    <li>zabbix64.proxy-mysql</li>
    <li>zabbix64.proxy-pgsql</li>
    <li>zabbix64.proxy-sqlite</li>
    <li>zabbix64.server</li>
    <li>zabbix64.server-mysql</li>
    <li>zabbix64.web</li>
  </ul>
</details>



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
