### PR TITLE
joplin-desktop: fix unpacking on x86_64-darwin with 7zz

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, appimageTools, fetchurl, makeWrapper, _7zz }:
+{ lib, stdenv, appimageTools, fetchurl, makeWrapper, undmg }:
 
 let
   pname = "joplin-desktop";
@@ -64,7 +64,7 @@ let
   darwin = stdenv.mkDerivation {
     inherit pname version src meta;
 
-    nativeBuildInputs = [ _7zz ];
+    nativeBuildInputs = [ undmg ];
 
     sourceRoot = "Joplin.app";
 

--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -68,7 +68,7 @@ let
 
     unpackPhase = ''
       runHook preUnpack
-      7zz x $src || true
+      7zz x -x'!Joplin ${version}/Applications' $src
       runHook postUnpack
     '';
 

--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -66,11 +66,19 @@ let
 
     nativeBuildInputs = [ _7zz ];
 
-    sourceRoot = "Joplin.app";
+    unpackPhase = ''
+      runHook preUnpack
+      7zz x $src || true
+      runHook postUnpack
+    '';
+
+    sourceRoot = if stdenv.hostPlatform.isx86_64 then "Joplin ${version}" else ".";
 
     installPhase = ''
-      mkdir -p $out/Applications/Joplin.app
-      cp -R . $out/Applications/Joplin.app
+      runHook preInstall
+      mkdir -p $out/Applications
+      cp -R Joplin.app $out/Applications
+      runHook postInstall
     '';
   };
 in

--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, appimageTools, fetchurl, makeWrapper, undmg }:
+{ lib, stdenv, appimageTools, fetchurl, makeWrapper, _7zz }:
 
 let
   pname = "joplin-desktop";
@@ -64,7 +64,7 @@ let
   darwin = stdenv.mkDerivation {
     inherit pname version src meta;
 
-    nativeBuildInputs = [ undmg ];
+    nativeBuildInputs = [ _7zz ];
 
     sourceRoot = "Joplin.app";
 


### PR DESCRIPTION
<!--



For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Revert to using `undmg` instead of `_7zz` to unpack the `joplin-desktop` package's `.dmg` archive on darwin because the unpackPhase with 7zz fails with a `Dangerous link path` when executed on my `x86_64-darwin` system.

i.e.

`nix build github:nixos/nixpkgs/master#joplin-desktop`

results in:

`nix log /nix/store/kanwwzmzknkcbywn6133g1q28sxvz12q-joplin-desktop-3.0.15.drv`:
```bash
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/bxnxm3cf2b7j5i6kkn97f69i6apg57q5-Joplin-3.0.15.dmg

7-Zip (z) 24.08 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-08-11
 64-bit locale=en_US.UTF-8 Threads:4 OPEN_MAX:1048576

Scanning the drive for archives:
  0M Scan /nix/store/                     1 file, 235780290 bytes (225 MiB)

Extracting archive: /nix/store/bxnxm3cf2b7j5i6kkn97f69i6apg57q5-Joplin-3.0.15.dmg
  7% Open         --
Path = /nix/store/bxnxm3cf2b7j5i6kkn97f69i6apg57q5-Joplin-3.0.15.dmg
Type = Dmg
Physical Size = 235780290
Method = Copy Zero2 ZLIB CRC
Blocks = 699
Cluster Size = 1048576
Comment = 
{
unpack-size: 795265024
ID: e0d7082eaaab495c839f3e8e61f7c548
master-checksum: CRC: 016E7F83
pack-checksum: CRC: 4E922735
pack-offset: 0
pack-length: 235730827
xml-offset: 235730827
xml-length: 48951
}
----
Path = 4.hfs
Size = 795226112
Packed Size = 235730414
Comment = disk image (Apple_HFS : 4)
Method = Copy Zero2 ZLIB CRC
Blocks = 692
Cluster Size = 1048576
Checksum = 0FCC6496
ID = 4
--
Path = 4.hfs
Type = HFS
Physical Size = 795226112
Method = HFS+
Cluster Size = 4096
Free Space = 75468800
Created = 2024-08-21 08:53:10
Modified = 2024-08-21 08:53:36

ERROR: Dangerous link path was ignored : Joplin 3.0.15/Applications : /Applications

Sub items Errors: 1

Archives with Errors: 1

Sub items Errors: 1
do not know how to unpack source archive /nix/store/bxnxm3cf2b7j5i6kkn97f69i6apg57q5-Joplin-3.0.15.dmg

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
