### PR TITLE
ipe: optional support for qvoronoi

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -15,9 +15,11 @@
 , qtbase
 , qtsvg
 , texliveSmall
+, qhull
 , wrapQtAppsHook
 , zlib
 , withTeXLive ? true
+, withQVoronoi ? false
 , buildPackages
 }:
 
@@ -48,6 +50,8 @@ stdenv.mkDerivation rec {
     zlib
   ] ++ (lib.optionals withTeXLive [
     texliveSmall
+  ]) ++ (lib.optionals withQVoronoi [
+    qhull
   ]);
 
   makeFlags = [
@@ -56,7 +60,10 @@ stdenv.mkDerivation rec {
     "LUA_PACKAGE=lua"
     "MOC=${buildPackages.qt6Packages.qtbase}/libexec/moc"
     "IPE_NO_SPELLCHECK=1" # qtSpell is not yet packaged
-  ];
+  ] ++ (lib.optionals withQVoronoi [
+    "IPEQVORONOI=1"
+    "QHULL_CFLAGS=-I${qhull}/include/libqhull_r"
+  ]);
 
   qtWrapperArgs = lib.optionals withTeXLive [ "--prefix PATH : ${lib.makeBinPath [ texliveSmall ]}" ];
 


### PR DESCRIPTION
By default Ipe does not include the ipelets for computing voronoi diagrams on linux. I added an optional parameter to easily include this ipelet.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
