### PR TITLE
emacs: elisp packages update

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -228,10 +228,10 @@
     elpaBuild {
       pname = "agitate";
       ename = "agitate";
-      version = "0.0.20240117.23316";
+      version = "0.0.20241021.65229";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/agitate-0.0.20240117.23316.tar";
-        sha256 = "0md795hvmz15bb3vsji4p12g9lm8j34mj9wqq338dhn6zw91n5hi";
+        url = "https://elpa.gnu.org/devel/agitate-0.0.20241021.65229.tar";
+        sha256 = "11f1yj937wfnn6d12845pwa8045wp5pk9mbcvzhigni3jkm8820p";
       };
       packageRequires = [ ];
       meta = {
@@ -312,10 +312,10 @@
     elpaBuild {
       pname = "altcaps";
       ename = "altcaps";
-      version = "1.2.0.0.20240913.70017";
+      version = "1.2.0.0.20241025.80421";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/altcaps-1.2.0.0.20240913.70017.tar";
-        sha256 = "1pblmksnvjm88acv3l08zn6cm8h6kxdiiimxbsxdc16ldxhf9iji";
+        url = "https://elpa.gnu.org/devel/altcaps-1.2.0.0.20241025.80421.tar";
+        sha256 = "1qnrahxi23xyzqlp3hqmhhqj87w1yfsw4cbh3hd36h44f344nxp0";
       };
       packageRequires = [ ];
       meta = {
@@ -419,10 +419,10 @@
     elpaBuild {
       pname = "async";
       ename = "async";
-      version = "1.9.9.0.20241005.182443";
+      version = "1.9.9.0.20241126.81020";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20241005.182443.tar";
-        sha256 = "11a8hy4y0rad9c38w74gpczzb45zgv63mikx9slkv5hfbhihjz2a";
+        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20241126.81020.tar";
+        sha256 = "0h101k5s68kgki9s50pg2hgwqrbnf21mcvcwxgy9jbrbs64snh4a";
       };
       packageRequires = [ ];
       meta = {
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.7.0.20241010.141835";
+      version = "14.0.7.0.20241129.84113";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.7.0.20241010.141835.tar";
-        sha256 = "121b3xh5329mfwfm2zf19ddcp3hjbkwz4qnz1ybbd2y9yd6qw19z";
+        url = "https://elpa.gnu.org/devel/auctex-14.0.7.0.20241129.84113.tar";
+        sha256 = "0z7a9zsbljwzrn3xzn9hcl1zlqczafvcbx62cbmlrib0cknlxqp8";
       };
       packageRequires = [ ];
       meta = {
@@ -462,10 +462,10 @@
     elpaBuild {
       pname = "auctex-cont-latexmk";
       ename = "auctex-cont-latexmk";
-      version = "0.2.0.20240625.221402";
+      version = "0.3.0.20241102.3051";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-cont-latexmk-0.2.0.20240625.221402.tar";
-        sha256 = "1yxc34q68cnri7k9m2gdnhhwyqz0gs1ip2r956fbxv65s0s7nbab";
+        url = "https://elpa.gnu.org/devel/auctex-cont-latexmk-0.3.0.20241102.3051.tar";
+        sha256 = "0p054cf7hgn06chniz536ai8sj1j3n0mfssipmv101n5b7gw21p8";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -484,10 +484,10 @@
     elpaBuild {
       pname = "auctex-label-numbers";
       ename = "auctex-label-numbers";
-      version = "0.2.0.20240617.174703";
+      version = "0.2.0.20241019.12742";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-label-numbers-0.2.0.20240617.174703.tar";
-        sha256 = "14zj8wgk1vs96z5sba4m3m0zhl02zr3mbapgpypf9ff4c28v8g1b";
+        url = "https://elpa.gnu.org/devel/auctex-label-numbers-0.2.0.20241019.12742.tar";
+        sha256 = "0y4y8267r3bmwshcb5qkfrpnaxs1zwy1rwdhngjci005n68bslk9";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -612,10 +612,10 @@
     elpaBuild {
       pname = "avy";
       ename = "avy";
-      version = "0.5.0.0.20230424.65712";
+      version = "0.5.0.0.20241101.125753";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/avy-0.5.0.0.20230424.65712.tar";
-        sha256 = "1z7d59fif97j12jx9vmk2p91sr01d53gp57gjvqdcdr2lqvdsaz8";
+        url = "https://elpa.gnu.org/devel/avy-0.5.0.0.20241101.125753.tar";
+        sha256 = "0rg6jgq1iyhw7vwf8kv3mzjpwzbq44n5csv3lgd3hj8f72y4jpvb";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -676,10 +676,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.1.1.0.20240913.70315";
+      version = "1.2.1.0.20241117.91644";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.1.1.0.20240913.70315.tar";
-        sha256 = "0didf8l9rnkvymyv8qv4vc1q47c2xc8n8n7n74akw021mfvyld8v";
+        url = "https://elpa.gnu.org/devel/beframe-1.2.1.0.20241117.91644.tar";
+        sha256 = "0s7cc79zd3cvmpn2i8lkn8xqy35yizps6nwhqgpf77xfbp8k3n13";
       };
       packageRequires = [ ];
       meta = {
@@ -697,10 +697,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.3.0.20240530.63226";
+      version = "0.1.3.0.20241101.92331";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.3.0.20240530.63226.tar";
-        sha256 = "0xmljjfx7a5b3jfqf7cbpb9102ci5vnkqqww1b328rr42v5sdmqm";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.3.0.20241101.92331.tar";
+        sha256 = "0fnkzb4m0ank7892cjqjzxdjf1amjnpfbm3wh0g5j3xf44g8hk44";
       };
       packageRequires = [ ];
       meta = {
@@ -754,20 +754,26 @@
   ) { };
   bluetooth = callPackage (
     {
+      compat,
       dash,
       elpaBuild,
       fetchurl,
       lib,
+      transient,
     }:
     elpaBuild {
       pname = "bluetooth";
       ename = "bluetooth";
-      version = "0.3.1.0.20241007.201319";
+      version = "0.4.1.0.20241028.70437";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bluetooth-0.3.1.0.20241007.201319.tar";
-        sha256 = "1zq3169ci5ysdxh3cvp8dnnzcg032swgh4akfymmi8swm7p1laz0";
+        url = "https://elpa.gnu.org/devel/bluetooth-0.4.1.0.20241028.70437.tar";
+        sha256 = "0j4znabnbzdj2kskvma63svhiq2l3nahd7saqk2v2jc1xrzllfvm";
       };
-      packageRequires = [ dash ];
+      packageRequires = [
+        compat
+        dash
+        transient
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/bluetooth.html";
         license = lib.licenses.free;
@@ -1035,10 +1041,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "1.7.0.20241007.50103";
+      version = "1.7.0.20241123.92531";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-1.7.0.20241007.50103.tar";
-        sha256 = "0gqyr8d7yh0sqwrl62h6kb9j6zv578xsas0skhm51bgkv5v7px92";
+        url = "https://elpa.gnu.org/devel/cape-1.7.0.20241123.92531.tar";
+        sha256 = "0f1l510lzhd2p6003mnp4bvrhjqpqfvvz30lrj1ic9x453z80fpq";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1197,7 +1203,6 @@
   ) { };
   cobol-mode = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
@@ -1205,12 +1210,12 @@
     elpaBuild {
       pname = "cobol-mode";
       ename = "cobol-mode";
-      version = "1.1.0.20241012.193933";
+      version = "1.1.0.20241020.181020";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cobol-mode-1.1.0.20241012.193933.tar";
-        sha256 = "0l04al26n7b6nh9824r75jv60byx32s0xk3b943d4lqn1g7ww9bv";
+        url = "https://elpa.gnu.org/devel/cobol-mode-1.1.0.20241020.181020.tar";
+        sha256 = "05vxahbqs8an5s5c7v40yhziaa61n5yg4j92k8pqjypqrwhpw7vw";
       };
-      packageRequires = [ cl-lib ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/cobol-mode.html";
         license = lib.licenses.free;
@@ -1227,10 +1232,10 @@
     elpaBuild {
       pname = "code-cells";
       ename = "code-cells";
-      version = "0.4.0.20241003.103649";
+      version = "0.5.0.20241119.142112";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/code-cells-0.4.0.20241003.103649.tar";
-        sha256 = "1lzr37w7i2bb2sqh48i92s6hbih1q0j311mavb8xsdsf04dz1yzb";
+        url = "https://elpa.gnu.org/devel/code-cells-0.5.0.20241119.142112.tar";
+        sha256 = "1jzqp6d7xj2ya18x0dahqn2if46wphbk63f76pw09bhwh71qc9g3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1263,19 +1268,24 @@
   ) { };
   comint-mime = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
+      mathjax,
     }:
     elpaBuild {
       pname = "comint-mime";
       ename = "comint-mime";
-      version = "0.6.0.20240928.153818";
+      version = "0.7.0.20241116.123039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/comint-mime-0.6.0.20240928.153818.tar";
-        sha256 = "1vhkv3a2vccj2lbb5dn1gz9dfni0f5y03qwfkyl6r785i0ss976i";
+        url = "https://elpa.gnu.org/devel/comint-mime-0.7.0.20241116.123039.tar";
+        sha256 = "0sypcmpx5fyl92kkcaas3k877lwqvy02694riqp0rpm5rnpr182v";
       };
-      packageRequires = [ ];
+      packageRequires = [
+        compat
+        mathjax
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/comint-mime.html";
         license = lib.licenses.free;
@@ -1312,10 +1322,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20240926.212727";
+      version = "1.0.2.0.20241106.200056";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20240926.212727.tar";
-        sha256 = "1qp8k5f0pa4c3mlk48dw3j9y67fhlfyfb123jbl213gdc6wlqjp9";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20241106.200056.tar";
+        sha256 = "10pn52y3pgi2cbqi96sr3gghashsqvinc7lbylwg7mrhjgj0jdnv";
       };
       packageRequires = [ ];
       meta = {
@@ -1408,10 +1418,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.0.0.0.0.20240910.150701";
+      version = "30.0.0.0.0.20241120.163841";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.0.0.0.0.20240910.150701.tar";
-        sha256 = "1mi1fk574fdi1xx6pj0i449ng9y8a8hpj46dxmjjl8kgzipi79pq";
+        url = "https://elpa.gnu.org/devel/compat-30.0.0.0.0.20241120.163841.tar";
+        sha256 = "0a67xpvjfzzbhwflldqhs8gd6cb38m6gqlv6il33d4w7wsnch4p2";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1451,10 +1461,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "1.8.0.20241001.205748";
+      version = "1.8.0.20241201.134410";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-1.8.0.20241001.205748.tar";
-        sha256 = "1y9mc132c4azj0jzcwy4dw22ch78aq0c3zl3amrvmj2ypnbjxmyg";
+        url = "https://elpa.gnu.org/devel/consult-1.8.0.20241201.134410.tar";
+        sha256 = "11ndnrjfk9s99kyyygyip8bwx0icb2n8bfxk05g3ll43scblpnpx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1474,10 +1484,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.2.1.0.20240915.62227";
+      version = "0.2.2.0.20241104.75213";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.2.1.0.20240915.62227.tar";
-        sha256 = "062wzk3yq2bbav24mxw184chv0g76xn7l1panvl4nwjsxsr3vxra";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.2.2.0.20241104.75213.tar";
+        sha256 = "17pqw2l9qdfqi5scbq7n7kr7x3ypv1l06hf6ck6s36cly8mnk6rb";
       };
       packageRequires = [
         consult
@@ -1494,21 +1504,17 @@
       consult,
       elpaBuild,
       fetchurl,
-      haskell-mode,
       lib,
     }:
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.2.2.0.20240922.132051";
+      version = "0.3.0.0.20241110.114039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-hoogle-0.2.2.0.20240922.132051.tar";
-        sha256 = "11x88j0j7lxfrf2lww4h9dw1m4sbxwz5d615cl8qsr2hsa46bv75";
+        url = "https://elpa.gnu.org/devel/consult-hoogle-0.3.0.0.20241110.114039.tar";
+        sha256 = "1ghirvjn26dhhh9ivdwc20z0ydd6k682mbs9l1i3xk1vha6fxni6";
       };
-      packageRequires = [
-        consult
-        haskell-mode
-      ];
+      packageRequires = [ consult ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/consult-hoogle.html";
         license = lib.licenses.free;
@@ -1525,10 +1531,10 @@
     elpaBuild {
       pname = "consult-recoll";
       ename = "consult-recoll";
-      version = "0.8.1.0.20231211.122134";
+      version = "0.8.1.0.20241119.180703";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-recoll-0.8.1.0.20231211.122134.tar";
-        sha256 = "1hpgcqbnvqcd6vzhxqi4axihjyp764hvbggk1skviys2apywk4s1";
+        url = "https://elpa.gnu.org/devel/consult-recoll-0.8.1.0.20241119.180703.tar";
+        sha256 = "0bha88jfb68bmgn4mfi04762ik8f3d6sxhrbpjc4ra0k3yyn2286";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1568,10 +1574,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "1.5.0.20241001.155010";
+      version = "1.5.0.20241127.155437";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-1.5.0.20241001.155010.tar";
-        sha256 = "0xmki9d0szqpqg1agyx9l6viqmcw6ndwj9mi4zkmxqyy8589qf16";
+        url = "https://elpa.gnu.org/devel/corfu-1.5.0.20241127.155437.tar";
+        sha256 = "15xs0mdbw5h84m5msviw6vp73yxjxkh6hynzaa011a8xwaz7r5v1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1637,10 +1643,10 @@
     elpaBuild {
       pname = "cpio-mode";
       ename = "cpio-mode";
-      version = "0.17.0.20211211.193556";
+      version = "0.17.0.20241101.133717";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cpio-mode-0.17.0.20211211.193556.tar";
-        sha256 = "0z9dkdz1s1b7gfd0fgfxjdvbjlwwqwa6q4jjf8kkvvkgwwvqv3yq";
+        url = "https://elpa.gnu.org/devel/cpio-mode-0.17.0.20241101.133717.tar";
+        sha256 = "0kf5h4x3yz69360vp3ikqxrg1nx4cxnlv01kgfpm5kcr94zdzyka";
       };
       packageRequires = [ ];
       meta = {
@@ -1679,10 +1685,10 @@
     elpaBuild {
       pname = "crdt";
       ename = "crdt";
-      version = "0.3.5.0.20230213.22302";
+      version = "0.3.5.0.20241129.104719";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/crdt-0.3.5.0.20230213.22302.tar";
-        sha256 = "0cl97di7s5a1v6widil63pwzywxpcxmhvhp34kqn256czsliv4pw";
+        url = "https://elpa.gnu.org/devel/crdt-0.3.5.0.20241129.104719.tar";
+        sha256 = "0aad3acn44av7c3cfdiyivqryvf3f330mm38w5hirv5v3zyx5arx";
       };
       packageRequires = [ ];
       meta = {
@@ -1785,10 +1791,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.1.0.0.20240914.63105";
+      version = "1.1.0.0.20241025.80704";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cursory-1.1.0.0.20240914.63105.tar";
-        sha256 = "0g5mv4sabmyz5d9b43zby6cm2bg6sfh3s0hn1wm86zv5zpzpy0hq";
+        url = "https://elpa.gnu.org/devel/cursory-1.1.0.0.20241025.80704.tar";
+        sha256 = "1d4wwpmzvyspdz0igazh5v4nskxfbr6kh4xawfnh01fxg3i5m4dk";
       };
       packageRequires = [ ];
       meta = {
@@ -1828,10 +1834,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.16.0.0.20241013.222215";
+      version = "0.17.0.0.20241203.221759";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.16.0.0.20241013.222215.tar";
-        sha256 = "0nfs1293sb5m5dn7cz7z983q7kp5qb7b5bmv54zp9lx33kxm5z9z";
+        url = "https://elpa.gnu.org/devel/dape-0.17.0.0.20241203.221759.tar";
+        sha256 = "1clhs99fh4d15mn2r5rpj9ag63nk8dksnr99zb81ywnvhf1934i0";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1915,10 +1921,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.41.0.20241011.103524";
+      version = "0.42.0.20241107.85529";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.41.0.20241011.103524.tar";
-        sha256 = "1lgr0bcaqifxmf27mhlhbyxbfbz98ykdzfmjhp8hbhjab08wxisg";
+        url = "https://elpa.gnu.org/devel/debbugs-0.42.0.20241107.85529.tar";
+        sha256 = "0vmd0qmfp05xbq504mh2xh98l0h48vn3ki8c1sl26i2y2pjvy6bf";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -1962,10 +1968,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "3.1.0.0.20241011.101951";
+      version = "3.1.0.0.20241203.81843";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20241011.101951.tar";
-        sha256 = "0m38i2pzl4182bxk356hwcja2j9xs0syq8qjdsydh80jaq8j2rsy";
+        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20241203.81843.tar";
+        sha256 = "1irr0z942qdjypaxx6q1scndzzkby0kcsa18jqsxnrc5np4f8p3i";
       };
       packageRequires = [ ];
       meta = {
@@ -2023,16 +2029,20 @@
       elpaBuild,
       fetchurl,
       lib,
+      mathjax,
     }:
     elpaBuild {
       pname = "devdocs";
       ename = "devdocs";
-      version = "0.6.1.0.20241006.5137";
+      version = "0.6.1.0.20241113.134137";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/devdocs-0.6.1.0.20241006.5137.tar";
-        sha256 = "19xbq406mlj6nm7dfp38kisxabjdqr89nsvnaghjilpc59bjqnxj";
+        url = "https://elpa.gnu.org/devel/devdocs-0.6.1.0.20241113.134137.tar";
+        sha256 = "0p8p0bp9wyrl4xqnj60k2hxmqcg40angzhsc240cvlyfg965ixx1";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        mathjax
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/devdocs.html";
         license = lib.licenses.free;
@@ -2098,10 +2108,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20241012.214233";
+      version = "1.10.0.0.20241128.233206";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20241012.214233.tar";
-        sha256 = "0i681c501a6hyzik6hrlwdgmq46ajj62hizm7j525wpwlv45012g";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20241128.233206.tar";
+        sha256 = "1728i37sz52hf2bsbr5msvzciqdcn98xlnv812sd7mc7zz6j2q27";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2225,10 +2235,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.3.0.0.20240916.102011";
+      version = "0.3.0.0.20241025.80757";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.3.0.0.20240916.102011.tar";
-        sha256 = "1yap9a1ywdld13pcbqgx42sczyah9rg398jpdlg93dl6a2df5ccw";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.3.0.0.20241025.80757.tar";
+        sha256 = "0xw629nhbcbk5sndgxgwl6nwf5rva7nj2h87fx73dy1fb89jz827";
       };
       packageRequires = [ ];
       meta = {
@@ -2554,10 +2564,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241002.0.20241013.214806";
+      version = "20241123.0.20241202.94858";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20241002.0.20241013.214806.tar";
-        sha256 = "19694hal4v7qfrpjmpm1m6yfgqmgyvzf5cwkiz290m3nc65znnzw";
+        url = "https://elpa.gnu.org/devel/eev-20241123.0.20241202.94858.tar";
+        sha256 = "0id1rqva96hpn6hfn3iiprwh5k99g3cs6bn368263m2h6xvrgzsh";
       };
       packageRequires = [ ];
       meta = {
@@ -2575,10 +2585,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.8.0.0.20241007.133203";
+      version = "1.9.0.0.20241116.183040";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.8.0.0.20241007.133203.tar";
-        sha256 = "07dzmvbzvyyxd747kgdsjwgg95minzfn5kw74qhy8x3xh95n6wwl";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20241116.183040.tar";
+        sha256 = "1xyw2pq4mv5pmssngqbvqbzqkirxm4xwg4xfbninwrk5474kmhip";
       };
       packageRequires = [ ];
       meta = {
@@ -2605,10 +2615,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.17.0.20241012.55327";
+      version = "1.17.0.20241024.85007";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.17.0.20241012.55327.tar";
-        sha256 = "14clgkni1awzac58ffqx9cwjy939y4y0fmzjkhnahii5sj1hp2mj";
+        url = "https://elpa.gnu.org/devel/eglot-1.17.0.20241024.85007.tar";
+        sha256 = "158022p4711xymcnkgck2bnv6w2bxj78kd7zgnxh7wp5424h4zd0";
       };
       packageRequires = [
         compat
@@ -2708,10 +2718,10 @@
     elpaBuild {
       pname = "elisa";
       ename = "elisa";
-      version = "1.0.4.0.20240721.124701";
+      version = "1.1.3.0.20241123.220535";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/elisa-1.0.4.0.20240721.124701.tar";
-        sha256 = "0p903ljagaza0n2kw2hicvara903mwwjia4587wqwvydrfvhal7a";
+        url = "https://elpa.gnu.org/devel/elisa-1.1.3.0.20241123.220535.tar";
+        sha256 = "0zvjnz4qxaxm2akg0hppyn8vn77zvmbgnw85mms2cq4148w7br2z";
       };
       packageRequires = [
         async
@@ -2754,19 +2764,21 @@
       lib,
       llm,
       spinner,
+      transient,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.11.14.0.20240915.152338";
+      version = "0.13.0.0.20241129.214739";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-0.11.14.0.20240915.152338.tar";
-        sha256 = "0qxwhk6kdj9w1436p7hxlwhi7c9mb8j3ghrp8sskcqy6dck7mqn3";
+        url = "https://elpa.gnu.org/devel/ellama-0.13.0.0.20241129.214739.tar";
+        sha256 = "1242ra8fbyq5lci44myvl62k76c234kxa0lsim1rmnbpsa3w3h0p";
       };
       packageRequires = [
         compat
         llm
         spinner
+        transient
       ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/ellama.html";
@@ -2861,10 +2873,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.16.0.20241012.164056";
+      version = "0.17pre0.20241122.210222";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ement-0.16.0.20241012.164056.tar";
-        sha256 = "0fsck2gx84y8r94770zhjiq37g97vgc61dkrp9k7f3q4xb05gqvi";
+        url = "https://elpa.gnu.org/devel/ement-0.17pre0.20241122.210222.tar";
+        sha256 = "1gn5hjlggcs7p31mkr8vg398jgzsnhjv04g1hpx4b03j31rxwhxl";
       };
       packageRequires = [
         map
@@ -2893,10 +2905,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "20.1.0.20240924.230829";
+      version = "20.2.0.20241129.151319";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-20.1.0.20240924.230829.tar";
-        sha256 = "1prhwlhfvfr81j02xsadh8gw1qbirmmzlhafnwq9w1qcaz9jnclw";
+        url = "https://elpa.gnu.org/devel/emms-20.2.0.20241129.151319.tar";
+        sha256 = "17rqxmrcr3p150nhi2yyn21g7hg68yjpxdg7bjdpif5086h8snff";
       };
       packageRequires = [
         cl-lib
@@ -2982,10 +2994,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20241011.161309";
+      version = "5.6.1snapshot0.20241201.105608";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20241011.161309.tar";
-        sha256 = "1pps1r3b49zppdqdfd4ikh121myw7fwpnk0glmr27d7fdrihwfmk";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20241201.105608.tar";
+        sha256 = "080ppzpc7r1myl2xig9jlzns9j8sbyd7qdmmijiwcfwgl6dsjg3b";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3029,10 +3041,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "24.1.1.0.20240821.145259";
+      version = "24.1.1.0.20241127.102031";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-24.1.1.0.20240821.145259.tar";
-        sha256 = "15qani3cvb5sb087k8rmsm55h3fx6dhhhjkv18c50060phwxr2q5";
+        url = "https://elpa.gnu.org/devel/ess-24.1.1.0.20241127.102031.tar";
+        sha256 = "19gkxkslg9y84fc9shc655fqgcr27rbjnn4rsnhkpqvwbzn54kkq";
       };
       packageRequires = [ ];
       meta = {
@@ -3149,10 +3161,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.32.0.20241006.3203";
+      version = "0.32.0.20241118.90416";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.32.0.20241006.3203.tar";
-        sha256 = "0rbn0w867wihfpg2d1hffnnvif300f8b7ss6a4r0ls6929i8qcr5";
+        url = "https://elpa.gnu.org/devel/exwm-0.32.0.20241118.90416.tar";
+        sha256 = "1ssryfd1x9cidch3w0xq8750c1ifg58b672grw8x70spy2mrvqr1";
       };
       packageRequires = [
         compat
@@ -3304,10 +3316,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.3.7.0.20240829.203038";
+      version = "1.3.7.0.20241024.85007";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20240829.203038.tar";
-        sha256 = "1iswrkqxhsfrqgm976iyd5rdvf6q99h805b4cdnbynfix3xp207j";
+        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20241024.85007.tar";
+        sha256 = "0vhfxvml2s678pxivss1nmm0ym62nxc4ab221jm6x8jpd6j1lff5";
       };
       packageRequires = [
         eldoc
@@ -3820,10 +3832,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.11.18.0.20240921.191926";
+      version = "0.11.18.0.20241025.123748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.11.18.0.20240921.191926.tar";
-        sha256 = "1bnss7xgzzclkk715i3v6bpr2zn1b85hr7mpxvpprm3hknpalq5p";
+        url = "https://elpa.gnu.org/devel/greader-0.11.18.0.20241025.123748.tar";
+        sha256 = "17sh65y476zd5lwmvialk399g5gl11d52p4jmhgjv7kpb4xl3jly";
       };
       packageRequires = [
         compat
@@ -3865,10 +3877,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.1.0.20240808.153728";
+      version = "1.8.2.0.20241113.2312";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gtags-mode-1.8.1.0.20240808.153728.tar";
-        sha256 = "1bfblsay8qsglhh4iqhv9wl8s445piwykyx4lz7cbn74wpn2prin";
+        url = "https://elpa.gnu.org/devel/gtags-mode-1.8.2.0.20241113.2312.tar";
+        sha256 = "0mxw27kn5f85rprk13171k56q2dq2gfmvgyhfxrbz3zj7ijvrfg1";
       };
       packageRequires = [ ];
       meta = {
@@ -4060,10 +4072,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20241008.11453";
+      version = "9.0.2pre0.20241126.91748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20241008.11453.tar";
-        sha256 = "015cwlrqz4pyxk6ffki0l44ycajzd509vlbz10skwikl2xqmp01x";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20241126.91748.tar";
+        sha256 = "136xbqhm4gwfw7cyd1p45hx6pnc6wbqc7dmv6q620vall1r9s7nb";
       };
       packageRequires = [ ];
       meta = {
@@ -4124,10 +4136,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.0.20241013.161522";
+      version = "0.8.2.0.20241126.83433";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.8.0.20241013.161522.tar";
-        sha256 = "0h7r1lm06rybqp7lq3ggclgv8b2akgqabizqy6xzimmibgf61vwj";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.8.2.0.20241126.83433.tar";
+        sha256 = "1jzw83jwg3pwl0y0dpmvzjmwykfgmrd0fr0ik2l4kplwcyv5hrwj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4145,10 +4157,10 @@
     elpaBuild {
       pname = "inspector";
       ename = "inspector";
-      version = "0.38.0.20240911.94847";
+      version = "0.38.0.20241108.155318";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/inspector-0.38.0.20240911.94847.tar";
-        sha256 = "1w7zaxf77f7r0bdwqa276vqnhql1jsxl3y13gc13ikibhxb5jf2w";
+        url = "https://elpa.gnu.org/devel/inspector-0.38.0.20241108.155318.tar";
+        sha256 = "1x0cgn7w1gdm60hg7a2ym82hvf60l594v7k4mrln87m1yk4wqgak";
       };
       packageRequires = [ ];
       meta = {
@@ -4327,10 +4339,10 @@
     elpaBuild {
       pname = "ivy-posframe";
       ename = "ivy-posframe";
-      version = "0.6.3.0.20211217.23411";
+      version = "0.6.3.0.20241023.25839";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-posframe-0.6.3.0.20211217.23411.tar";
-        sha256 = "03v4k7hx2bdxhjghanpmy9r50q9ksmz2xcwypxxhyywlglfk0d69";
+        url = "https://elpa.gnu.org/devel/ivy-posframe-0.6.3.0.20241023.25839.tar";
+        sha256 = "01wiviygb0c5kjdds1fk10jf9rcf6f59iychqp42yk2lghhw9k1z";
       };
       packageRequires = [
         ivy
@@ -4393,10 +4405,10 @@
     elpaBuild {
       pname = "javaimp";
       ename = "javaimp";
-      version = "0.9.1.0.20221221.80314";
+      version = "0.9.1.0.20241129.211411";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/javaimp-0.9.1.0.20221221.80314.tar";
-        sha256 = "0dj7mzdfj1gvd18mdnf19pv5zljhhada6a5s3bm5drpw12vx5334";
+        url = "https://elpa.gnu.org/devel/javaimp-0.9.1.0.20241129.211411.tar";
+        sha256 = "1i7jga44n7rdfb51y72x6c3j0k2pwb90x1xz3m0j0iq4avy89dj9";
       };
       packageRequires = [ ];
       meta = {
@@ -4437,10 +4449,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "1.10.0.20240926.181428";
+      version = "1.10.0.20241201.134324";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-1.10.0.20240926.181428.tar";
-        sha256 = "1qn5lrc2843x1bihg38iba8dc4r24d257hwnyqjfpgpffak7ma4b";
+        url = "https://elpa.gnu.org/devel/jinx-1.10.0.20241201.134324.tar";
+        sha256 = "19clhxy5p41ri0b2fsdk2rc9wf37nn90ya5mkhpn8mccfcs9kh7y";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4523,10 +4535,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25.0.20240720.4208";
+      version = "1.0.25.0.20241130.63516";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20240720.4208.tar";
-        sha256 = "0r5aw8w5qxf2kqxh4x4q1lyhci2cbcxf31shshagf16zpcm71qz3";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20241130.63516.tar";
+        sha256 = "1z2vwqj213bpygq5lp8b7inxjki9kzha6ymz315ls5w06kccvw3v";
       };
       packageRequires = [ ];
       meta = {
@@ -4630,10 +4642,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.1.0.20241004.194446";
+      version = "0.4.2.0.20241022.131056";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.4.1.0.20241004.194446.tar";
-        sha256 = "1ja8kk7vpwfayqkcf7maz8y25xlxl77i1mk8s4qq9q6fm06n14w5";
+        url = "https://elpa.gnu.org/devel/kubed-0.4.2.0.20241022.131056.tar";
+        sha256 = "02sg5h2iv9zb2i1prxab9xcm682j8y5c3h10cqd66gcvpiwb790f";
       };
       packageRequires = [ ];
       meta = {
@@ -4698,10 +4710,10 @@
     elpaBuild {
       pname = "leaf";
       ename = "leaf";
-      version = "4.5.5.0.20230803.74443";
+      version = "4.5.5.0.20241018.51628";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/leaf-4.5.5.0.20230803.74443.tar";
-        sha256 = "1xkqwkkk3k5k3lg10amh2lvric2xcqd35ad30c0jyvzn9fsxkbn0";
+        url = "https://elpa.gnu.org/devel/leaf-4.5.5.0.20241018.51628.tar";
+        sha256 = "1d2y0qhy9qz0wahclwnskf5kdqhr51iljnrki7jmkzxfya3r1dwa";
       };
       packageRequires = [ ];
       meta = {
@@ -4888,10 +4900,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.17.4.0.20241003.232025";
+      version = "0.19.1.0.20241129.152751";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.17.4.0.20241003.232025.tar";
-        sha256 = "1wsbf0c0hmspw3sx94ji0xr9h65q1xbls1nhhadajayclrp3rxhq";
+        url = "https://elpa.gnu.org/devel/llm-0.19.1.0.20241129.152751.tar";
+        sha256 = "07jcm718wivagwnr53rriwa7gp3zkxgybff5wivi1n6xdfhm9b1y";
       };
       packageRequires = [
         plz
@@ -5127,10 +5139,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "1.7.0.20240926.91821";
+      version = "1.7.0.20241124.113844";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-1.7.0.20240926.91821.tar";
-        sha256 = "1rdv3jkc7g59gypa949har94wl0sqpr6qpbjcravailbhd8a4zsn";
+        url = "https://elpa.gnu.org/devel/marginalia-1.7.0.20241124.113844.tar";
+        sha256 = "19b1xc3q4mdzlipjn47drhg4k818iigf95jy2cj4hcmg6d6k37r7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5181,6 +5193,27 @@
       };
     }
   ) { };
+  mathjax = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "mathjax";
+      ename = "mathjax";
+      version = "0.1.0.20241113.83941";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/mathjax-0.1.0.20241113.83941.tar";
+        sha256 = "1n49nj70bpxpm72caffx0lmcnlfqdljy8sn8mzwhfiingrif2spb";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/mathjax.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   mct = callPackage (
     {
       elpaBuild,
@@ -5190,10 +5223,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.0.0.0.20240913.71126";
+      version = "1.0.0.0.20241025.81140";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.0.0.0.20240913.71126.tar";
-        sha256 = "0nxw6vnc9q63vnly9ffvrj8m1dnn9wlhcidld478p07qlighp8lm";
+        url = "https://elpa.gnu.org/devel/mct-1.0.0.0.20241025.81140.tar";
+        sha256 = "121mb4aa0bgwndbvgxh8j9ra52ji7qn5vdrf7whn93rqaaygpk87";
       };
       packageRequires = [ ];
       meta = {
@@ -5382,10 +5415,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.5.0.0.20241007.133219";
+      version = "4.6.0.0.20241120.54202";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.5.0.0.20241007.133219.tar";
-        sha256 = "1smf7zlwvkinjm6kdlmb5qm2dc9qxg5dpn0nyd7vjz1krycmvni6";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20241120.54202.tar";
+        sha256 = "189vcdd2895x3smydr84s8ldjvi92bkh4samk4qi1gxdj9r397hg";
       };
       packageRequires = [ ];
       meta = {
@@ -5724,10 +5757,10 @@
     elpaBuild {
       pname = "notmuch-indicator";
       ename = "notmuch-indicator";
-      version = "1.2.0.0.20240913.71211";
+      version = "1.2.0.0.20241025.81216";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.2.0.0.20240913.71211.tar";
-        sha256 = "1h6ain7zhr6qv29r9i9zwyha3074198igq61swpx3xhajskkxa0y";
+        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.2.0.0.20241025.81216.tar";
+        sha256 = "1n29yddv4pbiwjfpa0ra3gvalhvcr5pxbzaqrg14z2grgqwbi4rh";
       };
       packageRequires = [ ];
       meta = {
@@ -5813,10 +5846,10 @@
     elpaBuild {
       pname = "ob-asymptote";
       ename = "ob-asymptote";
-      version = "1.0.0.20230908.121002";
+      version = "1.0.1.0.20241018.115612";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ob-asymptote-1.0.0.20230908.121002.tar";
-        sha256 = "1lpv4rf7qf1yvpm4j3wiajdk72lgl4gk8qgwflzyq9yvmksakdvp";
+        url = "https://elpa.gnu.org/devel/ob-asymptote-1.0.1.0.20241018.115612.tar";
+        sha256 = "0hr0rfj344yshrplcavncphrl16a1n7gx1r906dma53x7nmkhcf7";
       };
       packageRequires = [ ];
       meta = {
@@ -5963,10 +5996,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20241013.101728";
+      version = "9.8pre0.20241127.183434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20241013.101728.tar";
-        sha256 = "1lr95jkjdp19cv5k21h5yn29sy744sxr2995v4a6pkjif0dnvj5v";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20241127.183434.tar";
+        sha256 = "1v7inlp4mm2c9395jw814krg2yp5h70h0cj0q86m26zgg9f2wicy";
       };
       packageRequires = [ ];
       meta = {
@@ -5985,10 +6018,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20240807.73345";
+      version = "1.1.0.20241203.194117";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20240807.73345.tar";
-        sha256 = "1j0qwzhxaj1499qk0bjfvvgywi34v7p9cmpc585kxcanb8g1lvg2";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20241203.194117.tar";
+        sha256 = "03mbak4dv1z49j3sa3v97vmk82b4s5j5fhnwxdy7qqkf7v06jrha";
       };
       packageRequires = [ org ];
       meta = {
@@ -6055,10 +6088,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.5.0.20240926.92259";
+      version = "1.5.0.20241022.103450";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.5.0.20240926.92259.tar";
-        sha256 = "0i99ky6csk3gvshvr2f6gpql1k3a8dl6xvnyd8nk33jydacjs6bl";
+        url = "https://elpa.gnu.org/devel/org-modern-1.5.0.20241022.103450.tar";
+        sha256 = "1hbgf2yggrp2jfcgi1d9wk2fg3f7f082g8xn60znkyaa7zfsn5nb";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6124,10 +6157,10 @@
     elpaBuild {
       pname = "org-remark";
       ename = "org-remark";
-      version = "1.2.2.0.20241010.195850";
+      version = "1.2.2.0.20241102.192817";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-remark-1.2.2.0.20241010.195850.tar";
-        sha256 = "1y260csn6810dbv7libfyjlrx6r1rcna3kh4wbd5mn79ik1f8f6z";
+        url = "https://elpa.gnu.org/devel/org-remark-1.2.2.0.20241102.192817.tar";
+        sha256 = "0mac9diswm1pavhbf5hc7hw7p60ppajcbnyak9b8insp1spfbbbw";
       };
       packageRequires = [ org ];
       meta = {
@@ -6232,10 +6265,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.4.0.20241006.1334";
+      version = "1.4.0.20241122.13029";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.4.0.20241006.1334.tar";
-        sha256 = "0k6ncc3xlvz804m0ixqn2p18ggq6knx7xpvzcl99fcn85x0wqals";
+        url = "https://elpa.gnu.org/devel/osm-1.4.0.20241122.13029.tar";
+        sha256 = "0c4b0ddb5l2pipnnwcqqfjj08v9ppr93ailxq000hd683mw48kaz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6487,10 +6520,10 @@
     elpaBuild {
       pname = "pinentry";
       ename = "pinentry";
-      version = "0.1.0.20231126.141402";
+      version = "0.1.0.20241123.141";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pinentry-0.1.0.20231126.141402.tar";
-        sha256 = "056h9zfbk4mfpvfpli2kr48i5cdcrf73v15id0dk762iy7iz38af";
+        url = "https://elpa.gnu.org/devel/pinentry-0.1.0.20241123.141.tar";
+        sha256 = "14ssm8hrkx70iaww77yrhsbp7k6962bp4k2w7mgj4mj4wkfyrw89";
       };
       packageRequires = [ ];
       meta = {
@@ -6530,10 +6563,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.2pre0.20240924.181709";
+      version = "0.1.2pre0.20241106.190958";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.2pre0.20240924.181709.tar";
-        sha256 = "0ydi2xs9sbbc3qz4dp0jpaipdbmzc1nw36wm0cgmqk71a3s5aw67";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.2pre0.20241106.190958.tar";
+        sha256 = "1kpwrc4c48dspyk1zm0b2wp7xmr7h1wm1j7ppqi0wrl350wjzh6f";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -6552,10 +6585,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.2pre0.20240924.181631";
+      version = "0.2.3pre0.20241106.190902";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.2pre0.20240924.181631.tar";
-        sha256 = "0pm4hh03bgrq1c7xmb4xw4x7ns967biq0nq7y0bqn42bzcjfxbh9";
+        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.3pre0.20241106.190902.tar";
+        sha256 = "1yx1yqqqps6cj1bwr0dq9n850jr0vh6nph85rw4b70qy6g63k473";
       };
       packageRequires = [ plz ];
       meta = {
@@ -6658,10 +6691,10 @@
     elpaBuild {
       pname = "polymode";
       ename = "polymode";
-      version = "0.2.2.0.20230317.121821";
+      version = "0.2.2.0.20241129.123411";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20230317.121821.tar";
-        sha256 = "17dl20fzn15km0d2ypsrzij247yjr3nx5lk1sn5hwr3dvsapvagz";
+        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20241129.123411.tar";
+        sha256 = "0mrs7a8kp2mlidps76h5w0xgnilhpka7qi5pq2xc0i0lk09jd9gv";
       };
       packageRequires = [ ];
       meta = {
@@ -6679,10 +6712,10 @@
     elpaBuild {
       pname = "popper";
       ename = "popper";
-      version = "0.4.6.0.20240701.211603";
+      version = "0.4.6.0.20241130.171037";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/popper-0.4.6.0.20240701.211603.tar";
-        sha256 = "0jhcpz0y5girsqqfliyg3a4h798hz316i813qdhz1s1xivpd91pk";
+        url = "https://elpa.gnu.org/devel/popper-0.4.6.0.20241130.171037.tar";
+        sha256 = "1gypxgkzaf422pdv9v2rfj010mbvb0qcw3hl3aw99qd7w1ndrd9k";
       };
       packageRequires = [ ];
       meta = {
@@ -6700,10 +6733,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.4.4.0.20240827.65408";
+      version = "1.4.4.0.20241202.131153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/posframe-1.4.4.0.20240827.65408.tar";
-        sha256 = "0bpakrjgasx911k9niqmd4zf3g08zvwydfyxj6fr8096wazqyrrc";
+        url = "https://elpa.gnu.org/devel/posframe-1.4.4.0.20241202.131153.tar";
+        sha256 = "1rlzgl2bjc46g261m513dgl52n2vq0xlfmfpdm1qrdww06jjklg6";
       };
       packageRequires = [ ];
       meta = {
@@ -6764,10 +6797,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.3.0.20240915.183530";
+      version = "0.4.0.20241109.62806";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.3.0.20240915.183530.tar";
-        sha256 = "0di2idjrxz5xb9klb6cvcwdgnd9q5h8b3pl6qkg4m8nb30w71mka";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.0.20241109.62806.tar";
+        sha256 = "0vcrwi3pjvp46k1c52l4q774fkq93hn3dbbvrhaz160r6d9b477b";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -6786,10 +6819,10 @@
     elpaBuild {
       pname = "preview-tailor";
       ename = "preview-tailor";
-      version = "0.2.0.20240617.174356";
+      version = "0.2.0.20241018.170554";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-tailor-0.2.0.20240617.174356.tar";
-        sha256 = "17x74wzfi7kc08x1kwlzvsyiqmimxf77k58amskyg73l1iqmr8s8";
+        url = "https://elpa.gnu.org/devel/preview-tailor-0.2.0.20241018.170554.tar";
+        sha256 = "0wcqrannqgyd1fzydia3q8c5dgk8c89irfrikkz568g2jgwnih16";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -6808,10 +6841,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20241007.234715";
+      version = "0.11.1.0.20241204.74033";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20241007.234715.tar";
-        sha256 = "185nx2ww47c8808b0z8gsf2f4arc4cj3i31fp735i5qamxlx1bxp";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20241204.74033.tar";
+        sha256 = "15npdg1cm3c1h6isq2j87djvslv4c4wan4qni09pra5hqyjmd767";
       };
       packageRequires = [ xref ];
       meta = {
@@ -6871,10 +6904,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.1.0.0.20241006.54333";
+      version = "1.1.0.0.20241126.85951";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.1.0.0.20241006.54333.tar";
-        sha256 = "03q0mxkm06mdp9y11nmwxfbgcc4r4h2w41lj6ba67npawjc0m5mg";
+        url = "https://elpa.gnu.org/devel/pulsar-1.1.0.0.20241126.85951.tar";
+        sha256 = "01mqy0yl72kzydqq250a2vzyyk0w1q7fpf6bb1a49yh2hkd1g5s3";
       };
       packageRequires = [ ];
       meta = {
@@ -6942,10 +6975,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.28.0.20241013.93011";
+      version = "0.28.0.20241123.154630";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.28.0.20241013.93011.tar";
-        sha256 = "01rcnwk7hdzx5qlrhd8mnkqzsn7x5dpn3zwh16941cjc3fr9xq7r";
+        url = "https://elpa.gnu.org/devel/python-0.28.0.20241123.154630.tar";
+        sha256 = "09ir2jxjk7jvzv7mz5iir3wzx0zas4ikhhh3ig9kbrsj7bsdz6dd";
       };
       packageRequires = [
         compat
@@ -7093,10 +7126,10 @@
     elpaBuild {
       pname = "rcirc-sqlite";
       ename = "rcirc-sqlite";
-      version = "1.0.3.0.20240926.134441";
+      version = "1.0.4.0.20241108.161537";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/rcirc-sqlite-1.0.3.0.20240926.134441.tar";
-        sha256 = "1pz9gflnyz0p6bg0x87gs7byy34yhi1qf84f3mah79489wad1x84";
+        url = "https://elpa.gnu.org/devel/rcirc-sqlite-1.0.4.0.20241108.161537.tar";
+        sha256 = "0x5pngsnmny2ppg3cgdp5g3nmds6ys3zvamaj8wr6n1qw6k5b4z1";
       };
       packageRequires = [ ];
       meta = {
@@ -7196,10 +7229,10 @@
     elpaBuild {
       pname = "realgud-lldb";
       ename = "realgud-lldb";
-      version = "1.0.2.0.20230319.171320";
+      version = "1.0.2.0.20241118.210939";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-lldb-1.0.2.0.20230319.171320.tar";
-        sha256 = "0isnyflg507qngv8xjw8zwzwh4qy0d3c123d5rirwbissjcfxmrs";
+        url = "https://elpa.gnu.org/devel/realgud-lldb-1.0.2.0.20241118.210939.tar";
+        sha256 = "1wpl9608rg6a6nbrnqmhhd8wwwdaf6cpw4lxv59bz2n903bbyr1d";
       };
       packageRequires = [
         load-relative
@@ -7633,10 +7666,10 @@
     elpaBuild {
       pname = "setup";
       ename = "setup";
-      version = "1.4.0.0.20240413.75454";
+      version = "1.4.0.0.20241123.145918";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/setup-1.4.0.0.20240413.75454.tar";
-        sha256 = "1ryxa0991mzvx2ai4bkmjxnikpnalmr4gdggakfg8i8ag65149rn";
+        url = "https://elpa.gnu.org/devel/setup-1.4.0.0.20241123.145918.tar";
+        sha256 = "01s4dv75r850nq1g84ccjqzlr2xhvd1f6d3zyvdni98qm0vg9si5";
       };
       packageRequires = [ ];
       meta = {
@@ -7738,10 +7771,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.1.1.0.20240915.55011";
+      version = "0.1.1.0.20241025.81606";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-0.1.1.0.20240915.55011.tar";
-        sha256 = "0rfav8axwqkgihnhf51c3w1igi9w6ia2ambw6vd2zg7gl54ga2vm";
+        url = "https://elpa.gnu.org/devel/show-font-0.1.1.0.20241025.81606.tar";
+        sha256 = "0ha8fnnjx3j57g0gjz4p65xyys47p0qsy0wr5k858zvw61ka2jdn";
       };
       packageRequires = [ ];
       meta = {
@@ -8015,10 +8048,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.5.0.0.20240801.94014";
+      version = "0.5.0.0.20241114.85358";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.5.0.0.20240801.94014.tar";
-        sha256 = "0nv1gg30kwdcb0isp159ir03xh3l28yv11m9rznch48axwd1bjwp";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.5.0.0.20241114.85358.tar";
+        sha256 = "1xs9mac6mrhk6519g13rf8s7q9iivd021bnwmxn54pal904x6q83";
       };
       packageRequires = [ ];
       meta = {
@@ -8100,10 +8133,10 @@
     elpaBuild {
       pname = "sql-indent";
       ename = "sql-indent";
-      version = "1.7.0.20240323.40057";
+      version = "1.7.0.20241109.2223";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sql-indent-1.7.0.20240323.40057.tar";
-        sha256 = "0zrsglgw2zjxn9810r022kanvfj0zrhvr696yxlnvd05f9hv9bpp";
+        url = "https://elpa.gnu.org/devel/sql-indent-1.7.0.20241109.2223.tar";
+        sha256 = "0hrpal1di201x62hq2xhck0xhv2vnn972j6nb2mca9lxyvz6h625";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -8168,10 +8201,10 @@
     elpaBuild {
       pname = "ssh-deploy";
       ename = "ssh-deploy";
-      version = "3.1.16.0.20230702.92809";
+      version = "3.1.16.0.20241117.185025";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ssh-deploy-3.1.16.0.20230702.92809.tar";
-        sha256 = "0zjkc1gb3hpknx8012crcbdy3w1w597qk8qajhpaijhjhispm507";
+        url = "https://elpa.gnu.org/devel/ssh-deploy-3.1.16.0.20241117.185025.tar";
+        sha256 = "03slq2jz6npx33n8ygs761mgqzbain6gqyyl38581gsl8kawx9zs";
       };
       packageRequires = [ ];
       meta = {
@@ -8189,10 +8222,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.1.0.0.20240913.71400";
+      version = "2.1.0.0.20241025.81655";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.1.0.0.20240913.71400.tar";
-        sha256 = "1zxspsd2mca3pkwbkkkdy32lh5krqjlsi7p9z73xah68r8jyps7j";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.1.0.0.20241025.81655.tar";
+        sha256 = "0bba7mwilxhzjxcvqhgmj1gw8iw46wv6s6frx12cczfjdigjjxl4";
       };
       packageRequires = [ ];
       meta = {
@@ -8210,10 +8243,10 @@
     elpaBuild {
       pname = "stream";
       ename = "stream";
-      version = "2.3.0.0.20230908.74447";
+      version = "2.3.0.0.20241117.211530";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/stream-2.3.0.0.20230908.74447.tar";
-        sha256 = "1zfw7plnlsijs8aw5726adjwd65g1x3xs4vcs3rcc2ybv8cz886s";
+        url = "https://elpa.gnu.org/devel/stream-2.3.0.0.20241117.211530.tar";
+        sha256 = "1hhvp3rikl1dv2ca090cy5jh61nq3mvxznjwz8p39y0gn6ym3x7x";
       };
       packageRequires = [ ];
       meta = {
@@ -8231,10 +8264,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.3.1.0.20240913.71434";
+      version = "0.3.1.0.20241025.81721";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/substitute-0.3.1.0.20240913.71434.tar";
-        sha256 = "1a217jx9lwjl4hl7a3rd982004780d1p2pg1qqph9g16y0k36b7q";
+        url = "https://elpa.gnu.org/devel/substitute-0.3.1.0.20241025.81721.tar";
+        sha256 = "1lprh07yanx0m042nbdv667jd78i6dlbkg32niyn9zv4ic3xiiq7";
       };
       packageRequires = [ ];
       meta = {
@@ -8317,10 +8350,10 @@
     elpaBuild {
       pname = "svg-tag-mode";
       ename = "svg-tag-mode";
-      version = "0.3.2.0.20240828.82058";
+      version = "0.3.3.0.20241021.134153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/svg-tag-mode-0.3.2.0.20240828.82058.tar";
-        sha256 = "1jx2dx1d8w4p37q4x5shj1xf1fqbclv10i6a8q8inq05qjlfq1ak";
+        url = "https://elpa.gnu.org/devel/svg-tag-mode-0.3.3.0.20241021.134153.tar";
+        sha256 = "1zhmjpskaqsv2rl8lqbnb93b08d0xjk0d84ksjzwgr3bzmscpz5n";
       };
       packageRequires = [ svg-lib ];
       meta = {
@@ -8562,10 +8595,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.2.0.20240926.233155";
+      version = "1.2.0.20241116.82753";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.2.0.20240926.233155.tar";
-        sha256 = "0qflff5c96pipxnnjnb960qbh1dqr6bnjixqk86hnnddwv67p414";
+        url = "https://elpa.gnu.org/devel/tempel-1.2.0.20241116.82753.tar";
+        sha256 = "13qakkcx260iscxa8w6160bzdxg7n0mr3dfa44jnb9l7dc5cs6vh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -8626,10 +8659,10 @@
     elpaBuild {
       pname = "tex-parens";
       ename = "tex-parens";
-      version = "0.6.0.20241012.150939";
+      version = "0.6.0.20241101.151607";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tex-parens-0.6.0.20241012.150939.tar";
-        sha256 = "0f48c5x6mpf0c456d0jy2jprbclhcifmjid8s77ghmlnvazypg7b";
+        url = "https://elpa.gnu.org/devel/tex-parens-0.6.0.20241101.151607.tar";
+        sha256 = "16b5s137jnjln3l3x97cxxhn4bsxhn6gs6xkbszp4vkx3cww8kzk";
       };
       packageRequires = [ ];
       meta = {
@@ -8704,7 +8737,6 @@
   ) { };
   tmr = callPackage (
     {
-      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -8712,12 +8744,12 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.0.0.0.20240913.71556";
+      version = "1.0.0.0.20241111.101250";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.0.0.0.20240913.71556.tar";
-        sha256 = "11y91803ldwvij73zw7g7dchdpzz9qrx1jv37rlrav7j52rc1awx";
+        url = "https://elpa.gnu.org/devel/tmr-1.0.0.0.20241111.101250.tar";
+        sha256 = "19g5xz0vfxjrfghdl8h4566v6sdr8cf4svm5yx98jijdr5np2a6s";
       };
-      packageRequires = [ compat ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/tmr.html";
         license = lib.licenses.free;
@@ -8780,10 +8812,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.2.0.20241003.143209";
+      version = "1.2.0.20241018.155615";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/track-changes-1.2.0.20241003.143209.tar";
-        sha256 = "1xzx886gzvm0rchzchnd4cl675mlkgnjbmkvzjkx9wpi42xnw94j";
+        url = "https://elpa.gnu.org/devel/track-changes-1.2.0.20241018.155615.tar";
+        sha256 = "02m70rh2qzv3nnrs8ykwmpn6fsd2v9lvspiwx1q0yndgvhxwg5d4";
       };
       packageRequires = [ ];
       meta = {
@@ -8801,10 +8833,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.1.3.0.20240929.75703";
+      version = "2.7.1.5.0.20241130.82948";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.7.1.3.0.20240929.75703.tar";
-        sha256 = "0bcxhgbjaysrvj3y4dhq0xzwna3nlm332yvswsy4qw7fwa4n9x6c";
+        url = "https://elpa.gnu.org/devel/tramp-2.7.1.5.0.20241130.82948.tar";
+        sha256 = "0ypb44lhdv6hnx2rzpn8746sqa0wafknkf4bjxsvlh402xfjbypq";
       };
       packageRequires = [ ];
       meta = {
@@ -8887,10 +8919,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.7.7.0.20241008.182431";
+      version = "0.7.9.0.20241203.214158";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.7.7.0.20241008.182431.tar";
-        sha256 = "1vih4zkjzklj00fnp3yjj99vs0xy528316qf9b9bidgpqnsfk9mi";
+        url = "https://elpa.gnu.org/devel/transient-0.7.9.0.20241203.214158.tar";
+        sha256 = "0yrc8y035yxrirjnbq3hl4jb3mj5xdnv0sy6aji4pdln2ywv122d";
       };
       packageRequires = [
         compat
@@ -8981,10 +9013,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.4.0.0.20240831.171334";
+      version = "0.4.1.0.20241017.213639";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/triples-0.4.0.0.20240831.171334.tar";
-        sha256 = "1xa6yhgjpj8vb5i9znx7nhavz21yv0wbiknwiv2ccal03dfs3n1c";
+        url = "https://elpa.gnu.org/devel/triples-0.4.1.0.20241017.213639.tar";
+        sha256 = "1kzzpdaimk8bixf0fi2sba6958szmyp5vk08b60v5x80qzghmq9n";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9110,10 +9142,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.5.2snapshot0.20240822.215612";
+      version = "0.5.2snapshot0.20241024.210047";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.5.2snapshot0.20240822.215612.tar";
-        sha256 = "01bkcz0zmzgf75x9zqm67i6bgz7rj5kazqqv0yjvnz4657cb5isr";
+        url = "https://elpa.gnu.org/devel/urgrep-0.5.2snapshot0.20241024.210047.tar";
+        sha256 = "0m12x3mrryc0czihavx8kc48df6404bi534dicnjia2v9xv574jv";
       };
       packageRequires = [
         compat
@@ -9205,10 +9237,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20240907.62515";
+      version = "2.4.6.0.20241109.73512";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20240907.62515.tar";
-        sha256 = "0z6iz3v3k6jay4xp471nxlkaqvnwngdl3gq6r6d6s682svfs8hy7";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20241109.73512.tar";
+        sha256 = "1qxcl0nsry3in6n301240fg8n2bvxs58fxr8cf83vbwcfkp8n7sj";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9423,10 +9455,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "1.9.0.20241004.135012";
+      version = "1.9.0.20241130.70347";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-1.9.0.20241004.135012.tar";
-        sha256 = "1dfhnn1n3i8a916adgzbvpy1fiqbam40r4k0c8ildxg1rhq5zmwg";
+        url = "https://elpa.gnu.org/devel/vertico-1.9.0.20241130.70347.tar";
+        sha256 = "0xqyzmsyxrqvr1r25qyw59r5997f5ldj0c7nl8l821855dnm2c2y";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9446,10 +9478,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.7.7.0.20241010.24145";
+      version = "0.7.7.0.20241023.25940";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-posframe-0.7.7.0.20241010.24145.tar";
-        sha256 = "05np5iassbia1acn99cy4l4947lkq7vggcnh5gp21xjjm1mpk0jw";
+        url = "https://elpa.gnu.org/devel/vertico-posframe-0.7.7.0.20241023.25940.tar";
+        sha256 = "0gvi8z5jhgy5jqp4q80ax01djzswp2ygq9rfryy8p3m3pgf36g4n";
       };
       packageRequires = [
         posframe
@@ -9682,10 +9714,10 @@
     elpaBuild {
       pname = "which-key";
       ename = "which-key";
-      version = "3.6.1.0.20240928.75916";
+      version = "3.6.1.0.20241123.44609";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20240928.75916.tar";
-        sha256 = "0z2vl3w5yhy77y96c7hxkncwi0pgxanb712hhdyjybmkg73v8qmn";
+        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20241123.44609.tar";
+        sha256 = "0gn2z7l4fj5cff44k6xbqfbksbafm90i0wssak7c4ghai57wqqa2";
       };
       packageRequires = [ ];
       meta = {
@@ -9725,10 +9757,10 @@
     elpaBuild {
       pname = "window-tool-bar";
       ename = "window-tool-bar";
-      version = "0.2.1.0.20240609.122134";
+      version = "0.2.1.0.20241024.85007";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/window-tool-bar-0.2.1.0.20240609.122134.tar";
-        sha256 = "1xfwirfdy69c349052jx31c3ib708mwl68458lj8dar5y2cqwk0q";
+        url = "https://elpa.gnu.org/devel/window-tool-bar-0.2.1.0.20241024.85007.tar";
+        sha256 = "16226fm8hq862s9f4ja8wpkar4yp8v86pkq9kdv3mpbmw9lywq54";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9989,10 +10021,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20241005.224023";
+      version = "1.7.0.0.20241127.14322";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20241005.224023.tar";
-        sha256 = "0526agg3b6aj1pfdcr22yf666vpsbwhj2clskilk8axa0ki0cn2h";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20241127.14322.tar";
+        sha256 = "12983qax1jwbbcbd8zs1spi3z1hnnnmqih75dx0wy281zv1vwzp4";
       };
       packageRequires = [ ];
       meta = {
@@ -10018,6 +10050,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/xref-union.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  yaml = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "yaml";
+      ename = "yaml";
+      version = "1.0.0.0.20241129.211417";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/yaml-1.0.0.0.20241129.211417.tar";
+        sha256 = "0wvyq8hwh10ldpd56xw7n6z4w2zhn4nyk949pyf78vigvr7rv8ll";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/yaml.html";
         license = lib.licenses.free;
       };
     }

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -441,10 +441,10 @@
     elpaBuild {
       pname = "auctex-cont-latexmk";
       ename = "auctex-cont-latexmk";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-cont-latexmk-0.2.tar";
-        sha256 = "0ggyjxjqwpx3h1963i8w96m6kisc65ni9hksn2kjfjddnj1hx0hf";
+        url = "https://elpa.gnu.org/packages/auctex-cont-latexmk-0.3.tar";
+        sha256 = "1s1fp8cajwcsvrnvbhnlzfsphpflsv6fzmc624578sz2m0p1wg6n";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -655,10 +655,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.1.1";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/beframe-1.1.1.tar";
-        sha256 = "0xx2zvgjilivi6nnr2x9bwwcifinj66j6r07wxjawqkrsknyypas";
+        url = "https://elpa.gnu.org/packages/beframe-1.2.1.tar";
+        sha256 = "0a92n45dy5f0d69a2dxzqfy7wvi9d7mrfjqy2z52gr2f8nkl7qgf";
       };
       packageRequires = [ ];
       meta = {
@@ -733,20 +733,26 @@
   ) { };
   bluetooth = callPackage (
     {
+      compat,
       dash,
       elpaBuild,
       fetchurl,
       lib,
+      transient,
     }:
     elpaBuild {
       pname = "bluetooth";
       ename = "bluetooth";
-      version = "0.3.1";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/bluetooth-0.3.1.tar";
-        sha256 = "1yjqjm6cis6bq18li63hbhc4qzki3486xvdjkzs2gj4chc1yw1x4";
+        url = "https://elpa.gnu.org/packages/bluetooth-0.4.1.tar";
+        sha256 = "1chi9xjg5zcg6qycn2n442adhhmip1vpvg12szf1raq3zhg7lr01";
       };
-      packageRequires = [ dash ];
+      packageRequires = [
+        compat
+        dash
+        transient
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/bluetooth.html";
         license = lib.licenses.free;
@@ -1198,6 +1204,7 @@
   ) { };
   code-cells = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -1205,12 +1212,12 @@
     elpaBuild {
       pname = "code-cells";
       ename = "code-cells";
-      version = "0.4";
+      version = "0.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/code-cells-0.4.tar";
-        sha256 = "0kxpnydxlj8pqh54c4c80jlyc6jcplf89bkh3jmm509fmyr7sf20";
+        url = "https://elpa.gnu.org/packages/code-cells-0.5.tar";
+        sha256 = "04fvn0lwvnvf907k13822jpxyyi6cf55v543i9iqy57dav6sn2jx";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/code-cells.html";
         license = lib.licenses.free;
@@ -1241,19 +1248,24 @@
   ) { };
   comint-mime = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
+      mathjax,
     }:
     elpaBuild {
       pname = "comint-mime";
       ename = "comint-mime";
-      version = "0.6";
+      version = "0.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/comint-mime-0.6.tar";
-        sha256 = "017d62n3n2jmsxb3r9jm4vk8vpapddbxfjjh8ww1vgcbzqr76zwy";
+        url = "https://elpa.gnu.org/packages/comint-mime-0.7.tar";
+        sha256 = "1scf7b72kzqcf51svww3rbamdnm607pvzg04rdcglc2cna1n2apa";
       };
-      packageRequires = [ ];
+      packageRequires = [
+        compat
+        mathjax
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/comint-mime.html";
         license = lib.licenses.free;
@@ -1452,10 +1464,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-denote-0.2.1.tar";
-        sha256 = "15hih62a6lyfgw3ha86hppc9wp468gslrdcnx8kcz0dlkvp0k1kx";
+        url = "https://elpa.gnu.org/packages/consult-denote-0.2.2.tar";
+        sha256 = "1dpl9aq25j9nbrxa469gl584km93ry2rnkm0ydxljid9w15szpls";
       };
       packageRequires = [
         consult
@@ -1472,21 +1484,17 @@
       consult,
       elpaBuild,
       fetchurl,
-      haskell-mode,
       lib,
     }:
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-hoogle-0.2.2.tar";
-        sha256 = "07z98nnxcaaws18by4id6c45yxlfwb9fk3p0gzll4ngym29zkd8c";
+        url = "https://elpa.gnu.org/packages/consult-hoogle-0.3.0.tar";
+        sha256 = "0jpyncx1zc8kzmnr0wlq81qz0y3jgk421yw0picjj8yflj6905ix";
       };
-      packageRequires = [
-        consult
-        haskell-mode
-      ];
+      packageRequires = [ consult ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/consult-hoogle.html";
         license = lib.licenses.free;
@@ -1806,10 +1814,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.16.0";
+      version = "0.17.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.16.0.tar";
-        sha256 = "0zv2l2d91ywbi2v36kn7na94lm09zz5yyq50xdf5i44h9ridz7zw";
+        url = "https://elpa.gnu.org/packages/dape-0.17.0.tar";
+        sha256 = "113lmy0q1yk81cfi9dbig8p9bmhyqy6w1bvhn91m79my05ny2rxd";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1893,10 +1901,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.41";
+      version = "0.42";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/debbugs-0.41.tar";
-        sha256 = "0nchb7dnkrn34nh3bi0k5xmsn3da9m9v4iksh18045mfj6wn6bl5";
+        url = "https://elpa.gnu.org/packages/debbugs-0.42.tar";
+        sha256 = "0n0kvkyzggn8q72dpy6c7rsjwn1rjx0r33y5jc080j7sw85xpigg";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2531,10 +2539,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241002";
+      version = "20241123";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20241002.tar";
-        sha256 = "0cl65zxryr6mlhbbpb9nbmabn8vnwc17vpqr7611s79jb9a7xsvf";
+        url = "https://elpa.gnu.org/packages/eev-20241123.tar";
+        sha256 = "1bb2134jggj4xg49cwy8ivfb12yafxyy2p5k4rca9an3cr4s8ci7";
       };
       packageRequires = [ ];
       meta = {
@@ -2552,10 +2560,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.8.0";
+      version = "1.9.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-1.8.0.tar";
-        sha256 = "0fv7m4cd4sdn8skx5li8g41kyjniwzfp8sn7jd9s4f7wzls5rnay";
+        url = "https://elpa.gnu.org/packages/ef-themes-1.9.0.tar";
+        sha256 = "03gi3gwrng9arffypmlnd96404yxac78k59q5yb1y1f8fahy199k";
       };
       packageRequires = [ ];
       meta = {
@@ -2681,10 +2689,10 @@
     elpaBuild {
       pname = "elisa";
       ename = "elisa";
-      version = "1.0.4";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/elisa-1.0.4.tar";
-        sha256 = "07f9micfp3p8r58kdnqv0pa7i8nyqaz35llahwp2jl16c63pl9wn";
+        url = "https://elpa.gnu.org/packages/elisa-1.1.3.tar";
+        sha256 = "0370gvj3r701i2acp3wq705a9n534g719nzz8bg9a4lry76f2crv";
       };
       packageRequires = [
         async
@@ -2727,19 +2735,21 @@
       lib,
       llm,
       spinner,
+      transient,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.11.14";
+      version = "0.13.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-0.11.14.tar";
-        sha256 = "1xd1pj02kgz83wsvygi5p7hlzx2898d38jmwq899qzpjn80jajb1";
+        url = "https://elpa.gnu.org/packages/ellama-0.13.0.tar";
+        sha256 = "0wfn8fv124qxf9yxl4lsa3hwlicmaiv2zzn8w4vhmlni1kf37nlw";
       };
       packageRequires = [
         compat
         llm
         spinner
+        transient
       ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/ellama.html";
@@ -2866,10 +2876,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "20.1";
+      version = "20.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/emms-20.1.tar";
-        sha256 = "0h0v31f1q7k45k8s9kncvim3a7np7fgjz4qg9v8gjc5ag01dzwkx";
+        url = "https://elpa.gnu.org/packages/emms-20.2.tar";
+        sha256 = "0amc956amyfsjlq5aqc7nk2cs2ph2zcpci5wkms6w973wx67z2j6";
       };
       packageRequires = [
         cl-lib
@@ -3836,10 +3846,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.1";
+      version = "1.8.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gtags-mode-1.8.1.tar";
-        sha256 = "1n4mc33hz12p0fljrs4big317148272vz2zn16n98sakpv7jk4b6";
+        url = "https://elpa.gnu.org/packages/gtags-mode-1.8.2.tar";
+        sha256 = "1lmaaqlklsifjzagi3miplr17vmzqjzglbkxccffj50mi6y5w4cs";
       };
       packageRequires = [ ];
       meta = {
@@ -4099,10 +4109,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/indent-bars-0.8.tar";
-        sha256 = "0sy34xkghlwndyrismdrrsgnsz2901j8pdpfy8drbka6x4g6x36k";
+        url = "https://elpa.gnu.org/packages/indent-bars-0.8.2.tar";
+        sha256 = "1bhdrykkklsscgiz3p29x8kdkw0kbc4mlpnhxghvphx159clhgym";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4605,10 +4615,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/kubed-0.4.1.tar";
-        sha256 = "1p0r6jcwydh25ff613imr49yjw4hhy9wcxlzxrk3d2szipj4q8hs";
+        url = "https://elpa.gnu.org/packages/kubed-0.4.2.tar";
+        sha256 = "0qbc8cw8a823dhqa34xhbf3mdbdihzdg1v0ya7ykm3789c2dhddb";
       };
       packageRequires = [ ];
       meta = {
@@ -4857,16 +4867,22 @@
       fetchurl,
       lib,
       plz,
+      plz-event-source,
+      plz-media-type,
     }:
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.17.4";
+      version = "0.19.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.17.4.tar";
-        sha256 = "01a4vnbffrh53q1j2if63a05j4859rzrrf7p3fisfbfj1cr2ywvw";
+        url = "https://elpa.gnu.org/packages/llm-0.19.1.tar";
+        sha256 = "03f8yvnq1n2pns62iji2iz50f30wxw50n9a6cxgd9p2vkd4pjb0g";
       };
-      packageRequires = [ plz ];
+      packageRequires = [
+        plz
+        plz-event-source
+        plz-media-type
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/llm.html";
         license = lib.licenses.free;
@@ -5148,6 +5164,27 @@
       };
     }
   ) { };
+  mathjax = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "mathjax";
+      ename = "mathjax";
+      version = "0.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/mathjax-0.1.tar";
+        sha256 = "16023kbzkc2v455bx7l4pfy3j7z1iba7rpv0ykzk2rz21i4jan7w";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/mathjax.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   mct = callPackage (
     {
       elpaBuild,
@@ -5349,10 +5386,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.5.0";
+      version = "4.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-4.5.0.tar";
-        sha256 = "1f75rkl6bvqsc2s4fz67rk3h3fl9qw4vay0dj1agas4x0zskm89v";
+        url = "https://elpa.gnu.org/packages/modus-themes-4.6.0.tar";
+        sha256 = "19hg2gqpa19rnlj0pn7v8sd52q5mkinf39l7rb0a6xqbkfzqvsnd";
       };
       packageRequires = [ ];
       meta = {
@@ -5777,10 +5814,10 @@
     elpaBuild {
       pname = "ob-asymptote";
       ename = "ob-asymptote";
-      version = "1.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ob-asymptote-1.0.tar";
-        sha256 = "1hmqbkrqg18w454xg37rg5cg0q3vd0b0fm14n5chihqrwwnwrf4l";
+        url = "https://elpa.gnu.org/packages/ob-asymptote-1.0.1.tar";
+        sha256 = "0f1vpq691pna1p1lgqw2nzmdw25sjsmpcvgm2lj7n14kg7dizxal";
       };
       packageRequires = [ ];
       meta = {
@@ -5927,10 +5964,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.12";
+      version = "9.7.16";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.12.tar";
-        sha256 = "0v0mims57k5ffaf9i8szmrq3zvk3zd7xz7386k8lwc58mmhhdw15";
+        url = "https://elpa.gnu.org/packages/org-9.7.16.tar";
+        sha256 = "1d6vxd7ssfb1v00a37dr723v9cg8i8v78lcymqndqhy6f2ji1f06";
       };
       packageRequires = [ ];
       meta = {
@@ -6516,10 +6553,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.1.tar";
-        sha256 = "05hr78iw9s34vf2lpyh79xfnd4gs4q07rha1ahdrmxvkk9mnmk90";
+        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.2.tar";
+        sha256 = "0m1hm2myc5pqax8kkz910wn3443pxdsav7rcf7bcqnim4l0ismvn";
       };
       packageRequires = [ plz ];
       meta = {
@@ -6686,10 +6723,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.3";
+      version = "0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/preview-auto-0.3.tar";
-        sha256 = "19jih2bn6ac82jx6w7jhv9hbz47c8argv24lfglvv6532fda218r";
+        url = "https://elpa.gnu.org/packages/preview-auto-0.4.tar";
+        sha256 = "0jsahj6ylrs4hlr57i0ibkj9bhc3jbg84k3pk8g5rg27xiwncczy";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7010,10 +7047,10 @@
     elpaBuild {
       pname = "rcirc-sqlite";
       ename = "rcirc-sqlite";
-      version = "1.0.3";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/rcirc-sqlite-1.0.3.tar";
-        sha256 = "11m6n93qwfkn6jhn3vlvdz48wsqixlkbwbxsx3qdyj8jmjqpjvz6";
+        url = "https://elpa.gnu.org/packages/rcirc-sqlite-1.0.4.tar";
+        sha256 = "0bxih4m3rn76lq5q2hbq04fb0yqfy848cqfzl7gii1qsrfplqcal";
       };
       packageRequires = [ ];
       meta = {
@@ -8192,10 +8229,10 @@
     elpaBuild {
       pname = "svg-tag-mode";
       ename = "svg-tag-mode";
-      version = "0.3.2";
+      version = "0.3.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/svg-tag-mode-0.3.2.tar";
-        sha256 = "0wzcq00kbjpbwz7acn4d7jd98v5kicq3iwgf6dnmz2kflvkfwkvr";
+        url = "https://elpa.gnu.org/packages/svg-tag-mode-0.3.3.tar";
+        sha256 = "14vkjy3dvvvkhxi3m8d56m0dpvg9gpbwmmb0dchz8ap8wjbvc85j";
       };
       packageRequires = [ svg-lib ];
       meta = {
@@ -8651,10 +8688,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.1.3";
+      version = "2.7.1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.7.1.3.tar";
-        sha256 = "0ii16y283yidql05f69yx0x2jf71w8niq5k8mlrqq05z5h4h3sw3";
+        url = "https://elpa.gnu.org/packages/tramp-2.7.1.5.tar";
+        sha256 = "11a2zyk0d1y9bxhdqfzcx4ynazfs6hb3mdgpz5kp9p3lk8l6bz5g";
       };
       packageRequires = [ ];
       meta = {
@@ -8737,10 +8774,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.7.7";
+      version = "0.7.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.7.7.tar";
-        sha256 = "07c1n76nlchm5pp74hnx7bkwiibpal1ajdkmj559ja3099rgghkx";
+        url = "https://elpa.gnu.org/packages/transient-0.7.9.tar";
+        sha256 = "07d5pzd7nalnjxn6wpj6vpfg8pldnwh69l85immmiww03vl8ngrf";
       };
       packageRequires = [
         compat
@@ -8831,10 +8868,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.4.0";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/triples-0.4.0.tar";
-        sha256 = "0g29i33bmh9gh4mmk92h6vhhw42k1f2ph02qlrasn0w5fq3pg8vp";
+        url = "https://elpa.gnu.org/packages/triples-0.4.1.tar";
+        sha256 = "1x5sws7zhm9wz5d430bs8g8rnxn4y57pqkqhxcsi9d3vbs39wfn8";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9866,6 +9903,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/xref-union.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  yaml = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "yaml";
+      ename = "yaml";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/yaml-1.0.0.tar";
+        sha256 = "0yvfrijjjm17qidyi50nrsvw2m3bqw6p72za7w8v4ywxfl7b59c6";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/yaml.html";
         license = lib.licenses.free;
       };
     }

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1508,6 +1508,18 @@ let
 
         scad-preview = ignoreCompilationError super.scad-preview; # elisp error
 
+        sdml-mode = super.sdml-mode.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            patches = previousAttrs.patches or [ ] ++ [
+              (pkgs.fetchpatch {
+                name = "make-pretty-hydra-optional.patch";
+                url = "https://github.com/sdm-lang/emacs-sdml-mode/pull/3/commits/2368afe31c72073488411540e212c70aae3dd468.patch";
+                hash = "sha256-Wc4pquKV9cTRey9SdjY++UgcP+pGI0hVOOn1Cci8dpk=";
+              })
+            ];
+          }
+        );
+
         # https://github.com/wanderlust/semi/pull/29
         # missing optional dependencies
         semi = addPackageRequires super.semi [ self.bbdb-vcard ];

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -793,6 +793,18 @@ let
         # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
         auto-complete-distel = ignoreCompilationError super.auto-complete-distel;
 
+        auto-virtualenv = super.auto-virtualenv.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            patches = previousAttrs.patches or [ ] ++ [
+              (pkgs.fetchpatch {
+                name = "do-not-error-if-the-optional-projectile-is-not-available.patch";
+                url = "https://github.com/marcwebbie/auto-virtualenv/pull/14/commits/9a068974a4e12958200c12c6a23372fa736523c1.patch";
+                hash = "sha256-bqrroFf5AD5SHx6uzBFdVwTv3SbFiO39T+0x03Ves/k=";
+              })
+            ];
+          }
+        );
+
         aws-ec2 = ignoreCompilationError super.aws-ec2; # elisp error
 
         badger-theme = ignoreCompilationError super.badger-theme; # elisp error

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -93,10 +93,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.2.2.0.20240509.114401";
+      version = "2.2.3.0.20241017.150805";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.2.2.0.20240509.114401.tar";
-        sha256 = "0b78ilx6qwn2g0l6c1fn3vrm6bc2dgylpj8vm2wxwqyx621rf513";
+        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.2.3.0.20241017.150805.tar";
+        sha256 = "19m3xg2yhf9gxyvp3n143dkyb6r592b2bv7sxcj4g8fhm7qlj6jc";
       };
       packageRequires = [ ];
       meta = {
@@ -177,10 +177,10 @@
     elpaBuild {
       pname = "apropospriate-theme";
       ename = "apropospriate-theme";
-      version = "0.2.0.0.20240921.102210";
+      version = "0.2.0.0.20241118.190153";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20240921.102210.tar";
-        sha256 = "04x4s341lvygxxnjq3wjy8sp8p9y66kx3csklp46x33qyqbbdx82";
+        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20241118.190153.tar";
+        sha256 = "0nqnf57bf21wg2vlw85msg927618hhsn4qfwd60vrx70260432kf";
       };
       packageRequires = [ ];
       meta = {
@@ -284,10 +284,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.1.1.0.20240914.174817";
+      version = "3.1.1.0.20241118.194353";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.1.1.0.20240914.174817.tar";
-        sha256 = "1s5wx8374naay0silh95vlci5qrxxz04av4f5iz94iwvi6jz0fa0";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.1.1.0.20241118.194353.tar";
+        sha256 = "10cirfnwz34yc7glf1xzshq3926jdwdf3s7bdarykrkxmsrha4f7";
       };
       packageRequires = [ ];
       meta = {
@@ -544,10 +544,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.16.0.0.20240925.134028";
+      version = "1.16.1.0.20241203.160720";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.16.0.0.20240925.134028.tar";
-        sha256 = "1j874gyrdiy90f8hlxjkvxjdwzs8pixi19l28d009npj69mv0f6n";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.16.1.0.20241203.160720.tar";
+        sha256 = "0b6nqhg5c0ny8ilm4653c7pd34aj02bh6ya9bzc9swdpyq7pwnqr";
       };
       packageRequires = [
         clojure-mode
@@ -573,10 +573,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0snapshot0.20240611.73422";
+      version = "5.20.0snapshot0.20241125.112305";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20240611.73422.tar";
-        sha256 = "1jlmg2f4gvxqknyw5lqs7aqaar0ghw21hqphsmcvakpcn7d0nqiz";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20241125.112305.tar";
+        sha256 = "0hh17w63j5x4687kbd2vmlj9qs468ivq54mwwcm6p43wr7rvk2cj";
       };
       packageRequires = [ ];
       meta = {
@@ -594,10 +594,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.2.2.0.20240930.131600";
+      version = "0.2.2.0.20241104.213550";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.2.2.0.20240930.131600.tar";
-        sha256 = "0qs76xj2fjhp42882ay1sg7ihzanzdh8mq4yffmqj1ljhkdyxsxc";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.2.2.0.20241104.213550.tar";
+        sha256 = "0b37iccwh8l6z0q3ls3ysfy7pjp8q52kbiw4lipjgljg0lmj5lsv";
       };
       packageRequires = [ ];
       meta = {
@@ -638,10 +638,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20240926.91748";
+      version = "1.0.0.20241114.112007";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20240926.91748.tar";
-        sha256 = "1f5869y8614hv91f3sc7i10wr3393mygz841crw4an4m03kxkq7f";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20241114.112007.tar";
+        sha256 = "1jzli50sjr8pv2j9qg7glxdgm54sx2yw6xr7ka738gisa1r0iscl";
       };
       packageRequires = [
         consult
@@ -710,10 +710,10 @@
     elpaBuild {
       pname = "csv2ledger";
       ename = "csv2ledger";
-      version = "1.5.4.0.20240605.63224";
+      version = "1.5.4.0.20241109.230511";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20240605.63224.tar";
-        sha256 = "0vh626mic3nd4ci7hc1ci8rmfh3k6frh8azgkj4784n3nhgr18h8";
+        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20241109.230511.tar";
+        sha256 = "1ank47lk4qgmbgr7qb9fgkramc7qngs93rq0rnlvkdh2fm198ywj";
       };
       packageRequires = [ csv-mode ];
       meta = {
@@ -774,10 +774,10 @@
     elpaBuild {
       pname = "d-mode";
       ename = "d-mode";
-      version = "202408131340.0.20240813.65913";
+      version = "202408131340.0.20241126.105644";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/d-mode-202408131340.0.20240813.65913.tar";
-        sha256 = "1lf78x8bkb41mr5p8api0f447z9k5yd2v9w97qw6l4dxcj2dldv5";
+        url = "https://elpa.nongnu.org/nongnu-devel/d-mode-202408131340.0.20241126.105644.tar";
+        sha256 = "11hc3dyxyr1pcq25jvw9x3ys4v73rbqw9p19s4i59p9mdb0bnxpy";
       };
       packageRequires = [ ];
       meta = {
@@ -892,6 +892,28 @@
       };
     }
   ) { };
+  dirvish = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      transient,
+    }:
+    elpaBuild {
+      pname = "dirvish";
+      ename = "dirvish";
+      version = "2.0.53.0.20230519.150010";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.0.53.0.20230519.150010.tar";
+        sha256 = "0n73giyvg244s0cxfrkc3j0jrq20bs1zili6liab0s3ks02kvqdg";
+      };
+      packageRequires = [ transient ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/dirvish.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   doc-show-inline = callPackage (
     {
       elpaBuild,
@@ -943,10 +965,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.2.0.20240912.203213";
+      version = "1.8.2.0.20241102.130126";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20240912.203213.tar";
-        sha256 = "1wkyn7wswrgda7y267mxb6bi0h5ywp7hh2d4cmz3yfglnq1pmp1g";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20241102.130126.tar";
+        sha256 = "01f3g7cy9snm4f2b2rx7zd82kwxzlf9g0wapwa83k3i60p23rf5s";
       };
       packageRequires = [ ];
       meta = {
@@ -986,10 +1008,10 @@
     elpaBuild {
       pname = "dslide";
       ename = "dslide";
-      version = "0.5.3.0.20240704.131127";
+      version = "0.5.5.0.20241128.111432";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dslide-0.5.3.0.20240704.131127.tar";
-        sha256 = "0mr4p3w5932bz9cj9b4b2lmp5dkrix79s6vf4s2h2rr8cjhgbb6s";
+        url = "https://elpa.nongnu.org/nongnu-devel/dslide-0.5.5.0.20241128.111432.tar";
+        sha256 = "1d2rsqzn8w6w3qvsfsgpmjwn53nsj30jivli02d7n24q30pxzpv6";
       };
       packageRequires = [ ];
       meta = {
@@ -1050,10 +1072,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20240813.80135";
+      version = "0.11.0.0.20241027.181535";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20240813.80135.tar";
-        sha256 = "1ak09a6ay4234x4x9b8k6mqayb99129yk0p45iv782xsyc9r05h8";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20241027.181535.tar";
+        sha256 = "17vx1rf8dnyfkj1c7cv2zw9kvrc9cllm3wr4r0wik31xrkw7zpdj";
       };
       packageRequires = [ ];
       meta = {
@@ -1092,10 +1114,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.3.0.20240930.91332";
+      version = "3.6.4.0.20241022.162545";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.3.0.20240930.91332.tar";
-        sha256 = "1mf0d6gzykvpyjk2kxivlqs5xwxqdsxj9adfi92bna01dv5vrj3n";
+        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.4.0.20241022.162545.tar";
+        sha256 = "070njpzhspzgpry9wy69l76kmfdwzy8c5nx32kr0isx7b6qzvb5v";
       };
       packageRequires = [ ];
       meta = {
@@ -1113,10 +1135,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.0.3.0.20240906.134234";
+      version = "4.1.0.0.20241201.155153";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.0.3.0.20240906.134234.tar";
-        sha256 = "0a9456snizy8w47vh8zj00180kncg0h3vv3iq86lckqhv2qbp0az";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.1.0.0.20241201.155153.tar";
+        sha256 = "10sqyqba0jsf1w6i7x77vxgj13wjzr3k9bcpzmzxhqgprakndixy";
       };
       packageRequires = [ ];
       meta = {
@@ -1385,10 +1407,10 @@
     elpaBuild {
       pname = "evil-matchit";
       ename = "evil-matchit";
-      version = "3.0.4.0.20240418.73107";
+      version = "3.0.4.0.20241111.120111";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-matchit-3.0.4.0.20240418.73107.tar";
-        sha256 = "01fsamf87a35xmw03b93yvvlkz2mi7xg9pblzakacwfnwksxr76i";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-matchit-3.0.4.0.20241111.120111.tar";
+        sha256 = "1jv7rs102i00kwdkj1n3l0j9as0kbrylhkkn2rrgwv9b97lmlirs";
       };
       packageRequires = [ ];
       meta = {
@@ -1428,10 +1450,10 @@
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7.0.20240416.14058";
+      version = "0.7.0.20241204.12906";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20240416.14058.tar";
-        sha256 = "1xn9r9iycrha64n379q8kqdbywcfqcwc9qqlnxi268rcxzsq99rx";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20241204.12906.tar";
+        sha256 = "1r4ic5db8vl3mslp48w8lqx904raxi8lzp512jcjv21vs36gjl97";
       };
       packageRequires = [ evil ];
       meta = {
@@ -1519,10 +1541,10 @@
     elpaBuild {
       pname = "exec-path-from-shell";
       ename = "exec-path-from-shell";
-      version = "2.2.0.20240411.85903";
+      version = "2.2.0.20241107.71915";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20240411.85903.tar";
-        sha256 = "1z8dxx8x87ndx4mfq2nhj2q6m0h5zd2v80pbwxirz4qnvivqspgv";
+        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20241107.71915.tar";
+        sha256 = "17wyy2agi9j7vny0wdi5mxp1nz7zpzi6ayx55ls1cdxwd7v2jyvf";
       };
       packageRequires = [ ];
       meta = {
@@ -1588,10 +1610,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0snapshot0.20240726.45656";
+      version = "35.0snapshot0.20241130.150233";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20240726.45656.tar";
-        sha256 = "09hy61g6rcvl1xng2bnav9x58rg0ddq39mj4gicsyyxyqfyp2gc7";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20241130.150233.tar";
+        sha256 = "08viqbba50alfj3783ykymjqwpi08si6bi411sm29gagga1cjxr6";
       };
       packageRequires = [ ];
       meta = {
@@ -1681,10 +1703,10 @@
     elpaBuild {
       pname = "focus";
       ename = "focus";
-      version = "1.0.1.0.20240528.90117";
+      version = "1.0.1.0.20241029.150652";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/focus-1.0.1.0.20240528.90117.tar";
-        sha256 = "0krfsxswwjzajxzr6kjxnkmzgi5nysnwa1yrhd205z1spb36i9i0";
+        url = "https://elpa.nongnu.org/nongnu-devel/focus-1.0.1.0.20241029.150652.tar";
+        sha256 = "08ryv68xfvlgbsyq80r9bycj4d9dbdz0v7ipdgjxnxfkp3di2s01";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -1834,10 +1856,10 @@
     elpaBuild {
       pname = "geiser-chicken";
       ename = "geiser-chicken";
-      version = "0.17.0.20220717.113055";
+      version = "0.17.0.20241204.11932";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20220717.113055.tar";
-        sha256 = "1ajdmkykm23rxcnsbqadc39h72r30cdqzhxasq9s5hnnpk8qmyxk";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20241204.11932.tar";
+        sha256 = "1l95d72wl74mlfa50m9m999skj993vqdmm13qm42n0lp0y9ndvyf";
       };
       packageRequires = [ geiser ];
       meta = {
@@ -2068,10 +2090,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.5.0.20241009.160730";
+      version = "0.4.8.0.20241115.104152";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.4.5.0.20241009.160730.tar";
-        sha256 = "0kmmxhbmxi7l1ig01b2v36diidlz0192y8nxjr3znycx0qzdbn7x";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.4.8.0.20241115.104152.tar";
+        sha256 = "143pmwp5g2wzmmhmbwc1q6hhf86j1cywi8x2hzvlq0p5mhkkilr1";
       };
       packageRequires = [
         compat
@@ -2242,10 +2264,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.5.0.20241013.125757";
+      version = "0.9.6.0.20241202.163036";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.5.0.20241013.125757.tar";
-        sha256 = "123bvwfh6anp6arwznzinyckakpadagz6pn7381848k9zp5xz6lg";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.6.0.20241202.163036.tar";
+        sha256 = "0zlfrnp01hb6syrkgkwfi1hjxm9l4j9sqrwn7a8nmk5wlw4bi6xm";
       };
       packageRequires = [
         compat
@@ -2266,10 +2288,10 @@
     elpaBuild {
       pname = "graphql-mode";
       ename = "graphql-mode";
-      version = "1.0.0.0.20240918.121927";
+      version = "1.0.0.0.20241020.75405";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20240918.121927.tar";
-        sha256 = "198kbpazgczyb0qjclm8xgaha6wh6spr8ybvrbhm6nsf90zgv5kw";
+        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20241020.75405.tar";
+        sha256 = "0bds1zv0syg1jfdak2hk3kank4c532r6ki095wamxy06rwdbm2il";
       };
       packageRequires = [ ];
       meta = {
@@ -2373,10 +2395,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20241007.132004";
+      version = "17.5.0.20241111.151419";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20241007.132004.tar";
-        sha256 = "1dj72kjy3jjxbfxxhj27yspc7n0059p7bxrv66hrzb0iginip45f";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20241111.151419.tar";
+        sha256 = "1pshx7i45smkwg09w2am9q87iqawfds2nn48jczdyxh6bnk558zz";
       };
       packageRequires = [ ];
       meta = {
@@ -2416,10 +2438,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.0.20240925.24042";
+      version = "1.0.20241108.150811";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.0.20240925.24042.tar";
-        sha256 = "1kkfg9b0cfa2ygxkp5da98sc0w2b8q2q99rcfdqm00i8l6lj5wm9";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.0.20241108.150811.tar";
+        sha256 = "1ycbcwhj9j77jgpb3ag7hy8474qdj4rzzg7z5z79f0fqvlnv94m7";
       };
       packageRequires = [ ];
       meta = {
@@ -2439,10 +2461,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.0.20240929.41608";
+      version = "4.0.0.20241204.51511";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.0.20240929.41608.tar";
-        sha256 = "1xf7nbnd2399cz2qkpvb0h38cdwx76jk9sq9wk67y6l23kvqh0sr";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.0.20241204.51511.tar";
+        sha256 = "1dzc1jg6p9r589mzwdzhlhj58239ssy85mz27kwr7yyg36cz3m3l";
       };
       packageRequires = [
         helm-core
@@ -2464,10 +2486,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.0.20240929.41608";
+      version = "4.0.0.20241204.51511";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.0.20240929.41608.tar";
-        sha256 = "0lfk8hamfbaz0ifs4fkl836dqlcyw4g7kbsnmi5qjlyqc27yk8f9";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.0.20241204.51511.tar";
+        sha256 = "1xvx1x6p7r1ak40n3740q9iyah2d1npqg7aw1zybshcrai5bm9jm";
       };
       packageRequires = [ async ];
       meta = {
@@ -2597,10 +2619,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.5pre0.20241012.232703";
+      version = "0.5pre0.20241106.231359";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.5pre0.20241012.232703.tar";
-        sha256 = "1wj52cs86jzl2cx9a3599fjncnra1x8as9md6i5afwmm9flb3yn6";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.5pre0.20241106.231359.tar";
+        sha256 = "11b3dvwzrsgg2nj3kasgrz5bwhd2i3ig4v9blzlzhyybw6wy0i1f";
       };
       packageRequires = [
         compat
@@ -2628,10 +2650,10 @@
     elpaBuild {
       pname = "hyperdrive-org-transclusion";
       ename = "hyperdrive-org-transclusion";
-      version = "0.3pre0.20240930.224512";
+      version = "0.3.1.0.20241027.212737";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-org-transclusion-0.3pre0.20240930.224512.tar";
-        sha256 = "13wacgy29zm9yly58hznj0k1liah9kqw2b6gkpk8804yrjzjhgd4";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-org-transclusion-0.3.1.0.20241027.212737.tar";
+        sha256 = "1lwiqhjlanxkbv556m6f8xfp63b5xk66zhmg2zazw4sx0zy97s75";
       };
       packageRequires = [
         hyperdrive
@@ -2873,10 +2895,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.0.0.20240926.152808";
+      version = "1.0.1.0.20241120.85729";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.0.0.20240926.152808.tar";
-        sha256 = "0hhpzarz8xa61mp6drm0j98832h8sdammkp55ap6bj35vlyppc13";
+        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.1.0.20241120.85729.tar";
+        sha256 = "0a6xi5zcq1nfbsjqk84x6avlrzbjdh6fbq1h6jkqcczy7mm5rg5h";
       };
       packageRequires = [ ];
       meta = {
@@ -2981,10 +3003,10 @@
     elpaBuild {
       pname = "macrostep";
       ename = "macrostep";
-      version = "0.9.4.0.20240608.12616";
+      version = "0.9.4.0.20241025.145629";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/macrostep-0.9.4.0.20240608.12616.tar";
-        sha256 = "0wl8v174428vaxzf9ghyzm1ljsv0r5xw445lwzzj21yc4x1y2vh1";
+        url = "https://elpa.nongnu.org/nongnu-devel/macrostep-0.9.4.0.20241025.145629.tar";
+        sha256 = "1xbi45ymsqc2vbhl1s3wphirgqz5ky9880fzr949bhd0ff18bw6x";
       };
       packageRequires = [
         cl-lib
@@ -3011,10 +3033,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.1.1.0.20241001.205222";
+      version = "4.1.2.0.20241102.130025";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.1.1.0.20241001.205222.tar";
-        sha256 = "1qfaaqhm8m7cg4lrllv770w7bl2mfnpyx551accw757jxpnw8qdn";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.1.2.0.20241102.130025.tar";
+        sha256 = "1y3fr2qj8a1h7hkrh47zshbmrcfxhw6i8wiqcrrba7ypnas53gcg";
       };
       packageRequires = [
         compat
@@ -3042,10 +3064,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.1.1.0.20241001.205222";
+      version = "4.1.2.0.20241102.130025";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.1.1.0.20241001.205222.tar";
-        sha256 = "1lad3vqflf4fdsjfiyarjgcl7w73k8rj0bbsndc3xd6j5q53azfr";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.1.2.0.20241102.130025.tar";
+        sha256 = "1cnpklpsvbsi1wsmfbp5m8379cbr6jdifxm07zj4hnvi8lyr49vn";
       };
       packageRequires = [
         compat
@@ -3067,10 +3089,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.7alpha0.20240829.32430";
+      version = "2.7alpha0.20241203.113852";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.7alpha0.20240829.32430.tar";
-        sha256 = "0npgvcni0h5nr253fsn0d1cm3fnq1s662ba7aa23vsvkyk1x54d9";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.7alpha0.20241203.113852.tar";
+        sha256 = "14kkg7wj6qkq84jsa5cdwc7i7lqvilx21nb9lyddqxqxm8h7sld8";
       };
       packageRequires = [ ];
       meta = {
@@ -3086,18 +3108,20 @@
       lib,
       persist,
       request,
+      tp,
     }:
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.0.27.0.20240920.183931";
+      version = "1.1.7.0.20241202.183936";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.0.27.0.20240920.183931.tar";
-        sha256 = "0wy6ibdbj984aycscvsg24k4z3a0dlzi2ghbvrb8zq3lma8sy2a6";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.1.7.0.20241202.183936.tar";
+        sha256 = "08683fah6xkfzgxi6si4qgl4mxccczj4dcaivif1qlhfrc3bh66f";
       };
       packageRequires = [
         persist
         request
+        tp
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/mastodon.html";
@@ -3165,10 +3189,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.4.5.0.20241014.63605";
+      version = "1.5.0.0.20241203.160407";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.4.5.0.20241014.63605.tar";
-        sha256 = "1ws4i72gmr6g8fxvc27p28rm6wjdm71xpi03xiwy33x7m960g470";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20241203.160407.tar";
+        sha256 = "0a3zdx91j5q0mllm71951392hgnn5q9l960qs2lazs8plpv4pn9f";
       };
       packageRequires = [ ];
       meta = {
@@ -3249,10 +3273,10 @@
     elpaBuild {
       pname = "mpv";
       ename = "mpv";
-      version = "0.2.0.0.20220801.191738";
+      version = "0.2.0.0.20241121.230837";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mpv-0.2.0.0.20220801.191738.tar";
-        sha256 = "0fanxxgmpjmy13lawr15ccnlzc5k89pix6m020kxbpi6aj2n1apc";
+        url = "https://elpa.nongnu.org/nongnu-devel/mpv-0.2.0.0.20241121.230837.tar";
+        sha256 = "1aynlwp90xrprri3m1v8yxa5zvbx6d12m662lsn9qdzvhl2dy5hk";
       };
       packageRequires = [ ];
       meta = {
@@ -3270,10 +3294,10 @@
     elpaBuild {
       pname = "multiple-cursors";
       ename = "multiple-cursors";
-      version = "1.4.0.0.20240223.113445";
+      version = "1.4.0.0.20241202.163103";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.4.0.0.20240223.113445.tar";
-        sha256 = "17wq8apfvcrmx4mvyw2pbkp9jg5c960w8j81blzxq1qxh1ggdv3z";
+        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.4.0.0.20241202.163103.tar";
+        sha256 = "018f3fpv0ganvhcwykpb2rfw41nqlkj87dx1zfzkf7s9011grkfv";
       };
       packageRequires = [ ];
       meta = {
@@ -3424,10 +3448,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.6.0.20240907.102556";
+      version = "0.6.0.20241029.204012";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20240907.102556.tar";
-        sha256 = "16dv65jz0ykzi0dk2zd1gj46113wq1bnzxzbacpbddix53vkfbc1";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20241029.204012.tar";
+        sha256 = "12pfmv5ns5igdvc06glcc8nxqcj7lwjqc3s86720ys57y4py566w";
       };
       packageRequires = [ org ];
       meta = {
@@ -3657,10 +3681,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.24.0.20241007.131950";
+      version = "0.24.0.20241127.182614";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.24.0.20241007.131950.tar";
-        sha256 = "1srjs8xwwiqzjh550snzk0yzd4vy3ynk0d3i41y2i7wgfdggyl0p";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.24.0.20241127.182614.tar";
+        sha256 = "0wlz1hc387jcbh75hqjkxmydlsl0ai2adiam2axmqfdfn5p68llq";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -3700,10 +3724,10 @@
     elpaBuild {
       pname = "page-break-lines";
       ename = "page-break-lines";
-      version = "0.15.0.20240911.171451";
+      version = "0.15.0.20241107.72714";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20240911.171451.tar";
-        sha256 = "142s6q9fyr030rkdj1i349nbsfab7r742h2i1x430g8m19qai4zr";
+        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20241107.72714.tar";
+        sha256 = "0661kz0f8rippn1pi0jdzxa000vvakqv0s4y5f7f6vg41vhcna54";
       };
       packageRequires = [ ];
       meta = {
@@ -3721,10 +3745,10 @@
     elpaBuild {
       pname = "paredit";
       ename = "paredit";
-      version = "27beta0.20230718.202710";
+      version = "27beta0.20241103.213959";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/paredit-27beta0.20230718.202710.tar";
-        sha256 = "0fz65pr6p6dz3i78rzprzznzhyw34w8msnd4mzkls63bm4548gmd";
+        url = "https://elpa.nongnu.org/nongnu-devel/paredit-27beta0.20241103.213959.tar";
+        sha256 = "00xb4lzkbfsz7f7pnsjfzbhigp4r2piimj7cplq7fxjl80j39lka";
       };
       packageRequires = [ ];
       meta = {
@@ -3857,10 +3881,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20240912.223846";
+      version = "1.26.1.0.20241024.124149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20240912.223846.tar";
-        sha256 = "09jppnrpl6y1y41g7bshy674c3p39l8r060zq57kr2f022z93mg8";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20241024.124149.tar";
+        sha256 = "0h5lzvsssk0nf3g408a7jg25crglsjkhcfp1ckjnzpgiwf59i6w8";
       };
       packageRequires = [ ];
       meta = {
@@ -3920,10 +3944,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.0snapshot0.20241009.115247";
+      version = "2.9.0snapshot0.20241113.45011";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.0snapshot0.20241009.115247.tar";
-        sha256 = "0lns0g1b52ib512dc0mqr8si6yqvnpcv148s262j5jqmm4a2sdm5";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.0snapshot0.20241113.45011.tar";
+        sha256 = "1hnyq1rfldda4csmdykwsngh317cxgj0bmlqy8xjbfqpy4876gar";
       };
       packageRequires = [ ];
       meta = {
@@ -3941,10 +3965,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20241004.113700";
+      version = "4.6snapshot0.20241126.3245";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20241004.113700.tar";
-        sha256 = "1kki60ds5mqkm89lfyx2ac510200bqfnmlkfcjkn7zcrkkcl6s7r";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20241126.3245.tar";
+        sha256 = "12py1s85wrvxqiha2bfbdmszy4dl9wh8pbbhfx2q7qds2hd9c3wc";
       };
       packageRequires = [ ];
       meta = {
@@ -3984,10 +4008,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20241001.105847";
+      version = "1.0.20241129.85359";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20241001.105847.tar";
-        sha256 = "0yhvr3c6f2hsdj4i699h7z4gjjim359wk09z917lb8dqdd3ddjdv";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20241129.85359.tar";
+        sha256 = "0j6hs2wpaknzprcm18y1ayqjcr2sl0z22fhw1yla5rv74lyqzglx";
       };
       packageRequires = [ ];
       meta = {
@@ -4068,10 +4092,10 @@
     elpaBuild {
       pname = "reformatter";
       ename = "reformatter";
-      version = "0.8.0.20241007.102705";
+      version = "0.8.0.20241106.203153";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20241007.102705.tar";
-        sha256 = "1z3zdmq78vziv45g133y1bnyzaszx0v16vdmwdfpcakj7b11qqw7";
+        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20241106.203153.tar";
+        sha256 = "1gni5f8x8d6m063k9bgaqah80w2hnb12d7qwdw1ai0xg7jb92vp7";
       };
       packageRequires = [ ];
       meta = {
@@ -4152,10 +4176,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20240919.160702";
+      version = "1.0.6.0.20241112.43839";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20240919.160702.tar";
-        sha256 = "10ack1z2zpfsn2li5nl6l7rpsm43hivgikjdqz5zgiskmqdfy1m5";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20241112.43839.tar";
+        sha256 = "1jmby08vp18qr2cx3k6skw9mar7vb7wr5ph9q2g95wx8836g6mbp";
       };
       packageRequires = [ ];
       meta = {
@@ -4327,10 +4351,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.30snapshot0.20241013.100856";
+      version = "2.31.0.20241201.210325";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.30snapshot0.20241013.100856.tar";
-        sha256 = "19i9vgb1h20lmfskr13b7jkj7xg16dkm0ymhndi41xbimdnvav42";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31.0.20241201.210325.tar";
+        sha256 = "05skikmrfcwbahph8z50kf1zh5vps7459zw7l1bipgyvhfvpq9fn";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4411,10 +4435,10 @@
     elpaBuild {
       pname = "spacemacs-theme";
       ename = "spacemacs-theme";
-      version = "0.2.0.20240825.170904";
+      version = "0.2.0.20241101.103011";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20240825.170904.tar";
-        sha256 = "196nby3c283qls06m6vgjr0g964jpyy760y1mmllkczbm4ia34aw";
+        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20241101.103011.tar";
+        sha256 = "1sxj7xghkkayvpa1qb4d3ws81931r8s737wk3akwhayh50czh3fi";
       };
       packageRequires = [ ];
       meta = {
@@ -4516,10 +4540,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.16.0.20241006.204608";
+      version = "1.2.21.0.20241117.83905";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.16.0.20241006.204608.tar";
-        sha256 = "0xqqdjpkbf27yaixh60k79xnqpj8kppy9lc1z2ij73sp3lync0gb";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.21.0.20241117.83905.tar";
+        sha256 = "0v95g129yp9s3kknbw1fp4iqn0f0g65bhvw4433v3dbinw9l3k74";
       };
       packageRequires = [ ];
       meta = {
@@ -4538,10 +4562,10 @@
     elpaBuild {
       pname = "sweeprolog";
       ename = "sweeprolog";
-      version = "0.27.6.0.20240905.90947";
+      version = "0.27.6.0.20241107.191437";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20240905.90947.tar";
-        sha256 = "0wsl9dnz1vrr5qajcps5095gaxpqwspb16qac72sdafxidjfgabh";
+        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20241107.191437.tar";
+        sha256 = "0y543svzd7sqqb2izlflvmv0mdyfwwzjgli107ra89w5jl6jxawh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4645,10 +4669,10 @@
     elpaBuild {
       pname = "tangotango-theme";
       ename = "tangotango-theme";
-      version = "0.0.7.0.20240522.132740";
+      version = "0.0.7.0.20241117.114955";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tangotango-theme-0.0.7.0.20240522.132740.tar";
-        sha256 = "1psr1amscknyw41dmsw6mvy73v271l8mzibwhl6kfp41a97cnlki";
+        url = "https://elpa.nongnu.org/nongnu-devel/tangotango-theme-0.0.7.0.20241117.114955.tar";
+        sha256 = "1p9j3pqgp0nzsypqdx9bc1qhkgyc3s3p9rbm3la356yfc3d3wxa3";
       };
       packageRequires = [ ];
       meta = {
@@ -4770,6 +4794,28 @@
       };
     }
   ) { };
+  tp = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      transient,
+    }:
+    elpaBuild {
+      pname = "tp";
+      ename = "tp";
+      version = "0.6.0.20241031.72940";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.6.0.20241031.72940.tar";
+        sha256 = "1m8qhar75cglg8qjh3sbgwkzkhfp3640nm73nddxrshnajn978bf";
+      };
+      packageRequires = [ transient ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/tp.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   treesit-fold = callPackage (
     {
       elpaBuild,
@@ -4800,10 +4846,10 @@
     elpaBuild {
       pname = "treeview";
       ename = "treeview";
-      version = "1.2.0.0.20230728.234322";
+      version = "1.3.1.0.20241101.11503";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treeview-1.2.0.0.20230728.234322.tar";
-        sha256 = "0cf64zj3iv1qzzddr5hg9rsjilczfn2c84dcgpfny7l3wzqrmwl1";
+        url = "https://elpa.nongnu.org/nongnu-devel/treeview-1.3.1.0.20241101.11503.tar";
+        sha256 = "0hf893bhnqg4ixfvs16h3rdiizkd14gsiq0cfg63cz077vp9bskh";
       };
       packageRequires = [ ];
       meta = {
@@ -4843,10 +4889,10 @@
     elpaBuild {
       pname = "typescript-mode";
       ename = "typescript-mode";
-      version = "0.4.0.20240603.115709";
+      version = "0.4.0.20241119.194738";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typescript-mode-0.4.0.20240603.115709.tar";
-        sha256 = "0v00kk4035i7b4b7clcwqxiavz89l2zxfpgk7f773ymamxpr3g82";
+        url = "https://elpa.nongnu.org/nongnu-devel/typescript-mode-0.4.0.20241119.194738.tar";
+        sha256 = "0yndbfnalj22bp2bzmrsa24a0v4cbk85b5yiqcg2diknrvsxkg2c";
       };
       packageRequires = [ ];
       meta = {
@@ -4864,10 +4910,10 @@
     elpaBuild {
       pname = "ujelly-theme";
       ename = "ujelly-theme";
-      version = "1.2.9.0.20180214.162459";
+      version = "1.3.6.0.20241111.2243";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/ujelly-theme-1.2.9.0.20180214.162459.tar";
-        sha256 = "1frl87liqd9wdd6i1wwi94qzbwdx24p5shr90flrnpj6hs2yx1n3";
+        url = "https://elpa.nongnu.org/nongnu-devel/ujelly-theme-1.3.6.0.20241111.2243.tar";
+        sha256 = "16q5n2854x9km0kd4vfr0wskbkw66pd1rf1qy34v1yacq2phb77b";
       };
       packageRequires = [ ];
       meta = {
@@ -4969,10 +5015,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.6.3.0.20240411.65626";
+      version = "2.6.3.0.20241109.231059";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20240411.65626.tar";
-        sha256 = "0hyhxpqj39say3w9rpw3mhx7r9aici1wfsrr9631bnc0249qylj2";
+        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20241109.231059.tar";
+        sha256 = "1k6ih7fw0xmbm6m249cdinyx8g5k3gpdglla8242w64bqrxxcpr8";
       };
       packageRequires = [ ];
       meta = {
@@ -4992,10 +5038,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20240917.131054";
+      version = "8.3.0snapshot0.20241026.45603";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20240917.131054.tar";
-        sha256 = "0csg8ng38jqw5jlj5db24ngh5ay9qi8p8bvfgg3acxa26qjma03l";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20241026.45603.tar";
+        sha256 = "1ipasfr8g64n2i5yn992yw8aikkjzqw1lshlai90sxrdd1s3vlgm";
       };
       packageRequires = [
         cl-lib
@@ -5039,10 +5085,10 @@
     elpaBuild {
       pname = "webpaste";
       ename = "webpaste";
-      version = "3.2.2.0.20241002.53654";
+      version = "3.2.2.0.20241125.141806";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/webpaste-3.2.2.0.20241002.53654.tar";
-        sha256 = "0y63yrid0cxszfsm99pj6nig2siq85flma5l12fiydkpa6xh3ybj";
+        url = "https://elpa.nongnu.org/nongnu-devel/webpaste-3.2.2.0.20241125.141806.tar";
+        sha256 = "0356h3x2l0iaqk04zyp870r7bd1kzsldlqgdfn61x32krwml3iif";
       };
       packageRequires = [
         cl-lib
@@ -5127,10 +5173,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.2.0.20240831.223035";
+      version = "3.4.3.0.20241201.141907";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.2.0.20240831.223035.tar";
-        sha256 = "120v2n8py0qjcmlnf8l7p83w3bb5vg614ci65gliqhgmikhbwafh";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.3.0.20241201.141907.tar";
+        sha256 = "1srqg86809lb1b0dj421gb6n522cx19snhvhvxb4nxkk98afiywp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5216,10 +5262,10 @@
     elpaBuild {
       pname = "ws-butler";
       ename = "ws-butler";
-      version = "0.6.0.20201117.102839";
+      version = "0.7.0.20241107.1911";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-0.6.0.20201117.102839.tar";
-        sha256 = "0k1dwxw22ar3837i05a17pr52nzxjdcs1fldwlq0b5xynjfj2i3k";
+        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-0.7.0.20241107.1911.tar";
+        sha256 = "1571dns6zdvdqvz5mnca207jpbijm9aiaf6x4iy69w91hszsdda0";
       };
       packageRequires = [ ];
       meta = {
@@ -5237,10 +5283,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.6.20241009212806.0.20241009.212859";
+      version = "26.8.20241118173945.0.20241118.174137";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.6.20241009212806.0.20241009.212859.tar";
-        sha256 = "07vpnsrifc6nkf7zrhahzgxn196wm3w71zvsvb249sjf3za9gz07";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.8.20241118173945.0.20241118.174137.tar";
+        sha256 = "196hv8hjzp87b8y9k65w2zag46bx2jhmah1w9mdjxwkfbq6bjcmq";
       };
       packageRequires = [ ];
       meta = {
@@ -5323,10 +5369,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20240911.80118";
+      version = "1.0.0.20241014.94920";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20240911.80118.tar";
-        sha256 = "1wn5ckrlpacrlil6ap9j1x1lfr1yydnf0hcy268ji52hwvkdf55p";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20241014.94920.tar";
+        sha256 = "065wcvb295dhyi6jvb80vagzb8idqycchqgy32pj0fr6vcxx7y88";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5366,10 +5412,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20240507.233944";
+      version = "0.0.8.0.20241104.162434";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20240507.233944.tar";
-        sha256 = "1skx0if2ac40csgsrfvkd73ydsvr24ijkmqrpya65n67388gibfv";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20241104.162434.tar";
+        sha256 = "01g51mvsg578hcnr8kbda8pbgy7yrk57p9djy3bn1rp4vwjh2f46";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -93,10 +93,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.2.2";
+      version = "2.2.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/annotate-2.2.2.tar";
-        sha256 = "0hrb7kjzhgy46hxaa77rv5ilsdsv6zxpawnkx4viw5jq0v5s4fl6";
+        url = "https://elpa.nongnu.org/nongnu/annotate-2.2.3.tar";
+        sha256 = "1x0v51rbnyzwvjwp4xwsd2a4xisid65zgww6yk0bb81421i54ps3";
       };
       packageRequires = [ ];
       meta = {
@@ -544,10 +544,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.16.0";
+      version = "1.16.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.16.0.tar";
-        sha256 = "1chp9ixd0k6yv4m727si6pgn2kys3zi5xkiq88xbv7bjcjryqmgz";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.16.1.tar";
+        sha256 = "12nzhxy614fbmck7k7yy5yfknvmrsafc06vysc7c6ya6q4mmb91x";
       };
       packageRequires = [
         clojure-mode
@@ -915,6 +915,28 @@
       };
     }
   ) { };
+  dirvish = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      transient,
+    }:
+    elpaBuild {
+      pname = "dirvish";
+      ename = "dirvish";
+      version = "2.0.53";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/dirvish-2.0.53.tar";
+        sha256 = "02ji38zsb7lw43s919a8xfxcz2fl5cdrs3rk99cfqyvc4c1lywql";
+      };
+      packageRequires = [ transient ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/dirvish.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   doc-show-inline = callPackage (
     {
       elpaBuild,
@@ -1009,10 +1031,10 @@
     elpaBuild {
       pname = "dslide";
       ename = "dslide";
-      version = "0.5.3";
+      version = "0.5.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dslide-0.5.3.tar";
-        sha256 = "11q807jp90y37s1njmr6qlnqi9pk371gj8mwg57kgjvc55qdyas5";
+        url = "https://elpa.nongnu.org/nongnu/dslide-0.5.5.tar";
+        sha256 = "1hnmnl6ildr2cyc8hx1maa3vnz621d41yhsx8naxq3mssz4rkajp";
       };
       packageRequires = [ ];
       meta = {
@@ -1116,10 +1138,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.3";
+      version = "3.6.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.3.tar";
-        sha256 = "0vjsb2jfgnf9jya14zigy2jcd8agxsncm7cxg61jm940jyvs8fsq";
+        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.4.tar";
+        sha256 = "0f6hsw50a36jyp1ikawcdj9yn3isks03ax47x8vflmayydndir4g";
       };
       packageRequires = [ ];
       meta = {
@@ -1137,10 +1159,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.0.3";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.0.3.tar";
-        sha256 = "1179z8d5mzhmnq2b1q9pf450jflxvrk5y2i3hzdl8lvd4nrm6kgw";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.1.0.tar";
+        sha256 = "1nf7piakf1v23bnqdyivp4l9vq6xyzjxrgxaswncmvzqxb4qvhyx";
       };
       packageRequires = [ ];
       meta = {
@@ -2085,10 +2107,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.5";
+      version = "0.4.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.4.5.tar";
-        sha256 = "00rca3rfij2c8120kzs8wc6xsarpcj20gzwys05c7fhf7j8l5bdy";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.4.8.tar";
+        sha256 = "1sf6213qj6i306rqbp1a5wj7haw5vkmc1684fdfqzyqa1gw2ni5v";
       };
       packageRequires = [
         compat
@@ -2259,10 +2281,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.5";
+      version = "0.9.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.5.tar";
-        sha256 = "0ixji76xaqkm0ziidjmanax4q0xqyj1qcwva6r5sbsks6gpmrziv";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.6.tar";
+        sha256 = "0n7d8plabgmpyl224079cqrwlgqq7wwysba0wd0ry75h6z388rcb";
       };
       packageRequires = [
         compat
@@ -2644,10 +2666,10 @@
     elpaBuild {
       pname = "hyperdrive-org-transclusion";
       ename = "hyperdrive-org-transclusion";
-      version = "0.2";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/hyperdrive-org-transclusion-0.2.tar";
-        sha256 = "1zbhbsfrdcc5mfkpbzwkyn9bgapf8hs0jzy14lv9d5g99wskzbis";
+        url = "https://elpa.nongnu.org/nongnu/hyperdrive-org-transclusion-0.3.1.tar";
+        sha256 = "074ylcblg6wg2yg8jv1i6cn8vig56br0bqp5xwmhkslwrkqj05cj";
       };
       packageRequires = [
         hyperdrive
@@ -2889,10 +2911,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.0.0.tar";
-        sha256 = "02xab8qhf1z4cdn847n9ar2g65843qknca88jkaa94zzkxpv2bi1";
+        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.0.1.tar";
+        sha256 = "0203h99yia5k37ansy2wshkiyn105jaahmkm0ncf54far8dw6mwx";
       };
       packageRequires = [ ];
       meta = {
@@ -3027,10 +3049,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.1.1";
+      version = "4.1.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.1.1.tar";
-        sha256 = "0rjxlrs5ik6mqnvs9mz2pjmz23np3ch0ybkzimd9ji70283fyif6";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.1.2.tar";
+        sha256 = "1jyivrk78fnp7kcrac9sm2ldbxg9c96qhnlz06wv1m7hbvd3fgfx";
       };
       packageRequires = [
         compat
@@ -3058,10 +3080,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.1.1";
+      version = "4.1.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.1.1.tar";
-        sha256 = "1vbfvnmmm026zk098vxk21zh8r444cy476br4b6y20lhnniybh7s";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.1.2.tar";
+        sha256 = "0g24aj030fh55y44f3c33708fbm02jwzggh75zvg63bka3g6j242";
       };
       packageRequires = [
         compat
@@ -3102,18 +3124,20 @@
       lib,
       persist,
       request,
+      tp,
     }:
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.0.27";
+      version = "1.1.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-1.0.27.tar";
-        sha256 = "0kbbzmqnnh0pvd215660p1c2wljnxr5139vs17k9cnh8n5qsddjr";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-1.1.7.tar";
+        sha256 = "0qnkbab6y0gpqq0kvil4gnbajflpv0mz3pzcimcvz79dnmb0vc9p";
       };
       packageRequires = [
         persist
         request
+        tp
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/mastodon.html";
@@ -3181,10 +3205,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.4.5";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/meow-1.4.5.tar";
-        sha256 = "1d63mw88vq97rq3a7qhkxid2xaag5dp21ijisw9s3fk972kcks3s";
+        url = "https://elpa.nongnu.org/nongnu/meow-1.5.0.tar";
+        sha256 = "1fwd6lwaci23scgv65fxrxg51w334pw92l4c51ci9s0qgh1vjb01";
       };
       packageRequires = [ ];
       meta = {
@@ -4007,10 +4031,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20241001.105847";
+      version = "1.0.20241129.85359";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20241001.105847.tar";
-        sha256 = "0wwg30wbigmnb7yz9wc2yrq58jzysd2vp1g2324lbc95z61ng5yd";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20241129.85359.tar";
+        sha256 = "0ish7ysdqypw849k9d3cw0bl69r5ksc3hrqdmyh8k2ipq2xbcn2w";
       };
       packageRequires = [ ];
       meta = {
@@ -4346,10 +4370,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.30";
+      version = "2.31";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/slime-2.30.tar";
-        sha256 = "0gzgwrx6llj35kga21m3m4vp0g7f7dypim7pdnhy9sxrvl0k8v5f";
+        url = "https://elpa.nongnu.org/nongnu/slime-2.31.tar";
+        sha256 = "1s77j55nwz1s1c6763v0agsip5vrzd6f157q7i5z1jdmj3y0psck";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4535,10 +4559,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.16";
+      version = "1.2.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/subed-1.2.16.tar";
-        sha256 = "0fsxsp8g70mr36njmv2h3qrmp1mw3r4clrlzib33iq02wmw7q3rg";
+        url = "https://elpa.nongnu.org/nongnu/subed-1.2.21.tar";
+        sha256 = "1d0w96amchcpblcbkl16yiwsvj8qfpax66ysjg02550lhpb493x7";
       };
       packageRequires = [ ];
       meta = {
@@ -4811,6 +4835,28 @@
       };
     }
   ) { };
+  tp = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      transient,
+    }:
+    elpaBuild {
+      pname = "tp";
+      ename = "tp";
+      version = "0.6";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/tp-0.6.tar";
+        sha256 = "1a4n6bhaxiiwy11ig09w7p1jxrsl5gfk7ikma9jzv2z54f2p97kz";
+      };
+      packageRequires = [ transient ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/tp.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   treeview = callPackage (
     {
       elpaBuild,
@@ -4820,10 +4866,10 @@
     elpaBuild {
       pname = "treeview";
       ename = "treeview";
-      version = "1.2.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/treeview-1.2.0.tar";
-        sha256 = "1dmix7hn5yl69r987f0g2m00p866ln8412dm7fj399pmn1kdfsvy";
+        url = "https://elpa.nongnu.org/nongnu/treeview-1.3.1.tar";
+        sha256 = "02xac8kfh5j6vz0k44wif5v9h9xzs7srwxk0jff21qw32wy4accl";
       };
       packageRequires = [ ];
       meta = {
@@ -4884,10 +4930,10 @@
     elpaBuild {
       pname = "ujelly-theme";
       ename = "ujelly-theme";
-      version = "1.2.9";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/ujelly-theme-1.2.9.tar";
-        sha256 = "1yyjsdcwprynwk86phpqfifv6xkmn49yrj6fkh5s57w5sbby4fp0";
+        url = "https://elpa.nongnu.org/nongnu/ujelly-theme-1.3.6.tar";
+        sha256 = "19z3nf8avsipyywwlr77sy1bmf6gx5kk3fyph6nn4sn5vhcmgg0p";
       };
       packageRequires = [ ];
       meta = {
@@ -5121,10 +5167,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.2";
+      version = "3.4.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.2.tar";
-        sha256 = "0z6zi271p2ch4gylkz4ynj44hyxjmvvmg7xjsxwjmsyi800kwr58";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.3.tar";
+        sha256 = "1n0cnxhbqb49i6pknx47f81vlpwi9a6cjbjzr8b349fh6yv3q9w7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5210,10 +5256,10 @@
     elpaBuild {
       pname = "ws-butler";
       ename = "ws-butler";
-      version = "0.6";
+      version = "0.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/ws-butler-0.6.tar";
-        sha256 = "1jzlwj2pqan3bj0mipvh8vzvmgynrxf1dqphix7g86ppjv1ivmfy";
+        url = "https://elpa.nongnu.org/nongnu/ws-butler-0.7.tar";
+        sha256 = "1rwkwcb4079czdsccldzq4kjrl25y53k4zy2n7026cd7hxxvc959";
       };
       packageRequires = [ ];
       meta = {
@@ -5231,10 +5277,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.6.20241009212806";
+      version = "26.8.20241118173945";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.6.20241009212806.tar";
-        sha256 = "17xyb1dvsi2hqnhhk8vzbrskhlbh6w869c1iy14cdy3yndj7y8v2";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.8.20241118173945.tar";
+        sha256 = "1l6wwv1zmpsf64v23zzi2idjb14wnbpv5fcspiygiah62zag44vf";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1426,14 +1426,14 @@
   "repo": "abo-abo/ace-link",
   "unstable": {
    "version": [
-    20220901,
-    1710
+    20241101,
+    1344
    ],
    "deps": [
     "avy"
    ],
-   "commit": "06ab398df85e81d1dc763b3210732dd26cba60a1",
-   "sha256": "184n89m4daalzz10c6wyqxi8nzpki7bna9b0am39vxbi699k3pdk"
+   "commit": "d9bd4a25a02bdfde4ea56247daf3a9ff15632ea4",
+   "sha256": "0zdrxnd35dl9bdy2mb03zflb4mr8yw5s3qnpph2hvhlapkf19vwv"
   },
   "stable": {
    "version": [
@@ -2167,11 +2167,11 @@
   "url": "https://bitbucket.org/agriggio/ahg",
   "unstable": {
    "version": [
-    20230904,
-    701
+    20241113,
+    748
    ],
-   "commit": "6a8dd876d767b50431db2c695a8c21d5df9944e2",
-   "sha256": "1jq411g0ryxkqw4wig6mlm0dpjzx87cw3x277bcj796s3nxl95ln"
+   "commit": "d57b91d52e5c2c501cb7112af53c6549397ea1b5",
+   "sha256": "1whzlwad6fgg88fby7fsbzqdipz6s6xhqlnjna9vlcckbdzhs23b"
   }
  },
  {
@@ -3283,11 +3283,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20240928,
-    843
+    20241122,
+    614
    ],
-   "commit": "be75eb8b3f476770349b3fe0446fd7ae0edc5357",
-   "sha256": "1qx1q12z0cx87i2mqwfggbn0gbw7vim7dvf15g8z5i01r7dgh0qs"
+   "commit": "32706314adf6d02a407f2b0b411741d9c4722c05",
+   "sha256": "0kzqrz2dyx67jwhfqjv6j4fjvwn45jy7kxqfxd16iii4kqh24fr8"
   }
  },
  {
@@ -3398,11 +3398,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20240509,
-    1144
+    20241017,
+    1508
    ],
-   "commit": "bc82194ca5b10a05cab4169f6eacc5c18af61ec0",
-   "sha256": "0vzvy7bxp6pb42x16jms7sw2l1mp7m0xfz3xk55hwyxfz8rh66gp"
+   "commit": "c5a41ce5ac861e3fcd95669eb68c886ce702d39b",
+   "sha256": "1pqgqr3mq3iw8k6gi72kb328wi3i5mc0c5y5ca48cj9qndwslv37"
   },
   "stable": {
    "version": [
@@ -3520,28 +3520,28 @@
   "repo": "emacs-ansible/emacs-ansible",
   "unstable": {
    "version": [
-    20240926,
-    2144
+    20241129,
+    309
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "e171dacc12eeaba5dbd7fd887f94d11b357fe958",
-   "sha256": "11ls81zr5b62cykc28rldw1y1hx0bhf2s6xqypdsxblk5ymgr491"
+   "commit": "03e285bb54a687e3fd9e21026b088fdac46679a0",
+   "sha256": "0hpb8bcpyynzkc90jygp284l79vfgl5xb2hig0h5j7n5xvjcg1g9"
   },
   "stable": {
    "version": [
     0,
-    3,
-    2
+    4,
+    0
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "40af0d2bbb6c5bbcf7aa9269ac9a07e22622d263",
-   "sha256": "12k8mwlyiipsdjq5h1v04g3aa7ymjyhmy14j6vzjil4w9l6xyvdh"
+   "commit": "a005c70be00de6b8d45b51807fe1e049dd945fb3",
+   "sha256": "1i9fymfw8s05s3cy4rbldd6pya6y7gpaqcjcrkcyd96y5awb0w34"
   }
  },
  {
@@ -3796,17 +3796,17 @@
  },
  {
   "ename": "apel",
-  "commit": "235012164f093451c0f7409f57e271d8b895833c",
-  "sha256": "1w2ljg3pfxjp9jpl3f4p5iggd44gab7ps19xxdp8iz8dq0rxgpf9",
+  "commit": "8fe101b6d26bc501d5dc3515f10f972a53078a46",
+  "sha256": "0bx1fpy57ph08b7azrhhfryng84w90p6d6ncpb308qdrwdhj157a",
   "fetcher": "github",
-  "repo": "wanderlust/apel",
+  "repo": "emacsmirror/apel",
   "unstable": {
    "version": [
-    20221214,
-    1337
+    20241127,
+    1623
    ],
-   "commit": "1a6fd3bab2cc6b0a450c2d801f77a1c9da0f72fb",
-   "sha256": "03yjg14rvcxn59wga4jvx28ii16bx5ym93fzfyssm67gqwgyb2gf"
+   "commit": "c58622cc6d2f6b503d3a930a2c48050be8e695cf",
+   "sha256": "0whqwnmd97gam65hc5pbk1li8v2jfi7ncjnps528gk8sx9zp8963"
   }
  },
  {
@@ -3817,19 +3817,19 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20241006,
-    142
+    20241113,
+    351
    ],
-   "commit": "d6f520752a77923a420f2ef894a6f2d26d29d7d0",
-   "sha256": "0zsaxm72qbnjb35sain605zlrlxfia2m9yfp371cfgvn6bgpgn31"
+   "commit": "543f6d651d11322f26665f017f051fbcfc21ceb0",
+   "sha256": "0pw16nh2pbb33fkwk2wmr73x6z405w2acsjfli77j2j9vg4nxh52"
   },
   "stable": {
    "version": [
     4,
-    2
+    3
    ],
-   "commit": "3e347cff47eb0072b47c56f6188c4f440e477770",
-   "sha256": "1an8k1zgahsjscmdm5s4mp71afb1mf86s63vg3pc8kalj4yw9gbj"
+   "commit": "543f6d651d11322f26665f017f051fbcfc21ceb0",
+   "sha256": "0pw16nh2pbb33fkwk2wmr73x6z405w2acsjfli77j2j9vg4nxh52"
   }
  },
  {
@@ -3892,11 +3892,11 @@
   "repo": "Greybeard-Entertainment/app-monochrome",
   "unstable": {
    "version": [
-    20240611,
-    1623
+    20241110,
+    1142
    ],
-   "commit": "e319fcfeb56d0fe28bbda7fc813537593c2f368d",
-   "sha256": "0qgj8l22cyyxwknkwc0104nhi5kcswgx5amd1b67pmrxj6cni0ws"
+   "commit": "6fedc38316ecf9529bd700cfb691cd1248a31c77",
+   "sha256": "133jvvjmc8q8hqrz53cf308ajxc77iqn7mqfzvrflkm3j785c8iv"
   }
  },
  {
@@ -3962,29 +3962,6 @@
   }
  },
  {
-  "ename": "aproject",
-  "commit": "de10c48976352f273e8363c2f6fa60602ee86c9b",
-  "sha256": "0v3gx2mff2s7knm69y253pm1yr4svy8w00pqbn1chrvymb62jhp2",
-  "fetcher": "github",
-  "repo": "vietor/aproject",
-  "unstable": {
-   "version": [
-    20220410,
-    541
-   ],
-   "commit": "13e176ee69851403bec6471c5cceed17b7912b6f",
-   "sha256": "1kb1vlqla4l2mixkd5awmgbh0bzwbngj8sq5mjvrw6slf7i35xjn"
-  },
-  "stable": {
-   "version": [
-    0,
-    4
-   ],
-   "commit": "702caf5392288dfd821b1e744fef0bb4fd9f9281",
-   "sha256": "18n3gsghj7sxxd6kpp21b2p7qwv93giwyr1zfvgbs8pzsbc8i9rx"
-  }
- },
- {
   "ename": "apropospriate-theme",
   "commit": "1da33013f15825ab656260ce7453b8127e0286f4",
   "sha256": "10bj2bsi7b104m686z8mgvbh493liidsvivxfvfxzbndc8wyjsw9",
@@ -3992,11 +3969,11 @@
   "repo": "waymondo/apropospriate-theme",
   "unstable": {
    "version": [
-    20240921,
-    1422
+    20241119,
+    1
    ],
-   "commit": "055693f52b5179f896a49c0570b5a6ca441fb2b9",
-   "sha256": "0n9xyfxsd1ypn6psa4qwlbiwa5vvprh6js18rlhki67v6df3lwgp"
+   "commit": "56c8c1b575106e72bcab2227fd73cf34f7f3df79",
+   "sha256": "1ll2j35z2bgxfz4nkiminlfsmqb7gjcjapsmj001qb5sfzcy52p9"
   },
   "stable": {
    "version": [
@@ -4010,10 +3987,10 @@
  },
  {
   "ename": "apt-sources-list",
-  "commit": "141a22e593415302d64cf8ebd2635a1baf35eb38",
-  "sha256": "1gnl6zqv6imk2qpv4lj7qyjgf1ldxib3k14gsmwqm0c1zwjsid3j",
-  "fetcher": "git",
-  "url": "https://git.korewanetadesu.com/apt-sources-list.git",
+  "commit": "81c510927c3794cccd0a54feb5c1e82d7a6bd03b",
+  "sha256": "0hjn8ri29zksjgiv8wzm1gymdg29a44268sfx1767l5pyw1wyp2m",
+  "fetcher": "gitlab",
+  "repo": "joewreschnig/apt-sources-list-mode",
   "unstable": {
    "version": [
     20180527,
@@ -4474,11 +4451,11 @@
   "repo": "rnkn/astute",
   "unstable": {
    "version": [
-    20240910,
-    1312
+    20241015,
+    444
    ],
-   "commit": "54ed0a94b1f0ce03becf91847a026403c697d2b6",
-   "sha256": "02zgk44hv17qqp5065a84fdpqkwa5wzs6r68fqy0r6lag38j1aih"
+   "commit": "69d413c952771c0d06cda161fb25fe495fb895b0",
+   "sha256": "1jb00y23gk1rpm1gz11v4b4y087bblqyih2ca70y31i9gmyz7rq2"
   }
  },
  {
@@ -4522,11 +4499,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20241005,
-    1824
+    20241126,
+    810
    ],
-   "commit": "af47d6f930f93d4fdc4ca46e19e17547bf486c4c",
-   "sha256": "1kxxkjv9cys3z25g3bcq5sdm99s1kfj909vzi12dfyrzmxh30kk0"
+   "commit": "b99658e831bc7e7d20ed4bb0a85bdb5c7dd74142",
+   "sha256": "19vszyfvbp3gh73yxq0wzqigfihgk8jzpp27ihirpy3v6kc3bkr7"
   },
   "stable": {
    "version": [
@@ -5813,16 +5790,26 @@
   "repo": "marcwebbie/auto-virtualenv",
   "unstable": {
    "version": [
-    20240115,
-    1548
+    20241112,
+    1959
    ],
    "deps": [
-    "cl-lib",
-    "pyvenv",
-    "s"
+    "cl-lib"
    ],
-   "commit": "5771eb59fc2f589aa3066297ff3bbeeae474d846",
-   "sha256": "0vnl8k5dm9jjm5sr5gdp1405l20g2gx72nz26ha0g9r9qc6k4j8k"
+   "commit": "1f8efba02ef455aaa9cb84ab179949810e20213a",
+   "sha256": "0w9rfky6ms16c2ayr7bcd6cf9mn8imp6pcmqpi64s67f51vrqang"
+  },
+  "stable": {
+   "version": [
+    2,
+    2,
+    0
+   ],
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "1f8efba02ef455aaa9cb84ab179949810e20213a",
+   "sha256": "0w9rfky6ms16c2ayr7bcd6cf9mn8imp6pcmqpi64s67f51vrqang"
   }
  },
  {
@@ -6085,14 +6072,14 @@
   "repo": "abo-abo/avy",
   "unstable": {
    "version": [
-    20230420,
-    404
+    20241101,
+    1357
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "be612110cb116a38b8603df367942e2bb3d9bdbe",
-   "sha256": "0bv65i5n15shiq6cg6a2rvbkf9kigc4920rimn954ahncfn5x73i"
+   "commit": "933d1f36cca0f71e4acb5fac707e9ae26c536264",
+   "sha256": "1x3fbz7b3wq15rl05n3k17mfjij8133nkvvhlac2x21c17b1i0m7"
   },
   "stable": {
    "version": [
@@ -6797,11 +6784,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20230612,
-    1103
+    20241118,
+    1847
    ],
-   "commit": "f1daac0386c24cbe8a244a62c7588cc6847b07ae",
-   "sha256": "0s8p5xj2v3zgqj9z1iqpnca6wd78jhzvgfkpsd4bqwbrhi543sjm"
+   "commit": "f3a85184ef9cc925bedcdbd62f66dd63a658f181",
+   "sha256": "0nk62c0qkw4f365sxv21xnv6hk32mkrzr0bv0m5sl9n1li98b9kk"
   },
   "stable": {
    "version": [
@@ -7478,11 +7465,11 @@
   "repo": "technomancy/better-defaults",
   "unstable": {
    "version": [
-    20230611,
-    432
+    20241028,
+    4
    ],
-   "commit": "7d0e56b3a7f84bea6ee2dd9fda09da9df335f89e",
-   "sha256": "17gbbf6m548wiw6ra40vf2q0nl7sxrfia29ssx3ikn7j59q6cc7g"
+   "commit": "fde8d8f9cf8c038c8ef902d939df4745e88fac88",
+   "sha256": "1kdin9c9lnzfy096l3hf3g54czpds4kgg13drj0d6aa2i0d6n78l"
   }
  },
  {
@@ -7699,8 +7686,8 @@
   "repo": "jrasband/biblio-gbooks",
   "unstable": {
    "version": [
-    20240102,
-    2034
+    20241025,
+    1400
    ],
    "deps": [
     "biblio-core",
@@ -7708,16 +7695,16 @@
     "let-alist",
     "seq"
    ],
-   "commit": "991f214b8af23f168462a0006cf4d6216fbd7371",
-   "sha256": "0bsm51pz69q938wfbr9kc84mizwjbnclvs17ski1s30s6xkinfra"
+   "commit": "c7bdaba4dde8fca8b8e923f3c004d050a32c06c2",
+   "sha256": "18fg3anm09bigv8zlb2hd3mf83kghf8261xjpklpxy77d80j7gv7"
   }
  },
  {
   "ename": "bibliothek",
-  "commit": "8b8308e72c4437237fded29db1f60b3eba0edd26",
-  "sha256": "011wnya65vfnn17fn1vhq0sk8c1mli81x0nb44yi6zl1hwxivb55",
-  "fetcher": "github",
-  "repo": "cadadr/elisp",
+  "commit": "04fdd633207a28b91f0a6e64aa25d114ab229a13",
+  "sha256": "1hsk56nxy765h4ag672xh0dgx1zh66vmijhw3f277q4vsadjrqc3",
+  "fetcher": "codeberg",
+  "repo": "kutuptiyini/elisp",
   "unstable": {
    "version": [
     20190124,
@@ -7795,8 +7782,8 @@
   "repo": "tmalsburg/helm-bibtex",
   "unstable": {
    "version": [
-    20240220,
-    1216
+    20241116,
+    726
    ],
    "deps": [
     "biblio",
@@ -7806,8 +7793,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "8b71b4f5ce62eeaf18067f57faaddc06449fbe1c",
-   "sha256": "1zlg1bdjxjh1m3rb7i49il48ybj08wkbs17zcl0sxxmbldw3cvhp"
+   "commit": "6064e8625b2958f34d6d40312903a85c173b5261",
+   "sha256": "1q8dm14wdxx14rnlgmz88j6gskvrrsc0f2z2639jwmfhyibw7d77"
   },
   "stable": {
    "version": [
@@ -7950,21 +7937,21 @@
  },
  {
   "ename": "bind-chord",
-  "commit": "6240afa625290187785e4b7535ee7b0d7aad8969",
-  "sha256": "1hyhs3iypyg5730a20axcfzrrglm4nbgdz8x1ifkaa0iy5zc9hb0",
+  "commit": "6c1d8ed99c3769f6a789fb51dc37794b95f8bb37",
+  "sha256": "01a3c298kq8cfsxsscpic0shkjm77adiamgbgk8laqkbrlsrrcsb",
   "fetcher": "github",
-  "repo": "jwiegley/use-package",
+  "repo": "waymondo/use-package-chords",
   "unstable": {
    "version": [
-    20221117,
-    1610
+    20241115,
+    2228
    ],
    "deps": [
     "bind-key",
     "key-chord"
    ],
-   "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
-   "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
+   "commit": "a2b16a1e64b19ae9428a6cd8f3e09b8159707a29",
+   "sha256": "0krskz087vy4iws01w5wxsn7b0pkncsn6s1vj9ywagn5i1z6a34x"
   },
   "stable": {
    "version": [
@@ -7975,30 +7962,6 @@
    "deps": [
     "bind-key",
     "key-chord"
-   ],
-   "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
-   "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
-  }
- },
- {
-  "ename": "bind-key",
-  "commit": "d39d33af6b6c9af9fe49bda319ea05c711a1b16e",
-  "sha256": "1qw2c27016d3yfg0w10is1v72y2jvzhq07ca4h6v17yi94ahj5xm",
-  "fetcher": "github",
-  "repo": "jwiegley/use-package",
-  "unstable": {
-   "version": [
-    20230203,
-    2004
-   ],
-   "commit": "77945e002f11440eae72d8730d3de218163d551e",
-   "sha256": "1irr8a8r28n8c0c2x5w1flgv1f3z5jy2i5r5dknddiqa93b3rm84"
-  },
-  "stable": {
-   "version": [
-    2,
-    4,
-    4
    ],
    "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
    "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
@@ -8036,14 +7999,14 @@
   "repo": "divyaranjan/binder",
   "unstable": {
    "version": [
-    20241002,
-    1408
+    20241023,
+    1154
    ],
    "deps": [
     "seq"
    ],
-   "commit": "0a86e1e60c04b525c9017b0479c1135044273f32",
-   "sha256": "0nbczlvcdygfjy0grlxqpc5ygnwk8nyxi3pk8kkgp681c19bcpdi"
+   "commit": "928a68ff2cb186404f4247499a9d8a7a7a8c1f84",
+   "sha256": "0c1zfvfj0zgv6v6xvchyn63lsfni4vrg40ladf193ds9vz44mxjh"
   },
   "stable": {
    "version": [
@@ -8090,14 +8053,14 @@
   "repo": "liuyinz/binky.el",
   "unstable": {
    "version": [
-    20241011,
-    1931
+    20241029,
+    355
    ],
    "deps": [
     "dash"
    ],
-   "commit": "604cbee86e829f9db47887e092b0835a6dbf47dd",
-   "sha256": "1zlnwg5ggpjywqvdj2xxmk55bh8q50l8f1hh7anfqfkgfqr843lg"
+   "commit": "8841382a2b0925aca6644a2a0f1b87244b3e63c1",
+   "sha256": "15sl9dn5m59pprpqxbjc2kxa3rnk5kgi1rxzf8c3pdwvx5ll3fh0"
   },
   "stable": {
    "version": [
@@ -8994,28 +8957,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20240831,
-    2310
+    20241201,
+    1406
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "cdae2c905ea5f819dec3b183214f5e19670d35f4",
-   "sha256": "0m2h4mka751vxjac4c2ijznb8lwf473660d2nrrb84zh4h505xqf"
+   "commit": "497e1c02555852ee92d1c0ec70839e9ed93a02b8",
+   "sha256": "0vsazlnl3fa5i71cn74wk4pf4wakmx5navpfmf5f6aj475f1yk0s"
   },
   "stable": {
    "version": [
     4,
     1,
-    0
+    2
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "cdae2c905ea5f819dec3b183214f5e19670d35f4",
-   "sha256": "0m2h4mka751vxjac4c2ijznb8lwf473660d2nrrb84zh4h505xqf"
+   "commit": "497e1c02555852ee92d1c0ec70839e9ed93a02b8",
+   "sha256": "0vsazlnl3fa5i71cn74wk4pf4wakmx5navpfmf5f6aj475f1yk0s"
   }
  },
  {
@@ -9661,11 +9624,11 @@
   "repo": "ideasman42/emacs-buffer-name-relative",
   "unstable": {
    "version": [
-    20240421,
-    324
+    20241015,
+    1226
    ],
-   "commit": "2e681c7277f599a319d99182284eebe13cd654e3",
-   "sha256": "1flkps9v7dgggbd7pbz0pgj8p3gwyjlzzpbgv9xbpdmyfqxbb1m3"
+   "commit": "fdfd46bb14be76ad4de15f77d394f8ed1640cedd",
+   "sha256": "11lx849jj9zd7wgp6d1ljb7qy4gs4shrb8yqcmqb6f9azxka5zpd"
   }
  },
  {
@@ -10782,17 +10745,16 @@
   "repo": "emacsattic/call-graph",
   "unstable": {
    "version": [
-    20230222,
-    525
+    20241111,
+    117
    ],
    "deps": [
     "beacon",
-    "hierarchy",
     "ivy",
     "tree-mode"
    ],
-   "commit": "5fd5f3aad35e3561c253870e4d7fa34353b70b7b",
-   "sha256": "1x4s5h4qpw3cm2bqnpwz0fkpznbs2fyvdk2zssbikwn9wxvpfapi"
+   "commit": "c19effc6d230822e08d181fb5943582878a8903b",
+   "sha256": "12my47321jjajgdqniajxl7wv7r7nh0gnlk8s55qdvi742127zmh"
   },
   "stable": {
    "version": [
@@ -10921,14 +10883,14 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20241007,
-    501
+    20241123,
+    925
    ],
    "deps": [
     "compat"
    ],
-   "commit": "485d8d4ad5aeb17a0f5d3337e600070276448c54",
-   "sha256": "0r9igz35h3w3rqx9r34p9lwjs69xfq9cic4s6rwhsnix7n32apmf"
+   "commit": "9a7c44fe8b7ace73fa8ebf6b5805474f0ca07d01",
+   "sha256": "0qa4911y61y4nshb4nqq7yf7fp8ms39wjm1da51k48lypmw013yb"
   },
   "stable": {
    "version": [
@@ -11083,20 +11045,20 @@
   "repo": "ayrat555/cargo-mode",
   "unstable": {
    "version": [
-    20240928,
-    1910
+    20241121,
+    638
    ],
-   "commit": "8321d01fa4d30391a9918bd9782fadbab27843fd",
-   "sha256": "1ng8kwx45ycjglwywnyimzfsny11a1a1dczi8740vr8s9cpfjp9a"
+   "commit": "1b97dec6fc5f8ff3a531f8d6dd33fbcc4ae1ba27",
+   "sha256": "08031wl8jz0b1rh14v6d9x5igc2nccazwqdxlp20vnmv2sqj05p7"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
-   "commit": "8321d01fa4d30391a9918bd9782fadbab27843fd",
-   "sha256": "1ng8kwx45ycjglwywnyimzfsny11a1a1dczi8740vr8s9cpfjp9a"
+   "commit": "1b97dec6fc5f8ff3a531f8d6dd33fbcc4ae1ba27",
+   "sha256": "08031wl8jz0b1rh14v6d9x5igc2nccazwqdxlp20vnmv2sqj05p7"
   }
  },
  {
@@ -11291,35 +11253,33 @@
   }
  },
  {
-  "ename": "casual-agenda",
-  "commit": "f77aab9a5e31ccc0fc45876572172d234d204463",
-  "sha256": "08kygh0wxsan6qq26wp894pp1mkf04m2rzpb25cr0j72h65m0q7c",
+  "ename": "casual",
+  "commit": "b89f2ab853d0dd1c684591d5f05c12de8d3785e4",
+  "sha256": "0s2nagcj1v9mw77ag60fdxhivrraxs3gk7i1xnj2d48gwjksai18",
   "fetcher": "github",
-  "repo": "kickingvegas/casual-agenda",
+  "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20241001,
-    714
+    20241126,
+    133
    ],
    "deps": [
-    "casual-lib",
-    "org"
+    "transient"
    ],
-   "commit": "ca0433e257297d0adcd96238f64a1116d25b4372",
-   "sha256": "1y7idm7v9yxfddj9vrwwj98j610bc61r2wrcgkc0ganfm9fglvp3"
+   "commit": "a84775d63b5a85b0254f8b80d412f3421d001204",
+   "sha256": "19rzqzhy2z03lx65712p1p23c5ji1nv1gxk3hq5q5fhvlm7r8qlz"
   },
   "stable": {
    "version": [
-    1,
-    0,
-    5
+    2,
+    2,
+    2
    ],
    "deps": [
-    "casual-lib",
-    "org"
+    "transient"
    ],
-   "commit": "ca0433e257297d0adcd96238f64a1116d25b4372",
-   "sha256": "1y7idm7v9yxfddj9vrwwj98j610bc61r2wrcgkc0ganfm9fglvp3"
+   "commit": "a84775d63b5a85b0254f8b80d412f3421d001204",
+   "sha256": "19rzqzhy2z03lx65712p1p23c5ji1nv1gxk3hq5q5fhvlm7r8qlz"
   }
  },
  {
@@ -11330,304 +11290,28 @@
   "repo": "kickingvegas/casual-avy",
   "unstable": {
    "version": [
-    20241001,
-    649
+    20241021,
+    2353
    ],
    "deps": [
     "avy",
-    "casual-lib"
+    "casual"
    ],
-   "commit": "9aa3e63326d65590c22d42c3ed9f37626c2a2c31",
-   "sha256": "1fscfv91ii1pg7wi42xvk330f4fjq81334fk28ya47vwq3132ccn"
+   "commit": "7e8f7703f4ab4886f27241664aa5e1510103f74e",
+   "sha256": "0ln5abq0fvlph5zz008m5jajshdqj62c9y734mb6hn9pgfvh5hay"
   },
   "stable": {
    "version": [
-    1,
-    4,
-    3
-   ],
-   "deps": [
-    "avy",
-    "casual-lib"
-   ],
-   "commit": "9aa3e63326d65590c22d42c3ed9f37626c2a2c31",
-   "sha256": "1fscfv91ii1pg7wi42xvk330f4fjq81334fk28ya47vwq3132ccn"
-  }
- },
- {
-  "ename": "casual-bookmarks",
-  "commit": "19999b89a2fb2eddd3edbf0df4b9c674b4c2ef29",
-  "sha256": "18w9l94y9zzvdib8im232asw7vhqq49qhylph07ilj5gmqawdwfh",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-bookmarks",
-  "unstable": {
-   "version": [
-    20241001,
-    635
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "99aea407da07aef1a87d67b12648280347bdeed8",
-   "sha256": "0q3nrx4fwx2nm8mxc52rynishqp8zlaj7431z9nmb7ap1jhvbw1g"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    2
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "99aea407da07aef1a87d67b12648280347bdeed8",
-   "sha256": "0q3nrx4fwx2nm8mxc52rynishqp8zlaj7431z9nmb7ap1jhvbw1g"
-  }
- },
- {
-  "ename": "casual-calc",
-  "commit": "47f061be179f0c7f8b86faa99ff0d3e9d8552ac1",
-  "sha256": "1c0wk9zbh7rzi9s0jcdxnzxy989545ccz1xmj7cs9jw4dq0i63z6",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-calc",
-  "unstable": {
-   "version": [
-    20241001,
-    611
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "fa4a1bf695025908245651ee641262bce6de0369",
-   "sha256": "1695vgysn17zhk5wnrfh1cqp8rzrfmcxg3vj80axs961qd1mrm9w"
-  },
-  "stable": {
-   "version": [
-    1,
-    11,
-    4
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "fa4a1bf695025908245651ee641262bce6de0369",
-   "sha256": "1695vgysn17zhk5wnrfh1cqp8rzrfmcxg3vj80axs961qd1mrm9w"
-  }
- },
- {
-  "ename": "casual-dired",
-  "commit": "ee1942517d15e34316ce3d9cc60d22e41556e232",
-  "sha256": "1g3vrlfl9482rcx1bmqbprf921ywz5dbcm685yxmfbr2fwbbgad5",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-dired",
-  "unstable": {
-   "version": [
-    20241001,
-    709
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "9b42c976dcaeb3ea3baacfd67c850b82ef9d164c",
-   "sha256": "1ps2ffsl0smfp1zqp24slzw5zd7jrmacplnxbg714fb1r5z2pfya"
-  },
-  "stable": {
-   "version": [
-    1,
-    8,
-    3
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "9b42c976dcaeb3ea3baacfd67c850b82ef9d164c",
-   "sha256": "1ps2ffsl0smfp1zqp24slzw5zd7jrmacplnxbg714fb1r5z2pfya"
-  }
- },
- {
-  "ename": "casual-editkit",
-  "commit": "401fe3e5097d3187a67632e8cb2279043aa82227",
-  "sha256": "1h2hbyv9rn229x2gdnqdala3hvz24vvc615sy8bg00iwgwf90kyf",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-editkit",
-  "unstable": {
-   "version": [
-    20241009,
-    2252
-   ],
-   "deps": [
-    "casual-lib",
-    "casual-symbol-overlay",
-    "magit",
-    "transpose-frame"
-   ],
-   "commit": "53ea0e05e275f9359b5a3aed8a0c864eb3cf8b50",
-   "sha256": "08ixzsm4xml3mas0scnc2qcwq3if5v2r18p4qxj89fg4flbqmkm7"
-  },
-  "stable": {
-   "version": [
-    1,
+    2,
     0,
-    13
+    0
    ],
    "deps": [
-    "casual-lib",
-    "casual-symbol-overlay",
-    "magit",
-    "transpose-frame"
+    "avy",
+    "casual"
    ],
-   "commit": "53ea0e05e275f9359b5a3aed8a0c864eb3cf8b50",
-   "sha256": "08ixzsm4xml3mas0scnc2qcwq3if5v2r18p4qxj89fg4flbqmkm7"
-  }
- },
- {
-  "ename": "casual-ibuffer",
-  "commit": "de711e92fd2f8ff1c626c3f7f789f402e8e92007",
-  "sha256": "1gynvk22nhm8l7dix7hracr7m3y3d0h065mplkj78hpx2pkmhvja",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-ibuffer",
-  "unstable": {
-   "version": [
-    20241001,
-    622
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "6d58d18d42e5433d5eac271a7b987ee9756c9c89",
-   "sha256": "0wnfz5i0xrafqln9lsv6drfa5hc2mqq4d3fd84lhyn74ya86w2mc"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    5
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "6d58d18d42e5433d5eac271a7b987ee9756c9c89",
-   "sha256": "0wnfz5i0xrafqln9lsv6drfa5hc2mqq4d3fd84lhyn74ya86w2mc"
-  }
- },
- {
-  "ename": "casual-info",
-  "commit": "1b06cc08de41e82f3f148aa9e35663e2e06427ae",
-  "sha256": "1d6jmjhc0xalw1ll15k69bazbvprmw519lcsm2gd2jpkbngw9rmy",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-info",
-  "unstable": {
-   "version": [
-    20241001,
-    706
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "79d9bae486e92c0eabf82cc566d5578cf05015b3",
-   "sha256": "1cw3pcwp08bv6hrfkza2iprpqppas63v2sxyhn2b3z8wywh65vg6"
-  },
-  "stable": {
-   "version": [
-    1,
-    3,
-    3
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "79d9bae486e92c0eabf82cc566d5578cf05015b3",
-   "sha256": "1cw3pcwp08bv6hrfkza2iprpqppas63v2sxyhn2b3z8wywh65vg6"
-  }
- },
- {
-  "ename": "casual-isearch",
-  "commit": "7280670087e28ed08575c71165c095ee7be7da49",
-  "sha256": "02qb1bpx30cxyjrd821g4qc5v7xwv4rc1f67p1dx3fglms8p2zc5",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-isearch",
-  "unstable": {
-   "version": [
-    20241001,
-    700
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "1568edca4aeb280a10e943f38cff8d744d5822f4",
-   "sha256": "1913r2hf62zhldii1w175i5fg21c1famb8742nvikv8n6vj8d0p7"
-  },
-  "stable": {
-   "version": [
-    1,
-    10,
-    1
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "1568edca4aeb280a10e943f38cff8d744d5822f4",
-   "sha256": "1913r2hf62zhldii1w175i5fg21c1famb8742nvikv8n6vj8d0p7"
-  }
- },
- {
-  "ename": "casual-lib",
-  "commit": "fd3bb4b191bf416dd419c5c76d510c7f5890e673",
-  "sha256": "18g739n2dbcywamvkkpnrhsmmnk1l5b9v05d173b9qq1fj06pn8p",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-lib",
-  "unstable": {
-   "version": [
-    20241001,
-    704
-   ],
-   "deps": [
-    "transient"
-   ],
-   "commit": "212313b1cd80e2757224d34ab34a098ff1cb37ee",
-   "sha256": "0s9yx9s1d4zr35j3pd6dnhldax1h0sgr5zrraqva4ysbflwlvy50"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    4
-   ],
-   "deps": [
-    "transient"
-   ],
-   "commit": "212313b1cd80e2757224d34ab34a098ff1cb37ee",
-   "sha256": "0s9yx9s1d4zr35j3pd6dnhldax1h0sgr5zrraqva4ysbflwlvy50"
-  }
- },
- {
-  "ename": "casual-re-builder",
-  "commit": "4963d8a23ffb1ed7222f3672e35239798ee1560d",
-  "sha256": "0li8vx0vq8abjnnssm2kx29mqzlpc7x8gcxjl1n4za315m3007wb",
-  "fetcher": "github",
-  "repo": "kickingvegas/casual-re-builder",
-  "unstable": {
-   "version": [
-    20241001,
-    655
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "5b4af74b7e7a82cc15122035e4e6286d843f1ef0",
-   "sha256": "09cqpji9zshwn9gaf7rw34w8pggkkp3g5rq8a7pizx7hxjlaskkd"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    3
-   ],
-   "deps": [
-    "casual-lib"
-   ],
-   "commit": "5b4af74b7e7a82cc15122035e4e6286d843f1ef0",
-   "sha256": "09cqpji9zshwn9gaf7rw34w8pggkkp3g5rq8a7pizx7hxjlaskkd"
+   "commit": "7e8f7703f4ab4886f27241664aa5e1510103f74e",
+   "sha256": "0ln5abq0fvlph5zz008m5jajshdqj62c9y734mb6hn9pgfvh5hay"
   }
  },
  {
@@ -11638,46 +11322,30 @@
   "repo": "kickingvegas/casual-suite",
   "unstable": {
    "version": [
-    20241001,
-    607
+    20241022,
+    3
    ],
    "deps": [
-    "casual-agenda",
+    "casual",
     "casual-avy",
-    "casual-bookmarks",
-    "casual-calc",
-    "casual-dired",
-    "casual-editkit",
-    "casual-ibuffer",
-    "casual-info",
-    "casual-isearch",
-    "casual-re-builder",
     "casual-symbol-overlay"
    ],
-   "commit": "fbab88e8390085079df60b2295979d73205bc64f",
-   "sha256": "0d0xjnfyab26xki89nb2q0r1zplir99ywa0p661njvj5gqmviwxg"
+   "commit": "c590e78d756bc6b3d43ab5cf8618e41b2a5bc88b",
+   "sha256": "0i1n0bnlmgzp9yk0kgss3pyffwc42gbh1ymha2yjqjf4kf9004aq"
   },
   "stable": {
    "version": [
-    1,
-    7,
-    4
+    2,
+    0,
+    0
    ],
    "deps": [
-    "casual-agenda",
+    "casual",
     "casual-avy",
-    "casual-bookmarks",
-    "casual-calc",
-    "casual-dired",
-    "casual-editkit",
-    "casual-ibuffer",
-    "casual-info",
-    "casual-isearch",
-    "casual-re-builder",
     "casual-symbol-overlay"
    ],
-   "commit": "fbab88e8390085079df60b2295979d73205bc64f",
-   "sha256": "0d0xjnfyab26xki89nb2q0r1zplir99ywa0p661njvj5gqmviwxg"
+   "commit": "c590e78d756bc6b3d43ab5cf8618e41b2a5bc88b",
+   "sha256": "0i1n0bnlmgzp9yk0kgss3pyffwc42gbh1ymha2yjqjf4kf9004aq"
   }
  },
  {
@@ -11688,28 +11356,28 @@
   "repo": "kickingvegas/casual-symbol-overlay",
   "unstable": {
    "version": [
-    20241008,
-    2317
+    20241021,
+    2358
    ],
    "deps": [
-    "casual-lib",
+    "casual",
     "symbol-overlay"
    ],
-   "commit": "9481daf1b9b027dbd12cfed8219b89e73ec3728a",
-   "sha256": "1m1bfds64adfa3r1al1fchb7skfj6m19dv3k9vi67nd50sal7w4r"
+   "commit": "1453e7486dd0921f0319f21dd8c8b603e4eb7300",
+   "sha256": "0pdck93ijdxjcmss763cg0ap4wm5pqymylbqkkwjib3cmas6fvsv"
   },
   "stable": {
    "version": [
-    1,
-    1,
+    2,
+    0,
     0
    ],
    "deps": [
-    "casual-lib",
+    "casual",
     "symbol-overlay"
    ],
-   "commit": "9481daf1b9b027dbd12cfed8219b89e73ec3728a",
-   "sha256": "1m1bfds64adfa3r1al1fchb7skfj6m19dv3k9vi67nd50sal7w4r"
+   "commit": "1453e7486dd0921f0319f21dd8c8b603e4eb7300",
+   "sha256": "0pdck93ijdxjcmss763cg0ap4wm5pqymylbqkkwjib3cmas6fvsv"
   }
  },
  {
@@ -11744,11 +11412,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20241006,
-    2057
+    20241016,
+    2258
    ],
-   "commit": "f579a6aa26234f067c06e85e203ac2b89db99b4d",
-   "sha256": "1bxamcmh8qzz2ncmy7yhlr05zry2np0l5y5cw8sglivnbfcnb054"
+   "commit": "4441d5114fdcc2eb05186a974b4bbad7224e43b5",
+   "sha256": "1y2ads0w5l3mm0mxxbi2ppb6csq8hw2fd9cmak3myv13qzw92x3w"
   },
   "stable": {
    "version": [
@@ -12290,15 +11958,15 @@
   "repo": "plandes/cframe",
   "unstable": {
    "version": [
-    20240223,
-    2335
+    20241109,
+    1403
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "580a20573ef413c269c032221de04abc1c97a6a8",
-   "sha256": "0s2n4b7g1b48j2mmfjmp1ir8bacbyiqffmjh6g62vxabbhnyc6fh"
+   "commit": "b5259f8e5f7e8788ab412224933d8f12f0d2ccc0",
+   "sha256": "0d50n0yl8qhkyjwkw28g9wpr69zfc8ca4wj1aj4xvhcqkxxqs227"
   },
   "stable": {
    "version": [
@@ -12523,32 +12191,32 @@
  },
  {
   "ename": "chatgpt-shell",
-  "commit": "c7f36f62391f888e2485c096890739de0c71305a",
-  "sha256": "1sggzb13i70n81q7jr96hyq179p6g7b4yxh37wwfxwlvqrkik2y7",
+  "commit": "bd7bfd8814e2e81d4022984f6b2baf2b1d1d0225",
+  "sha256": "17x7c6fhm01shphd28k85bsr6ylkq882xzncps5lzp1f77qjwvhm",
   "fetcher": "github",
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20241011,
-    1057
+    20241201,
+    2252
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "433f7625e885ef72b5fdc6ea0ada95a6c529367d",
-   "sha256": "13ms3kazw1z01hmg00hbdxnja8973q1hmd6x2bwdijv7agxzcbxc"
+   "commit": "5fc6c7dba6ef16e57d14f90c1ae05a0b0d36ba36",
+   "sha256": "12raxg5lf3cicj5rib48kc4mh4jdzp8nxhfxjkf807amp6rrlw74"
   },
   "stable": {
    "version": [
-    1,
-    8,
-    1
+    2,
+    2,
+    7
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "63c7c092d80daa02d85890178bb879ddcfd04bde",
+   "sha256": "022wgc2mdd7b4xs7xjabmy95dx30yjgfbnv773vxfaq7z1c4ymbi"
   }
  },
  {
@@ -13214,8 +12882,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20240924,
-    1959
+    20241115,
+    343
    ],
    "deps": [
     "clojure-mode",
@@ -13226,8 +12894,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "0b70bf86ef726dd8947b9fdfd459e805a2487c89",
-   "sha256": "0qkhl1q0araykzdvxqagc5in1nghb6fsp6f88jcxb8pa9h1sv94b"
+   "commit": "c228dec27df6b2c68262f17158208fe699e1ce02",
+   "sha256": "0gxrmi9ykhmhmldrrijl73cz38473y8wapr4i9an4yv34r5g9mng"
   },
   "stable": {
    "version": [
@@ -13448,14 +13116,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20240630,
-    2055
+    20241101,
+    1641
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3ae38790506311fd32b2d499804af69b16307652",
-   "sha256": "1gmzjcsk7vyp0mnx1ak4a5xi1wz9j1jcz5lvia68sx5wrwn2vicg"
+   "commit": "0346f3f64383d88bb3ea49a492fcb80334a55cc4",
+   "sha256": "0m8fyd3g0xhd9ihzdd8mb82fl3difz2061xbslfahcgpxa49d6f4"
   },
   "stable": {
    "version": [
@@ -13526,16 +13194,16 @@
   "repo": "emacs-citar/citar",
   "unstable": {
    "version": [
-    20240907,
-    1157
+    20241027,
+    1331
    ],
    "deps": [
     "citeproc",
     "org",
     "parsebib"
    ],
-   "commit": "0f1786b7fee58452a3225e4b9b7c94176fff9b5a",
-   "sha256": "032k6wi8kxcgfbff6qbawkl8cvicp7hzaf8agj70451qxqiav8xi"
+   "commit": "46bc177f53147a387407b1578ca38a3e96ad49a3",
+   "sha256": "0alzz664l1c062zzk3vzwnqxd1sd5l85lycqyyid6ipk1x5k0r7y"
   },
   "stable": {
    "version": [
@@ -13626,15 +13294,15 @@
   "repo": "emacs-citar/citar-org-roam",
   "unstable": {
    "version": [
-    20240212,
-    2159
+    20241124,
+    1352
    ],
    "deps": [
     "citar",
     "org-roam"
    ],
-   "commit": "999268c7a077aad6a8f4dfc88d0eeabdf4267fea",
-   "sha256": "0fhi42jg3h7iba9dpyd4lp2y4yvj6fb5vnrvxi62z1sd06h8qaqm"
+   "commit": "e2cd111456d59fbf0b79e6684ad46c3686169f53",
+   "sha256": "1772k4jg1pr1a43bn80i0f4qhayhvlzvrmfcdh3nv0bxs14ssmwr"
   },
   "stable": {
    "version": [
@@ -13740,11 +13408,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20240630,
-    721
+    20241028,
+    1548
    ],
-   "commit": "d99483767016cada88a2877a77b9b76f8e118b80",
-   "sha256": "10sp5256354p6f3wcgvgniv7jsvb000nffzhq4lkc4kzf3b579q3"
+   "commit": "9220f430b5588f7e2d9ca82797eb37d1d7752620",
+   "sha256": "14698vwnsm1q3s3waz2mq5f36amgxyns2ygsg32dnxlssi3yai04"
   },
   "stable": {
    "version": [
@@ -13835,14 +13503,14 @@
   "repo": "emacsmirror/clang-format",
   "unstable": {
    "version": [
-    20240828,
-    1832
+    20241019,
+    2151
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7a955a4ed7e92fdb82983e307cb523547bb0285a",
-   "sha256": "1x9zw2css02cmy3l7wy96qh4zhv4c5z04xg94xwb6vc33ca09lgx"
+   "commit": "f01d16be89a4421169c421d25cfdddb3ad62460f",
+   "sha256": "0f53sbr970spyl9k4mnh03y6kc3gxzh77b70s04bw8sda5sb980b"
   }
  },
  {
@@ -13886,14 +13554,33 @@
   "repo": "arminfriedl/claude-shell",
   "unstable": {
    "version": [
-    20240707,
-    1743
+    20241130,
+    2024
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "6fb330578a84a8753e32b9ffc50a2506406f1099",
-   "sha256": "1v6jbqd3djk4h3id4spqax6wzg1sgqc7mypci1j1qvgxafg6iqyh"
+   "commit": "8e9e7e22b6fab50e19b293d1ebcf435ad937a41f",
+   "sha256": "00zipqxp4dy06mj0wyk3vnvqz0jls9bf99mw4pavjy77j8j50gfn"
+  }
+ },
+ {
+  "ename": "claudia",
+  "commit": "f164afd56fe77159209247c648c8f3adc21067dc",
+  "sha256": "0fbp1w50jv0z6s4s056ym3njlzwc5y9dz3qd1y0zlmvxhqa3dsqn",
+  "fetcher": "github",
+  "repo": "mzacho/claudia",
+  "unstable": {
+   "version": [
+    20241104,
+    2217
+   ],
+   "deps": [
+    "markdown-mode",
+    "uuidgen"
+   ],
+   "commit": "f041f619a0e93ac5b07a05862bcb38a811d56d24",
+   "sha256": "141z590hb2cmrg5q1lv6f5z54gbyxaxl1v91ailsa22jxxr4qnq8"
   }
  },
  {
@@ -13904,14 +13591,14 @@
   "repo": "martianh/clause.el",
   "unstable": {
    "version": [
-    20230405,
-    1235
+    20241020,
+    1144
    ],
    "deps": [
     "mark-thing-at"
    ],
-   "commit": "0ea166fa218618c1b80b60c995f927310c25b02a",
-   "sha256": "0v5xf51f1imricf9rn9f3iwz37cljk3iwq50dad1wzm1pamggzw1"
+   "commit": "e51261495d88e80709443817af3159633c9a2d7b",
+   "sha256": "0b2rc8s1x1gc1xr8v1p63nnza6f30iwzjd2nrf6wpg8nkbf9a9ix"
   }
  },
  {
@@ -14550,11 +14237,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20240526,
-    1825
+    20241125,
+    1123
    ],
-   "commit": "815bc387ec1436fb2fcac00ba8a61207636d0186",
-   "sha256": "0rx7r4v6dfz26n9bqhfbd4jv0fj9zqnc22jk8pa5y4ldjzkas35c"
+   "commit": "63356ee3bd6903e7b17822022f5a6ded2512b979",
+   "sha256": "1g1wac0nwlp0kl6wq1aivv0fymrwxb81sd3zy6k20yjg4s5aagvg"
   },
   "stable": {
    "version": [
@@ -14666,11 +14353,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20240930,
-    1316
+    20241104,
+    2135
    ],
-   "commit": "dc74c4546f3bd9e026eef5b0519e8b5aff9781cc",
-   "sha256": "0a6pdkzcmv23yj5bj26wp7n4m7h36h6fw0g5aymnr50hl9r695f2"
+   "commit": "3ca382c3ccf2ad560d0974229ec88963e82d2fe7",
+   "sha256": "194sw4fb9845sysn23dv64c7qwj4kfz02hzdij05wn01xkjscgph"
   },
   "stable": {
    "version": [
@@ -14725,28 +14412,28 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20240808,
-    1934
+    20241201,
+    1553
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "c1a346d56ecee16d1f0d7707f0d62c72604a8802",
-   "sha256": "0fh7mvm2qcwkkmzpkagwzrsi11nm4laj2bvjdmyrv8pnmjigwwqw"
+   "commit": "b1522c4bcb3a30eba0b49513c6d61dd7817baf1a",
+   "sha256": "17i5gni6hw8lvg0660c0hldr0xbrdry4hmx9n5i4pry3wwnhzngr"
   },
   "stable": {
    "version": [
     2,
-    0,
+    1,
     0
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "c1a346d56ecee16d1f0d7707f0d62c72604a8802",
-   "sha256": "0fh7mvm2qcwkkmzpkagwzrsi11nm4laj2bvjdmyrv8pnmjigwwqw"
+   "commit": "b1522c4bcb3a30eba0b49513c6d61dd7817baf1a",
+   "sha256": "17i5gni6hw8lvg0660c0hldr0xbrdry4hmx9n5i4pry3wwnhzngr"
   }
  },
  {
@@ -14919,20 +14606,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20240814,
-    1725
+    20241121,
+    1615
    ],
-   "commit": "cf1bc1b9371dc6063a1734a1cd80d6cb654ad53e",
-   "sha256": "1anxrj0bdl1z811dqz6cmxqyw0ipsim0hgxlqc0kngms9dnjilnx"
+   "commit": "eb281d34548f4234e68ff31d1050aca7e8441d86",
+   "sha256": "1r0s0scrdakp6fiwp91zj7i5svq3wyszhp0cq2lg2wssgkiphgz4"
   },
   "stable": {
    "version": [
     3,
-    30,
-    5
+    31,
+    1
    ],
-   "commit": "9c4a0a9ff09735b847bbbc38caf6da7f6c7238f2",
-   "sha256": "0v6aqbrmk2mlbjd03319panq9zsz03rph230ypb9njliv7lxd6kv"
+   "commit": "eb281d34548f4234e68ff31d1050aca7e8441d86",
+   "sha256": "1r0s0scrdakp6fiwp91zj7i5svq3wyszhp0cq2lg2wssgkiphgz4"
   }
  },
  {
@@ -15000,11 +14687,11 @@
   "repo": "tumashu/cnfonts",
   "unstable": {
    "version": [
-    20240430,
-    536
+    20241120,
+    2133
    ],
-   "commit": "1f57d4f64f50e4dbc7ab4d963278b746f904c454",
-   "sha256": "1jrrpmlagncv46pyq10182bi7mcqy85iy46nw33fskaswypxhwji"
+   "commit": "0b4fb8c2f743594010bb8137db6e71087efdaf67",
+   "sha256": "01dkmzc88knh06r0fb78vknjlh006v8rkrjwr88g5757jf3bvlb5"
   },
   "stable": {
    "version": [
@@ -15047,6 +14734,24 @@
   }
  },
  {
+  "ename": "coc-dc",
+  "commit": "df9255e363e96363a7d976abd3276a3cb08dd601",
+  "sha256": "1zfd2pzgmisksq7jprwhrpx7x92fhjfk4camrjqhlkwmanlbql67",
+  "fetcher": "github",
+  "repo": "S0mbr3/coc-damage-calculator",
+  "unstable": {
+   "version": [
+    20241104,
+    1739
+   ],
+   "deps": [
+    "hydra"
+   ],
+   "commit": "097bc2496263fc1e69a04d0528b41baf2fd08115",
+   "sha256": "0y8x197zlmg0ipbk6jjcjcwmw2ncfplbdpjhpdk4lj684hacxsr9"
+  }
+ },
+ {
   "ename": "codcut",
   "commit": "0fcd1c7a483dd377674a71a07fd86297f05cc83b",
   "sha256": "1pmbsv7pzmlbkfcw4ihpi5k7pgcrwlcg1hp0wkhkii8w61dq62x6",
@@ -15084,14 +14789,14 @@
   "repo": "astoff/code-cells.el",
   "unstable": {
    "version": [
-    20241003,
-    1036
+    20241119,
+    1421
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6511793ce9092c3f68f7cd5340267472a4b1b7dc",
-   "sha256": "1gpfzgv32mfms2x0k3d5wjp6vbsayhsk6hpbis7wrq6x0a6m8m2j"
+   "commit": "caffb420be106cebbdfe4474ed0507a601603f83",
+   "sha256": "0ba5125pq0im27rl964il78543n56jm88129zv05dfq6pv7fkplv"
   }
  },
  {
@@ -15102,8 +14807,8 @@
   "repo": "ag91/code-compass",
   "unstable": {
    "version": [
-    20231108,
-    1618
+    20241125,
+    2243
    ],
    "deps": [
     "async",
@@ -15111,8 +14816,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "67ec53f9ca43bea941ec5ba6fccba8565c1d937f",
-   "sha256": "1k6cc2m7kdr6g69cn7r3i43cq6iww74sqimlw6q1paf66lm35xld"
+   "commit": "6510b97280892d8831ff35dedefe9a7aa7b6326a",
+   "sha256": "0bs5kn9jr7lfaw472aq2c80ii7i76a0pdbijmh2dvdf33k6hy88l"
   }
  },
  {
@@ -15317,11 +15022,11 @@
   "repo": "liuyinz/coercion.el",
   "unstable": {
    "version": [
-    20240107,
-    2154
+    20241029,
+    401
    ],
-   "commit": "a96ecfa3a44f2e15349abf265905c6c607cf2c07",
-   "sha256": "0200bq5qv5dkf1mvyhnza0m08z5p7g5irbrmwxd65znr99d648lh"
+   "commit": "62da6ca2d18cb627de48f5b590309001c69864a8",
+   "sha256": "18skc9j48hrgiqm747r13vk0901p5wqgamczb36h3ap14psa387g"
   },
   "stable": {
    "version": [
@@ -15419,14 +15124,14 @@
   "repo": "ankurdave/color-identifiers-mode",
   "unstable": {
    "version": [
-    20240930,
-    2149
+    20241023,
+    2217
    ],
    "deps": [
     "dash"
    ],
-   "commit": "3a11607d7b02d7783572d7f4a1a6e30441f3cd4b",
-   "sha256": "0sivgxz18sr9dcy48fv3wsahky37yg29d6ap47i2b54cq1rph5lm"
+   "commit": "89343c624ae64f568b5305ceca3db48d65711863",
+   "sha256": "1dly1xf2im3x1ikyrdc613jici16xgbhdb3sz357w1bfkxjhxzbj"
   },
   "stable": {
    "version": [
@@ -15536,14 +15241,11 @@
   "repo": "purcell/color-theme-sanityinc-solarized",
   "unstable": {
    "version": [
-    20240712,
-    1038
+    20241126,
+    1028
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "e1854917d84051393b64de54883f2df7b9cec797",
-   "sha256": "121y3hb2v17shv5r0y4vqsbw1avc19rv9bk99l3ls7apx6xma8ji"
+   "commit": "f42431850e0ff0cff90c6cc39edc222faa40323d",
+   "sha256": "1772ragmyj7jzyqc3qlwx6q288vhcggrfbzl33dznf8jp888d288"
   },
   "stable": {
    "version": [
@@ -15562,11 +15264,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20240621,
-    1005
+    20241028,
+    1458
    ],
-   "commit": "ddf2920a8866040e57359d2e1c5517fffcad2e38",
-   "sha256": "0qnn3dxzi40skrmi6a2w68c1dcn89zbdxnm18nw7axa7c0q0wcqs"
+   "commit": "2548eb47dcf09ce433f48f5d027890ef259dabe7",
+   "sha256": "1xj1k23mj78wnpvgndfd9lisfm8ax67dps3gbvfzdm38sp4wkkq5"
   },
   "stable": {
    "version": [
@@ -15758,11 +15460,14 @@
   "repo": "hying-caritas/comint-intercept",
   "unstable": {
    "version": [
-    20230930,
-    956
+    20241021,
+    629
    ],
-   "commit": "79cfa3f15558f99285734ff36e80e3c4628565ae",
-   "sha256": "1v34m2f0ni8zvvbqnv0i8daa05rg22wb11468xyq3c0h7pd0k7xv"
+   "deps": [
+    "vterm"
+   ],
+   "commit": "99b17be632ff1d892f427244cad9e37752cbf71b",
+   "sha256": "0z3z0xh726z1k27zmw56bj5b01x12vcrhspynwahaqvhkn1qp0vs"
   }
  },
  {
@@ -16005,20 +15710,20 @@
   "repo": "mekeor/communinfo",
   "unstable": {
    "version": [
-    20240709,
-    913
+    20241126,
+    2028
    ],
-   "commit": "2e1481c2441725f1938d8b11848e954906d118b8",
-   "sha256": "01vf2fz8s02ph3ppnx4sprk7cl7m3ifd5qfbz5d777swhar0wdsl"
+   "commit": "294aadda671ca53b802394e3bbb39a984a48bb2f",
+   "sha256": "1zxdk4ffy8589m9v5nx99gbsbaaibnb19r85fqyrfq0qlr42hici"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
-   "commit": "07bc9343c13809619f2c2229841d690df7f78312",
-   "sha256": "0f5yd86dym98jgf0h4ns6gq22cf9fgk3m382n18kiwpkgzxcdqx0"
+   "commit": "2e1481c2441725f1938d8b11848e954906d118b8",
+   "sha256": "01vf2fz8s02ph3ppnx4sprk7cl7m3ifd5qfbz5d777swhar0wdsl"
   }
  },
  {
@@ -16029,11 +15734,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20240926,
-    2127
+    20241106,
+    2000
    ],
-   "commit": "9c273fc7c1a9dd69ccf508589211c4f8bd0e0765",
-   "sha256": "0p55yaf8ac2q53l9palsyw8qrxjiylbs0npid8v5rdgf8ah9n6ag"
+   "commit": "0ae7c293112248a0c36377d6859a95d216ae5e96",
+   "sha256": "0rg1i31qg4212i9d0020p37snzcaq22fb9lmv4p4x0xysk3wgp8v"
   },
   "stable": {
    "version": [
@@ -16341,19 +16046,18 @@
   "repo": "tsukimizake/company-dcd",
   "unstable": {
    "version": [
-    20240218,
-    1726
+    20241024,
+    1152
    ],
    "deps": [
     "cl-lib",
     "company",
     "flycheck-dmd-dub",
-    "ivy",
     "popwin",
     "yasnippet"
    ],
-   "commit": "29dc3dc7fd0f7effe8f6a3dfbe7028a2019de48e",
-   "sha256": "1w9d5qa6zvsvf56q3flgw7xz1sq47c72iii0mqvdl6s7ribaz6mn"
+   "commit": "d1f0bf4ed3b86ba6e4173450d237185df37ef464",
+   "sha256": "08x8j9fx8pq9kxdp73mgddwvndcdm97nn3a765y844mw8wchczyi"
   }
  },
  {
@@ -16837,28 +16541,6 @@
   }
  },
  {
-  "ename": "company-lean",
-  "commit": "0bad7f91094d96d387bf0b121d6223afdc0f236c",
-  "sha256": "1grfa9944ssbpprrrz77jk6x0r8840kx6cb9pnd4mxwckgb7p2hv",
-  "fetcher": "github",
-  "repo": "leanprover/lean3-mode",
-  "unstable": {
-   "version": [
-    20210305,
-    1705
-   ],
-   "deps": [
-    "company",
-    "dash",
-    "f",
-    "lean-mode",
-    "s"
-   ],
-   "commit": "5c50338ac149ca5225fc737be291db1f63c45f1d",
-   "sha256": "13vrg0pp7ca0lh4j9cyg4pgfnbvf2kvbrgvvcmn1h7l9py2n8alj"
-  }
- },
- {
   "ename": "company-ledger",
   "commit": "546bc62530136a7fdf3886731e4316c6c8081ead",
   "sha256": "0y54wbky6jq9r3h4ghpkjywj78hw8k83ri6szph6s8w5m6dkji82",
@@ -17087,10 +16769,10 @@
  },
  {
   "ename": "company-nixos-options",
-  "commit": "6846c7d86e70a9dd8300b89b61435aa7e146be96",
-  "sha256": "1yrqqdadmf7qfxpqp8wwb325zjnwwjmn2hhnl7i3j0ckg6hqyqf0",
+  "commit": "7f298cdc6773f3aeb7baf9c6a32c97d2b60f55a3",
+  "sha256": "100xpwnjrs92vlw9zndc7nlrax3s1vhpmr90678zkx4rs4l2m88i",
   "fetcher": "github",
-  "repo": "travisbhartwell/nix-emacs",
+  "repo": "nix-community/nix-emacs",
   "unstable": {
    "version": [
     20160215,
@@ -17975,6 +17657,30 @@
   }
  },
  {
+  "ename": "compile-angel",
+  "commit": "6b476137c3d87eaaa96a0884d7a3db3cfea9e7d3",
+  "sha256": "1w7i1b8c5msmy1zjvs2hspr9fiz8rqq6iqjbn58ihlzzdk1yifhy",
+  "fetcher": "github",
+  "repo": "jamescherti/compile-angel.el",
+  "unstable": {
+   "version": [
+    20241130,
+    442
+   ],
+   "commit": "67a12504ebf2cc43a6846a3e05b6e5c2e179db2f",
+   "sha256": "1kyrcpd5q938byc83f5a100jb4igzxgpj82f7ql39alzhibzskcn"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    4
+   ],
+   "commit": "67a12504ebf2cc43a6846a3e05b6e5c2e179db2f",
+   "sha256": "1kyrcpd5q938byc83f5a100jb4igzxgpj82f7ql39alzhibzskcn"
+  }
+ },
+ {
   "ename": "compile-multi",
   "commit": "608806259721eaa046b8a3cb653deb0827b682da",
   "sha256": "0mq76lnjpch7w0n862y17kin5gm004x9v5q1ni5frmnn20c3ql0a",
@@ -18094,8 +17800,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20241009,
-    2026
+    20241129,
+    809
    ],
    "deps": [
     "eldoc",
@@ -18103,13 +17809,13 @@
     "plz",
     "seq"
    ],
-   "commit": "0d94e8b8a7ac81777cb8cccd801db7a2e082f0d6",
-   "sha256": "0kv0kd5qqaa4vvhkp3dnbsvd9kfyawhppnxvzxzfdpvvd6rkms8b"
+   "commit": "b8e7c34757c6b77aec948c143d8c89df08d4b7e8",
+   "sha256": "1lrjxkaf5979k0v0p20p9lk4azwbi629krqq66mybr1bmlw00vi6"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
@@ -18118,8 +17824,8 @@
     "plz",
     "seq"
    ],
-   "commit": "f7b440125264efc043b9d61186e4ac662cb8b67c",
-   "sha256": "0yih4rl037f14v1cq13g49fx1dy6yl6v7ps13lrklv0pjjf7gc9c"
+   "commit": "b8e7c34757c6b77aec948c143d8c89df08d4b7e8",
+   "sha256": "1lrjxkaf5979k0v0p20p9lk4azwbi629krqq66mybr1bmlw00vi6"
   }
  },
  {
@@ -18154,15 +17860,15 @@
   "repo": "emacs-php/composer.el",
   "unstable": {
    "version": [
-    20240618,
-    1112
+    20241016,
+    1900
    ],
    "deps": [
     "php-runtime",
     "seq"
    ],
-   "commit": "42cf9848d438f8dc4c07ac684a83280ace7bb94c",
-   "sha256": "0a7hwikxzw1y6i4ny9bxj4lnyaz2p25sx5w97rhnkagr0859jflg"
+   "commit": "6c7e19256ff964546cea682edd21446c465a663c",
+   "sha256": "1s0vridw8fgc8zjhdznfqcvgixx42wvfgp8na5qbxfvb19y39dfh"
   },
   "stable": {
    "version": [
@@ -18442,14 +18148,14 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20241001,
-    2057
+    20241201,
+    1337
    ],
    "deps": [
     "compat"
    ],
-   "commit": "07ea5421fbcb65b2207a43a0941124a95a47abc7",
-   "sha256": "0xhn7sxzx7qwij76mi5s52xrvh2af6sjppmqspd445vxpl8pgffx"
+   "commit": "eb26bdd008c4c92b1d79e49e2df71acc2a42faa3",
+   "sha256": "1xydhja0hrjv851vs66nwd8amm93qraccad78nxwhlimw2lw1fgn"
   },
   "stable": {
    "version": [
@@ -18599,14 +18305,14 @@
   "repo": "karthink/consult-dir",
   "unstable": {
    "version": [
-    20240506,
-    236
+    20241114,
+    454
    ],
    "deps": [
     "consult"
    ],
-   "commit": "15891383f34d43acc5bb82bda92239b1f54cf178",
-   "sha256": "1jq931w66iawc1rf01n9mfmnxwvrv2zc711nwnmykdv6ynd636dm"
+   "commit": "26fd5516511747ecefe98ef8e4592e330d99e6ae",
+   "sha256": "1sl6cwsj7jnylv4idjmcfs2z2i17a5b3aqb93q00hkbmqig94gam"
   },
   "stable": {
    "version": [
@@ -18629,16 +18335,16 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20240324,
-    1211
+    20241107,
+    2125
    ],
    "deps": [
     "consult",
     "eglot",
     "project"
    ],
-   "commit": "64262e72452f8fe6dd49d31bcdd4bd577b7d682d",
-   "sha256": "0mn9d87m05bhqrw7sscx4a2a5h7gkqyhv06a80ky9vbzlfjfk6hh"
+   "commit": "c5f87d92448cd9c22a33ebd1feb54ca2fb89afa8",
+   "sha256": "0l7fg36zqcy0mzcs1fx515mppkf94r4fvss65vhambblrcd7z6nd"
   },
   "stable": {
    "version": [
@@ -18663,15 +18369,15 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20240324,
-    1211
+    20241107,
+    2125
    ],
    "deps": [
     "consult-eglot",
     "embark-consult"
    ],
-   "commit": "64262e72452f8fe6dd49d31bcdd4bd577b7d682d",
-   "sha256": "0mn9d87m05bhqrw7sscx4a2a5h7gkqyhv06a80ky9vbzlfjfk6hh"
+   "commit": "c5f87d92448cd9c22a33ebd1feb54ca2fb89afa8",
+   "sha256": "0l7fg36zqcy0mzcs1fx515mppkf94r4fvss65vhambblrcd7z6nd"
   }
  },
  {
@@ -18682,15 +18388,15 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20240926,
-    917
+    20241114,
+    1120
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "bad8a8a25328782dfce3a9e4de6ad6d325b353d7",
-   "sha256": "1wg8n0lxmrwm8m7rv3bkjrj33qyms1fvg7cqb3cj8cazsqrz92h2"
+   "commit": "fa7a3a3b5d31d318582f7a1935a3c812fcdc4368",
+   "sha256": "1adwmvx48dfp5qrcy02k2d1972ysrazpdl5c7m90b8allcg01y60"
   },
   "stable": {
    "version": [
@@ -18905,14 +18611,14 @@
   "repo": "rcj/consult-ls-git",
   "unstable": {
    "version": [
-    20240529,
-    641
+    20241023,
+    1113
    ],
    "deps": [
     "consult"
    ],
-   "commit": "b1ca94f7c43cbd3811d09a0c9ab04f67f6318e95",
-   "sha256": "1r8d42r4dszg7jdabgs60inn6hkd293fddps1sjrs8y4ygkxcp61"
+   "commit": "beb253374e2cee10b8682fb8b377ca1f2caa4e27",
+   "sha256": "1znlvjplgmkp0zl94xf8z9jlkr9f4r39kv2nfd47ajnqccczkr85"
   }
  },
  {
@@ -19076,14 +18782,14 @@
   "repo": "jao/consult-recoll",
   "unstable": {
    "version": [
-    20231211,
-    1221
+    20241119,
+    1807
    ],
    "deps": [
     "consult"
    ],
-   "commit": "ba68d052d9479aeaa5dda15a57a2c070df7d9bca",
-   "sha256": "02igkdhqpl3zylh5v3aw0a93krr2rzdy5kb6azvf4s461jpmwgqv"
+   "commit": "c81d40c70b73a7351d7a4591b14f222682b7a084",
+   "sha256": "07ihnmh1jk42cmkrvhb8y2nn6mwba35q9jx640ypal7msc13cs5a"
   },
   "stable": {
    "version": [
@@ -19155,15 +18861,15 @@
   "repo": "liuyinz/consult-todo",
   "unstable": {
    "version": [
-    20231022,
-    2059
+    20241029,
+    409
    ],
    "deps": [
     "consult",
     "hl-todo"
    ],
-   "commit": "84f3c9876a285f733d75053076a97cc30f7d8eb9",
-   "sha256": "0v336l9dary68i910yvpk9c24b9vrc1cx615hiv9dz8zi1khz8rr"
+   "commit": "bd67bca32a69bf09f137cacb01c0310da9e76575",
+   "sha256": "1xmvwwr4wpp6kq2l3rmn4axprxl32s700jy28swg94l3px3ah9la"
   },
   "stable": {
    "version": [
@@ -19364,25 +19070,31 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20241008,
-    2152
+    20241126,
+    815
+   ],
+   "deps": [
+    "chatgpt-shell",
+    "magit",
+    "markdown-mode",
+    "request"
+   ],
+   "commit": "b6d919022a81ae6f8e024a9cce2a8250a2451d09",
+   "sha256": "1s1g45h2mbs7xsl8wdra5zlgw5rvvamgvc9iicvhbsjhxhpr48vv"
+  },
+  "stable": {
+   "version": [
+    1,
+    2,
+    0
    ],
    "deps": [
     "chatgpt-shell",
     "markdown-mode",
     "request"
    ],
-   "commit": "48445c1d42f29cea7d02fc1aa15c38c47a0d4119",
-   "sha256": "1ndgf0p70s7yi2rwihm05hs1ysg7yjlfvvv5bax78244l9ca186p"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "commit": "80918ac52c118f987fa1bc2eec8aeb6f76a5c92f",
-   "sha256": "001niz36am46mfn1a6z2w9jmq5zv92hpb1bdk8gv2zdgr9pkqg9x"
+   "commit": "e8235960cc568bf2026e8c4206b4e43a7a9b9c02",
+   "sha256": "1p5jm19awr9azjjjwk8ywckl1riv5g1j221azwhsak24zb5y8l0i"
   }
  },
  {
@@ -19453,14 +19165,14 @@
   "repo": "zonuexe/emacs-copyit",
   "unstable": {
    "version": [
-    20190919,
-    1258
+    20241030,
+    543
    ],
    "deps": [
     "s"
    ],
-   "commit": "c4f2c28e5b6270e8e3364341619f1154bb4e682e",
-   "sha256": "17xqpshwc48srwljpbad7vhx3rkxqav0ygp0ff4xh7wgy21fp2mp"
+   "commit": "09556ba8407dc2b132b7f76cd1b458c0773a1fe8",
+   "sha256": "1rf670pfxlks2nbqm2gl1a46xxvz3qqsga5n8glvghy0f8ixlwap"
   },
   "stable": {
    "version": [
@@ -19535,14 +19247,14 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20241014,
-    915
+    20241127,
+    1554
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fa2be6c66ff2eb10b4b609832f25df49e90381af",
-   "sha256": "15fmwmsbbb4609rcg0xmcip88rzy6vv9ri8camdysy6lisi9fhsa"
+   "commit": "f10f58f446e2cbda738ae8738cf4a7464a8aeeab",
+   "sha256": "186y5x8hhq46l7a3m6k8cxg2wm2g4yynrm3fgasy9ys4xb7kjb7r"
   },
   "stable": {
    "version": [
@@ -19648,14 +19360,14 @@
   "repo": "rob137/Corsair",
   "unstable": {
    "version": [
-    20241007,
-    922
+    20241018,
+    1015
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "bb46a8004de71f715bc60ed52fbcb5fd7a27103f",
-   "sha256": "1k8lxh8z0k1hjcwyb8dz7pi3lnm50w7zy3kk2495fqkwcjj5b35w"
+   "commit": "f750a435d6be68f0d75dc5a90f8aa3cb58e8c16a",
+   "sha256": "0xwkfv63klpyqkgx1ihwqh1aqyk8yi3z3appygp28q60rybsyiyl"
   }
  },
  {
@@ -19666,15 +19378,15 @@
   "repo": "conao3/cort.el",
   "unstable": {
    "version": [
-    20211020,
-    18
+    20241019,
+    936
    ],
    "deps": [
     "ansi",
     "cl-lib"
    ],
-   "commit": "3f64a7b03a4c5b768ec21fd5987acd0d62d16c7b",
-   "sha256": "1bkyx8sd2qqnhmmqbl9wyxk3xhrplq9zprmfpyhf5k0zin3zd31y"
+   "commit": "262966c9bc7fd3aa7bcf2dc3b9edc286c7f19e58",
+   "sha256": "01n7rcvdw98q0dvc51pk6nyrjwcf76cfs7r7c93xnjv5pmpjczfr"
   },
   "stable": {
    "version": [
@@ -20599,6 +20311,30 @@
   }
  },
  {
+  "ename": "crc",
+  "commit": "28cbd69b950ff176f82da0bacaadebbe1ef12348",
+  "sha256": "03d93i4a8yl4igsdds2d51gj69nvq4q9kldqhqa9c4d2mjgzwcbl",
+  "fetcher": "codeberg",
+  "repo": "WammKD/Emacs-CRC",
+  "unstable": {
+   "version": [
+    20241115,
+    253
+   ],
+   "commit": "0c2d6bd56963c3a8b36e88d748a6cbaf3541c6a1",
+   "sha256": "02i6d0dyh1wfd5rcq91vk516n11mcp7w18m11z2nqdpr588b7zn2"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    2
+   ],
+   "commit": "0c2d6bd56963c3a8b36e88d748a6cbaf3541c6a1",
+   "sha256": "02i6d0dyh1wfd5rcq91vk516n11mcp7w18m11z2nqdpr588b7zn2"
+  }
+ },
+ {
   "ename": "creamsody-theme",
   "commit": "488f95b9e425726d641120130d894babcc3b3e85",
   "sha256": "0l3mq43bszxrz0bxmxb76drp4c8721cw8akgk3l5a800wqbfp2l7",
@@ -21103,15 +20839,15 @@
   "repo": "neeasade/ct.el",
   "unstable": {
    "version": [
-    20230519,
-    1319
+    20241106,
+    2223
    ],
    "deps": [
     "dash",
     "hsluv"
    ],
-   "commit": "02f209fe6c8ad85c832d8f80193255d0bf78e218",
-   "sha256": "1vgjp6py9rf8xqv6lklk3l1p6sb57jfdskwpzna5y0rajg39bygr"
+   "commit": "6cb398e3a04545153a7428af263ae2fa1a4c4737",
+   "sha256": "0qrcm7zl5j992xd7ar6mnrs15pa47wh7xj9vqjxc6qrbbnys8dyl"
   }
  },
  {
@@ -21766,11 +21502,11 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20240813,
-    659
+    20241126,
+    1056
    ],
-   "commit": "9b1676d70edbc2f2788130adfd5797515a5c8538",
-   "sha256": "1fwrf9iy85z1hz1g65k52yyg9z17lmnk4bwci5p6pvcqb8dm2qgm"
+   "commit": "de2a20eb21ae9bddfa86468a7522b0ba29f0c387",
+   "sha256": "18d9ndgsx66f0w3a6gsvff6l7lqbmfqqjahm3zzjj50yk43yykig"
   },
   "stable": {
    "version": [
@@ -21790,20 +21526,20 @@
   "repo": "andorsk/d2-mode",
   "unstable": {
    "version": [
-    20240707,
-    1850
+    20241107,
+    236
    ],
-   "commit": "69374e0249df20139f3f2d475de9eae2b201d019",
-   "sha256": "0hr2q2d3qfrbd7vpxbcamawvdzvak30rdsbrkxcqz9d36grhsj97"
+   "commit": "872a0d79223d2fe0ecad02fd4474831ec623672f",
+   "sha256": "1hrxn43wavi1q3djbrqrsv732kzadkpnfm58prqrsv8k010ws886"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
-   "commit": "cbe7b16141bd80fe4344f0403e61fd7ee4e0fd89",
-   "sha256": "1mdiafxbfz31blp7c86m6sp0dmn4yhnbs2mhzh75mczsg0gzqc4v"
+   "commit": "872a0d79223d2fe0ecad02fd4474831ec623672f",
+   "sha256": "1hrxn43wavi1q3djbrqrsv732kzadkpnfm58prqrsv8k010ws886"
   }
  },
  {
@@ -21852,15 +21588,15 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20231212,
-    1324
+    20241127,
+    1211
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "6b6b97b7bac3040cfc58ea5ca7bd9dc9003068fb",
-   "sha256": "1ay1dchhnq1kjp8ygpdimylrnwwacdpxnfnllgwcps9w9cwslipx"
+   "commit": "0dc7f1ec81fa70b3cafdc394413fe14fd3a413e4",
+   "sha256": "1p5f2lf6jlsvyh6zhd6drc2njadlkn73djrykridsphzh92q88k0"
   },
   "stable": {
    "version": [
@@ -21904,32 +21640,32 @@
  },
  {
   "ename": "dall-e-shell",
-  "commit": "578e261826b0825cdcae0ab07bea4226bdef7fa3",
-  "sha256": "016x2fga6iq3llxp7yd7f4pc4w0gi0bxv9abhhznncsn008mgnj1",
+  "commit": "bd7bfd8814e2e81d4022984f6b2baf2b1d1d0225",
+  "sha256": "1ivbi9z7gld8dzh91gs3msfyw77dgqjfrd8clgr6kci3h4akyw9w",
   "fetcher": "github",
-  "repo": "xenodium/chatgpt-shell",
+  "repo": "xenodium/dall-e-shell",
   "unstable": {
    "version": [
-    20241011,
-    805
+    20241118,
+    1015
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "d7f54f002c9271bc46c7403af898ed12e3abea69",
+   "sha256": "0cf81h9acc1ql5148y00jsl7v80190s2q71wd0q9j70vdghz8xhv"
   },
   "stable": {
    "version": [
     1,
-    8,
+    20,
     1
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "a24c003c79a720eafffc79bc3885070735f667f6",
+   "sha256": "161q8d2b4sq481jh4zwagvh88wg51dsnf76n2l2b7wv3nh7cjh2m"
   }
  },
  {
@@ -21980,11 +21716,11 @@
   "repo": "rails-to-cosmos/danneskjold-theme",
   "unstable": {
    "version": [
-    20240723,
-    1000
+    20241114,
+    749
    ],
-   "commit": "d495ba64e4a9e3e44b028b9fbc3898da3348ffdc",
-   "sha256": "00x2r95xivww43al98w0pak7dh9rrh1vdjhkspyw8cdvq4259s3y"
+   "commit": "96c000887d5bf7be17ff315c939bb7c8c962b86a",
+   "sha256": "1vbb5s5vl08lx0rjvn4a0czhnfdndn70vsk68kzfbchycpd3m7pp"
   }
  },
  {
@@ -22036,8 +21772,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20240611,
-    1356
+    20241101,
+    659
    ],
    "deps": [
     "bui",
@@ -22050,8 +21786,8 @@
     "posframe",
     "s"
    ],
-   "commit": "b407773ebca56e3bd8e6a4643854e91cbde0c35e",
-   "sha256": "1a1iwx299xcm5ldd2sh7sjhmpb6wndyrwx7q0q6nih6j8ly0nppr"
+   "commit": "605448b4fd90ca25924bf029acf2bdd047045133",
+   "sha256": "1lpw7pgkq2nq5br8am8jz34lvgnkx61nkwf54b83w1rk2rrssam9"
   },
   "stable": {
    "version": [
@@ -22164,11 +21900,11 @@
   "repo": "grtcdr/darkman.el",
   "unstable": {
    "version": [
-    20240919,
-    651
+    20241019,
+    1404
    ],
-   "commit": "f4c11edc86f16b7ce88c33dc6112e17e751171dc",
-   "sha256": "0bg99fz8f94p81p4zvihli7nh0m0r4p9j7bb0y7m54h3hhj6p1cz"
+   "commit": "beb2186e6eaf13ebe1ae56e460bcd1a4c0cb4f07",
+   "sha256": "0mw1rfv0nmpb2h79wg5mk23wr9cfyhgd6jjaxllr8gabkvajpsvg"
   },
   "stable": {
    "version": [
@@ -22411,11 +22147,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20240923,
-    2345
+    20241120,
+    2030
    ],
-   "commit": "946b9957470a3cac6b089bdf2d9edd07a29fcc9c",
-   "sha256": "0baz0kyzmp9zjdsh79sh4shfx4wbkgq8fcrp8rhih9x1jwg2bk4k"
+   "commit": "9479466d39652a8e32b74ee83822421fa08024d9",
+   "sha256": "0xch9w4l1zs52pwlcyy6nrxnp31ysaxkbqpx4wx5nf2sglc8jixc"
   },
   "stable": {
    "version": [
@@ -22741,20 +22477,20 @@
   "repo": "KeyWeeUsr/dbml-mode",
   "unstable": {
    "version": [
-    20240928,
-    1643
+    20241116,
+    752
    ],
-   "commit": "42ddcf4f19a823120477a9f22881d02099b85f1f",
-   "sha256": "1dxr5xzx5qa5bq4p138l6nkdjzfshxjysz0gnzqv8bd62lj3rf20"
+   "commit": "8baafca584012247859fe1a9e1d55eeed757a714",
+   "sha256": "0sf7qd5dsd11bawchf6mykxz2nmmisx2yjy933bphn3lqaczkg1a"
   },
   "stable": {
    "version": [
     1,
-    0,
+    2,
     0
    ],
-   "commit": "42ddcf4f19a823120477a9f22881d02099b85f1f",
-   "sha256": "1dxr5xzx5qa5bq4p138l6nkdjzfshxjysz0gnzqv8bd62lj3rf20"
+   "commit": "8baafca584012247859fe1a9e1d55eeed757a714",
+   "sha256": "0sf7qd5dsd11bawchf6mykxz2nmmisx2yjy933bphn3lqaczkg1a"
   }
  },
  {
@@ -22842,16 +22578,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20241012,
-    1511
+    20241130,
+    2235
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "8d9213990a50e55b8fd1ab6bed99e5c6a4ae229b",
-   "sha256": "187i1pzz8fspislj0c6d2bd08wzzxngpn3wpgj72zdgqx9y99yd3"
+   "commit": "d89468d82abb778ef0938c5753be4498d5802a10",
+   "sha256": "0yaik954w89mg3vi6490p3c7aqjq885v5wg8gccdkaa2hl7acsdm"
   },
   "stable": {
    "version": [
@@ -22875,11 +22611,11 @@
   "url": "https://salsa.debian.org/emacsen-team/debian-el.git",
   "unstable": {
    "version": [
-    20241009,
-    2240
+    20241026,
+    559
    ],
-   "commit": "7a955451f923c05eba40b56488dacff9f0fcc893",
-   "sha256": "1rlkj0gs3abg2dp6nzl86qy6zx7y0f85pvwrhjxghrhzv01h2cqc"
+   "commit": "89e0fdfb0c6a387c1fd693b34ee9608d758d0742",
+   "sha256": "1qzg2yky3mjygl8347pn8kms6k6y6br9bii1yq9qnwvwabbxxln4"
   },
   "stable": {
    "version": [
@@ -22943,11 +22679,11 @@
   "repo": "lifelike/decide-mode",
   "unstable": {
    "version": [
-    20241013,
-    2142
+    20241014,
+    1927
    ],
-   "commit": "cdd1cf76fdf4f08fb9dbe7de25b59af81337cce6",
-   "sha256": "00ns3kss0pir3ig0zqfww3k3lc7dpn9mzf56f8q2zsw47fisqn3w"
+   "commit": "fa97462f9c9237551e99ec56dbfe13af14391ca6",
+   "sha256": "0i9gc1hg18biw2b1x3crfjmam6v0qc2hr1hy5fgvrpagdbxg9lkf"
   },
   "stable": {
    "version": [
@@ -23473,21 +23209,6 @@
   }
  },
  {
-  "ename": "derl",
-  "commit": "f661504203b6990094307244a1c93cb62c1521d9",
-  "sha256": "03j9jn4xidbvs2llp7nm0lx55x4ian6dk5d54ji58zkis3qpjy84",
-  "fetcher": "github",
-  "repo": "axelf4/derl.el",
-  "unstable": {
-   "version": [
-    20231004,
-    821
-   ],
-   "commit": "6f31592bb3083de366cdb13a7db0ed69fc72de47",
-   "sha256": "1nqzw42vn1w1dh871izyalwkxvrq73ykyzkggrv070cyfyhbc177"
-  }
- },
- {
   "ename": "describe-hash",
   "commit": "8c6c5cd96acd3deeb86503341dd9cd729e20185e",
   "sha256": "0a26d46p46fypq3snh52grnjcgp6isb5k4qv2fm2m6ha2n7jdi5a",
@@ -23690,14 +23411,15 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20241006,
-    51
+    20241113,
+    1341
    ],
    "deps": [
-    "compat"
+    "compat",
+    "mathjax"
    ],
-   "commit": "98518166efe18c2f2dd9a1c4c89430b83fdbbe3c",
-   "sha256": "0nm9ryq29hsgvmis2f51vwlhm5lw1571smmb2gq0qbm4zrd1h9pk"
+   "commit": "d2214d34cdeb4483a594dd6973fcd095cef4653f",
+   "sha256": "0qgc2wb5bmpqjm7r9127cby97ps2bfxx5cx3yqcm0crmlgrayw2p"
   }
  },
  {
@@ -23963,14 +23685,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20241012,
-    2142
+    20241128,
+    2332
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9e39dfc666ac03a8474b3a05da17e0c935894414",
-   "sha256": "0dclq2v92n2raaj80p9k6z44a5ini56z7gf3d5japllqqys2cn9q"
+   "commit": "d9f54b512a0f583c6c3b51ce0c8ef62bffac7763",
+   "sha256": "1piy6ivq504zcgam9wabs5k2hinsmwj37wxlq0iy9qb0jhdakpdr"
   },
   "stable": {
    "version": [
@@ -24086,15 +23808,15 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20240528,
-    1657
+    20241030,
+    1038
    ],
    "deps": [
     "compat",
     "magit"
    ],
-   "commit": "79753bfec7c32f44dc0d5ed57a8bc6b370392a87",
-   "sha256": "02rl4zrh871cck7gr0b7jgw2xzlx50lgldbdcx2vdmd3ljkq383h"
+   "commit": "4980c08f7ad7777c364a3251bcc314b0f0d4d7dc",
+   "sha256": "1yrj9alg55rd4n9n3jsv3w2v8xv3b0bwi6xnw8fzs7zcdi4zn1n1"
   }
  },
  {
@@ -24456,14 +24178,26 @@
   "repo": "tilmanrassy/emacs-dir-treeview",
   "unstable": {
    "version": [
-    20230922,
-    2328
+    20241025,
+    2251
    ],
    "deps": [
     "treeview"
    ],
-   "commit": "9024df99284414aa9dc2dff5f3ee9f874830ab74",
-   "sha256": "11wzi9wfib1gaag3g88mn3yfx313vzky93cgjxxc0040zrqlxfp5"
+   "commit": "09cf976b0f5999e378141bb66361395f1832aeae",
+   "sha256": "020ywr028af4kqy4n1hh3m7j9gg2c10118bwr37q3dcwy6mg1dm2"
+  },
+  "stable": {
+   "version": [
+    1,
+    4,
+    0
+   ],
+   "deps": [
+    "treeview"
+   ],
+   "commit": "09cf976b0f5999e378141bb66361395f1832aeae",
+   "sha256": "020ywr028af4kqy4n1hh3m7j9gg2c10118bwr37q3dcwy6mg1dm2"
   }
  },
  {
@@ -24694,20 +24428,20 @@
   "repo": "knu/dired-fdclone.el",
   "unstable": {
    "version": [
-    20231128,
-    1614
+    20241201,
+    1626
    ],
-   "commit": "82f161e4d0d9994d128c922170df54f966af182a",
-   "sha256": "0135pr0wqkfj60iq270nglkq111ljyqqqcsh2s1n293qmyr288b9"
+   "commit": "e77bf1d5d2dcea903201e9c03fcdff9f0be72aa4",
+   "sha256": "1ch3kqidszva0cyhk3aj05jabcqcwj1xg93fx7zsd8qdir69s98f"
   },
   "stable": {
    "version": [
     1,
     6,
-    1
+    3
    ],
-   "commit": "38555dc5a9427664b9b24af352de7550939625de",
-   "sha256": "0n84wyzvr05kkyfzzdz7fm4n4mcxrznknm37l070qzww2rarq96f"
+   "commit": "e77bf1d5d2dcea903201e9c03fcdff9f0be72aa4",
+   "sha256": "1ch3kqidszva0cyhk3aj05jabcqcwj1xg93fx7zsd8qdir69s98f"
   }
  },
  {
@@ -25276,14 +25010,14 @@
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "dired-subtree"
    ],
-   "commit": "cfc70763131ae668ff7b4884651f894fd102ffb6",
-   "sha256": "090dqaqyjmkzrz4szjpk1iip0bdvb0frp4l79393f8ki8w7c16c1"
+   "commit": "702165ad53a473992d84e0207b984b9be5114bde",
+   "sha256": "0f9cikyb53ybsawkm9g1sja2wsz2lmnc9zq63sx2h8d86acza2cp"
   }
  },
  {
@@ -25420,11 +25154,11 @@
   "repo": "purcell/diredfl",
   "unstable": {
    "version": [
-    20240909,
-    1723
+    20241201,
+    1141
    ],
-   "commit": "bca8f0f7b3e9e46b9c7692275ced8c1d59e0d208",
-   "sha256": "125a49ibbaicp6kxv0ja9mz9paryqgz30xhl0pk3kvnm8z40hlr6"
+   "commit": "fe72d2e42ee18bf6228bba9d7086de4098f18a70",
+   "sha256": "19nzg9h0hi516c9xqifbdy9mdr4lj0hmba94dl4qfin9j4c8wgqm"
   },
   "stable": {
    "version": [
@@ -25854,6 +25588,36 @@
   }
  },
  {
+  "ename": "disproject",
+  "commit": "c3539929eec8fc91f31dab208122a96f8c959c00",
+  "sha256": "10d722rbmkjf4f7pdgdr0ar4m2g34h0j82fl4hfa59ydm6n5sdx2",
+  "fetcher": "github",
+  "repo": "aurtzy/disproject",
+  "unstable": {
+   "version": [
+    20241128,
+    2134
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "15431e0d6947682ffba80f89e70918c86745eb57",
+   "sha256": "0d5bbkzzklr2v2b431mxf5xqm4vdbk220ihwyf90m12b5iq6gzp0"
+  },
+  "stable": {
+   "version": [
+    1,
+    2,
+    0
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "15431e0d6947682ffba80f89e70918c86745eb57",
+   "sha256": "0d5bbkzzklr2v2b431mxf5xqm4vdbk220ihwyf90m12b5iq6gzp0"
+  }
+ },
+ {
   "ename": "dispwatch",
   "commit": "580cee72ac9871f8f256069b371f7fb66367a048",
   "sha256": "1cq5lbh3r9jjwixn2q30gryy4j4l8jb70nkhsjbaln1c3jdwrf9p",
@@ -25953,14 +25717,14 @@
   "repo": "unhammer/dix",
   "unstable": {
    "version": [
-    20230126,
-    1017
+    20241128,
+    1111
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "5eeed9362fbeaf5a032bccd69b861b8a36877516",
-   "sha256": "0w23qcmlpy23v481nqikjpd3kgwpjapihlwhxdxmpd5h90khkj9j"
+   "commit": "9770a2edd1fd0f872cc4ca72fa8f4b1007cb3da8",
+   "sha256": "050xh28jhk6gqm4psqkgjh3wqh5jrggrp9ky380f05x8v1ijgvhq"
   },
   "stable": {
    "version": [
@@ -26228,14 +25992,14 @@
   "repo": "emacs-jp/dmacro",
   "unstable": {
    "version": [
-    20200803,
-    633
+    20241027,
+    830
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0008e7d2403a20f444b29a63fad65819aefabe18",
-   "sha256": "0ij0mafvgc3fxgnp27gx19i80z6cbr80ddmwl1fjl0gzc1ivqrxl"
+   "commit": "cb3ce0e1d6ce868baf47cb9225c8daae4b610dab",
+   "sha256": "1fvinc3gmxzqklcrrh723n5axcxv6s8pj16q1xmfmzlhb8ldv2xl"
   }
  },
  {
@@ -26331,8 +26095,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20240917,
-    1355
+    20241111,
+    859
    ],
    "deps": [
     "aio",
@@ -26341,8 +26105,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "6f8bba0d11a5143872dfc25afdabe16cae410d11",
-   "sha256": "00bc768jknzym99k56jhbrj1hyzj7yygi513vw2wz89vq2axjdkg"
+   "commit": "ec2391a8e3404958cefee3dda23b2c89dcf807a2",
+   "sha256": "1wn3wks97vx74hgqc42q7fwblyarvjrbgcy2h1r7yf5cliwsl0v5"
   },
   "stable": {
    "version": [
@@ -26732,16 +26496,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20241002,
-    1003
+    20241201,
+    1338
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "ec6bc00ac035e75ad10b52e516ea5d95cc9e0bd9",
-   "sha256": "0sk1h3g3dslngzrl5ghw1g8a4gpz59pcm5ivyafiv2qqw5gvdjwi"
+   "commit": "d4985f0f6ebbc125995fdfd5a909ba6afe692d7d",
+   "sha256": "175c8qa0bfa15d85dn1sajpyajbv1kmsqcn8z9a6xc9g88y8midd"
   },
   "stable": {
    "version": [
@@ -26785,14 +26549,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20240909,
-    2117
+    20241120,
+    157
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1cac71a4b2434036496a49b4440fdba3d0b5b387",
-   "sha256": "0423xhs2vd08adh1ar3qz651fdi6a2131c5haq3a9jx3fk464pdd"
+   "commit": "3c03f525d5c0ac0859f31231778f97e10a705e0d",
+   "sha256": "0mw0lvl3a3fz2xrh2cy7d48kzjgsf545m9lknab566wp2f7mg4ng"
   },
   "stable": {
    "version": [
@@ -27012,14 +26776,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20240924,
-    529
+    20241026,
+    627
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "eb37cb7a464f205650962d7dc7b0e39d72daeb7d",
-   "sha256": "1gk5vi1v7bd4j597h1fwgar88mas66264gl3vqkblkjk2ynnqkif"
+   "commit": "719c1dbea93f4b524937d280f18871981714a012",
+   "sha256": "1q28dhdx6bc4sr6qrg6in8a21np1bwi3b4adl3d9yrdv65b1dxzx"
   },
   "stable": {
    "version": [
@@ -27065,11 +26829,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20240912,
-    2032
+    20241102,
+    1301
    ],
-   "commit": "c1614c68bb7cb6f9a6f4f779f47cf0d24b938b6f",
-   "sha256": "1n1pdgm6xa2g1bk5wnb8lhwabzl05cms3qn52sag8xngph2p43vh"
+   "commit": "4e521e716c2c914d7003243238a00ed330cd17c9",
+   "sha256": "11jqkp1h2v05k7iasfhgx9j675md13iy8cf2bviyd3g2jz4p99fs"
   },
   "stable": {
    "version": [
@@ -27277,20 +27041,20 @@
   "repo": "positron-solutions/dslide",
   "unstable": {
    "version": [
-    20240703,
-    1523
+    20241128,
+    1102
    ],
-   "commit": "2d8a9ac3e37157ce8b78880ebc1defc61303a44d",
-   "sha256": "177cfim8hd6292lhvvsapk695i0q378v4wk221l57nv197rnmy4n"
+   "commit": "c0e4aff0ac8a51df4020bd591d19bd749c92f024",
+   "sha256": "1ah1319lnjzvja5yv0qjb6jz5b0i3xaa5m708c1xgr4mxk3blzvs"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    5
    ],
-   "commit": "2d8a9ac3e37157ce8b78880ebc1defc61303a44d",
-   "sha256": "177cfim8hd6292lhvvsapk695i0q378v4wk221l57nv197rnmy4n"
+   "commit": "0d9a1f6c27e0543e912213d0a5047999f9e5deb5",
+   "sha256": "02c4v3zv8q2dqln3lfn2055bnffafc7yczrn3jyvw0f9hcw77ibr"
   }
  },
  {
@@ -27491,6 +27255,25 @@
   }
  },
  {
+  "ename": "dumber-jump",
+  "commit": "6b421a7803bfcbb14761524960cfbd1d43d1cd82",
+  "sha256": "1xki5ckrd0crj5vwpkzdg3djrgrnc575b7fqd2i6ah8fby4z4cij",
+  "fetcher": "github",
+  "repo": "zenspider/dumber-jump",
+  "unstable": {
+   "version": [
+    20241028,
+    1822
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "37ca96bd065ac6869549e17dec98940edfc59f5a",
+   "sha256": "1y9gqy1nyhhlfk5aihp97fzzp1mq81h7mz20ayz9h3s2cm6qmq4v"
+  }
+ },
+ {
   "ename": "dummyparens",
   "commit": "e1f6199a9afece4d6eb581dc8e513601d55a5833",
   "sha256": "1yah8kpqkk9ygm73iy51fzwc8q5nw0xlwqir2qld1fc5y1lkb7dk",
@@ -27581,14 +27364,14 @@
   "repo": "liuyinz/duplexer.el",
   "unstable": {
    "version": [
-    20240919,
-    1018
+    20241029,
+    356
    ],
    "deps": [
     "dash"
    ],
-   "commit": "883e9e24f1c7bb7132c1eac0bf5bedf78081058f",
-   "sha256": "0mpjjyqnr8izirpgnyckci2fmnxfnmlblzayribgzqrj8mgyzdhy"
+   "commit": "e46b9414de3913f7fbfa9b0e8b2a33f6bbf57cb5",
+   "sha256": "013y7j5np0hybwxna9q9hgg2cf267qrcy0iivaa6p31vpk0zqiq7"
   },
   "stable": {
    "version": [
@@ -27665,11 +27448,11 @@
   "repo": "sadiq/dwim-coder-mode",
   "unstable": {
    "version": [
-    20240712,
-    1047
+    20241121,
+    1117
    ],
-   "commit": "02f5fa0c3ae5cc17ca860c792d988705f41b0eee",
-   "sha256": "0p1yz2lnzifqsjqcbk2jk9darj72icnydaxwhs2h0hmvl786g4gi"
+   "commit": "dda1e9b991c9dc7ff2a2779731783db3176c3b61",
+   "sha256": "1kq29hrbdyfa2gc13w5f2c92pb9k2hr4m86f9s7vjc1lhx32v7gw"
   }
  },
  {
@@ -27680,11 +27463,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20240925,
-    2058
+    20241115,
+    845
    ],
-   "commit": "9ee831bf05eb54f04baeb3d2e57d70752661e286",
-   "sha256": "0izngjxkv0ffn81hha0jd211anr0k5wyigmps7mppx5bcjv5dgax"
+   "commit": "1fa8b9d361f01618bf65111ac0b253adb0599a09",
+   "sha256": "1alkd06m9f7p16a1fw1c8kmgg9az21fkc4xfspai122az1wpp83n"
   },
   "stable": {
    "version": [
@@ -27722,11 +27505,11 @@
   "repo": "dylan-lang/dylan-emacs-support",
   "unstable": {
    "version": [
-    20220115,
-    1804
+    20241102,
+    2315
    ],
-   "commit": "9d2891e3e06405b75072d296f385fa795aeb9835",
-   "sha256": "0fxyl50n2s1pb86z46s1f0lh361q34i2x8hir91wvqsqkfajbhz0"
+   "commit": "21e5953e2b1832f6a2c72012bd13795dc1ede52f",
+   "sha256": "01jkk7gq6pqls6yvc6j77zmnppm2qpx876s596y7vz1q1c5i2fii"
   },
   "stable": {
    "version": [
@@ -27834,19 +27617,19 @@
   "repo": "countvajhula/dynaring",
   "unstable": {
    "version": [
-    20240615,
-    129
+    20241126,
+    252
    ],
-   "commit": "90daf413abee1723c37697e72bb700a06727ff4b",
-   "sha256": "12634kmx7fdb3lndyjgf7hisdzcqg3hn90xqr56gjdj0m5yzq310"
+   "commit": "42333fcb734f675cab5d25d1b9d142d502914388",
+   "sha256": "1i17i0rigxm8isri5ygb1pk695ywlfmgkpgmbgqyzw5zmb9w4gm1"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
-   "commit": "c17de670bc5ab4cc866d470f44faf733351428d6",
-   "sha256": "02ffmssibnx78m352f6qr705cswyzz5lvgpryv9d7kjpbzvqya6k"
+   "commit": "42333fcb734f675cab5d25d1b9d142d502914388",
+   "sha256": "1i17i0rigxm8isri5ygb1pk695ywlfmgkpgmbgqyzw5zmb9w4gm1"
   }
  },
  {
@@ -27893,14 +27676,14 @@
   "repo": "kiwanami/emacs-window-manager",
   "unstable": {
    "version": [
-    20170215,
-    36
+    20241104,
+    914
    ],
    "deps": [
     "window-layout"
    ],
-   "commit": "4353d3394c77a49f8f0291c239858c8c5e877549",
-   "sha256": "12midsrx07pdrsr1qbl2rpi7xyhxqx08bkz7n7gf8vsmqkpfp56s"
+   "commit": "33efca5504db9d8b3fdbd412c3d79663c9eec77a",
+   "sha256": "1a1n9b5gw6985qi1dm56vyw8jacx4k3jyl4cadkhj38rz24yiyx8"
   },
   "stable": {
    "version": [
@@ -28135,6 +27918,21 @@
   }
  },
  {
+  "ename": "earl",
+  "commit": "900e956e83f8ef7ef8a88827602677b11acf605f",
+  "sha256": "0jilp5ppavyxk4qnk0pily7nr2rz9bqi05xkyv26q77zkhnf3knc",
+  "fetcher": "github",
+  "repo": "axelf4/earl",
+  "unstable": {
+   "version": [
+    20241020,
+    1847
+   ],
+   "commit": "aa10aae9891a599f523f269cc391ed316775d12a",
+   "sha256": "18pi10csnxbjpx6naym1mnz16fz9lv7wc6n6xqcm55wqppf7ln4i"
+  }
+ },
+ {
   "ename": "earthfile-mode",
   "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
   "sha256": "1md8c7mds7zqzkfblijz64qywz1195sszixay6srr0r4lc1jlvyp",
@@ -28157,11 +27955,11 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20241014,
-    738
+    20241123,
+    1454
    ],
-   "commit": "34fd32468a62604b5d75e3ad562cb9e84a5e5ac7",
-   "sha256": "10sv8d22zqrh7qijh19byddbry971xk72b7lvdmp15i1ra3842xv"
+   "commit": "106755df719ceb202d52146d436f370f5bf8f095",
+   "sha256": "04k7q2jka4dr2sbxx54i18y2j78rfky8fmghxk5sb3pvmkz0j7c1"
   },
   "stable": {
    "version": [
@@ -28423,26 +28221,26 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20241014,
-    1422
+    20241118,
+    1601
    ],
    "deps": [
     "f"
    ],
-   "commit": "d8a5a491cbfe0536348713b556bd2790450136bb",
-   "sha256": "0rx9j64c4rlf2g4ch5zc9fisrncwziwki8plhmyjm0n8yfd32a40"
+   "commit": "157f2d2130280720190198f74b850e228348ffaa",
+   "sha256": "0h4801v9fspqhd920c19nv6kdsl6lja51ymkr7az9jgnc3vxbjs4"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "f"
    ],
-   "commit": "0ed3925e768ccf177328242dd2403838de52d13d",
-   "sha256": "0x0wp5m3rma1sr983017wgmyqr799fs49y9q3b88cj45i1ffr94h"
+   "commit": "f45896a6d29966c7a9f63f0a4c603245c1609877",
+   "sha256": "1rcav779l4xbml9157cqrj4fkxan19q2lpj8wg0cj6gmvw536agv"
   }
  },
  {
@@ -28518,27 +28316,28 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20240925,
-    2235
+    20241125,
+    1941
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "92da7850b864af89f4b546bb8f562fcbbe042392",
-   "sha256": "0sk5q205cw0cihidmaakg3jyp6z1b8rib0x57gsh3qw5g5bzhbq1"
+   "commit": "dabc7d5b14e4371475ddc1061e9c52f0ef91e671",
+   "sha256": "0y9w0b09djji6v1ayrqins7awms121q2k1z9mxyc0kl9d8q72n4d"
   },
   "stable": {
    "version": [
     2,
-    44
+    44,
+    1
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "73159eba01c34ec103db9e15e959eee87c2242eb",
-   "sha256": "1fl3spc2090nwswsqxmkw55ibw0ncdmi4igac0ywqs515cw07ywl"
+   "commit": "315a8b067059f7d2c4e19220586dfbb042161fc4",
+   "sha256": "1lba6556ilml3kq8fxd1nkmx3dank36n68v3msad0npkj8083xlb"
   }
  },
  {
@@ -29092,11 +28891,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20240813,
-    801
+    20241027,
+    1815
    ],
-   "commit": "648f0cf9aeb72db77b252832a58367332b7bc055",
-   "sha256": "03fms46mfdqi9czp1nkccm9zpi1g5n41djfh299phs4sz8nl19lk"
+   "commit": "24f5b2b1cd4e37adc245fb59f7edeb6872a707a4",
+   "sha256": "1yh5pz34aldn75z6vpfmc93jklvd7fd8azvwcq1d7cl352jf5i5r"
   },
   "stable": {
    "version": [
@@ -29235,11 +29034,11 @@
   "repo": "sinic/ednc",
   "unstable": {
    "version": [
-    20240209,
-    2028
+    20241129,
+    1636
    ],
-   "commit": "2580ada68ecc93aa693c61f997c9cf581698242e",
-   "sha256": "0fr36z0fgz4k9mdv1297dyp2rpdxv8pzx3sklx1nayq4raavnmx3"
+   "commit": "e181e0bbf12b6516afba3785192d88432d8ebc6c",
+   "sha256": "1b545ibacpvjvwh0lhyx6g483xkdf8lqiiddddch3pq3dnm38yzg"
   },
   "stable": {
    "version": [
@@ -29252,14 +29051,14 @@
  },
  {
   "ename": "edts",
-  "commit": "949da8f16687bad96f53714ccbde895587d439ff",
+  "commit": "6d23ade0346f071f0302453a8ecba340901b15e9",
   "sha256": "0nabh5xfpskxjm2fvhg5blvh8xlnalfvq0qs57lraqc42699f8pk",
   "fetcher": "github",
   "repo": "sebastiw/edts",
   "unstable": {
    "version": [
-    20230926,
-    2146
+    20241202,
+    25
    ],
    "deps": [
     "auto-complete",
@@ -29270,8 +29069,8 @@
     "popup",
     "s"
    ],
-   "commit": "5c3cded3fab56baa60874f4e1efd14155cec587f",
-   "sha256": "1gqb7v51xgwjd68nb2msfbg8s83f5082ha0ybqh7765qdlhrxfpf"
+   "commit": "d38f538c8e3fb285fb3c66b87eb68eba4ed074c3",
+   "sha256": "00yzvgvriak3ykgr13hvsvb51gai4p2m2wijjrrs3m5bzrsg0qkm"
   },
   "stable": {
    "version": [
@@ -29605,20 +29404,26 @@
   "repo": "kennethloeffler/eglot-luau",
   "unstable": {
    "version": [
-    20240401,
-    2209
+    20241102,
+    1924
    ],
-   "commit": "3926860036402cce4a55faec534b88c0bf6006fd",
-   "sha256": "03zva7sykc1ja5kz8x21z5r10d49iwa67i4wafi8vnymmw3rfcai"
+   "deps": [
+    "eglot"
+   ],
+   "commit": "23335f45fb91de606e6971e93179df0fee0fd062",
+   "sha256": "1k43zsw82l07i9va9w9fxhl9cnz1vbpl90m6jvbnrl8fxhzw2kvh"
   },
   "stable": {
    "version": [
     0,
-    1,
-    2
+    2,
+    0
    ],
-   "commit": "3926860036402cce4a55faec534b88c0bf6006fd",
-   "sha256": "03zva7sykc1ja5kz8x21z5r10d49iwa67i4wafi8vnymmw3rfcai"
+   "deps": [
+    "eglot"
+   ],
+   "commit": "23335f45fb91de606e6971e93179df0fee0fd062",
+   "sha256": "1k43zsw82l07i9va9w9fxhl9cnz1vbpl90m6jvbnrl8fxhzw2kvh"
   }
  },
  {
@@ -29663,16 +29468,16 @@
   "repo": "fejfighter/eglot-tempel",
   "unstable": {
    "version": [
-    20241012,
-    1053
+    20241115,
+    1110
    ],
    "deps": [
     "eglot",
     "peg",
     "tempel"
    ],
-   "commit": "72d5069809084db4447cad40531449714d75041e",
-   "sha256": "00v94h3zvl2pm1yizjmdfqgmzwqq8aghjixdcb23x703inq5p82x"
+   "commit": "c6c9a18eba61f6bae7167fa62bab9b637592d20d",
+   "sha256": "0wgkcfyj9a22kxizippnx2nca16vs2y7qzmi487530w9f17lm17y"
   },
   "stable": {
    "version": [
@@ -29806,16 +29611,16 @@
   "repo": "kostafey/ejc-sql",
   "unstable": {
    "version": [
-    20240106,
-    1848
+    20241111,
+    117
    ],
    "deps": [
     "clomacs",
     "dash",
     "spinner"
    ],
-   "commit": "b80b773238719fa7160e598219f300dfbc4db06d",
-   "sha256": "1whgbwdv3zrhxq2casxj784bx95j0vzlpnvi51i4xdxpdf77g521"
+   "commit": "1fc5a38d974aed401424ecd3b49a74e0a0ebc3bb",
+   "sha256": "1ry9ylnbkd2p0xswnh8cd9qac1j6idysak4lb4fplvamff4nc2v5"
   },
   "stable": {
    "version": [
@@ -29856,28 +29661,28 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20240928,
-    1903
+    20241118,
+    224
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "839c6ce9a40bd7b7a12b791dc74f172ac1f378e6",
-   "sha256": "0953qmg8mfpd018w95y90sns41gcng9fw6spb31a496yvqs85z68"
+   "commit": "942457bb75574f17058cba1da25e46aeee3fde4b",
+   "sha256": "0cmridxl0ngvh93lbndpbvzp4wbi5wd3hm30hhh4wp8qw280xygj"
   },
   "stable": {
    "version": [
     0,
     6,
-    3
+    4
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "12d2524b4b7fdbb2e60b564456c463e594919ca2",
-   "sha256": "0pqdlwwm67r26pf90q93xkxhsbpv02pac3b9d8p7haxxdsdv10vd"
+   "commit": "942457bb75574f17058cba1da25e46aeee3fde4b",
+   "sha256": "0cmridxl0ngvh93lbndpbvzp4wbi5wd3hm30hhh4wp8qw280xygj"
   }
  },
  {
@@ -30033,6 +29838,36 @@
    ],
    "commit": "dcc595ba51b5aff972292278aa528c7ddb46f1b5",
    "sha256": "1488wv0f9ihzzf9fl8cki044k61b0kva604hdwpb2qk9gnjr4g1l"
+  }
+ },
+ {
+  "ename": "el-job",
+  "commit": "ccf13778c703948af96a4e0cc356acc907180452",
+  "sha256": "0cav794g0a1rkdjfdp6r4gk30xk53n4jnwwppal1ifbwimr8i15s",
+  "fetcher": "github",
+  "repo": "meedstrom/el-job",
+  "unstable": {
+   "version": [
+    20241201,
+    1208
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "1bb6865aae4368b6e9f7491bd7c3f3e6fb1d7e7c",
+   "sha256": "1762ck9zp5p9qykf6spl0fs89k7drznjrm3q59j2lgwf1i0dzb9m"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    15
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "1bb6865aae4368b6e9f7491bd7c3f3e6fb1d7e7c",
+   "sha256": "1762ck9zp5p9qykf6spl0fs89k7drznjrm3q59j2lgwf1i0dzb9m"
   }
  },
  {
@@ -30413,11 +30248,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20240920,
-    1226
+    20241115,
+    1459
    ],
-   "commit": "481b7ea70b8ba6c972b33abad169494097e699cd",
-   "sha256": "0kc3m1khd8fnq15c8hzfi12yh8mykl16sxfj8dxbrvmwhyx4k7gg"
+   "commit": "c6e7d4b5da6f1116b479c71d9c7fa0aca71d4030",
+   "sha256": "1xd8nd55dhdf1dx622x2618zj3xk196p2yr4123hk8hlqlb46h2d"
   }
  },
  {
@@ -30428,20 +30263,20 @@
   "repo": "emacs-eldev/eldev",
   "unstable": {
    "version": [
-    20241012,
-    1650
+    20241129,
+    2121
    ],
-   "commit": "9e11978ad72a1c97a2d35ef72176226b58fc9800",
-   "sha256": "1wzq4hmj0qp55i8h1gfm68hvzfnd2lqzh0qav1ap35xxja3cqzff"
+   "commit": "7001727c9cbb8ee29de7b9761afd887db8cb0a94",
+   "sha256": "1ckhr6h57d5rqzw30079pc92yv6125vls17nwylxvawbj24imng9"
   },
   "stable": {
    "version": [
     1,
     10,
-    2
+    3
    ],
-   "commit": "260f13a21e3733d24ccaffccd04c4de6196cb21c",
-   "sha256": "0qs2n7zwsn4gffdl67329ww0dfr403q5c7229wpkc92zg29xi979"
+   "commit": "b5f583c70742ba371ff5c176d515c71d5407cf79",
+   "sha256": "0ha2ppxqp36m26nv6lyspq6m6xvvr03cf82rygq45w729gakdw9r"
   }
  },
  {
@@ -30452,11 +30287,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20240928,
-    1746
+    20241026,
+    259
    ],
-   "commit": "0af5a65934f2fc4d83a1936c02cb3551b2563fae",
-   "sha256": "1bap3xq398rqvjv95bhn8wn9wg5g2s7a6plyi333w26r8vbq7awv"
+   "commit": "cd01cc9cc9aee1f604f4259a41b0ab2659c946af",
+   "sha256": "14dn43v8plz3m9r79jpx60h13g2vs0jcjrkmh7fgi80cdzyf54rn"
   },
   "stable": {
    "version": [
@@ -30646,27 +30481,25 @@
   "repo": "davidshepherd7/electric-operator",
   "unstable": {
    "version": [
-    20231014,
-    1107
+    20241201,
+    1151
    ],
    "deps": [
     "dash"
    ],
-   "commit": "18e555a5cdfd7264c179f810d7fd4c71a80b715a",
-   "sha256": "1r5g2n4lzns65lil9291jhxzwm3q4s1z99zhmyj9nmnxl3mf7aax"
+   "commit": "1dbda747a3164018a0bb11cf39088627cc892019",
+   "sha256": "12lndaqg2nx1ls4srmy9xrmr94yz2k817xzj2bcfc4z1xmhh53yh"
   },
   "stable": {
    "version": [
-    1,
-    1,
-    0
+    2,
+    1
    ],
    "deps": [
-    "dash",
-    "names"
+    "dash"
    ],
-   "commit": "21e6b84754118912768263a393442a7aefb4742b",
-   "sha256": "1bgz5vn4piax8jm0ixqlds0qj5my26zczaxs21fah11pwbdc0xyk"
+   "commit": "92c3eae146cb9bfcebef4b33498ab7d0973033fe",
+   "sha256": "0200358i9hgn8wmzzw1b7qn3mv85qmhc55cvh5vn3i0kn6nrkmqj"
   }
  },
  {
@@ -30811,11 +30644,11 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20240729,
-    1741
+    20241202,
+    22
    ],
-   "commit": "904b6d4feca78e7e5336d7dbb7b8ba53b8c4dac1",
-   "sha256": "0yq93abyadzrmcd40pi06wcr4jg9ddhlz2phg0wjypprqvv4q49z"
+   "commit": "a39fb78e34ee25dc8baea83376f929d7c128344f",
+   "sha256": "1rys5z7shn45z07dfcm5g06pnpx5kccdz94xkwizmrf882xzmmvh"
   },
   "stable": {
    "version": [
@@ -31229,8 +31062,8 @@
   "repo": "s-kostyaev/elisa",
   "unstable": {
    "version": [
-    20240721,
-    1247
+    20241123,
+    2205
    ],
    "deps": [
     "async",
@@ -31238,14 +31071,14 @@
     "llm",
     "plz"
    ],
-   "commit": "85373924896c92b7c27d6737d247f0084df99d6a",
-   "sha256": "09w1vvpx8zbsnp8sxk3ywzmim4w6msqg2cg19azgyd1kllxzsz0q"
+   "commit": "322d7eb839f1e981b8aa09a6ee4a7d6a22173772",
+   "sha256": "0slmp0fzmkww8al6w3h2b0vimbsppxbjrz29braw4j3lskq1isd7"
   },
   "stable": {
    "version": [
     1,
-    0,
-    4
+    1,
+    3
    ],
    "deps": [
     "async",
@@ -31253,8 +31086,8 @@
     "llm",
     "plz"
    ],
-   "commit": "85373924896c92b7c27d6737d247f0084df99d6a",
-   "sha256": "09w1vvpx8zbsnp8sxk3ywzmim4w6msqg2cg19azgyd1kllxzsz0q"
+   "commit": "322d7eb839f1e981b8aa09a6ee4a7d6a22173772",
+   "sha256": "0slmp0fzmkww8al6w3h2b0vimbsppxbjrz29braw4j3lskq1isd7"
   }
  },
  {
@@ -31579,30 +31412,32 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20240915,
-    1523
+    20241129,
+    2147
    ],
    "deps": [
     "compat",
     "llm",
-    "spinner"
+    "spinner",
+    "transient"
    ],
-   "commit": "74767cbd6dc582bd6ce99a83bc84d41bfad4b4ee",
-   "sha256": "1nkd6dvmad54w2x13agmzfqmhil3rh8dw5v23brna9ldl1x0ap57"
+   "commit": "d4927093e2988084eac86c3254a7b7f5d4cbd761",
+   "sha256": "1abjp70q9ms6kdd1rs4zcrqzz0hfy7a5bizgl0ddrx7r0sfk9r06"
   },
   "stable": {
    "version": [
     0,
-    11,
-    14
+    13,
+    0
    ],
    "deps": [
     "compat",
     "llm",
-    "spinner"
+    "spinner",
+    "transient"
    ],
-   "commit": "74767cbd6dc582bd6ce99a83bc84d41bfad4b4ee",
-   "sha256": "1nkd6dvmad54w2x13agmzfqmhil3rh8dw5v23brna9ldl1x0ap57"
+   "commit": "d4927093e2988084eac86c3254a7b7f5d4cbd761",
+   "sha256": "1abjp70q9ms6kdd1rs4zcrqzz0hfy7a5bizgl0ddrx7r0sfk9r06"
   }
  },
  {
@@ -31962,20 +31797,20 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20240930,
-    913
+    20241022,
+    1625
    ],
-   "commit": "e3760dfedbd803dd8ff2a5d4fbbda249c1963bd1",
-   "sha256": "0w8n30wdpf9alx7cjb2d8vb9a6a66dn181va2sg2cb2vl5j87lpj"
+   "commit": "a1c5fbf16b528fb67d087437d44d66e9edc99664",
+   "sha256": "0pkgk7608w31kvdjid54xfrc5zrbrzwi98wrglwl07s429xlbai2"
   },
   "stable": {
    "version": [
     3,
     6,
-    0
+    4
    ],
-   "commit": "56bc74e224d9835c41b6e6b68c9705b60e6dbbe2",
-   "sha256": "00z41vw63vm71i5szmvrxspvnzkpzflpip56jnmkjc94qfla2l8s"
+   "commit": "a1c5fbf16b528fb67d087437d44d66e9edc99664",
+   "sha256": "0pkgk7608w31kvdjid54xfrc5zrbrzwi98wrglwl07s429xlbai2"
   }
  },
  {
@@ -32344,15 +32179,15 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20240805,
-    1311
+    20241123,
+    2125
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "be1afda54a182c726d7f0c584b2ac4854384ffda",
-   "sha256": "02wy4wsp2lk07kwb2pzi9bsb947walsndbjgllqpc35bhky50l0k"
+   "commit": "02ceae51c97ee0b05433c58faf874f68a88fa255",
+   "sha256": "0m67xcb1aks29c9zymlwmvkaswzpb8vx9m6x3s6qg9y13kvnxmhh"
   },
   "stable": {
    "version": [
@@ -32376,14 +32211,14 @@
   "repo": "lanceberge/elysium",
   "unstable": {
    "version": [
-    20241012,
-    2351
+    20241102,
+    2222
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "89d025337aae6aff2f32e06865d20d9a7ee4bb22",
-   "sha256": "086nxx6pzn77q1dchkg4fsd80fagyrv4dm7f56fwbj5275n7hn6j"
+   "commit": "dcb194e0e49e2c1864e0fa2ccec3d7e37b0a44b6",
+   "sha256": "0cygwyg0x136h6im8n87lpw8vck2zava87bqhjv2pp6ibjw3nsqw"
   },
   "stable": {
    "version": [
@@ -32421,21 +32256,20 @@
   "repo": "knu/emacsc",
   "unstable": {
    "version": [
-    20240629,
-    1325
+    20241119,
+    1435
    ],
-   "commit": "49b0bbbcd021424da4000bf47193bd2d928b2228",
-   "sha256": "0fyxhbng9cckdbmp0jc2x88azajr68r14jzak2zqh5pqlvs6hcjz"
+   "commit": "0868b7f52adae264fb79e10e57a7481632eee76e",
+   "sha256": "1hs8arpbw1q1y3mwz2kyanqp2qs6pfbzfk9icba0cavk481whhjv"
   },
   "stable": {
    "version": [
     1,
     5,
-    20240629,
-    1
+    20241119
    ],
-   "commit": "49b0bbbcd021424da4000bf47193bd2d928b2228",
-   "sha256": "0fyxhbng9cckdbmp0jc2x88azajr68r14jzak2zqh5pqlvs6hcjz"
+   "commit": "0868b7f52adae264fb79e10e57a7481632eee76e",
+   "sha256": "1hs8arpbw1q1y3mwz2kyanqp2qs6pfbzfk9icba0cavk481whhjv"
   }
  },
  {
@@ -32461,164 +32295,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20240906,
-    1342
+    20241201,
+    1551
    ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
+   "commit": "d6529f010a0573630122b826230e72157ab8fa88",
+   "sha256": "1wp6sx6nwjvn1laxgsm5pciilq59sigk85l1iwlchhi5i94ma29z"
   },
   "stable": {
    "version": [
     4,
-    0,
-    3
+    1,
+    0
    ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-mysql",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "1bpi5iqfydcii7di990l5nskgxk0cqg6zg1yddadbdfdznsi37hm",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-pg",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "0pryfj9wi3kd6cbxnh8wwgyxhj17ihnic26a9a21rd769m2bsg5a",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-psql",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "1kgpmjc81y1851cwn3z2hfs4ia3hllh5b7h7iw5kzpb44kpicqpl",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-sqlite",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "1dxc8iyshlg5k4hn3alpg4wwfs138f0i65bdjj9rlwl6qinxq0ab",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-sqlite-builtin",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "0yyabz7ai276lhqyc9w7jac8rky96635p34jy9bssh3nq2l99b9b",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
-  }
- },
- {
-  "ename": "emacsql-sqlite-module",
-  "commit": "9875de56d4c4f5e1d6f127a0b2e408e87a9dd932",
-  "sha256": "07flj471cxdbhx4z8qzqghgk0n4y72mnw947ighasg9042564vqs",
-  "fetcher": "github",
-  "repo": "magit/emacsql",
-  "unstable": {
-   "version": [
-    20240825,
-    1837
-   ],
-   "commit": "b9f19ac5e17a90d5b7314d67e3b790992be7d82d",
-   "sha256": "1n11zkjh0x30n1ny0fw44w3k64yydcmyhlnfvycvf879k4j9r2zj"
-  },
-  "stable": {
-   "version": [
-    4,
-    0,
-    3
-   ],
-   "commit": "fb05d0f72729a4b4452a3b1168a9b7b35a851a53",
-   "sha256": "15nmp5dl2a1iyc99wlaywclnqsi2p34vgrp2x62671ccxnvzg8ii"
+   "commit": "d6529f010a0573630122b826230e72157ab8fa88",
+   "sha256": "1wp6sx6nwjvn1laxgsm5pciilq59sigk85l1iwlchhi5i94ma29z"
   }
  },
  {
@@ -32963,29 +32653,29 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20240925,
-    308
+    20241129,
+    1513
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "ccbcc509d09301289e2be279e34304ba06644073",
-   "sha256": "16kqxf2k744hh45sv114pym8cmrkxi4v8g7andx59r78nzgxl304"
+   "commit": "c8b56ade72452b3fe1d3eed7b6d2518d592db386",
+   "sha256": "0xwcyq1i4jf51rzp5nam9wk1mmd12n00459z443r5fc390vgzi0p"
   },
   "stable": {
    "version": [
     20,
-    1
+    2
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "e0331bd7c480b3ac326140bd5b312bfdbc4881c9",
-   "sha256": "06vsf3mlj0sxhmcgz70haihsrskr98w2jnhy68h7g3b9rkbxgmhc"
+   "commit": "b7e4a4cdbdb7e55300882d6c9a4f71048ec298d5",
+   "sha256": "1csgnhczw761j9kl1kfb173rla31lyyjq5f48m98h92nb07yc9xc"
   }
  },
  {
@@ -33556,6 +33246,38 @@
   }
  },
  {
+  "ename": "enhanced-evil-paredit",
+  "commit": "aa5f922022cd20eb8908a67e27a3f8f57f4a4271",
+  "sha256": "1f52wzf9jpff2b8arj91bl4h51y44ncbyh6hrc2vyn8qlq1wcicr",
+  "fetcher": "github",
+  "repo": "jamescherti/enhanced-evil-paredit.el",
+  "unstable": {
+   "version": [
+    20241201,
+    2142
+   ],
+   "deps": [
+    "evil",
+    "paredit"
+   ],
+   "commit": "cc5218d3487605d67056a5738a82875363c61eeb",
+   "sha256": "1annrn991yvqjy5nbxjkxr06xjnwa4prijlilklsc2d8a20n5cyr"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "deps": [
+    "evil",
+    "paredit"
+   ],
+   "commit": "3e43209270bcce1141a13bbffd7b3b372cc3d31c",
+   "sha256": "0m7i10a43acps9fb83clncbif5xndajdimmhxp35r5hh8qq4n9si"
+  }
+ },
+ {
   "ename": "enlight",
   "commit": "b7f467a2dcf96f67e641b6bea9262bee469bea3a",
   "sha256": "14ygvcd6ppvdcwlxj5mnhxp47h6ls9azhnjw0zalhb55rq62vq89",
@@ -33708,14 +33430,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20240613,
-    907
+    20241118,
+    1700
    ],
    "deps": [
-    "inheritenv"
+    "inheritenv",
+    "seq"
    ],
-   "commit": "2316e004c1574234fe4d991bd75a254cdeaa83ae",
-   "sha256": "1kx5p85p2c682j50cah18njdraj07v9dg8imi7p97bkx7n5malxm"
+   "commit": "9bbe723eb0749b66da0dead9d7eb49aa62a36bb9",
+   "sha256": "06gh4nm80gzz5h1364rrb60qq77n8y48pr75lii275gyxpx2663x"
   },
   "stable": {
    "version": [
@@ -33851,8 +33574,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20241001,
-    1037
+    20241123,
+    2129
    ],
    "deps": [
     "closql",
@@ -33860,8 +33583,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "f568083014664cc63eb942ee04a925634527793e",
-   "sha256": "1kg0jd8067brd4772sd6r0lj7vbf5pxhbj916nd6293a0hc10i58"
+   "commit": "cb104ca2f22686f94bbaba6b96eda0f22c094184",
+   "sha256": "0sym9q4i35cgp02vk3an52j9v9ysj1fnyv0nryi4g78jlxnawhn0"
   },
   "stable": {
    "version": [
@@ -34568,20 +34291,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20241004,
-    914
+    20241107,
+    1409
    ],
-   "commit": "088d904d0abdc68f031fa3e17b1aa67d903bfc7f",
-   "sha256": "0j66glb69i0kbcsy2a95jscmv23004x5ql2syf0yw8q2kkpvgxx5"
+   "commit": "7cbfeee1e0d5a7645fa5931ae916eb944520fb17",
+   "sha256": "0v1b2aq5klpwk7jiiyyllcnyv8h2x14ah62q3d87sw6qblm0yq2s"
   },
   "stable": {
    "version": [
     27,
     1,
-    1
+    2
    ],
-   "commit": "f4d130fd3512875ee95ce05b30f77e7c7689915f",
-   "sha256": "1j4n8zl79hnskpncc0jcgkqjpi15xkmmma77vpmpmzznk43zignb"
+   "commit": "44ffe8811dfcf3d2fe04d530c6e8fac5ca384e02",
+   "sha256": "1j4dihlbrfz95552fmb5dj8341w4qimnk0hv42n6yp1xz8qckcds"
   }
  },
  {
@@ -35630,11 +35353,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20240821,
-    1952
+    20241127,
+    1620
    ],
-   "commit": "d60c13a6a347ea7a91ea3408bb464cff0ab4fef6",
-   "sha256": "1i3g0bm0nih8ww3qp8rq8zr7chiz5bhm5rli4yq6sa02h7imviz5"
+   "commit": "e7b0bbc4ac40e6ea209c345042e280d3af0c6d07",
+   "sha256": "0ikp872gfhibc0q5rd5h5lxvnj7vqb2sqz1lbf26wy1j5bzn9lf7"
   },
   "stable": {
    "version": [
@@ -36227,11 +35950,11 @@
   "repo": "crmsnbleyd/evangelion-theme",
   "unstable": {
    "version": [
-    20240907,
-    723
+    20241116,
+    1036
    ],
-   "commit": "59fb3f39611d995c2e322a22e661165b87f4667e",
-   "sha256": "0r5c1s0in6al72b3hrhnfiqixsmxabgi31b60m13292hfm4f13ks"
+   "commit": "89577330e93f1c11b3e75d1c8bbae6accc18fc48",
+   "sha256": "107x89654dyvp3zm134kmqcybph1bhnx4zfdyzc6s2c3qyahhdfn"
   }
  },
  {
@@ -36254,6 +35977,36 @@
   }
  },
  {
+  "ename": "evedel",
+  "commit": "5bcbd3b3db68a50d8a67ece2c834d6a91b9ba4b8",
+  "sha256": "00j790q3vvp039vqq8cpdzfcwfyzcv70xmj2dwnpd06iynry3mii",
+  "fetcher": "github",
+  "repo": "daedsidog/evedel",
+  "unstable": {
+   "version": [
+    20241124,
+    1710
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "baba80b7e38935cd9209aa24867f87aa862ee4ab",
+   "sha256": "0alkmfrqqqpxdfj1gkxr0v1hwf8ixa6wgbd7x2pbbkj89srsp61s"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    16
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "bea64bd0475d1c2a4a84b9533740ae03712d0d6f",
+   "sha256": "0qz1x1zah1zm51pf2qh2vr9c96d2d2w5z4izb9djmaqrw112gara"
+  }
+ },
+ {
   "ename": "evenok",
   "commit": "c2568edb7d30ce34acd64ce0a211699ae87a0cb1",
   "sha256": "03kvr25rd91hkrrymyhsv1j48hr06p1k6hrz0skfd4ns617ambd0",
@@ -36261,11 +36014,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20240718,
-    723
+    20241031,
+    2134
    ],
-   "commit": "2963a451b12c3287879e3872dcc85c9ac476ac3d",
-   "sha256": "0sqgyks726lsy3lqasvkkm10pvm57s8ksj4d6qrvcnn43h7g54yq"
+   "commit": "06a84eea4cf9a845266f8bde68abe25d85bd2b77",
+   "sha256": "0fblw7h0w40ipixa0jiwli7hrc8bw7gva61wzblw9xdb0hscx3rk"
   },
   "stable": {
    "version": [
@@ -36510,15 +36263,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20241011,
-    2043
+    20241201,
+    1942
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "d9399cb3eb03b54bbf535d5be96a15d4b51c42a4",
-   "sha256": "1dk47pdi9nhh8rrg2c3lkj9hjr0mima54fg38yg21r98zi99kg2c"
+   "commit": "ed8c652b1f49e3b01d787bf33ccb2345399572d4",
+   "sha256": "15ivxqdp90snkq40qvsvf86ndd6c58nsqsd87fvdp1y0f7v97clz"
   },
   "stable": {
    "version": [
@@ -36728,14 +36481,14 @@
   "repo": "edkolev/evil-expat",
   "unstable": {
    "version": [
-    20190521,
-    714
+    20241120,
+    1350
    ],
    "deps": [
     "evil"
    ],
-   "commit": "f4fcd0aa3edc359adb5c986b5dd9188d220d84e2",
-   "sha256": "0872ix682hkdz0k8pn6sb54rqkx00rz5fxpd5j2snx406yagpaxz"
+   "commit": "23610598a9f1450f2deafc47726d5b7ce61e8695",
+   "sha256": "09yvysacsaka7pw2jkf0208igi10cclkdr2gk9zx4xc8khkd2213"
   }
  },
  {
@@ -36957,14 +36710,14 @@
   "repo": "edkolev/evil-lion",
   "unstable": {
    "version": [
-    20220317,
-    1030
+    20241120,
+    1351
    ],
    "deps": [
     "evil"
    ],
-   "commit": "4da660e124731ed65e7aaa6c067c30e876619429",
-   "sha256": "0akhw0a9qsk65lvanb57fqh7hf601xdzkbyi560ximfrsr7f94pi"
+   "commit": "5a0bca151466960e090d1803c4c5ded88875f90a",
+   "sha256": "1fmb5rdzc063rhrkm7945xabyzjm1j84nh9spg7caydbndkhhva3"
   }
  },
  {
@@ -37088,11 +36841,11 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20240418,
-    731
+    20241111,
+    1201
    ],
-   "commit": "c75b2c6c3123824ff7ae35deef22a3a5d9b619b2",
-   "sha256": "050r48nv2w13jj1d4n4y442p4vmwwqnnqb691nvlz48vfymdx6mm"
+   "commit": "19a6cad56bf1080fc526107ff48f2948f2511970",
+   "sha256": "1qri6gnbyblmmvc3lygil6gfinpa9ygprjd38svczj756vrr95js"
   },
   "stable": {
    "version": [
@@ -37112,15 +36865,15 @@
   "repo": "gabesoft/evil-mc",
   "unstable": {
    "version": [
-    20240701,
-    140
+    20241025,
+    2045
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "cff3374bfe1b7b1932743425d7fc5d4ab66d747e",
-   "sha256": "1kmc9vmryqnzkc1xmdkycrrakcyscg2apixff63hdcr715bljrm9"
+   "commit": "7e363dd6b0a39751e13eb76f2e9b7b13c7054a43",
+   "sha256": "0gzy2mqcdxhkg0hmxqzbjy5ihfal1s21wxd04mrikqri54sck4z5"
   },
   "stable": {
    "version": [
@@ -38073,11 +37826,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20240829,
-    247
+    20241118,
+    1711
    ],
-   "commit": "b4ef204ff80ed00b03cf8839ee29101ed867dd58",
-   "sha256": "0jjvx0p78wqxba22llvayrl9lyd4fqhb2qgbhr99r85m5ksixn73"
+   "commit": "bce236e5d2cc2fa4eae7d284ffd19ad18d46349a",
+   "sha256": "1w8ghsgi41kb08hwfcd4a5wr87aas93iyxp16ivwxj2rb4r4cc3h"
   },
   "stable": {
    "version": [
@@ -38316,38 +38069,6 @@
    ],
    "commit": "eb996eca0081b6e8bab70b2c0a86ef1c71087bf6",
    "sha256": "11y2jrwbsw4fcx77zkhj1cn2hl1zcdqy00bv3mpbcrs03jywssrk"
-  }
- },
- {
-  "ename": "evm",
-  "commit": "bbcead697f745d197459f90ee05b172e35af2411",
-  "sha256": "19l6cs5schbnph0pwhhj66gkxsswd4bmjpy79l9kxzpjf107wc03",
-  "fetcher": "github",
-  "repo": "rejeep/evm.el",
-  "unstable": {
-   "version": [
-    20141007,
-    1156
-   ],
-   "deps": [
-    "dash",
-    "f"
-   ],
-   "commit": "d0623b2355436a5fd9f7238b419782080c79196b",
-   "sha256": "0739v0m9vj70a55z0canslyqgafzys815i7a0r6bxj2f9iwq6rhb"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    2
-   ],
-   "deps": [
-    "dash",
-    "f"
-   ],
-   "commit": "d0623b2355436a5fd9f7238b419782080c79196b",
-   "sha256": "0739v0m9vj70a55z0canslyqgafzys815i7a0r6bxj2f9iwq6rhb"
   }
  },
  {
@@ -38620,8 +38341,8 @@
   "repo": "anonimitoraf/exercism.el",
   "unstable": {
    "version": [
-    20240831,
-    715
+    20241019,
+    1120
    ],
    "deps": [
     "a",
@@ -38633,8 +38354,8 @@
     "s",
     "transient"
    ],
-   "commit": "44fb97fe6e34925b13bfb1dc027a7a3f55ab145d",
-   "sha256": "0v4j84whlnf2rl5b92yg9lh4zdfnbisbpfjrcvs8hx9xg362w2zj"
+   "commit": "62c008b0e845c26f2e855969e9f87b405011a3ec",
+   "sha256": "1d56rwr8nnxfbrx3jws07jy12kl6qmla8ih4z8bbybkm508pkqyd"
   }
  },
  {
@@ -38853,11 +38574,11 @@
   "url": "https://repo.or.cz/external-dict.el.git",
   "unstable": {
    "version": [
-    20240817,
-    149
+    20241101,
+    1326
    ],
-   "commit": "0399b1c086417030f914bd26fff636dfdd55833a",
-   "sha256": "032ydp8vcl576hamq16wwmk6fl2j13yp6bimsscxjjz0lwiwsr39"
+   "commit": "3515a8d3485cede35e8cfcf791a83ce30d0f728e",
+   "sha256": "1286isnlxj5lgx7yw4m1a4k9crgc0a8in60hkcizizh3amy4jspw"
   }
  },
  {
@@ -39809,14 +39530,14 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20241010,
-    725
+    20241020,
+    1139
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "9d4f0d501e4b65210e233554ff90941adff2ebac",
-   "sha256": "0z9zhw9hijh68zfq5jdbgxijlk2vwbfzy673dvd6ngc1my4kdkvv"
+   "commit": "0b59528b738229421faf4c0b32033150902e5af4",
+   "sha256": "0sl1yq9c9yvb8vrmg4a4dd4x93ajpr3c8mbkiv4yxd4nrxy6myfp"
   },
   "stable": {
    "version": [
@@ -39906,11 +39627,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20240721,
-    1732
+    20241110,
+    2157
    ],
-   "commit": "f4bd34e1c3b14313c20af94dd34430b40c0ef35f",
-   "sha256": "1wfk3blx89afdllr47xgqz2ikfl8ya3lblrfwdydwcnbhv2jvq7w"
+   "commit": "259470b29748fdfec3d3a4f9603f3f42ddd9cc50",
+   "sha256": "0wb5hqzll4b4s2505cwnvldaxi8cp7dnhlfs2n8mq2kv5na5a7wf"
   },
   "stable": {
    "version": [
@@ -40446,8 +40167,8 @@
   "repo": "LaurenceWarne/finito.el",
   "unstable": {
    "version": [
-    20240818,
-    1003
+    20241109,
+    1535
    ],
    "deps": [
     "async",
@@ -40458,8 +40179,8 @@
     "s",
     "transient"
    ],
-   "commit": "9ad22dbf34574c5d6070724eba0d22350b347e6b",
-   "sha256": "1vigknjchsz60pg9qgx95h3xkng5yhrn118rdldsyv03725ld7h8"
+   "commit": "d5b48c426e4f236127ff256a16be0299c743271f",
+   "sha256": "1bggi8jj5dqhmd71ld4cqr81w8v5f1q1y07chjp96bwrpchbngkf"
   },
   "stable": {
    "version": [
@@ -41042,27 +40763,27 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20240930,
-    2208
+    20241018,
+    2140
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "a31aa3b8c2844829b8a2ddd0f56ad31ecfb2eb70",
-   "sha256": "0w3c7w108rgcqk0911m5s4n8l2jihzqai2bfw04y9mddxz6cc6zg"
+   "commit": "713c07b6be627fc05417d477ec6d1526ab1797fe",
+   "sha256": "01afnw8hw6k4h2xs23k41aaf3v4aqw4pzias7sy9s82bczx70ya6"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "58890e08800059550565a20dc7029e8bcccc55de",
-   "sha256": "1q5604da9b9gmg1ci5931fzwrqzkc5n5f02mcfvdk7vfhsakdlaj"
+   "commit": "713c07b6be627fc05417d477ec6d1526ab1797fe",
+   "sha256": "01afnw8hw6k4h2xs23k41aaf3v4aqw4pzias7sy9s82bczx70ya6"
   }
  },
  {
@@ -41097,21 +40818,21 @@
  },
  {
   "ename": "flim",
-  "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
-  "sha256": "0s1xjvizn3jwn9h5iq83vdmw6lgmpfk7dhvlj2ayb59q7bmf4xla",
+  "commit": "5e4ccfc8ab211349b577a06dea355ea59b3eb888",
+  "sha256": "05dm9wvchjmf32j6p4ghw32sf4q5v9icr2zf1d1kddv2b9znnywr",
   "fetcher": "github",
-  "repo": "wanderlust/flim",
+  "repo": "emacsmirror/flim",
   "unstable": {
    "version": [
-    20240221,
-    1353
+    20241125,
+    2201
    ],
    "deps": [
     "apel",
     "oauth2"
    ],
-   "commit": "23bb29d70a13cada2eaab425ef80071564586a6d",
-   "sha256": "14ihl59sj829hycbw182byk4npmrsmhcgl98j5v7i81vmxdfrcm9"
+   "commit": "4ee02945854e4dc94327aad5da2e43d85a777420",
+   "sha256": "04crqqgxwbfkfj1f3rpmbq00w6bakpg1fdv99q2l7dwjksbn35ca"
   }
  },
  {
@@ -41404,11 +41125,11 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20240726,
-    456
+    20241130,
+    1502
    ],
-   "commit": "7a6398ea3538a898eba0276f0f89b2f878325a89",
-   "sha256": "12y29m1gp0gdq8lfc2cd80869xsyasgsp4n2ck8rn4h164bnnn4q"
+   "commit": "ebaf48359b3e21879c8f6f3c1b5d0221b345035e",
+   "sha256": "1spbkhsdf7crns2wr4ghs1pdfwz2ff001pbbzmcc39v5d71pb5ri"
   },
   "stable": {
    "version": [
@@ -42614,8 +42335,8 @@
   "repo": "flycheck/flycheck-haskell",
   "unstable": {
    "version": [
-    20230706,
-    1439
+    20241119,
+    1046
    ],
    "deps": [
     "dash",
@@ -42624,8 +42345,8 @@
     "let-alist",
     "seq"
    ],
-   "commit": "b7c4861aa754220b7d0cfc05aa0895bb35665683",
-   "sha256": "0fmmzwnrrki8bw6nsspcsgzkcxmsrgfkm2200nqgk27fqppjgpgw"
+   "commit": "0977232112d02b9515e272ab85fe0eb9e07bbc50",
+   "sha256": "0sxqxskflnhx1n83knm817j5l4svx9szkfy5yzsfwm7gnn7piixs"
   },
   "stable": {
    "version": [
@@ -42700,14 +42421,14 @@
   "repo": "DamienCassou/flycheck-hledger",
   "unstable": {
    "version": [
-    20240423,
-    1307
+    20241029,
+    1710
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "77369d78c8a00cd55a3ff8b12dc99db136748a4e",
-   "sha256": "0kzfil5nyk9y1nmvz3hn5vgaycid2r34p9vx4m1j02r3y5z0amhm"
+   "commit": "66e12fce7d4875327bce06b2fc33043924c710ed",
+   "sha256": "1r3g9v5035nyp0gb7g4qjspag9cn5nf0xz1c12q3hinn21c69yna"
   },
   "stable": {
    "version": [
@@ -42997,26 +42718,26 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20240101,
-    851
+    20241018,
+    1225
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "e80a23bcdc91df09f6013b553d60a813481086ff",
-   "sha256": "1gvhmaq9ka28hvm8gv2rd8v3sk0a9w9rd1zsz2xkv1hhw5ch4hf1"
+   "commit": "03d023c78cca177901afe7223ee57a8e396dcf49",
+   "sha256": "0s11sn0qbq3g6dwrr9r476c59zmp5fya89pf71pl02jijd4a3gr4"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8f488c0d765c3d42e84612561530c5ba925e8c9b",
-   "sha256": "0zynqp7r1k3ycgrk93mkwg3ycl14gny1sspgaxb1z3gsc54ya7sv"
+   "commit": "03d023c78cca177901afe7223ee57a8e396dcf49",
+   "sha256": "0s11sn0qbq3g6dwrr9r476c59zmp5fya89pf71pl02jijd4a3gr4"
   }
  },
  {
@@ -43374,15 +43095,15 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20240527,
-    2142
+    20241107,
+    408
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "6f1c7bb357b1eb90b10a081f1831c1c548c40456",
-   "sha256": "1hnnhbma3mgbralp1f5c1gvm9pfswzf5xzi2nr22rs5d9r0zk2fj"
+   "commit": "b616f5fa5f8aff9aa220c7fe63b39df6d10588a5",
+   "sha256": "0xjr6vi158qm6rnrfvpcmh2grrlvixdd44kik333250298vc3nx3"
   },
   "stable": {
    "version": [
@@ -44243,20 +43964,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20240922,
-    1632
+    20241026,
+    2053
    ],
-   "commit": "77a4488e7d13b556db81c6b3edb40e3bca999dfa",
-   "sha256": "1wqaazggarv39ms51228xxqdycfr11880bpxg5sjh21rap95zm4p"
+   "commit": "0503a9b7ace1d0909ba5d20f9474451621c2011a",
+   "sha256": "0bfv9mpxdd767gxjgyw56h8z18gbhrjl6rqv57wc30vbc3p5frpv"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "77a4488e7d13b556db81c6b3edb40e3bca999dfa",
-   "sha256": "1wqaazggarv39ms51228xxqdycfr11880bpxg5sjh21rap95zm4p"
+   "commit": "0503a9b7ace1d0909ba5d20f9474451621c2011a",
+   "sha256": "0bfv9mpxdd767gxjgyw56h8z18gbhrjl6rqv57wc30vbc3p5frpv"
   }
  },
  {
@@ -44371,15 +44092,15 @@
   "repo": "mohkale/flymake-collection",
   "unstable": {
    "version": [
-    20240903,
-    1828
+    20241117,
+    1157
    ],
    "deps": [
     "flymake",
     "let-alist"
    ],
-   "commit": "ecc15c74630fa75e7792aa23cec79ea4afc28cc2",
-   "sha256": "1fqqjl9nd6gam790m7d3pzq162w2q7lwvk38cmh0nq9v318h8vqv"
+   "commit": "1b62fd9b5844b231cb48b4919064420d64a123ff",
+   "sha256": "0rqviv2m50f2z4kigylfpyprldi5y0hsc69ni1cc84jnwwn8x915"
   },
   "stable": {
    "version": [
@@ -45154,9 +44875,9 @@
  },
  {
   "ename": "flymake-markdownlint",
-  "commit": "0cdb9c33a827d870da79a63d3c0b923fb5b02073",
-  "sha256": "1myfk8pk02svr6506ccgs4qhcgq89jhyf91hpwvf1jfc1icr1ph6",
-  "fetcher": "github",
+  "commit": "601cff5eb7caa70232a63d497dcbfb9578fd136c",
+  "sha256": "019mrnaa81fcgpqbxpys48fphvhrcif6jcwknpbdg8354hncs6ls",
+  "fetcher": "codeberg",
   "repo": "shaohme/flymake-markdownlint",
   "unstable": {
    "version": [
@@ -45515,14 +45236,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20240721,
-    2006
+    20241016,
+    1600
    ],
    "deps": [
     "project"
    ],
-   "commit": "6405c8a8eb48f371581a05c34ac1110a3d585dd7",
-   "sha256": "0lqjqp8v6ykvpm137cj2fmdw9y3vf2h0rxv5hhls88r72qh0wsdc"
+   "commit": "17a8345f95761090d86e7c97d14f58fad77c0e29",
+   "sha256": "07lqqvpnaffc77aczg5d7p9agwhlqllj9pqiyf514bvrr4nn2jhr"
   }
  },
  {
@@ -45708,9 +45429,9 @@
  },
  {
   "ename": "flymake-yamllint",
-  "commit": "b8420c724747b635fb7cc208561e03ebca463c90",
-  "sha256": "1mkmwdv53hz4xzmb6kl74wll74zfs8wm4v5bjnp1caf8c6flvzja",
-  "fetcher": "github",
+  "commit": "601cff5eb7caa70232a63d497dcbfb9578fd136c",
+  "sha256": "0r4xndn5q973rgjdk0dq8w0lngnw31kg0vabcs1amn538gba62hb",
+  "fetcher": "codeberg",
   "repo": "shaohme/flymake-yamllint",
   "unstable": {
    "version": [
@@ -45724,10 +45445,10 @@
    "version": [
     0,
     1,
-    5
+    4
    ],
-   "commit": "0134f9f864749f30f8ea3c6a86865b35d4352cea",
-   "sha256": "00ys5k6xx3wcccj37n326749ypifc43dafjp28kmqgf218lrfng4"
+   "commit": "f269e6614993f3c56d545e7d7b225ca2ba1da342",
+   "sha256": "0pw2c22nvy4fkcqbhkrj94q66sx7ggcan26wvy9z6wp04qzaiva8"
   }
  },
  {
@@ -46046,14 +45767,14 @@
   "repo": "larstvei/Focus",
   "unstable": {
    "version": [
-    20240528,
-    901
+    20241029,
+    1506
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "17c471544f540f2cf9a05fd6cd87e52e5de317e2",
-   "sha256": "0aqcnvnla4rmpc9iy679jaw1vqqg16j2fw7m9iis7j3w0wcw5c77"
+   "commit": "29b412b209c3542a7932c201f0166e48c9fd7fee",
+   "sha256": "01h1wxmrf954azwj1kgr8yxlzrg5bri0wpd6mhjr5yr8nddcd2ix"
   },
   "stable": {
    "version": [
@@ -46361,10 +46082,10 @@
  },
  {
   "ename": "forecast",
-  "commit": "a7ea18a56370348715dec91f75adc162c800dd10",
-  "sha256": "0zng8xdficpfccq484pghzg8yylihcy8aq0vpxd1w6l40m2qf6zn",
-  "fetcher": "github",
-  "repo": "cadadr/elisp",
+  "commit": "04fdd633207a28b91f0a6e64aa25d114ab229a13",
+  "sha256": "0k8g6xwqgaw2ngwcyjyx7gdiizlcswbr3rnrx3xw50qrcbn8xmbq",
+  "fetcher": "codeberg",
+  "repo": "kutuptiyini/elisp",
   "unstable": {
    "version": [
     20191004,
@@ -46448,8 +46169,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20241014,
-    1340
+    20241201,
+    700
    ],
    "deps": [
     "closql",
@@ -46464,8 +46185,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "c819271dd056d9608e6dd7e788bb3007f0a44517",
-   "sha256": "01gvx5imldgx3mmj1glgrspvxwnp8x068d1x6k8c928ad535z60x"
+   "commit": "8f9e94949f4490273c4991b45f1ef02b9503dfcd",
+   "sha256": "02d5wxv0hnpjf83az96jz8hbldfp48za80ql0xc3ccah6s0hp7mn"
   },
   "stable": {
    "version": [
@@ -46537,15 +46258,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20241001,
-    839
+    20241126,
+    829
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "9ae47456dad2925e4d41f58bd2c864b87f82aa8b",
-   "sha256": "17ighxn3nk6i6k03hdri572z5d1dv7jbvcbhyib3p48clvqki0qb"
+   "commit": "fd9c013f5f8094fef99ddabde07d9041737b8454",
+   "sha256": "17cdnncilrqwa4x72vzbcpgx24d8zi9ng3fdpv89ffwbx5s4ny0r"
   },
   "stable": {
    "version": [
@@ -46685,14 +46406,14 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20240914,
-    535
+    20241106,
+    219
    ],
    "deps": [
     "seq"
    ],
-   "commit": "c809fe6f44ef765cae2a33124705b41febb80f6e",
-   "sha256": "0qxzs5ph0ajq9fnf5ac0q8nx56kmx1dalv1pi1fgnby73k44fl10"
+   "commit": "74ddc5a783e8204beeda3343ea6725a3c198f4bc",
+   "sha256": "1rbhcnn6cdxdhalhy3nw9s4m6adrqz1c6v0aljd0wq9bs56b1w89"
   },
   "stable": {
    "version": [
@@ -46838,15 +46559,15 @@
   "repo": "davidshepherd7/frames-only-mode",
   "unstable": {
    "version": [
-    20240716,
-    706
+    20241201,
+    1533
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "057462df122e588dceef472023343dee3315ceea",
-   "sha256": "00cirlblx28q5b6691l93v9ay8ry1gl4v2sxzn1r61d9ni8ig7c5"
+   "commit": "9c82e779d89ead844ebd0e1a008af413e4cfc185",
+   "sha256": "0brbrhd6anz3lcigic695011s2yqmyni4n06ap3bkls8y49iis9i"
   },
   "stable": {
    "version": [
@@ -47533,25 +47254,26 @@
   "repo": "jojojames/fussy",
   "unstable": {
    "version": [
-    20240607,
-    2153
-   ],
-   "deps": [
-    "flx"
-   ],
-   "commit": "21f4ac6b971f61890d46308d7ac5db64c20228e6",
-   "sha256": "0skjr9pqjbr4am3cdq78frf5bckpv5761j0ppp0pg6pfbrcdbaa3"
-  },
-  "stable": {
-   "version": [
-    1,
+    20241202,
     6
    ],
    "deps": [
+    "compat",
     "flx"
    ],
-   "commit": "27baf4c5bd7c38876f8c408628e4a8d966849cd1",
-   "sha256": "1ysi6mbcsjm4z2s66ads0g41gp2gyhqnajiw5bpl258y7pcj4ml2"
+   "commit": "5c8165619f4c94f7f620df69ab67d7d5bcd15501",
+   "sha256": "1vcqf3pjmhqfsppjvdx0lzqxzr1kia5b21ypdhqxx3b8splg86si"
+  },
+  "stable": {
+   "version": [
+    2,
+    0
+   ],
+   "deps": [
+    "flx"
+   ],
+   "commit": "cd2c93b9b5fd0fe6c61fcc6e1d62b4c1cbb142aa",
+   "sha256": "11i6228xbw4g8ks2z073lzdrsmyilppr1dbcg91r9y267ppl1ijw"
   }
  },
  {
@@ -47562,15 +47284,15 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20241003,
-    1821
+    20241120,
+    854
    ],
    "deps": [
     "cl-lib",
     "reformatter"
    ],
-   "commit": "54246aa75867d72648effd9cbb8d8b41a4d448e4",
-   "sha256": "0pkvg0l2a27kz8xwc8lx9lv16ivjda5d94xw017km6whrh94q925"
+   "commit": "a9cb4ee550d1ae14a7274d4e0c9bb6a2dff17c5a",
+   "sha256": "0kl8xcg5lp26cx5r8ikprzw2py7d0s4gibfkn525fnx94fdqcswr"
   }
  },
  {
@@ -47807,11 +47529,11 @@
   "repo": "ShiroTakeda/gams-mode",
   "unstable": {
    "version": [
-    20240709,
-    410
+    20241024,
+    448
    ],
-   "commit": "6fb90d9c83747ac020743cd7a8c2efda0c5936eb",
-   "sha256": "09ldm491m1zf47x6gwdylilc5slcwzsbl498axlpzy723ysf916y"
+   "commit": "0bbce5fd884960f7d797dbae4d2b27b0c6dc2241",
+   "sha256": "09xh3ymx7agh4vg46dkmyzhkh2ck9a464gg57r3vf4qn343jbv73"
   },
   "stable": {
    "version": [
@@ -47929,11 +47651,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20240509,
-    1523
+    20241104,
+    821
    ],
-   "commit": "32086df83335ce0e5120b21b80cf7996edb2232e",
-   "sha256": "1w4bkqg17abxzpcb4w5askspps6zcq503544qnj1j97fmc2zmvha"
+   "commit": "bee7f99c6f780497ec112bf01196181fc83511c8",
+   "sha256": "0808lgdca1vpsj1rwyvqcxrqiq60z9ww5yjsrg7fg28c9vba44b2"
   },
   "stable": {
    "version": [
@@ -48415,11 +48137,11 @@
   "repo": "arjca/gemtext-mode.el",
   "unstable": {
    "version": [
-    20231029,
-    2010
+    20241129,
+    820
    ],
-   "commit": "431b3b1d7c4310ef09ba16adbc870bc0af2c0e9b",
-   "sha256": "1zizjq3cx5y7mdgapm2kzc4bs13fcg55nay996350ha986isa834"
+   "commit": "9e6a7373759afbb8b05e322a3c7b52fc9255c16c",
+   "sha256": "0balbk2rj33v6m2gicrgsfkg2iflk5jq38wn4hgrz9disvrybwa7"
   }
  },
  {
@@ -48585,16 +48307,16 @@
   "repo": "twmr/gerrit.el",
   "unstable": {
    "version": [
-    20240306,
-    1947
+    20241014,
+    1940
    ],
    "deps": [
     "dash",
     "magit",
     "s"
    ],
-   "commit": "8a98747155712d751239e5699e3a6fd090848b33",
-   "sha256": "1l02fm864j7ml8anm9ykf9yd5x8r12zrn2p4psadxpzkqa5r5zg0"
+   "commit": "58e5bbe1485cb15c02b74c327fac6a533e8663da",
+   "sha256": "1v2akprnfmc89iq68aprydgb28lrj497jm8bgmkf8cwljf4x1kh5"
   }
  },
  {
@@ -48893,16 +48615,16 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20241001,
-    1025
+    20241123,
+    2135
    ],
    "deps": [
     "compat",
     "let-alist",
     "treepy"
    ],
-   "commit": "23d1cd6b089db6619d02d66957c6a274311abd60",
-   "sha256": "1p5lx781z603q943p73p6q9k6qz75ldjwrr9z3h6zvi80gxd7afy"
+   "commit": "4f39b86544ab064204efd0dda381af90fae70f43",
+   "sha256": "1dxcm82q23djj51ic7j2702jyaygwganrsrcd3fpvg2nw3r5gz7i"
   },
   "stable": {
    "version": [
@@ -49252,15 +48974,15 @@
   "repo": "liuyinz/git-cliff.el",
   "unstable": {
    "version": [
-    20240915,
-    1127
+    20241029,
+    358
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "ca71436f8cdbdd37d07f91c94231234d3fc9c8b4",
-   "sha256": "09zla0cblyg4am6d5g4h6s8l24f6z94k8zp34x1yy5ygxkw2xf7r"
+   "commit": "7b73709928770959ef731192726ade76f85da877",
+   "sha256": "0225n41dcqm53c4nl0m9a17zg63gnqf90cfhp777vjdfry0mxsfl"
   },
   "stable": {
    "version": [
@@ -49327,10 +49049,10 @@
    "version": [
     4,
     1,
-    1
+    2
    ],
-   "commit": "93e86ceca7bf5b0ff9023d7f138e5f06990fc276",
-   "sha256": "1ckjq068728wwfm4fv0z4rrdmrj09zvarip2s5rqdr8ny722dxfn"
+   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
+   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
   }
  },
  {
@@ -49649,11 +49371,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20240923,
-    2245
+    20241022,
+    2208
    ],
-   "commit": "2107af13e15fab4e42f52844af080e4485ea5470",
-   "sha256": "0ybfwg7d4dqzilw4ka5i1zggzq4zhnpdpa2a7mn3mq3l8rdzkr0p"
+   "commit": "8df5f1f0a70c0668bafb1b70421b651df3bde999",
+   "sha256": "0fy0v3w7w23ch9z9bkjg7ssplgb5v8vng73c1xd2csja8kfkcirv"
   },
   "stable": {
    "version": [
@@ -49790,14 +49512,14 @@
   "repo": "pidu/git-timemachine",
   "unstable": {
    "version": [
-    20240427,
-    924
+    20241125,
+    750
    ],
    "deps": [
     "transient"
    ],
-   "commit": "3780835fcd67c3703ffa768206121851e6895ece",
-   "sha256": "1r2cjz0x30myy9hzbv5iwmq0j9n490rnv6pxfvb00g2kcbvknyna"
+   "commit": "62ebb0c6588d848b1b7b90bf1a3aa4c04e873822",
+   "sha256": "0bc742ifxwc70l5xbddybyz9ck7il4kx4y6abdv2dvg7bjqnangz"
   },
   "stable": {
    "version": [
@@ -50340,14 +50062,14 @@
   "repo": "TxGVNN/gitlab-pipeline",
   "unstable": {
    "version": [
-    20241008,
-    316
+    20241101,
+    356
    ],
    "deps": [
     "ghub"
    ],
-   "commit": "3f60765ecb1d02f08f2cb5cde45216748a738140",
-   "sha256": "1vggqy28ggqpcl0bkm59y0rflb1wsbbvnkb8g65qy8akvif6mm5l"
+   "commit": "9f6e7a1523b6ac63214a9d71b269360ebd0fa30e",
+   "sha256": "00r9k7gb3k7hl9lnwikljgcgw2hi9kdpsl211p27h0asrlglgyaf"
   },
   "stable": {
    "version": [
@@ -50616,11 +50338,11 @@
   "repo": "jimhourihan/glsl-mode",
   "unstable": {
    "version": [
-    20210808,
-    1945
+    20241021,
+    919
    ],
-   "commit": "9b2e5f28e489a1f73c4aed734105618ac0dc0c43",
-   "sha256": "101y46bdxxgp58li66pwqn6c3skww72gkfmhxpps2v2ijxcvqkl9"
+   "commit": "c5f2c2e7edf8a647eda74abe2cdf73fa6f62ebd2",
+   "sha256": "1ilx7zgkbnsxlq3np6yli7d6r09hww455kl9lsydpr448mqqifkm"
   }
  },
  {
@@ -50826,30 +50548,30 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20241009,
-    1607
+    20241115,
+    1041
    ],
    "deps": [
     "compat",
     "emacsql",
     "transient"
    ],
-   "commit": "505ce5cff58923acec6e83351042f2b1d150f65c",
-   "sha256": "15x7ny693ch8bsdjlf3mg2apvkyf9r49d7kv9qz3zdg574cnh0pf"
+   "commit": "eefd0abb3cb7ca8a09c249686ff67555724624da",
+   "sha256": "1g6a5vr5cqnjf15idzqnh6p377dia3bz8x260kiyf157n3h11ms8"
   },
   "stable": {
    "version": [
     0,
     4,
-    4
+    8
    ],
    "deps": [
     "compat",
     "emacsql",
     "transient"
    ],
-   "commit": "4f437a3b23090d2591eb36a26c146ff3595a6256",
-   "sha256": "1fmfhmsfkw3rhbgrwj59p0z8jfjyplprfb7rzdg19qwv4km680iq"
+   "commit": "b30a06fc16c18b6de7d5a21facf2b5fd8d90b613",
+   "sha256": "1y9f5ms7aivwjfc951m68jfmwncfq5f4h876xvivxhfph4xnc76y"
   }
  },
  {
@@ -52384,8 +52106,8 @@
   "stable": {
    "version": [
     0,
-    44,
-    1
+    46,
+    2
    ],
    "deps": [
     "dash",
@@ -52393,8 +52115,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "8234db495a8d1a3362d328e30c8ea084ff5bf698",
-   "sha256": "12a6x2cgq9p0j1s1wyf6lyqnmc396v0y6rxilkab0snkzbrqqmff"
+   "commit": "c3916ff7728451023ce84c2eaf726b1d23e623b6",
+   "sha256": "1jr9zwknxbz7f4vlnfjzzslzxy05m24x857rsh4aj9mnwawdppc3"
   }
  },
  {
@@ -52444,11 +52166,11 @@
   "repo": "brownts/gpr-ts-mode",
   "unstable": {
    "version": [
-    20240404,
-    1258
+    20241127,
+    2221
    ],
-   "commit": "a92ab100759cddb51d042adf109f1831a57dbff8",
-   "sha256": "0ijyn9x6i47h9rxnfj51mhkd8qh5mippnnbbh8h388wsbgkj470s"
+   "commit": "2f23e4ca2225c614314b4d66ab5312dd9cfdd419",
+   "sha256": "01hdip8ivldz00r3ci96zz5m2i2jc18272bx4riy7gn08sw5cdxs"
   }
  },
  {
@@ -52477,11 +52199,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20240721,
-    1747
+    20241020,
+    1841
    ],
-   "commit": "06afbecccac8bf0d7a47b4c1b768a74ed66c5e84",
-   "sha256": "0jnaafsnridafqwndgjkp980pnz0lm4nrw2fqnhx15pzqz1w2v34"
+   "commit": "3f3d0c4c1f2d5460ed3296a63c7938c5040aaa8e",
+   "sha256": "1prb83vwr16jya920lbbd6pfk9xbdm6fh81s30j3jqyin3vpjkhq"
   }
  },
  {
@@ -52548,28 +52270,28 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20241013,
-    1957
+    20241130,
+    1959
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "25c39a03771a8b2f71d7026fe06f0f5f21e29a9c",
-   "sha256": "1s23cn069j40abv6kl2qgl09zwjp72d43izkisg6zqjvzcdgqvwx"
+   "commit": "7934106b74ce60fd5782e840c7efc4f0bbdbc646",
+   "sha256": "1rmfaymci96pf0qmy12cpgsyly04jzy93apa7bdjjnj017pshsyx"
   },
   "stable": {
    "version": [
     0,
     9,
-    5
+    6
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "37ca1069326aefc54bdb1722fcac1e81f90b2ff3",
-   "sha256": "1ihcdxpwqawvrb1l8l8lnj20gn8m5z47q2fmpvzwdqbjd0nl2xnp"
+   "commit": "f24e5ad4740ce5f9829b14e499c9181f9bd7c76e",
+   "sha256": "0cb5wxlc598fs1cmjvkbc76x098ljmik3s39hjfjzn6537yps4da"
   }
  },
  {
@@ -53043,15 +52765,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20240921,
-    1919
+    20241025,
+    1237
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "e163aec6109ba24ec543f087d9be7bf6b6efa389",
-   "sha256": "054jlv1vrb7wbhr0w97xirjwp42mx0k07j7f0383jxsjn08qik5g"
+   "commit": "0977a4aea839a6f3907d5475baf4012151a4e556",
+   "sha256": "1jhscp9q5b9qdg9b6k5vypgmnj7hgflx6a68v7b5pg0qj2rxxk8p"
   }
  },
  {
@@ -53200,10 +52922,10 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20240820,
-    825
+    20241111,
+    936
    ],
-   "commit": "9adac9c98902e42d73a64788b69f2c07e21f7851",
+   "commit": "d6c7e33e40d10b529b059ea1d237161dc3e88428",
    "sha256": "0918ycvbfv5ckmgvjn413v39bz7948f03sjqw6wzcha88hgdizv6"
   },
   "stable": {
@@ -53932,11 +53654,11 @@
   "repo": "idlip/haki",
   "unstable": {
    "version": [
-    20241007,
-    1441
+    20241118,
+    1802
    ],
-   "commit": "9d5771e23140b02101b8d6c410b56143df3d7756",
-   "sha256": "1v2zx6mkdkpc42snqrrdh64h782kdlzarc49790m4gb7lp5a9s47"
+   "commit": "3b13b5dd594d6cc5798117f216b266d86f1ffa16",
+   "sha256": "19wk54k2z0s073yk84f1wq76a28srqd9wsh1qhs8sr26vjldg24y"
   }
  },
  {
@@ -54422,11 +54144,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20240911,
-    1020
+    20241111,
+    1514
    ],
-   "commit": "cf387f92b160ee87ce3e247542558d1b6ed84b3c",
-   "sha256": "0671fxy312cx1sqgpjy6p63q0l5n3ia829xg1d6l08i4cwxjbkz6"
+   "commit": "1a285fc4c50ca74bb5cd9b2a8c1a46a64a77384a",
+   "sha256": "13z6bvhg8lflk0y42x5pjdfkxyy8nvd2xxx6jbfydwq4a87n3gbi"
   },
   "stable": {
    "version": [
@@ -54764,15 +54486,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20240929,
-    416
+    20241130,
+    526
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "c0fd64b5491576853ecad9337996b38743effeee",
-   "sha256": "102s2gzcnrv73xa7xsj3i5caja1w6zmcazg6vv0k9ww0c6hjqihl"
+   "commit": "3ca35edd5a5e8f1bee1b03facbbf44df8c729e3f",
+   "sha256": "00xfzw7nvas0x68s9q4s3k737jgrganqyizvr10pybqjyhzlllzm"
   },
   "stable": {
    "version": [
@@ -54864,14 +54586,14 @@
   "repo": "emacsorphanage/helm-ag",
   "unstable": {
    "version": [
-    20240925,
-    744
+    20241028,
+    144
    ],
    "deps": [
     "helm"
    ],
-   "commit": "c9d514c5c0a7283f730d237f7ae69b96736c7c9e",
-   "sha256": "0cf3r6bqmbgkp6a9g5nbmzv1m3l0hka1599kri23fi3s2k88c70h"
+   "commit": "01d36d6eb689305ea3aae0a23aa8be0029f0410f",
+   "sha256": "1fipr4vaafsvkkypj3qlyigq2dqiy1jgkm99djzv0378g7mk25k8"
   },
   "stable": {
    "version": [
@@ -55653,14 +55375,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20240929,
-    353
+    20241201,
+    648
    ],
    "deps": [
     "async"
    ],
-   "commit": "77c1663455c77f2e3a407414db37e06ea1d4cf33",
-   "sha256": "1lhid932hnwwnj2ahrzms6iz92sp2idg748v1z770pqh55in040q"
+   "commit": "05c2a8262fb47762bbd7112b8149578b02d4e44e",
+   "sha256": "06x4xlbq63h4mjr3hcbp9kdaz0xhzlph2z5knhmglny6riqqilyz"
   },
   "stable": {
    "version": [
@@ -57112,26 +56834,6 @@
   }
  },
  {
-  "ename": "helm-lean",
-  "commit": "0bad7f91094d96d387bf0b121d6223afdc0f236c",
-  "sha256": "0aszjrv08n8lzpzsj694kldnmmx9b9qh9xmwnb6d7qxygzmbw1dj",
-  "fetcher": "github",
-  "repo": "leanprover/lean3-mode",
-  "unstable": {
-   "version": [
-    20210305,
-    1705
-   ],
-   "deps": [
-    "dash",
-    "helm",
-    "lean-mode"
-   ],
-   "commit": "5c50338ac149ca5225fc737be291db1f63c45f1d",
-   "sha256": "13vrg0pp7ca0lh4j9cyg4pgfnbvf2kvbrgvvcmn1h7l9py2n8alj"
-  }
- },
- {
   "ename": "helm-lib-babel",
   "commit": "d6718da5d8849a8c3ec17188b89a1273cf963047",
   "sha256": "0ddj6xrhz4n0npplkjmblqb43jnd6fmr4i4vv1cigrgb7zj6bjx4",
@@ -57287,29 +56989,29 @@
   "repo": "emacs-lsp/helm-lsp",
   "unstable": {
    "version": [
-    20210419,
-    2014
+    20241118,
+    1931
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "c2c6974dadfac459b1a69a1217441283874cea92",
-   "sha256": "0xpz9qrcbxknnncqf0hw7hs9k6sv9dckzsf081k2zmsks3l5qh4p"
+   "commit": "e740efb2abbc0ffd43f6dbcdb4527bc55723b842",
+   "sha256": "0cmxdd3fgyiixg81zmxa0j68slhkq8rg5z840cx4dbb3j9w06yd1"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "5c960e7800dc8f4432f3a1466a637d484b87dc35",
-   "sha256": "1vq3qpqm3ndqyvf5bk8qhqcr60x9ykc0ipk2a43rr3yjm4z1b6s9"
+   "commit": "e740efb2abbc0ffd43f6dbcdb4527bc55723b842",
+   "sha256": "0cmxdd3fgyiixg81zmxa0j68slhkq8rg5z840cx4dbb3j9w06yd1"
   }
  },
  {
@@ -57510,10 +57212,10 @@
  },
  {
   "ename": "helm-nixos-options",
-  "commit": "6846c7d86e70a9dd8300b89b61435aa7e146be96",
-  "sha256": "1nsi4hfw53iwn29fp33dkri1c6w8kdyn4sa0yn2fi6144ilmq933",
+  "commit": "7f298cdc6773f3aeb7baf9c6a32c97d2b60f55a3",
+  "sha256": "0657p0wlzdcjj3al32d20ysjp3visxs1198l0fhy4g0dc0am3lzw",
   "fetcher": "github",
-  "repo": "travisbhartwell/nix-emacs",
+  "repo": "nix-community/nix-emacs",
   "unstable": {
    "version": [
     20151013,
@@ -57693,7 +57395,7 @@
    "version": [
     0,
     8,
-    9
+    10
    ],
    "deps": [
     "dash",
@@ -57701,8 +57403,8 @@
     "org-ql",
     "s"
    ],
-   "commit": "81281350d44a3903a0866431342299f5f3c74beb",
-   "sha256": "1mw07y82r3b9brphx2j8gj95rbs4632fgq0b79824zqpwm8m291j"
+   "commit": "9c53c1bddfcbda3475ffd8810f012be6de07d963",
+   "sha256": "043m90flbmmcaiv1n5lfw6pd5hr978r9kqbhy34rgyzm0k34sk72"
   }
  },
  {
@@ -59834,30 +59536,6 @@
   }
  },
  {
-  "ename": "hierarchy",
-  "commit": "7aea238a2d14e9f58c0474251984b6c617b6854d",
-  "sha256": "0fh1a590pdq21b4mwh9wrfsmm2lw2faw18r35cdzy8fgyf89yimp",
-  "fetcher": "github",
-  "repo": "DamienCassou/hierarchy",
-  "unstable": {
-   "version": [
-    20190425,
-    842
-   ],
-   "commit": "a5bc6bf2e1bbd48cc17c508043134f24abb41944",
-   "sha256": "18y5xj8j07hca7qk5ygxqpiybv58qf4c85hqw52a59fkn0vvdbhg"
-  },
-  "stable": {
-   "version": [
-    0,
-    7,
-    0
-   ],
-   "commit": "4ab1372c252847c316f8978a81e2fe92ff79579e",
-   "sha256": "1kykbb1sil5cycfa5aj8dhsxc5yrx1641i2np5kwdjid6ahdlz5r"
-  }
- },
- {
   "ename": "highlight",
   "commit": "38433e95f73ab20f27254a084d0b245c6e62d882",
   "sha256": "0ik2kci2y404zzvs78h74v21ssgi6f0jdzzbq45fhdhjra02kzzz",
@@ -60304,26 +59982,26 @@
   "repo": "mihaimaruseac/hindent",
   "unstable": {
    "version": [
-    20240907,
-    1847
+    20241128,
+    1601
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3295a2f0b6d3b98255a82c11c329c5f5275a6ae1",
-   "sha256": "0c2z2sfr42fj35w7yw4flq34r6kd0zn7p5m44hx2mn90y0jbvql1"
+   "commit": "beafb2610fb9a724bdd78339375e6673d46c23fe",
+   "sha256": "1hx0sj5afy0glxr3lfr6hvnk0iphmfnfg3wilx2s013a5v0drmxc"
   },
   "stable": {
    "version": [
     6,
     2,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3295a2f0b6d3b98255a82c11c329c5f5275a6ae1",
-   "sha256": "0c2z2sfr42fj35w7yw4flq34r6kd0zn7p5m44hx2mn90y0jbvql1"
+   "commit": "beafb2610fb9a724bdd78339375e6673d46c23fe",
+   "sha256": "1hx0sj5afy0glxr3lfr6hvnk0iphmfnfg3wilx2s013a5v0drmxc"
   }
  },
  {
@@ -60722,16 +60400,16 @@
   "repo": "thanhvg/emacs-hnreader",
   "unstable": {
    "version": [
-    20221117,
-    650
+    20241109,
+    1931
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "8444e177035e236e991f9ea73074c053a45426ad",
-   "sha256": "0v49fvc3phvff2scwlvjdy98y91dmkywij9dl8j95i5iahksq2fp"
+   "commit": "b422628a272d7672cc2c7dfcef1c8bf06371afd5",
+   "sha256": "1zi7v0bkssl8pv6hgpgkyww1645zxpwr8s2rxw5yw8ddxm5b7zzr"
   }
  },
  {
@@ -60898,11 +60576,19 @@
   "repo": "axelf4/hotfuzz",
   "unstable": {
    "version": [
-    20240907,
-    1735
+    20241125,
+    2036
    ],
-   "commit": "e41827ef0226de7874e60b2f6c7ceb13116cd4ee",
-   "sha256": "06vhls7yz7gnzvmplvla5l697bj3r9rhn4aa9h0sm2whny5vzhs5"
+   "commit": "cb0ce382d98cbc35ea55f4533b3c321119ed18b7",
+   "sha256": "04x9dy4nhg6zvs0h4zsbp1vbbm58capnpsc995gnr78gqxlya9vk"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "cb0ce382d98cbc35ea55f4533b3c321119ed18b7",
+   "sha256": "04x9dy4nhg6zvs0h4zsbp1vbbm58capnpsc995gnr78gqxlya9vk"
   }
  },
  {
@@ -61010,14 +60696,14 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20241014,
-    1050
+    20241018,
+    1153
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "280eead4fffdc2ef78aee4fcb522f24a3f1f4dec",
-   "sha256": "00w8dnszispfv1y7zqggmjfn2xhmn0fls1gdx8gx7vhkyjyzpvqr"
+   "commit": "f7c0b6a71a7dcc97a4ba15295373c3d627ab9a6c",
+   "sha256": "0sl1fzkf29qb7m9m523rzrv5w90f2vhyhw71n7ir844jwlwmhpga"
   },
   "stable": {
    "version": [
@@ -61336,11 +61022,11 @@
   "repo": "pnor/huecycle",
   "unstable": {
    "version": [
-    20240614,
-    49
+    20241129,
+    1717
    ],
-   "commit": "8f3e8641f950072ebf4bb03afd49b87aad147ad9",
-   "sha256": "0v5d96sgfmglm4q2gi676ardkigdqws5k5cwcg8bk72cc2b35di1"
+   "commit": "60eed50ffe83e2e139c8a675ff8e53cf94c8a1ee",
+   "sha256": "1n9n39h3i4nq3664d5b92zp0cycqs833sjbi5rrjf5kfp5ffcs5c"
   },
   "stable": {
    "version": [
@@ -61637,11 +61323,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20241008,
-    514
+    20241126,
+    917
    ],
-   "commit": "a8d5eaae30162e61dc854c904f831a83fcd4da8a",
-   "sha256": "041sx0qliacn9lwa8iwsxzvb3ya9jhqjxs44f4nv65dvrjm91ll4"
+   "commit": "e2749c6348f4783c5175b225e0f964d23c1ccc1f",
+   "sha256": "1rnf3kdwwhhpzcmlix8795zcrlkzhsy31l73pgmvr2fpd36agrli"
   },
   "stable": {
    "version": [
@@ -61661,8 +61347,8 @@
   "repo": "ushin/hyperdrive.el",
   "unstable": {
    "version": [
-    20241012,
-    2253
+    20241101,
+    2353
    ],
    "deps": [
     "compat",
@@ -61673,8 +61359,8 @@
     "taxy-magit-section",
     "transient"
    ],
-   "commit": "640585f58623e9e1f00f36055b7ec247aaff64e0",
-   "sha256": "16yzpndf8fdhljg47gs1c8037w4sw5a2p27vrbzm4j5iz3c2ivdq"
+   "commit": "581752cad8bcd701c863b08a779e4ca982325cae",
+   "sha256": "0f6h20jq10b1drad7j3m7k47l6ddphm2s8fc2sc1cjlbhzn5q70j"
   },
   "stable": {
    "version": [
@@ -61693,6 +61379,38 @@
    ],
    "commit": "6b70954da945664ca798bf483f1d60e9d5859409",
    "sha256": "1banr2v1gp9ng7ls32w5yavsb2mks7pazp9pn27570329nl40cy7"
+  }
+ },
+ {
+  "ename": "hyperdrive-org-transclusion",
+  "commit": "929e1d7654b2f927363c595a9636ed98eb1c9332",
+  "sha256": "1icd35spamkbbbyf12vafjcwy99j01zszgd5igaa21h7bl9bkhkk",
+  "fetcher": "sourcehut",
+  "repo": "ushin/hyperdrive-org-transclusion",
+  "unstable": {
+   "version": [
+    20241028,
+    427
+   ],
+   "deps": [
+    "hyperdrive",
+    "org-transclusion"
+   ],
+   "commit": "252e2df3fe7a07a122a365a637c47a43b26e179c",
+   "sha256": "1abay7xrwnfv19ap45spynd95qhyrm36fc29yrwdx0byhhbchd1h"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "deps": [
+    "hyperdrive",
+    "org-transclusion"
+   ],
+   "commit": "25570c6e4b90dce0858b80b7f557db19744b3955",
+   "sha256": "0b393icpm0fpsnl7s934dswmzi25zj226x2n32wm4gmz0dasai4i"
   }
  },
  {
@@ -61802,14 +61520,14 @@
   "repo": "zzkt/i-ching",
   "unstable": {
    "version": [
-    20240729,
-    1054
+    20241113,
+    1642
    ],
    "deps": [
     "request"
    ],
-   "commit": "0870cb1fa5bca0b7848e3f4e902e6d58445eab09",
-   "sha256": "19prq2kmzk33i2w4bargls7zad41rvmdflbw7f1gyz4lyh7spgzg"
+   "commit": "e4339cb64a97e0d04a4cb8e7183aeec4e4ae6a29",
+   "sha256": "08827zq4jni4bxlmjq24nbj6k2q07ks6mb47xfs2bp8hjqb0m07f"
   }
  },
  {
@@ -61835,11 +61553,11 @@
   "repo": "Stebalien/i3bar.el",
   "unstable": {
    "version": [
-    20230724,
-    305
+    20241025,
+    1417
    ],
-   "commit": "82efd5c87a3b3e9bcb5257c0a678f861f24e477e",
-   "sha256": "15wqx8jhms9w22v9jdc2c3lshbaqfm0192qmckygjh86iyjqv041"
+   "commit": "2e8df32559bad0a77ef87daa13d0740c5328a50a",
+   "sha256": "0sa08gp39cjmdac11mp7ckwm3igy61bfiybrghqdkdh8sm1by5ih"
   }
  },
  {
@@ -62069,14 +61787,14 @@
   "repo": "purcell/ibuffer-vc",
   "unstable": {
    "version": [
-    20230817,
-    606
+    20241106,
+    1518
    ],
    "deps": [
     "seq"
    ],
-   "commit": "1388d2ea18287c74a79d053619dbdfa9090c26a2",
-   "sha256": "0mnxh6annmys4h1xhc2c7l7ajp4pwvdg68n30x7a21ad9qlvizil"
+   "commit": "890c692da9348ef071a4b27940082a4dad05b27c",
+   "sha256": "1xqwvid17wgr850zhh6n5ihnayai87363kkmhmminicci2bp6sjw"
   },
   "stable": {
    "version": [
@@ -62128,11 +61846,11 @@
   "repo": "CeleritasCelery/icl-mode",
   "unstable": {
    "version": [
-    20221003,
-    2316
+    20241030,
+    1743
    ],
-   "commit": "1ef19c3c1c7f2667796907391d5337bbc2d73df3",
-   "sha256": "0jzly3l4a6769ins869chb752297p4702xcbxq8qx96wdigipsdz"
+   "commit": "9cc7fbb7f290fd8c63795765cf309e8a57a49b14",
+   "sha256": "10b3wk136mzzgwwy95y6bbizxczl7hijj41ycp2nvx1fwg1gb36d"
   }
  },
  {
@@ -62803,28 +62521,28 @@
   "repo": "KarimAziev/igist",
   "unstable": {
    "version": [
-    20240713,
-    920
+    20241108,
+    1947
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "b3d6d3d95d0a394e19b3068e3ff553009b498fbc",
-   "sha256": "0byfi9ksms0hdzqx51qmv6as9bhjfmf5l0mpp48lcz0b0mbj542z"
+   "commit": "13193a29544dc50a442a1a336e5d82c50f6663c0",
+   "sha256": "1pznh051rpwzpydgxw2j8ky36iqb5azb50p0zz0azrf134k8dcav"
   },
   "stable": {
    "version": [
     1,
     6,
-    3
+    4
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "b3d6d3d95d0a394e19b3068e3ff553009b498fbc",
-   "sha256": "0byfi9ksms0hdzqx51qmv6as9bhjfmf5l0mpp48lcz0b0mbj542z"
+   "commit": "13193a29544dc50a442a1a336e5d82c50f6663c0",
+   "sha256": "1pznh051rpwzpydgxw2j8ky36iqb5azb50p0zz0azrf134k8dcav"
   }
  },
  {
@@ -63165,6 +62883,30 @@
    ],
    "commit": "a524a46263835aa474f908827ebab4e8fa586001",
    "sha256": "1fhhpz29x9vkhzms2qkxblic96kqzg0rqsxj71vgz6fpwdb4f9gy"
+  }
+ },
+ {
+  "ename": "imgur",
+  "commit": "a68ccf73c00cedbe00eb5c252b007754d0cfe6d5",
+  "sha256": "0qiv4hzkq43f2ks70w7wqxvfr55bfrkm69izvpm565shdd25gvvk",
+  "fetcher": "github",
+  "repo": "KeyWeeUsr/imgur",
+  "unstable": {
+   "version": [
+    20241201,
+    1257
+   ],
+   "commit": "9a7f47d6da3f6a7365f8575c0403f05398ad05c5",
+   "sha256": "0m117q2jr2hfah23isaz0jsawyzrrqhmvyiv7w6aycr2hhhx76g1"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "3eb96d58909c5c62613ee57495bdfe7e92d0c4b7",
+   "sha256": "0imi8b6gc3wrw0h1ligqfkzm7drlpmrmmahl3l4gds9s2l7lwy07"
   }
  },
  {
@@ -64008,11 +63750,11 @@
   "repo": "purcell/inheritenv",
   "unstable": {
    "version": [
-    20230804,
-    651
+    20241119,
+    1355
    ],
-   "commit": "00106bb208d06e5f1ec25d0c2f41c000cbb25076",
-   "sha256": "04na9m3z3k94jjqcqps95xcmvjklnddhli2xaac16m4ackw2wv9b"
+   "commit": "b9e67cc20c069539698a9ac54d0e6cc11e616c6f",
+   "sha256": "0ghd8iy9g2h8pw3drrxhwdswam8xiwkq59wrqhr38famxawkncxb"
   },
   "stable": {
    "version": [
@@ -64021,6 +63763,30 @@
    ],
    "commit": "00106bb208d06e5f1ec25d0c2f41c000cbb25076",
    "sha256": "04na9m3z3k94jjqcqps95xcmvjklnddhli2xaac16m4ackw2wv9b"
+  }
+ },
+ {
+  "ename": "inhibit-mouse",
+  "commit": "f1945a7004f8bbe4043a8579b16e1147f19d7623",
+  "sha256": "0wyg2yd4yycdq1dssqfgwjwxlap4gf7mgbs8bdgm22ycdy71izc7",
+  "fetcher": "github",
+  "repo": "jamescherti/inhibit-mouse.el",
+  "unstable": {
+   "version": [
+    20241114,
+    1902
+   ],
+   "commit": "ce8180dd631d4aadd8b3c434ecbb77c2f5e31012",
+   "sha256": "0nmwx9nckq4gn3nxsf3gpqmk5cyvgy8lhr89gzvl12070npy8r4z"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "ce8180dd631d4aadd8b3c434ecbb77c2f5e31012",
+   "sha256": "0nmwx9nckq4gn3nxsf3gpqmk5cyvgy8lhr89gzvl12070npy8r4z"
   }
  },
  {
@@ -64266,11 +64032,11 @@
   "repo": "nverno/inputrc-mode",
   "unstable": {
    "version": [
-    20240908,
-    414
+    20241109,
+    10
    ],
-   "commit": "e174b20ed043f4b0218e284b92a77bcfa1762aab",
-   "sha256": "1cizy2k71cyj3vyhx64h3108iziy01lq8jbl7krmzsswalbw98yg"
+   "commit": "2ccf09ae19f3cbb2b8c35dcd54ed333d688fffae",
+   "sha256": "1c60cci5099wx8r6b4sh0czhg6blbj4yvjlc08wyqiabfi2vprcd"
   }
  },
  {
@@ -64677,11 +64443,11 @@
   "repo": "BriansEmacs/insert-pair-edit.el",
   "unstable": {
    "version": [
-    20240428,
-    852
+    20241018,
+    749
    ],
-   "commit": "98a7dd345c20db85a5477272148d6fb7801ac651",
-   "sha256": "0wdyv5i5p4banp100x7y6cldbg7dvrzsyj7z8pldyi4d6iardxy2"
+   "commit": "757a9c3bd7b2d1f803e7e83af1a07c1656f3ba1a",
+   "sha256": "006k6mll9p86c6iv34rlvqly4rx7r7mq7xbss9p82hms45za6jyl"
   }
  },
  {
@@ -65762,15 +65528,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20211217,
-    234
+    20241023,
+    258
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "533a8e368fcabfd534761a5c685ce713376fa594",
-   "sha256": "137mh0jgvkawdrv1d7w9giazz57c40n0yw2580q8zmxmv5dvkrl7"
+   "commit": "660c773f559ac37f29ccf626af0103817c8d5e30",
+   "sha256": "05p2n86a57mdkqkr554maa85n47w8ma0ygszhp9jgfczf9c8qm64"
   },
   "stable": {
    "version": [
@@ -66952,14 +66718,14 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20240926,
-    1814
+    20241201,
+    1341
    ],
    "deps": [
     "compat"
    ],
-   "commit": "316e470633d9bbe365079cf237e3ddef1f37a80e",
-   "sha256": "0rvnpmr6hyp96i563vck53z72bhq09wvsv8wzrb9dbg0zgjgx8d0"
+   "commit": "1be1a91c14031b0cf152c87f2cd5341559b2a1ec",
+   "sha256": "0a1frjjdkbhxjsn97bsjmil8winycwdvd4qwabgrzk8c5flnjiaa"
   },
   "stable": {
    "version": [
@@ -67336,11 +67102,11 @@
   "repo": "redguardtoo/js-comint",
   "unstable": {
    "version": [
-    20231126,
-    230
+    20241112,
+    609
    ],
-   "commit": "ef2ccccad5740f3d8b5295f52a35df4f62471480",
-   "sha256": "0ll9yyj3p4yyvc00jvx72r06xhxyl7zrky77l750kx151mv1aixc"
+   "commit": "a2e6f01b999e26047808c1720b7be0805afc7cb6",
+   "sha256": "0ap744yp8m1wfws61k8xi53wj3dk4pg25wfzfafs1y6n2jx9r145"
   },
   "stable": {
    "version": [
@@ -67702,26 +67468,20 @@
   "repo": "DamienCassou/json-navigator",
   "unstable": {
    "version": [
-    20230904,
-    1757
+    20241031,
+    630
    ],
-   "deps": [
-    "hierarchy"
-   ],
-   "commit": "f3489153e8509f88296786cb00e31f59597a43f2",
-   "sha256": "1sa4c4pxmfjp9k0549ljk2alan316n1ms2r4lcfqcci5ls51hv0l"
+   "commit": "8ab49b066bc23de731a29ef07bbafa29999e1852",
+   "sha256": "1nrvksg7ylvr1fhp4c2d3ng2r82akni0dgsdmm180z74z2wdra3m"
   },
   "stable": {
    "version": [
-    0,
     1,
-    1
+    0,
+    0
    ],
-   "deps": [
-    "hierarchy"
-   ],
-   "commit": "f4cde60c4203fc70cc7ff22ed1d6579159ce2598",
-   "sha256": "0xrjbx6rkm8a6pmzhdph0r6l468hj827dvvq2hxhcm8v5gk6m690"
+   "commit": "8ab49b066bc23de731a29ef07bbafa29999e1852",
+   "sha256": "1nrvksg7ylvr1fhp4c2d3ng2r82akni0dgsdmm180z74z2wdra3m"
   }
  },
  {
@@ -68054,11 +67814,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20240926,
-    1528
+    20241120,
+    857
    ],
-   "commit": "09897a8cbab48adaacdef6f852d7cebd3945a645",
-   "sha256": "01lyz25i41320jlcpykvg2zdm4klwzhf1lcbqfn8shjdjm41svw0"
+   "commit": "709c43410fb5da068d7d582cf3f545f7a7a68133",
+   "sha256": "0dmh3cd5mbsxz6fahvq2apzij53zdv2pvlxhqb3ix7ayb8l67a62"
   },
   "stable": {
    "version": [
@@ -68077,14 +67837,14 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20240408,
-    850
+    20241120,
+    1523
    ],
    "deps": [
     "s"
    ],
-   "commit": "801d0fc3d8f6f08f66a11515e6517739a0b312a1",
-   "sha256": "074m8hzg66j9xk44l5qh3fdzwbs5sn97nlwnr5b097431hxwk119"
+   "commit": "1f4f6b4e01ff1529b0d7917fbd9ce29451a66510",
+   "sha256": "0pp7sixpn0hh3743llxjz9rigq4ifsn249kvb4ph1fl0ys6ckj43"
   },
   "stable": {
    "version": [
@@ -68346,8 +68106,8 @@
   "repo": "emacs-jupyter/jupyter",
   "unstable": {
    "version": [
-    20241004,
-    241
+    20241120,
+    230
    ],
    "deps": [
     "cl-lib",
@@ -68356,8 +68116,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "674af0481a94f2ce56c62aa7668a966254ef26ef",
-   "sha256": "06nbmc136hb8bvrkqnpbhkd9sckk93ygsd9fdvzl59zfsvq0rgdc"
+   "commit": "577371744b36aa0afa117b7ded21d08f60331ff6",
+   "sha256": "1d2945irdi5s2cm2kzx87k28w2gcg1z8f5zm889rm5fv6dj6x1zj"
   },
   "stable": {
    "version": [
@@ -68400,6 +68160,21 @@
   }
  },
  {
+  "ename": "just-ts-mode",
+  "commit": "acca52a2fbedee1afee504cd6a665578fc42d94e",
+  "sha256": "1q08zyslgyg9hlmwgzmpsakly6f2jswimiqwcx3fr4nsyjj5a7bh",
+  "fetcher": "github",
+  "repo": "leon-barrett/just-ts-mode.el",
+  "unstable": {
+   "version": [
+    20241014,
+    2252
+   ],
+   "commit": "acb598f1edabae9f679a507c8e22c21b3f2da132",
+   "sha256": "0v9pgnlz7xm0kigpq3ymalx0jay1553rl3yra0fmggykmqi9gi17"
+  }
+ },
+ {
   "ename": "justl",
   "commit": "5a74b3213ab362fd00a11409e046854ec832c827",
   "sha256": "01s9szxr83mdjnzhjy0xr9fqk4vzv3spphq68jpzcj56njah6r9b",
@@ -68407,8 +68182,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20240925,
-    455
+    20241123,
+    1442
    ],
    "deps": [
     "f",
@@ -68416,8 +68191,8 @@
     "s",
     "transient"
    ],
-   "commit": "a46b95425c8f55d5ebfa674f09d606a6321e51e9",
-   "sha256": "1bcaq8w0g77q49di99ffpbspv5bjl59wp03x7k2h41sij47dzsxk"
+   "commit": "16b6ed54ceae839da032e5850075cab43c46be08",
+   "sha256": "0k2m89y9j8i60iwj5pqphf8n9cqkzx7fz6q4if3rddbxp17n72l4"
   },
   "stable": {
    "version": [
@@ -68472,20 +68247,20 @@
   "repo": "joshbax189/jwt-el",
   "unstable": {
    "version": [
-    20240923,
-    1831
+    20241031,
+    2258
    ],
-   "commit": "98c9fb2e8a45592062b9bf84cec1be0e51f70f7b",
-   "sha256": "14dfwkvk7dm8hjgsnpv4an9fy2a401bcbg361b4ai0gs3m8691zh"
+   "commit": "d7deb62f8c2df58d5cfebf087a147c75207964e8",
+   "sha256": "01ngwb7xzzf6pdzv894dqwvmgj4nqkdjjnbmh67iv7xjd2m29dja"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "98c9fb2e8a45592062b9bf84cec1be0e51f70f7b",
-   "sha256": "14dfwkvk7dm8hjgsnpv4an9fy2a401bcbg361b4ai0gs3m8691zh"
+   "commit": "d7deb62f8c2df58d5cfebf087a147c75207964e8",
+   "sha256": "01ngwb7xzzf6pdzv894dqwvmgj4nqkdjjnbmh67iv7xjd2m29dja"
   }
  },
  {
@@ -68776,11 +68551,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20240910,
-    1649
+    20241028,
+    1204
    ],
-   "commit": "94418acc89f789f4172c5f68b2afacd784bf176d",
-   "sha256": "1zihas9i1w679rir3vbvy3rjifl1y0nq5g1rx3y0ms2dy5nmy6x1"
+   "commit": "6fe28070d7b3581415faa3e61af786b596ef3bb0",
+   "sha256": "1akcgvl29lv01cvsrc0lrgkas680dq45lvhfq63prwmgbinb2x6y"
   }
  },
  {
@@ -68806,11 +68581,11 @@
   "repo": "wsgac/kanji-mode",
   "unstable": {
    "version": [
-    20230928,
-    1113
+    20241120,
+    1923
    ],
-   "commit": "731b3a5447bcb899ba1d86b645a344e0915d04f3",
-   "sha256": "0qgwl8iza0dkrpfsc5xpc1fgjmrxd6x4gxkid8wxn270s9mzal68"
+   "commit": "09719b00d60e22bd31c93b21c0c817eced9d0406",
+   "sha256": "07873z1adfa4mysldd0jid9s1zklsv20ms162x67z3p9jqpfz04x"
   }
  },
  {
@@ -68855,28 +68630,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20241012,
-    1918
+    20241104,
+    1
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "8ce06c0ecbd366663d07c2ee04ed9c2674112335",
-   "sha256": "0xnry3w30zg7mxgc465q97ann7rk30srz5fszygnn8jlh3f5lkbg"
+   "commit": "343ad8cd73c7509af2ea7af5eb856ece97dee7a3",
+   "sha256": "0s4pnb8wblnj0kpqd35b6z7b719p7rfs0n2qcs6l8wyd8f3xdzwa"
   },
   "stable": {
    "version": [
     1,
     7,
-    0
+    1
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "b03749c914b1319caccce4cf96630e3fba5335f5",
-   "sha256": "15246nsiwdfy5zl5iml4qxslz8p7k9lrzdr7p6bn71afk721vz5y"
+   "commit": "343ad8cd73c7509af2ea7af5eb856ece97dee7a3",
+   "sha256": "0s4pnb8wblnj0kpqd35b6z7b719p7rfs0n2qcs6l8wyd8f3xdzwa"
   }
  },
  {
@@ -69607,28 +69382,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20241011,
-    107
+    20241129,
+    343
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "0a1c3e4f411ea3657428366acdce6c64a322289a",
-   "sha256": "1g1brx4sqg9r2xkbvagng3zbqbzz9k3fszhx56ip75rgnlgvmf99"
+   "commit": "439b18c21f0d540fc6c6a9aea0c9b22e4259e6e0",
+   "sha256": "09bzvm603kzh3md5plcc01jwwj3mmb87z7c3p9wz0k662hg7nwdk"
   },
   "stable": {
    "version": [
     1,
-    25,
-    0
+    30,
+    10
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "0a1c3e4f411ea3657428366acdce6c64a322289a",
-   "sha256": "1g1brx4sqg9r2xkbvagng3zbqbzz9k3fszhx56ip75rgnlgvmf99"
+   "commit": "439b18c21f0d540fc6c6a9aea0c9b22e4259e6e0",
+   "sha256": "09bzvm603kzh3md5plcc01jwwj3mmb87z7c3p9wz0k662hg7nwdk"
   }
  },
  {
@@ -70201,8 +69976,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20240822,
-    1507
+    20241110,
+    1456
    ],
    "deps": [
     "dash",
@@ -70210,8 +69985,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "e124c555d1a889055ddb1426163d24652cc281b4",
-   "sha256": "1i7ack3v0gm1q2lnsrs7fz6928n1mdx95c0n8sa618gr17h89p57"
+   "commit": "52d1bbdb74fd885b32188784144bb84b980da5e1",
+   "sha256": "0vcb5svjr7fp96z4svpg1wpb370c5m94chrbckpd7xigzg3n9win"
   },
   "stable": {
    "version": [
@@ -70613,16 +70388,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20240729,
-    1656
+    20241110,
+    1640
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "230d5726b91d11d4b356235f37445ead0a99f3f5",
-   "sha256": "0azizlidvjxs9dhl5g669cbf13w7i17n5hjk1s41kys1jvc48faa"
+   "commit": "bd45582bb912bad97f614264ff3142d11a6399a1",
+   "sha256": "07aiywrdy4r2y5bm8pmf04lpdj4gwngkkyf2bl8h7kj07s8zy9pq"
   },
   "stable": {
    "version": [
@@ -70786,11 +70561,11 @@
   "repo": "lassik/emacs-language-id",
   "unstable": {
    "version": [
-    20240609,
-    1616
+    20241024,
+    854
    ],
-   "commit": "44452e4f7962aca41cc2539fce1d27799d6e656c",
-   "sha256": "1x87qrqyg12w5ncgv6592amp08bpdn4sybhwyf3nwfp8zpfficms"
+   "commit": "dbfbc4903ffb042552b458fac76ee9f67a022036",
+   "sha256": "0qiml5k43hhh5m9z7blzbhhl2492d2z3an1n0v4mia2c38ijsq1q"
   },
   "stable": {
    "version": [
@@ -71215,26 +70990,26 @@
   "repo": "christophermadsen/emacs-lazy-ruff",
   "unstable": {
    "version": [
-    20240911,
-    1201
+    20241127,
+    1434
    ],
    "deps": [
     "org"
    ],
-   "commit": "7bf9650e9a2df381043ba26ac8930d0a8902dc6e",
-   "sha256": "123l4p7wanwkdz8w5r7rxd9qvfr88kyy9a9xfpgiadagvx3kpkxw"
+   "commit": "4eeea363a133e0e7ed7c02a5e2f1f7b63a78c3f4",
+   "sha256": "16ykhkjjsgf2iqsk9vhg7fxb2ilwwjrj4rsifiznn436z6sivkn9"
   },
   "stable": {
    "version": [
     0,
     3,
-    0
+    1
    ],
    "deps": [
     "org"
    ],
-   "commit": "7bf9650e9a2df381043ba26ac8930d0a8902dc6e",
-   "sha256": "123l4p7wanwkdz8w5r7rxd9qvfr88kyy9a9xfpgiadagvx3kpkxw"
+   "commit": "4eeea363a133e0e7ed7c02a5e2f1f7b63a78c3f4",
+   "sha256": "16ykhkjjsgf2iqsk9vhg7fxb2ilwwjrj4rsifiznn436z6sivkn9"
   }
  },
  {
@@ -71331,11 +71106,11 @@
   "repo": "conao3/leaf.el",
   "unstable": {
    "version": [
-    20230803,
-    729
+    20241018,
+    516
    ],
-   "commit": "fce3378f987bf118a0a5f1a24c4408ac920f858d",
-   "sha256": "11fw6qh9fdy8f1zkfa0n1dkd0ppk9b96mgmaxnbb8zxivdhj9nhc"
+   "commit": "69c9b057cdeee560450c1d04a9a058235ecff0f7",
+   "sha256": "0jgdwx1g7k4dkbr1sp7y8vk1x9nbsav8sm35xh1j1r62mznlcpsf"
   },
   "stable": {
    "version": [
@@ -71478,27 +71253,6 @@
   }
  },
  {
-  "ename": "lean-mode",
-  "commit": "95d2d051c47697fa09c37a64ce9070aded61503d",
-  "sha256": "1sgi79s2d511gb448cjd5sxrxrm2k0kv4ic7a27izm24vgfy77x4",
-  "fetcher": "github",
-  "repo": "leanprover/lean3-mode",
-  "unstable": {
-   "version": [
-    20230611,
-    728
-   ],
-   "deps": [
-    "dash",
-    "f",
-    "flycheck",
-    "s"
-   ],
-   "commit": "99d6a34dc5b12f6e996e9217fa9f6fe4a6af037a",
-   "sha256": "1m6kzhlifzb2qyb1y578r4jbfm73lxs611zgqjng9nbhprymal33"
-  }
- },
- {
   "ename": "leanote",
   "commit": "b00b806ae4562ca5a74f41c12ef35bfa597bcfa8",
   "sha256": "1xnfv7bpkw3ir402962zbp856d56nas098nkf7bamnsnax6kkqw7",
@@ -71588,11 +71342,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20241007,
-    1655
+    20241114,
+    1751
    ],
-   "commit": "9be25db0566d495299eaa8595eb4b6dd6b7a1080",
-   "sha256": "0ybviqpqb2c1ai3ffizqgwjsmarxbg4qi4b6lfnfgczinslnh0fm"
+   "commit": "15b7d29f2539f9e9671ab3c062bd5165e5b80ae8",
+   "sha256": "1hn6lznhis7xgq0c14yp3jdazgq3c23k53zlm3fkqs9qzy1h1j4m"
   },
   "stable": {
    "version": [
@@ -71627,17 +71381,16 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20240807,
-    1731
+    20241115,
+    527
    ],
    "deps": [
     "aio",
-    "dash",
     "log4e",
     "s"
    ],
-   "commit": "064a03d3407d67391fd8c0f6494d0e0f0d867edc",
-   "sha256": "0k0mqaj65sq6h45wh9y7qqv434n292r81iyam2ybxyxn99rzjmvh"
+   "commit": "bf259182a18a44c49ccc5449d1353ec4009a9480",
+   "sha256": "095cmlizfmpbygn9x6yavjnlkczfycay3ijfxqd64idagvwkx0dp"
   },
   "stable": {
    "version": [
@@ -71679,15 +71432,15 @@
   "repo": "martianh/lem.el",
   "unstable": {
    "version": [
-    20240630,
-    1228
+    20241102,
+    1553
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "2dc5036f0991db352948ea93ae895654c0fe775d",
-   "sha256": "0zf3wpzqxphzxlgvqhns4yf1aa6yfgkxi5r32wi2gcrwnd97qwqn"
+   "commit": "79c4b8112be95df0193e7dff99a097ec818b04cb",
+   "sha256": "0arhjcx9yzf9jgrl6f87lqviaq8sqkn8wfbxzbkk952fgp32v6h6"
   },
   "stable": {
    "version": [
@@ -72314,11 +72067,11 @@
   "repo": "janestreet/line-up-words",
   "unstable": {
    "version": [
-    20180219,
-    1024
+    20241121,
+    2033
    ],
-   "commit": "2c236f5772e18d0e50d7ca2eee7eebbe356d9b60",
-   "sha256": "0sazx4a6hn0z7318mdc80z87n5ix4hhyyh4p4f37pv5p9q6y8sd2"
+   "commit": "3c1339a3fb3840dfaea50d8cb966c90b19d14925",
+   "sha256": "1jrck3mx4mv3nrps02540i3c394789nwn9gl0jlf580p8hvzlcgk"
   },
   "stable": {
    "version": [
@@ -72787,11 +72540,11 @@
   "repo": "purcell/list-unicode-display",
   "unstable": {
    "version": [
-    20230216,
-    958
+    20241119,
+    1152
    ],
-   "commit": "57b4384ebe0c5d10890ee0dfcf66d0b16e5f5060",
-   "sha256": "0182irm3vai6ngl2xlqpj94qzx673rygzik36amrcw2ji9ssf4f9"
+   "commit": "68feedd776082c1743588c2b07dbb6539dbe51bf",
+   "sha256": "0sf1irb51l8n3732fllynsdvqc6c1m94swv7r7yy0qmngz9fqqss"
   },
   "stable": {
    "version": [
@@ -72813,20 +72566,20 @@
   "repo": "rolandwalker/list-utils",
   "unstable": {
    "version": [
-    20230422,
-    1740
+    20241106,
+    1849
    ],
-   "commit": "f02dcef36330871855346f9eab97eef58d323d9a",
-   "sha256": "1ry6dmfs10b30w37ffyhbz04nilbf5q5dyi73cxr2dbk0j92lzga"
+   "commit": "bbea0e7cc7ab7d96e7f062014bde438aa8ffcd43",
+   "sha256": "0rc7ql78qraa35lv6igkd81j5ap9zgn6ri9rp9cajp86s2b46dg6"
   },
   "stable": {
    "version": [
     0,
     4,
-    6
+    7
    ],
-   "commit": "9bb2487c83ec46a0b6e6c4158af69334ac797b82",
-   "sha256": "07hbz2md52ccy95gv4d5n6szrfmpfqf3w4kwqdg2cf54c7kgf7hw"
+   "commit": "bbea0e7cc7ab7d96e7f062014bde438aa8ffcd43",
+   "sha256": "0rc7ql78qraa35lv6igkd81j5ap9zgn6ri9rp9cajp86s2b46dg6"
   }
  },
  {
@@ -73141,20 +72894,20 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20240720,
-    1532
+    20241127,
+    2323
    ],
-   "commit": "86f27626ca3c1350cb459aa2b72c12219962e8d8",
-   "sha256": "1i97jfmzq7q4xrp0h87s7kv2wszhjxa0z30sl4mxyqmv8q9qcc4x"
+   "commit": "b417ad93191e8eecaca347f5407dd4bb4c07b6f8",
+   "sha256": "101dd0b1czc28yjsdz0fdvkh8b76rd03a1br7sldlmsy3dfhk669"
   },
   "stable": {
    "version": [
     4,
-    11,
-    4
+    12,
+    0
    ],
-   "commit": "bea9903bca0ece7546df9a00883f17e4eb49b4c7",
-   "sha256": "0mv9fsmjvixdk3db8j1cw7i2bgi2phwbdwwr0fq96azxzzgqh5jx"
+   "commit": "b417ad93191e8eecaca347f5407dd4bb4c07b6f8",
+   "sha256": "101dd0b1czc28yjsdz0fdvkh8b76rd03a1br7sldlmsy3dfhk669"
   }
  },
  {
@@ -73255,23 +73008,20 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20241003,
-    1906
+    20241104,
+    2206
    ],
-   "commit": "8fdcde4aafbd6d5768fa135d9e2a7bc1ae95b23a",
-   "sha256": "0rywy2awnixap2brp9p6pp6xbgpljjzl27snx92vq5znwx3iln28"
+   "commit": "f4e80a582f7ec857783274bee6614560ce49d497",
+   "sha256": "1km89ks7xg89sjqxiri9lxj58hc17z13z7mzcq3y66yv1dfrrziz"
   },
   "stable": {
    "version": [
     0,
-    3,
-    1
+    4,
+    0
    ],
-   "deps": [
-    "seq"
-   ],
-   "commit": "beddc6a85787e2a95910e284076c162068c6f0de",
-   "sha256": "0rgm5jv9iv8b0xabdwicrpih2d3slchmv17xdjk705dqhfc18f4w"
+   "commit": "f4e80a582f7ec857783274bee6614560ce49d497",
+   "sha256": "1km89ks7xg89sjqxiri9lxj58hc17z13z7mzcq3y66yv1dfrrziz"
   }
  },
  {
@@ -73699,27 +73449,27 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20240924,
-    2033
+    20241118,
+    1819
    ],
    "deps": [
     "datetime",
     "extmap"
    ],
-   "commit": "8e020b9296b8e1adc810ebc9d36985f64d93dbc2",
-   "sha256": "1hkjb37kjw34611n83f384si2623wgd5kx85yw8pvhk2shmrn00h"
+   "commit": "de9694cfdc7006017781e7d32bb8bad38c7fda46",
+   "sha256": "0rl05yy16x0gsc6y58a2zyxc0dbyh5w1c6jx67mkvjxldpqah1sl"
   },
   "stable": {
    "version": [
     0,
-    18
+    19
    ],
    "deps": [
     "datetime",
     "extmap"
    ],
-   "commit": "0f957d4b8766f6bd927966090d0a0a311990dc60",
-   "sha256": "0pfva621bgz7hgcdp6jp9fzvafxxjz1y9npjgkz7byydvy64j2vv"
+   "commit": "50f0b12f9cb3b8bdc9b28c16187495770ff6dff6",
+   "sha256": "1z9w1rdr1d7j6fw9rb05wjrpdj9zka683xj35cxws7qplk3dlz29"
   }
  },
  {
@@ -73855,8 +73605,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20240914,
-    1445
+    20241129,
+    1652
    ],
    "deps": [
     "compat",
@@ -73864,8 +73614,8 @@
     "seq",
     "stream"
    ],
-   "commit": "7d76cee0a1c05f64457466fc183bc51497bc2633",
-   "sha256": "1spnn8z98z15wjicdv2i9y6xxkjx31bjhnxma3dmhsklhf9fv4xa"
+   "commit": "159cf1811c2d27552166c9976f8612c487054d31",
+   "sha256": "1dzrh3wiqc8yb6kcrbb38pngygspm9zjm2wrhs041albkj7sz1cx"
   },
   "stable": {
    "version": [
@@ -74013,8 +73763,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20240520,
-    1834
+    20241114,
+    2005
    ],
    "deps": [
     "dap-mode",
@@ -74026,8 +73776,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "1f52e81c9371055ff9188117ace81f009d1c79f2",
-   "sha256": "18wvsbszdxgmjvpj6b32scg0g8lj54cm3fz725zph44brm98v391"
+   "commit": "7e3d3429418bc42cda7fa7b58e6644a705cf2f89",
+   "sha256": "06mxy8vw64szhik58g5qsw4a6jwzm92v474dkb2sfi8cxw5zp8vs"
   },
   "stable": {
    "version": [
@@ -74080,15 +73830,15 @@
   "repo": "emacs-lsp/lsp-focus",
   "unstable": {
    "version": [
-    20200906,
-    1917
+    20241119,
+    1451
    ],
    "deps": [
     "focus",
     "lsp-mode"
    ],
-   "commit": "d01f0af156e4e78dcb9fa8e080a652cf8f221d30",
-   "sha256": "1pi6vmykp6x5c1yz9cgcf4nc5cbkbxhxqmp6g9aipwd8kwii1xx6"
+   "commit": "3420d82c6c8635b4184ebacd50e0902deeeb9845",
+   "sha256": "13vn09i2jna2vh55ql02nni3ys81v5n1540yxj1mw3mwgfv5icnc"
   },
   "stable": {
    "version": [
@@ -74150,15 +73900,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20240921,
-    2345
+    20241024,
+    1701
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "d229fdcd25a2d557d9d05a74f6fb4731e1341671",
-   "sha256": "037y70bri8ncfw1znj75px3pywziv3sg9fcnd8d6zz1zvqj1dkn0"
+   "commit": "6981f8d1225c038c1a130e8cf70530cfe15f976e",
+   "sha256": "1l51v2di8hgm2n8fb8kj5q6ns501vfkv5706v1q0fa8amvmralgb"
   }
  },
  {
@@ -74187,16 +73937,16 @@
   "repo": "emacs-lsp/lsp-ivy",
   "unstable": {
    "version": [
-    20220831,
-    1823
+    20241119,
+    1452
    ],
    "deps": [
     "dash",
     "ivy",
     "lsp-mode"
    ],
-   "commit": "9ecf4dd9b1207109802bd1882aa621eb1c385106",
-   "sha256": "1k9q5fsv6gqy4k5bprcvmybc2mv0zqj6m4j1wcbp5rkl2596mlhh"
+   "commit": "553276f3c8a6bc15859a9be666b0a50af65e9bc6",
+   "sha256": "10yij9ml3wwvk4z9hglpjydviwkc18czvv81s7hj99yarvn3ldg6"
   },
   "stable": {
    "version": [
@@ -74377,14 +74127,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20240425,
-    2049
+    20241130,
+    801
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "c473ed37aa0f2769bb0b4c344cc28f95975dbc17",
-   "sha256": "1bqvrhmvp0bxk10fqmra38aczgs6r6gwac2ppmn0fxz85g7ryvfp"
+   "commit": "8338c47dc2ea99dea4797ad110592139b2c66e59",
+   "sha256": "011x1daddvdbih3nawr1f4j0frjnmg8q8p0727bi9xm86yffln51"
   },
   "stable": {
    "version": [
@@ -74409,8 +74159,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20240821,
-    1959
+    20241112,
+    1142
    ],
    "deps": [
     "dap-mode",
@@ -74419,12 +74169,11 @@
     "ht",
     "lsp-mode",
     "lsp-treemacs",
-    "posframe",
     "scala-mode",
     "treemacs"
    ],
-   "commit": "0dc938be1190d147e7013e3dce08ac8bff5d1662",
-   "sha256": "06fbmw01ax5rybkhxya5fs6ndjx3p7zn6rjhxr0124dqhmq2jlzh"
+   "commit": "b5139c959336758a93d0e55458e6ca938d9fd16a",
+   "sha256": "1axbcmfnz176dfpd5nbx2f1nfad8pzl8ah9gddia4smad23cpvcm"
   },
   "stable": {
    "version": [
@@ -74454,8 +74203,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20241014,
-    1431
+    20241201,
+    2156
    ],
    "deps": [
     "dash",
@@ -74466,8 +74215,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "8200fa1e71f16e10f42fce95c47822c4bd756df1",
-   "sha256": "0iq509iiy1xpdhpxk80v74lmwby2i1nl46iszlc7d07c2wvbjdm1"
+   "commit": "57ea512212b4cdd650b0bc4bcadd14fd678c212d",
+   "sha256": "0b11lqi7n00xqk9miyazi39nrhf0p110rl7177xy0gbzxjzpcvfm"
   },
   "stable": {
    "version": [
@@ -74615,16 +74364,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20241011,
-    1620
+    20241102,
+    1425
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "327edcea22b27b8ea133aad678123f6d177e247e",
-   "sha256": "0k2j7rskc2z1jv70qj0wjcksnpzgdaga64c0j0a7hfkk93hidqwb"
+   "commit": "dd54b3ae7c22d34faaced7b1a89739063c552b1f",
+   "sha256": "1807i3127m08h47aj3jj92yrhlf4xjkj3irs02vwlgsbix6fnlqg"
   },
   "stable": {
    "version": [
@@ -74812,15 +74561,15 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20240420,
-    1411
+    20241018,
+    200
    ],
    "deps": [
     "f",
     "lsp-mode"
    ],
-   "commit": "3e3cc80a448e9dd24663eaa41742cda686dac5ab",
-   "sha256": "1llnign4yb4v6c8r7q25b4s63swxlgfxr5acf51s8h4x8rrb11w2"
+   "commit": "ca5e611d2a38fea8802a365bcdd6fdc73e3d79af",
+   "sha256": "0632nrmdfcwgzl1cqf83rwsxrk3fckg7y8h3fhcaa3j47zd32q53"
   },
   "stable": {
    "version": [
@@ -75238,14 +74987,14 @@
   "repo": "amake/macports.el",
   "unstable": {
    "version": [
-    20240814,
-    1020
+    20241130,
+    1219
    ],
    "deps": [
     "transient"
    ],
-   "commit": "594b0dcd596464270d5e954d7c78015df2132c33",
-   "sha256": "1i6kh84z7cifyb5h0a0p2sajbq6xyqm4pbf9pspqxphgmaspi2mp"
+   "commit": "ff24e67cf1e5b3b009f82812049b0406aa3a9fab",
+   "sha256": "1rps0q2djyvxlvs926x15rkfc7iycdk7z54jfbn6si75dvs8qck8"
   }
  },
  {
@@ -75279,27 +75028,28 @@
   "repo": "emacsorphanage/macrostep",
   "unstable": {
    "version": [
-    20240513,
-    2203
+    20241025,
+    1456
    ],
    "deps": [
     "cl-lib",
     "compat"
    ],
-   "commit": "4939d88779761e8b5461b4cf73f86600172987db",
-   "sha256": "03lriwibv3r8prkg8rih8p80ykxqg9hvax88bg64mdx2jv9l4ygb"
+   "commit": "419873665f3d0b3d5779aa119b58a3daa96e3326",
+   "sha256": "0271j0f9cb0nwbip2qc9pqr27si3vaalyv6l6w9n39pcmxdxvy8n"
   },
   "stable": {
    "version": [
     0,
     9,
-    2
+    4
    ],
    "deps": [
-    "cl-lib"
+    "cl-lib",
+    "compat"
    ],
-   "commit": "633586421e7fc14072cc1ca1655c1103b81a9093",
-   "sha256": "1sxvp1q8naf0328l9fs90nk8bzsv485sajx4khh77nwkz3v4sr9f"
+   "commit": "31d4adcca4f08cfd7a45f85e691aaa7a9316b355",
+   "sha256": "0f0rjpjwzpw6hxqbh8ghr7838slf7w22z7szy68bbg3bbnrjjlai"
   }
  },
  {
@@ -75410,14 +75160,14 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20241013,
-    815
+    20241111,
+    1446
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d2bf2ae285080173d57525ee59ba48f15494c8c0",
-   "sha256": "1vxz8ys55krbdks081vyrvsqfycvnzfj6bf3g1mxak8jc6xsdvvp"
+   "commit": "441389f75bdf6990556b96597979bf4a0b9cbdec",
+   "sha256": "1df4dpaygy0nnkqw4f6df5i186396dg05cp6imf83ipg7jnlypsq"
   },
   "stable": {
    "version": [
@@ -75440,8 +75190,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20241010,
-    1930
+    20241130,
+    1707
    ],
    "deps": [
     "compat",
@@ -75451,14 +75201,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "66731bda44f3e7810306f2910f18fefb348415ae",
-   "sha256": "1jmxi7h138wypm822r89qns64xxbgrpswx47gnr24k3kq9mr9s00"
+   "commit": "e8b85e43d491ca0c0a3fc41ee5d8c4aa34649cd3",
+   "sha256": "0zf8455gix847f8qf24a427mh0bi8bdjmha01fgd09dh4yxjrn4h"
   },
   "stable": {
    "version": [
     4,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -75468,8 +75218,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "93e86ceca7bf5b0ff9023d7f138e5f06990fc276",
-   "sha256": "1ckjq068728wwfm4fv0z4rrdmrj09zvarip2s5rqdr8ny722dxfn"
+   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
+   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
   }
  },
  {
@@ -75510,14 +75260,14 @@
   "repo": "ideasman42/emacs-magit-commit-mark",
   "unstable": {
    "version": [
-    20240421,
-    931
+    20241110,
+    245
    ],
    "deps": [
     "magit"
    ],
-   "commit": "d09d0df6f8a697446e9fac77428b32997b94c59e",
-   "sha256": "1cd1z9vrmavxdwzxnwbimzcq51c3g8rzd7va01z5k8alh6n98gim"
+   "commit": "e468518c7b8f90deda03cc4f0e2616b367cfdee8",
+   "sha256": "00daa22z32zksxgmrls6fkywf01wvr6h28fjhw3mrirgdwz5i7ab"
   }
  },
  {
@@ -75662,15 +75412,15 @@
   "repo": "emacsorphanage/magit-gerrit",
   "unstable": {
    "version": [
-    20240514,
-    1139
+    20241026,
+    1641
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "46fe81c76fd2d3e5e97207cd1d951f22ecb16573",
-   "sha256": "16xb13mamx0rnlsxg4xs0nc1xif59rw3xa22y7fz4897cjyrlp84"
+   "commit": "ddf9c8db7c1c0d8063dc010c3a795a10e9eaa5e0",
+   "sha256": "0r668mk6rdw9ja39145mlb7rb8gkp534aksgnxndzidhllpk5cz7"
   },
   "stable": {
    "version": [
@@ -75795,16 +75545,16 @@
   "repo": "douo/magit-gptcommit",
   "unstable": {
    "version": [
-    20240625,
-    356
+    20241127,
+    131
    ],
    "deps": [
     "dash",
     "llm",
     "magit"
    ],
-   "commit": "91b23fde4a880566a4e493240865e3582cad7306",
-   "sha256": "0zbj8bk3vdzfpih8242gan7a8i4gkmixxzs952mm15wg2fd98gm5"
+   "commit": "dfec4f9a13af50b5506f375749f5d822ec7be71d",
+   "sha256": "0kwpi6wrdgvwamllf41k0amczw1d0m8djql9zfflzc2mgr95rfbc"
   }
  },
  {
@@ -76029,30 +75779,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20241001,
-    2052
+    20241122,
+    1431
    ],
    "deps": [
     "compat",
     "dash",
     "seq"
    ],
-   "commit": "93e86ceca7bf5b0ff9023d7f138e5f06990fc276",
-   "sha256": "1ckjq068728wwfm4fv0z4rrdmrj09zvarip2s5rqdr8ny722dxfn"
+   "commit": "93a7752842b2d4feff6b5deba44411e9c4249dfe",
+   "sha256": "152i6p9snjpni3ywlfcvj6z6fxr8aa60bjfxvz8i4ddgkp7ymr6n"
   },
   "stable": {
    "version": [
     4,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
     "dash",
     "seq"
    ],
-   "commit": "93e86ceca7bf5b0ff9023d7f138e5f06990fc276",
-   "sha256": "1ckjq068728wwfm4fv0z4rrdmrj09zvarip2s5rqdr8ny722dxfn"
+   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
+   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
   }
  },
  {
@@ -76859,14 +76609,14 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20240926,
-    918
+    20241124,
+    1138
    ],
    "deps": [
     "compat"
    ],
-   "commit": "be2e57efff640880251c082ac93bd365b7202e6a",
-   "sha256": "1r1gyjk6f4628xhl6mj811507da2zyagn6hvrsvvvsvj5bgwxhsj"
+   "commit": "643a5f50c9f9d0698c8b1d72678886aefcf69052",
+   "sha256": "0lh7hgqkm4vhnnizarjw5zlxdpmjcmjrvmazzirk9rb7i72b56ia"
   },
   "stable": {
    "version": [
@@ -76903,14 +76653,14 @@
   "repo": "plandes/mark-thing-at",
   "unstable": {
    "version": [
-    20231019,
-    1111
+    20241022,
+    2232
    ],
    "deps": [
     "choice-program"
    ],
-   "commit": "06cc38fb92c0c1badb06f6744f0110742ffdfe6c",
-   "sha256": "12dnkicqqk22sqf9vmrxf9bdlmjq2z0x9b3vv3qf817rskz7xkwh"
+   "commit": "d9499bc82e214e35eac074303a64c023fb10ea5c",
+   "sha256": "0lmagbhm9fjz4bh1zwp0wwzraihf4rd1pp8i1jc75hfas827k5hg"
   },
   "stable": {
    "version": [
@@ -77001,11 +76751,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20240829,
-    324
+    20241117,
+    1510
    ],
-   "commit": "6102ac5b7301b4c4fc0262d9c6516693d5a33f2b",
-   "sha256": "0zbbbiqna372h06c3xj8abrh8nixrjig9ip09m342saa4mcr6c5j"
+   "commit": "b8637bae075231d70fe7f845305eaba2c0240d89",
+   "sha256": "1sz7l7kbdahczqg52f4qnfpvykzczgrc9iwfn32i8n2cbby25clk"
   },
   "stable": {
    "version": [
@@ -77109,16 +76859,16 @@
   "repo": "ardumont/markdown-toc",
   "unstable": {
    "version": [
-    20210905,
-    738
+    20241129,
+    1248
    ],
    "deps": [
     "dash",
     "markdown-mode",
     "s"
    ],
-   "commit": "4e8f97d7d94c53fd706da9e3d5006e1c9dff5ff8",
-   "sha256": "1lihgisgsyhn8vxp6p8nhjsf4c0193jv6bbn8kf0qvl5624xnk95"
+   "commit": "ba74a85ec94a638054ee65cbc8d95581946d018b",
+   "sha256": "0rm8hx0a2ppp0z4jl5c6kyhlwkrla6xvr2nkw7bl7wk46i9hh2g5"
   },
   "stable": {
    "version": [
@@ -77346,28 +77096,30 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20240920,
-    1839
+    20241121,
+    1724
    ],
    "deps": [
     "persist",
-    "request"
+    "request",
+    "tp"
    ],
-   "commit": "e593ad461ae275c641c6c4c90f67d62a920610a0",
-   "sha256": "1jq54rz27xabwswwas9j254r9ldymza2la288vbh2w0nfbmnr1m9"
+   "commit": "cf6416313084a04e5028f46274e88284e2d120ee",
+   "sha256": "0pc5xjkzxhjwmcbmn9zsqw9z2yyh4vp4qbihk14qyzhz00ni113h"
   },
   "stable": {
    "version": [
     1,
-    0,
-    27
+    1,
+    6
    ],
    "deps": [
     "persist",
-    "request"
+    "request",
+    "tp"
    ],
-   "commit": "e593ad461ae275c641c6c4c90f67d62a920610a0",
-   "sha256": "1jq54rz27xabwswwas9j254r9ldymza2la288vbh2w0nfbmnr1m9"
+   "commit": "cf6416313084a04e5028f46274e88284e2d120ee",
+   "sha256": "0pc5xjkzxhjwmcbmn9zsqw9z2yyh4vp4qbihk14qyzhz00ni113h"
   }
  },
  {
@@ -77499,17 +77251,17 @@
  },
  {
   "ename": "matlab-mode",
-  "commit": "08b700ce0068646b51cd856df98ca583e21da8a1",
-  "sha256": "1qxbcklmhwn4478chnf9n8hwc4qznjb7y8cj78a179hhws70l97j",
-  "fetcher": "git",
-  "url": "https://git.code.sf.net/p/matlab-emacs/src",
+  "commit": "9f8a242497f554bb87e5069d12b2c1a79d479c06",
+  "sha256": "1v5vr5lm6ss9awk4ymgjdqcy99pcwb17ix654d3as8v98zgxd46s",
+  "fetcher": "github",
+  "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20241006,
-    1633
+    20241117,
+    1628
    ],
-   "commit": "c021c7f7c95f01bf9b0f10ee1e466658e3e65a1d",
-   "sha256": "14j33vr2lnxnkby5pnpzslph797rqp0dzrz0jpg3zh3n7jh0k84m"
+   "commit": "390bca3fd9ac440e6c3dcdc524e77c7590423f08",
+   "sha256": "1dfv6f05v7i7966q39knilqjnz1rif4zg6cdk31sy6h8prc6arc3"
   }
  },
  {
@@ -78091,20 +77843,20 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20241014,
-    636
+    20241201,
+    1935
    ],
-   "commit": "2f6fac3410640437b4b1aaf1bc373a5c5d558a8c",
-   "sha256": "0yr3dh85mmk6mhs89rbm00pi3frz756qx3r41q0p1q9l67wp40am"
+   "commit": "2d352b94df1a4e633d7941acdafd7b13363eccef",
+   "sha256": "05q2ri3b5m3l3c5nkwgb6nkzrb6df0r3ldy8ysa32qqsn9zyaw9x"
   },
   "stable": {
    "version": [
     1,
-    4,
-    5
+    5,
+    0
    ],
-   "commit": "54d4e933039827c158a4f593a94681a64e0d8042",
-   "sha256": "0xv6wg4lyi5bv68h5hk5hfxdwxa2g3ybxd8z0l420az4rnhr6zhq"
+   "commit": "ebf7ebb5eb3ac7bb3cfaca9c32d9063f385aee9a",
+   "sha256": "1gfvqzp00vwbhxgp2wdcm4waba0r280dx0qbb7vpzyx93bqiplig"
   }
  },
  {
@@ -78115,14 +77867,14 @@
   "repo": "skissue/meow-tree-sitter",
   "unstable": {
    "version": [
-    20240701,
-    1422
+    20241124,
+    2224
    ],
    "deps": [
     "meow"
    ],
-   "commit": "d8dce964fac631a6d44b650a733075e14854159c",
-   "sha256": "0fzj8hnf9qiylx2b2s2vj8js32rd79gnw0x2c6l35zs9mm9dxm2x"
+   "commit": "d8e80d5ab97c85340b21be125f1e17edec2f21dd",
+   "sha256": "13r4s6nr0p5fj38swrgz5hnd12cazyigligr18ikwc6sxzz9yj9z"
   },
   "stable": {
    "version": [
@@ -78729,6 +78481,30 @@
   }
  },
  {
+  "ename": "miasma-theme",
+  "commit": "ebe44ef0683356abec66e834ae732f187a229893",
+  "sha256": "0k6159r5s889j3f3s9hiyy5qcfd2c7llrk18xwbyrdl1wndhwy7n",
+  "fetcher": "github",
+  "repo": "daut/miasma-theme.el",
+  "unstable": {
+   "version": [
+    20241201,
+    2218
+   ],
+   "commit": "c7a424832aaf982cdb2853b269f2b6fc43685195",
+   "sha256": "1l3zs0jxbbpnn18n9f22jgqsgpnk7bpy99is1nl163dhphna4jzz"
+  },
+  "stable": {
+   "version": [
+    1,
+    4,
+    0
+   ],
+   "commit": "c7a424832aaf982cdb2853b269f2b6fc43685195",
+   "sha256": "1l3zs0jxbbpnn18n9f22jgqsgpnk7bpy99is1nl163dhphna4jzz"
+  }
+ },
+ {
   "ename": "mic",
   "commit": "5a37253a8a1b2f107705c2f323f104c091f39204",
   "sha256": "0grjdymn8qy5lyg0l98ayz7w5rjdmzqmhc03r8690zsfh9sk8f6w",
@@ -78894,14 +78670,14 @@
   "repo": "countvajhula/mindstream",
   "unstable": {
    "version": [
-    20240908,
-    2036
+    20241121,
+    19
    ],
    "deps": [
     "magit"
    ],
-   "commit": "cdcd2d234dec2c143c4e5a302c8ffde59a864f72",
-   "sha256": "0fg41gjf1hz533gbvshhrfkzk78pyvhahf4h7kp1vrzlndxhnqfm"
+   "commit": "cad6a33c7e45f7c52f627d38d3d1f8f35a53413e",
+   "sha256": "1xvmm53s59fkg0cibcim0ivi258w26a2sg9aizg1gw3iqhyjy1rr"
   },
   "stable": {
    "version": [
@@ -78956,15 +78732,15 @@
   "repo": "liuyinz/mini-echo.el",
   "unstable": {
    "version": [
-    20241013,
-    438
+    20241201,
+    2106
    ],
    "deps": [
     "dash",
     "hide-mode-line"
    ],
-   "commit": "83b6c6f36d318943f33b347b87f8ce6bdc0cb852",
-   "sha256": "1vkm5r5hbbysgp5hvjbym42d0m4v5jbanbb89z9l87rk17n90cjr"
+   "commit": "0e6054359a1826694d50a1be18c419b485ab3d81",
+   "sha256": "04hx6rk1snwjkpvgapqf9naqqac0klk6f0wlxfb9ndx6j60865hj"
   },
   "stable": {
    "version": [
@@ -79187,14 +78963,14 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20240805,
-    1422
+    20241123,
+    2136
    ],
    "deps": [
     "compat"
    ],
-   "commit": "413b95a0d1c7c10d0f8d440d1982062b73d5ea4a",
-   "sha256": "10pxhsl9yr1nkbkhhvz5iq1q2dbcl315b6q02v23wmns66a9akya"
+   "commit": "e04415dc028ba252f079cfc7d6dff3059a047fbd",
+   "sha256": "1y5a7najnfi2bxpigf0j686z0i07ss81z8dxxsw1vsjxfn47rhl2"
   },
   "stable": {
    "version": [
@@ -79252,6 +79028,21 @@
    ],
    "commit": "2512521ba7f8e263a06db88df663fc6b3cca7e16",
    "sha256": "1yrawvvn3ndzzrllh408v4a5n0y0n5p1jczdm9r8pbxqgyknbk1n"
+  }
+ },
+ {
+  "ename": "minizinc-ts-mode",
+  "commit": "7b8db9ce73c5f88f8a4e0f99bdf1ae9171cd2d1f",
+  "sha256": "199rrkphi8dkx3ibzh2ixbqm8y96062snibdy2p1xrk5ls1z547g",
+  "fetcher": "github",
+  "repo": "AjaiKN/minizinc-ts-mode",
+  "unstable": {
+   "version": [
+    20241202,
+    17
+   ],
+   "commit": "0587165602bcf8c6ab768be9cfdc5465d1f1febd",
+   "sha256": "17xihxspc0rii0zz5996rn5zh99vqqya4jwnynkmv2jbpr843k7l"
   }
  },
  {
@@ -79355,15 +79146,15 @@
   "repo": "liuyinz/mise.el",
   "unstable": {
    "version": [
-    20240707,
-    1428
+    20241106,
+    1515
    ],
    "deps": [
     "dash",
     "inheritenv"
    ],
-   "commit": "20179a58132e5518a0868eac01dcd1d72db2e254",
-   "sha256": "0s81nsk500g5aqh1d8q3rbp4b9jkv4msfxsiqbgkf60ypzchc3zp"
+   "commit": "6e32b3787dd926cc9d8e9202b5aaa82682398261",
+   "sha256": "10irz22ph0ic9v6l4x1m072nwq63d5j1i7jj01mmh428dnwc84v5"
   },
   "stable": {
    "version": [
@@ -79387,19 +79178,19 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20241013,
-    1752
+    20241124,
+    1049
    ],
-   "commit": "92ce320189c26b7368df5b52a8338c126eb5b7eb",
-   "sha256": "0byxmxaqmh8v008al2420rw3ibwyf2jwk0ylfpci2h27r2cmpx9y"
+   "commit": "45f1b757a3c4bc75103a8eb3c687cd3c08b137c1",
+   "sha256": "0drssrc36pn6fafc45lgvk5iskz0970hjqr2v1ri8xrymvrb9idh"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "d2e1ba09bef4d8cac31c4128c29fdd275f065988",
-   "sha256": "1j7ylsmly1ifq6qlx8xaxsd8cy7s47rf9zndcxg3xwj718mwdhdk"
+   "commit": "f70ea7f5c91f5df6ac0d3a09eaccc283fbdbce70",
+   "sha256": "16l0smp5y2ss9802jijjxs0v42sgcswlpambkc4fa17n47zbb4g1"
   }
  },
  {
@@ -79467,20 +79258,20 @@
   "repo": "jdtsmith/mlscroll",
   "unstable": {
    "version": [
-    20240606,
-    1855
+    20241021,
+    255
    ],
-   "commit": "805d913771270f8157730f634108a237ca03137e",
-   "sha256": "0id3jglmqvzdpl5r26czxyb5vf0namvcxrql9b8djanvkd1pasz4"
+   "commit": "c1bc37709c27d005190d7fcd6a17376b9413381f",
+   "sha256": "1fp166qgsj95smg2918r33pw5vpwwd395fr6xd7y7asjbwzaqpjy"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
-   "commit": "805d913771270f8157730f634108a237ca03137e",
-   "sha256": "0id3jglmqvzdpl5r26czxyb5vf0namvcxrql9b8djanvkd1pasz4"
+   "commit": "c1bc37709c27d005190d7fcd6a17376b9413381f",
+   "sha256": "1fp166qgsj95smg2918r33pw5vpwwd395fr6xd7y7asjbwzaqpjy"
   }
  },
  {
@@ -79984,20 +79775,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20241007,
-    1332
+    20241120,
+    542
    ],
-   "commit": "817ff75d11599b65acf583e0f8b5d69163550299",
-   "sha256": "0jd9xdc5d56zdvxqgmgg2wimn3ds20vw7ss0jhakl31ndr8izbp9"
+   "commit": "df1798234edd56678da975d0d65b64bdebafc314",
+   "sha256": "0n7sbap1y72l9z8ifngfkl1bm2zgmx570i2dc0yd41la54q9ka0r"
   },
   "stable": {
    "version": [
     4,
-    5,
+    6,
     0
    ],
-   "commit": "db70c2ca923261591419de084f9e4c806b409b60",
-   "sha256": "04nr06w7zvvkk0m368pkp4pdlv6m91qnxizrvns2530prddb4c7i"
+   "commit": "895e10936adac93aa8187c9cc91092dbca898677",
+   "sha256": "05vzbjhas9a4zapjk2d57a6ljabf2q24d9c1zxncyff8kyimzkq2"
   }
  },
  {
@@ -80669,20 +80460,20 @@
   "repo": "amnn/move-mode",
   "unstable": {
    "version": [
-    20240409,
-    2159
+    20241118,
+    1527
    ],
-   "commit": "f974cc69f279c45026f7386e0194be74779334a8",
-   "sha256": "1wz3dw39bv351gxqwis7lbsynr04fniprymjdb0xdcfhdfxnpy3x"
+   "commit": "6e4aaf6aae1e9b4aee096557c9f7b1f3550a1e59",
+   "sha256": "0fdksdq8dmi9ixmsn7yyc7y50kfqsv2zbv8gqg4ir6d0jqbrvnhz"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
-   "commit": "f974cc69f279c45026f7386e0194be74779334a8",
-   "sha256": "1wz3dw39bv351gxqwis7lbsynr04fniprymjdb0xdcfhdfxnpy3x"
+   "commit": "6e4aaf6aae1e9b4aee096557c9f7b1f3550a1e59",
+   "sha256": "0fdksdq8dmi9ixmsn7yyc7y50kfqsv2zbv8gqg4ir6d0jqbrvnhz"
   }
  },
  {
@@ -81020,11 +80811,11 @@
   "repo": "kljohann/mpv.el",
   "unstable": {
    "version": [
-    20220801,
-    1917
+    20241121,
+    2308
    ],
-   "commit": "2e0234bc21a3dcdf12d94d3285475e7f6769d3e8",
-   "sha256": "0mvzg2wqpycny2dmiyp8jm0fflvll7ay6scvsb9rxgfwimr2vbw5"
+   "commit": "62cb8825d525d7c9475dd93d62ba84d419bc4832",
+   "sha256": "1r3z9mhz9mbjz82g5ljjh559f2awh5cfg1vv3qdgqk6djvwzhpay"
   },
   "stable": {
    "version": [
@@ -81325,20 +81116,20 @@
   "repo": "mkcms/mu4e-overview",
   "unstable": {
    "version": [
-    20240521,
-    1445
+    20241201,
+    1012
    ],
-   "commit": "51327c894721680633292a43a4e610542b4eceb3",
-   "sha256": "1pxapgihcf5c8ycmqzd2gysm0v6r0pw41kbym4xdwyqr6alhz94a"
+   "commit": "25a1c0c5fbac240e5faa1518b511609b709e3c53",
+   "sha256": "0q2xc3dpg70j3xk9f6c7wpiznvmscdfggzxkf8c4xxg4jfvbdcxh"
   },
   "stable": {
    "version": [
     0,
-    4,
-    1
+    5,
+    0
    ],
-   "commit": "11e16c36aaa14da777a068761055b57c49168f1e",
-   "sha256": "0hi2waz0bwzsq3sk6x7zdx7qn3dns82rphpnfd9r7cqyqjlmzy74"
+   "commit": "25a1c0c5fbac240e5faa1518b511609b709e3c53",
+   "sha256": "0q2xc3dpg70j3xk9f6c7wpiznvmscdfggzxkf8c4xxg4jfvbdcxh"
   }
  },
  {
@@ -81445,8 +81236,8 @@
   "repo": "mihaiolteanu/mugur",
   "unstable": {
    "version": [
-    20240517,
-    504
+    20241028,
+    828
    ],
    "deps": [
     "anaphora",
@@ -81454,8 +81245,8 @@
     "dash",
     "s"
    ],
-   "commit": "7fe7f6a9dd80389fcd9754e9191192e697a88882",
-   "sha256": "010jns9id9gxggxgd2d3wpjag1nf8ahqmq57a3mdmfrr1lnvvxzi"
+   "commit": "757e06ba7a062a12e5976a5ce2a47f23eaa454af",
+   "sha256": "1hfbib09a224dysh9synwqzdj3rrgcl2az9zm05xcnlbxcnhgjv4"
   },
   "stable": {
    "version": [
@@ -81698,14 +81489,14 @@
   "repo": "magnars/multiple-cursors.el",
   "unstable": {
    "version": [
-    20240223,
-    1134
+    20241201,
+    1841
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c870c18462461df19382ecd2f9374c8b902cd804",
-   "sha256": "1703ca0k0mlvjh7l0jv2nzgzah8ixb3n9av725cs2c07cih6vhsa"
+   "commit": "46635e7f693560213b56ca8eca1adb13559672e5",
+   "sha256": "19ldrdwpv7ga4vk3lx397zl875kdnr94apg3ni5manr2x0fdcl2c"
   },
   "stable": {
    "version": [
@@ -82826,20 +82617,20 @@
   "repo": "babashka/neil",
   "unstable": {
    "version": [
-    20240701,
-    1458
+    20241017,
+    1337
    ],
-   "commit": "054ca51542837fec87e289a74ab139b4ae6e108b",
-   "sha256": "1jhpk9h9dv1zqba9076lvvy5cayirb49fzw9gfrqi1qp8zqi41cb"
+   "commit": "78ffab1868dc04b2eec5d7195d2d8f92c416e528",
+   "sha256": "0z3imz4b2j64pri0nml3v4lhlycw5ah271q4qi5g8qifbfn9anms"
   },
   "stable": {
    "version": [
     0,
     3,
-    67
+    68
    ],
-   "commit": "054ca51542837fec87e289a74ab139b4ae6e108b",
-   "sha256": "1jhpk9h9dv1zqba9076lvvy5cayirb49fzw9gfrqi1qp8zqi41cb"
+   "commit": "78ffab1868dc04b2eec5d7195d2d8f92c416e528",
+   "sha256": "0z3imz4b2j64pri0nml3v4lhlycw5ah271q4qi5g8qifbfn9anms"
   }
  },
  {
@@ -82927,11 +82718,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20240816,
-    1555
+    20241106,
+    1533
    ],
-   "commit": "c3d641d8e14bd11b5f98372da34ee5313636e363",
-   "sha256": "0dmi01x8vk165i8161scqg3vmaspfih6pblr3iaw8ksp5ps1hnlf"
+   "commit": "a6ee08f1619bcde1a69b2defcfe8970c983640c1",
+   "sha256": "16k8wlvpxmjbvrn6abkgk6f97im9d1vhxlwmf81ypfrj9x05fwqg"
   },
   "stable": {
    "version": [
@@ -82970,26 +82761,26 @@
   "repo": "LuigiPiucco/nerd-icons-corfu",
   "unstable": {
    "version": [
-    20231019,
-    1618
+    20241101,
+    2309
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "7077bb76fefc15aed967476406a19dc5c2500b3c",
-   "sha256": "13m20k242zma6jw7pkbw89fk3dnbkwdajcpiyay5xx2l9241snb7"
+   "commit": "721830b42b35e326a88b338fc53e4752f333fad2",
+   "sha256": "0mls7hz1c2f68lzj4g38plgxyndr3km8lpzyi91ssg4j61zmrbgm"
   },
   "stable": {
    "version": [
     0,
-    3,
-    0
+    4,
+    2
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "cbc14c73032ebe1b2043757221d198ff6be1b670",
-   "sha256": "05hnq6yv0xcisk5vkdzjz2sdzn4cayirf3zyz40xj1pzf33lra4r"
+   "commit": "721830b42b35e326a88b338fc53e4752f333fad2",
+   "sha256": "0mls7hz1c2f68lzj4g38plgxyndr3km8lpzyi91ssg4j61zmrbgm"
   }
  },
  {
@@ -83235,11 +83026,11 @@
   "repo": "vekatze/neut-mode",
   "unstable": {
    "version": [
-    20240929,
-    553
+    20241130,
+    1223
    ],
-   "commit": "4c2d56fdd6295589439ffef214666452cc45c7d6",
-   "sha256": "0870c7wmvk1bbh1xh826qgjcnizm662db8n8i9iaqh0dslmr0qd3"
+   "commit": "2373c428f314948d433cb6070b237b6243922312",
+   "sha256": "1zvngs8fnpywgn7ryrdb78rj0b730fy1brbl1zqzqzhb4rj54pxh"
   }
  },
  {
@@ -83557,17 +83348,17 @@
  },
  {
   "ename": "ninja-mode",
-  "commit": "f9103b6c58996e75c0e5c23fc0fb12afd65424c0",
-  "sha256": "0r0hjrw79bj67r79kfqikcmxnn93d324l3zlh203kvnzvrggfwra",
+  "commit": "7c157fd47c9b7783c8bef103eaa42d0f5a626026",
+  "sha256": "1xsx71znz85afr73a3nz2ks85bak6fa7kanp48k2bmigy3r4b6j5",
   "fetcher": "github",
-  "repo": "ninja-build/ninja",
+  "repo": "ninja-build/ninja-emacs",
   "unstable": {
    "version": [
-    20240528,
-    1945
+    20241103,
+    1737
    ],
-   "commit": "0b4b43aa3e2fee391443dcc0c961c9d2354d8954",
-   "sha256": "1g779g7x1d0f7vi7d2sraqmd9zsccnmglp9fn7w5146swqpgsvqp"
+   "commit": "573c3aaedc6e90e9a8954bb70a24e079af7df390",
+   "sha256": "04cjm43fikdrwv5qg6czq6gkm1mv351b0m35nhvw520vyc79scgc"
   },
   "stable": {
    "version": [
@@ -83706,10 +83497,10 @@
  },
  {
   "ename": "nix-sandbox",
-  "commit": "258a113cb0f7902ca083c931c064c093b3721b52",
-  "sha256": "1kiscg761zx4mnq2hksfzmdz0g9b7z7lzm8ncy0dgs40yb803ijv",
+  "commit": "7f298cdc6773f3aeb7baf9c6a32c97d2b60f55a3",
+  "sha256": "1zs10qf28imnzhrh9r398m4zciar86m2j6r899pnlk7z1xllkbnj",
   "fetcher": "github",
-  "repo": "travisbhartwell/nix-emacs",
+  "repo": "nix-community/nix-emacs",
   "unstable": {
    "version": [
     20210325,
@@ -83755,11 +83546,11 @@
   "repo": "jwiegley/nix-update-el",
   "unstable": {
    "version": [
-    20220816,
-    2212
+    20241123,
+    2159
    ],
-   "commit": "aab70a38165575a9cb41726f1cc67df60fbf2832",
-   "sha256": "01cc86wvlwl5sy758vcjhwwh1has4ng6sqyrsd5y610qahs8cbib"
+   "commit": "77022ccd918d665acbb519b243e7e3dc5eae1c47",
+   "sha256": "18p4wf3f149n27d1divkzd39y1iy75ig2986flzfd06l8x1d2fa3"
   }
  },
  {
@@ -83782,10 +83573,10 @@
  },
  {
   "ename": "nixos-options",
-  "commit": "6846c7d86e70a9dd8300b89b61435aa7e146be96",
-  "sha256": "1m3jipidk10zj68rzjbacgjlal31jf80gqjxlgj4qs8lm671gxmm",
+  "commit": "7f298cdc6773f3aeb7baf9c6a32c97d2b60f55a3",
+  "sha256": "12dl59wa2b3qpdaprjllfbybaazxc9qp1bs2rq8ygdkr56v12nvx",
   "fetcher": "github",
-  "repo": "travisbhartwell/nix-emacs",
+  "repo": "nix-community/nix-emacs",
   "unstable": {
    "version": [
     20160209,
@@ -83894,17 +83685,15 @@
   "repo": "dickmao/nndiscourse",
   "unstable": {
    "version": [
-    20230705,
-    1229
+    20241014,
+    2134
    ],
    "deps": [
-    "anaphora",
-    "dash",
     "json-rpc",
     "rbenv"
    ],
-   "commit": "d54edbd7cf6b75c5101a961cab54efbafef7d80e",
-   "sha256": "0c38j3drf89f98b6h3xcky6alggszrr86325g72mlbkknszkhh95"
+   "commit": "c8aaf40d3d8f10b0bbb40fa60a2d98c864b05aaf",
+   "sha256": "1kw023rc4a0p0k6zvq03nr4k6ndc6p6h7s70y2macabn4z1z3fyq"
   }
  },
  {
@@ -83950,8 +83739,8 @@
   "repo": "dickmao/nnreddit",
   "unstable": {
    "version": [
-    20240629,
-    2347
+    20241014,
+    1932
    ],
    "deps": [
     "anaphora",
@@ -83961,8 +83750,8 @@
     "s",
     "virtualenvwrapper"
    ],
-   "commit": "f8e26834b523c03dfcb0c751373123ffd32b8522",
-   "sha256": "1a0b0dk578kw33qgfbb4zvqnc4cmix4mfwrlqy2rcg13z3ax39c7"
+   "commit": "4f8f6e8d1bf584a2bdbb4e9039576ad361f9636d",
+   "sha256": "0mxqgx7dajlxzvpasj03n2sg42iv7aivzdrszkxmx2ayc8dlx1gz"
   }
  },
  {
@@ -84026,26 +83815,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20241001,
-    1020
+    20241201,
+    2109
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7474c55122f568212103efe325f347ee05878f70",
-   "sha256": "04vwi1w6j80s2nlz7r1md82fxdckryncr93ixrif4xzqdwlbb0x9"
+   "commit": "74431db47edf44fc1f5f013033560f7bc4f26f24",
+   "sha256": "0l88l1np4s5925d6i33l1cas8mk0nwbgbyw7fa1akzj8qv6782sm"
   },
   "stable": {
    "version": [
     1,
     7,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7474c55122f568212103efe325f347ee05878f70",
-   "sha256": "04vwi1w6j80s2nlz7r1md82fxdckryncr93ixrif4xzqdwlbb0x9"
+   "commit": "74431db47edf44fc1f5f013033560f7bc4f26f24",
+   "sha256": "0l88l1np4s5925d6i33l1cas8mk0nwbgbyw7fa1akzj8qv6782sm"
   }
  },
  {
@@ -84707,11 +84496,11 @@
   "repo": "muirdm/emacs-nova-theme",
   "unstable": {
    "version": [
-    20230906,
-    1542
+    20240904,
+    2127
    ],
-   "commit": "ca1a4cb71452ece3e18c0c46f9e7abc20f7123ca",
-   "sha256": "1gi1zbgbwjlw7sd8433xplg1zm9a7kp8i4y76b4vfn0g5ybhvqcz"
+   "commit": "51b2899ac56c29638d11336d3b2a9894bb35b86e",
+   "sha256": "1bk5cg1kq62pg0gdw97vlfgjxkifj5xhr8ippyic04dv02b3kkz8"
   }
  },
  {
@@ -85457,32 +85246,32 @@
  },
  {
   "ename": "ob-chatgpt-shell",
-  "commit": "deb0341c1559472ae28a2dbd72b3d83340232b8d",
-  "sha256": "1gy5zcznzaialvnxfdyia847i974n41hzwsrg0fcgj4s6abhcsw4",
+  "commit": "bd7bfd8814e2e81d4022984f6b2baf2b1d1d0225",
+  "sha256": "025qr0jwf9w3px7azdrjh625r7rjp1cj4ynjczpqyfm8m0xzfipi",
   "fetcher": "github",
-  "repo": "xenodium/chatgpt-shell",
+  "repo": "xenodium/ob-chatgpt-shell",
   "unstable": {
    "version": [
-    20241011,
-    805
+    20241118,
+    1001
    ],
    "deps": [
     "chatgpt-shell"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "754ddf54a99bd98427c91a6c7374757026f8bd45",
+   "sha256": "19xj8vm7kkv4a1xa7l5lrz1fk14v34pcbly8i3fpjqx1wgj04waa"
   },
   "stable": {
    "version": [
     1,
-    8,
+    20,
     1
    ],
    "deps": [
     "chatgpt-shell"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "a24c003c79a720eafffc79bc3885070735f667f6",
+   "sha256": "161q8d2b4sq481jh4zwagvh88wg51dsnf76n2l2b7wv3nh7cjh2m"
   }
  },
  {
@@ -85630,32 +85419,32 @@
  },
  {
   "ename": "ob-dall-e-shell",
-  "commit": "578e261826b0825cdcae0ab07bea4226bdef7fa3",
-  "sha256": "1ljqcg9qa3av6r4512f7sym641dymjv4fnymhw1sqz8bjgq0m775",
+  "commit": "bd7bfd8814e2e81d4022984f6b2baf2b1d1d0225",
+  "sha256": "1b2xbnwr01fax1qsknh1vcwlhhd5phwvgjd8014bnf370xzwb4fi",
   "fetcher": "github",
-  "repo": "xenodium/chatgpt-shell",
+  "repo": "xenodium/ob-dall-e-shell",
   "unstable": {
    "version": [
-    20241011,
-    805
+    20241112,
+    2008
    ],
    "deps": [
     "dall-e-shell"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "1ef7951bf47f63d2d0808c3f475f82eac8c9b219",
+   "sha256": "0188whx3yr0p8c6xzx5zmh1rxavan8a6z6ibmzfhsxgj8a1zid6f"
   },
   "stable": {
    "version": [
     1,
-    8,
+    20,
     1
    ],
    "deps": [
     "dall-e-shell"
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "a24c003c79a720eafffc79bc3885070735f667f6",
+   "sha256": "161q8d2b4sq481jh4zwagvh88wg51dsnf76n2l2b7wv3nh7cjh2m"
   }
  },
  {
@@ -86642,15 +86431,15 @@
   "repo": "xenodium/ob-swiftui",
   "unstable": {
    "version": [
-    20231009,
-    918
+    20241119,
+    1735
    ],
    "deps": [
     "org",
     "swift-mode"
    ],
-   "commit": "af65a8e60602ca90ab3f61811190a3da67ac0414",
-   "sha256": "1cyv3f4h7dj9fhlgivgh7mqgaaf7q5mxs4mmp833sh0mgk4p6vmk"
+   "commit": "c16b4cddb5387fcebdd1d61a4c6c015f778d2d08",
+   "sha256": "0lqff7cjxc0x4xdza2jm58gbg6rbwfg0w7112jpfvyp98x025abm"
   }
  },
  {
@@ -86941,20 +86730,20 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20240924,
-    756
+    20241129,
+    1514
    ],
-   "commit": "f8e16b3d70e5418db11a096108093d2a55012704",
-   "sha256": "1n0vc32kfmhqpygsqdga64hxvyyygq25g606dpqljydq425ncaq4"
+   "commit": "72cbfd716e619cb8ae3ae52cc0c5288eb2a2f2a8",
+   "sha256": "0fz8a92xdims2rnmhlv60yv5ylci80n4qgavg6jsfaf6fljz13gg"
   },
   "stable": {
    "version": [
     0,
-    26,
-    2
+    27,
+    0
    ],
-   "commit": "f5727b32127730a2722f86c7119eb6d8f884e26d",
-   "sha256": "0qkralffnq141ksl5y6564lmryqhks72kvf3rblg8pnzjbcsad5v"
+   "commit": "72cbfd716e619cb8ae3ae52cc0c5288eb2a2f2a8",
+   "sha256": "0fz8a92xdims2rnmhlv60yv5ylci80n4qgavg6jsfaf6fljz13gg"
   }
  },
  {
@@ -87332,20 +87121,20 @@
   "repo": "rnkn/olivetti",
   "unstable": {
    "version": [
-    20240727,
-    431
+    20241030,
+    542
    ],
-   "commit": "1a6a521273e70173af6dcf34e3c9f8bb97dd7afc",
-   "sha256": "0ngafkirgfhcq8vkphwd9z4whxwlv62y17a9ihav8f31v5d4kbm1"
+   "commit": "845eb7a95a3ca3325f1120c654d761b91683f598",
+   "sha256": "0hpw8q4x1ns6l838r2m0zfm7ykxsrfx893bvsn92nsn6k10p0yvr"
   },
   "stable": {
    "version": [
     2,
     0,
-    6
+    7
    ],
-   "commit": "1a6a521273e70173af6dcf34e3c9f8bb97dd7afc",
-   "sha256": "0ngafkirgfhcq8vkphwd9z4whxwlv62y17a9ihav8f31v5d4kbm1"
+   "commit": "b64c0ac8c3ec9bdc67373fa754fe493be4cc81bd",
+   "sha256": "0q1z07z0nkvzplmsqni25hqhv81x3r7f1xahjjkskmllrhksz0bh"
   }
  },
  {
@@ -88232,26 +88021,26 @@
   "repo": "rksm/org-ai",
   "unstable": {
    "version": [
-    20240806,
-    1340
+    20241020,
+    644
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "0184f063484cfd8079aa9aa30fa171a7a47f465e",
-   "sha256": "18y9c86zj88kijl205h34ra6kqqb5bljshng6sfr51833yjd4vc7"
+   "commit": "5adfde1bc7db9026747fbfae4c154eeac4ef8e59",
+   "sha256": "1h7cmrvj64zfdxx28a4ajmbibf30ff5a680s5hvlv5lmn13isg12"
   },
   "stable": {
    "version": [
     0,
     5,
-    1
+    4
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "812b59f88851536ed3ded199fb55d303c16c7c12",
-   "sha256": "00f6k2gcglcr5mwdr3ixy5gazn2p1dnw3cvzsvzz870pl855f8fk"
+   "commit": "5adfde1bc7db9026747fbfae4c154eeac4ef8e59",
+   "sha256": "1h7cmrvj64zfdxx28a4ajmbibf30ff5a680s5hvlv5lmn13isg12"
   }
  },
  {
@@ -88468,6 +88257,36 @@
   }
  },
  {
+  "ename": "org-auto-export-pandoc",
+  "commit": "caa8d7c66b896f468f578eb39c7887e62afcae3c",
+  "sha256": "0phx71gnrpadjcg267bhljpg6xp1n1ki6piv619k8icg30zih5hq",
+  "fetcher": "github",
+  "repo": "Y0ngg4n/org-auto-export-pandoc",
+  "unstable": {
+   "version": [
+    20241026,
+    832
+   ],
+   "deps": [
+    "ox-pandoc"
+   ],
+   "commit": "4c63da7ed3c6bae6fd512d2b886ed3c57c850219",
+   "sha256": "035c3plxyh14ipg8paqk8wzf85rml8g14jyssh0bjn7hfca0lyzk"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "deps": [
+    "ox-pandoc"
+   ],
+   "commit": "caba13b56e32ba49ab9eca01a60b7e6edcdbb786",
+   "sha256": "1sccpi70g1gdd2i82808c1vg5d0fbyn8jnipak8sfgykpk0vxccm"
+  }
+ },
+ {
   "ename": "org-auto-tangle",
   "commit": "8cdae87606068b7b47530e0744e91aead86d288e",
   "sha256": "1cr34yjr43ah9bqvrghlyx2vag7xnamgfijb417k5m70cbk8vcb8",
@@ -88505,25 +88324,25 @@
   "repo": "zondo/org-autoexport",
   "unstable": {
    "version": [
-    20240902,
-    2253
+    20241130,
+    1655
    ],
    "deps": [
     "org"
    ],
-   "commit": "54b5e836c36d8faa9a3cc67ec1fe52f38b2c3c83",
-   "sha256": "1914rkjpfrmbdvcy1ac487v464bkynzi1vicp7ci2kv4fqjw4rnh"
+   "commit": "f5819f21ba4a92d1742371a3422102bb965f0706",
+   "sha256": "1fpn2f0fl32n4hqsdfvld1qfz5xz8d0hv16wak2mhn5ssw4qw68j"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
    "deps": [
     "org"
    ],
-   "commit": "47acc4a367c621075cfd27ddc3ad7c9282865771",
-   "sha256": "11a93qs86jxwvwsjvda6c51gg1db1w6zwp2disd3bnplbrsyskdr"
+   "commit": "0d3944d055ce4e8922991f892418a9bafd3eba15",
+   "sha256": "1fpn2f0fl32n4hqsdfvld1qfz5xz8d0hv16wak2mhn5ssw4qw68j"
   }
  },
  {
@@ -88666,14 +88485,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20240906,
-    1018
+    20241115,
+    1106
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "42e1100b0e99bf91b532d7e06d246a2f2660d853",
-   "sha256": "0kaawmf3d5smvpgyb411mp5zypznw9q715gz05kbb852y0qw31yw"
+   "commit": "22c8d837b01b0967910d731592402b57f6d2a3e9",
+   "sha256": "0j6yraf7h6iri6aq5qbxkg38p4rzvvg0b7i6cb20xvqp4sl9rv58"
   },
   "stable": {
    "version": [
@@ -89313,14 +89132,14 @@
   "repo": "abo-abo/org-download",
   "unstable": {
    "version": [
-    20220906,
-    1929
+    20241118,
+    1846
    ],
    "deps": [
     "async"
    ],
-   "commit": "19e166f0a8c539b4144cfbc614309d47a9b2a9b7",
-   "sha256": "0a2nw2vf9j335yz40x10q0vmnhxkn9frrm82apvjqsl5p7igvzvs"
+   "commit": "c8be2611786d1d8d666b7b4f73582de1093f25ac",
+   "sha256": "17i4fc0fy8icmw46i49y8vnmvf71r6zq7g2cz55f0v940b3g7ri7"
   },
   "stable": {
    "version": [
@@ -90406,15 +90225,15 @@
   "repo": "seokbeomKim/org-linenote",
   "unstable": {
    "version": [
-    20240410,
-    410
+    20241201,
+    1208
    ],
    "deps": [
     "projectile",
     "vertico"
    ],
-   "commit": "a015295ebf271c8b518238f7969a0b6e60429805",
-   "sha256": "1jn22rvlxy5d2p56vm2jgs5jz4nm76ji4xmd71pnc18x2ci2p2c8"
+   "commit": "bbf8ea8667003ffbda497b8ec21aedeca0ab0ff0",
+   "sha256": "1zprrslqz0dzf6dfypgzs9xbsc25647r2xwd28pzag6yzd7mcf2z"
   }
  },
  {
@@ -90425,16 +90244,16 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20240930,
-    1046
+    20241130,
+    1258
    ],
    "deps": [
     "fb2-reader",
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "b232a19ed4cc45291d31c6a4ca1eb185fd0247cb",
-   "sha256": "0ywyjm7pq4cxvbndkz5q6hbbxwrp3lprpix16cwmc8g2pyaz8wsv"
+   "commit": "d3428752d3e961087ccc462593bd1a0922d3bb67",
+   "sha256": "1dcnpmbww6w96nw2bckzmq0mfk3w2zgks7xfxi3bpvwiqm512h1g"
   },
   "stable": {
    "version": [
@@ -90750,11 +90569,11 @@
   "repo": "bpanthi977/org-mpv-notes",
   "unstable": {
    "version": [
-    20240926,
-    138
+    20241119,
+    1627
    ],
-   "commit": "22b9ac4c0bf3144f0a8ac3fb370efe0ac074d128",
-   "sha256": "0rapddcqsca5w9cfvdxwabw8qxql3dd03kfix1zlskwx1iiypvjj"
+   "commit": "f6c0fc5546cf7168d997a3605cce7c08714cb599",
+   "sha256": "013c90h8qajil7wk1m1q6kqxgl5812bd004lqn0k886mahfm75qn"
   }
  },
  {
@@ -90924,28 +90743,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20241007,
-    2215
+    20241201,
+    2012
    ],
    "deps": [
     "compat",
+    "el-job",
     "llama"
    ],
-   "commit": "886a0a08b8ab9c8537cc15c39af9463926d04446",
-   "sha256": "0ma5cn57dng5i1jmq9q7nh9a9sdnm5jlihyd4xgn465q4dqsch2p"
+   "commit": "c1e8d8b1e8bf9463c7b97f290a8307184a19c041",
+   "sha256": "05gniyrl3pffdaa6kbb5cssvmi0gjg6isnyk17zl3c23lf3s4mnf"
   },
   "stable": {
    "version": [
     1,
-    5,
-    2
+    9,
+    10
    ],
    "deps": [
     "compat",
+    "el-job",
     "llama"
    ],
-   "commit": "886a0a08b8ab9c8537cc15c39af9463926d04446",
-   "sha256": "0ma5cn57dng5i1jmq9q7nh9a9sdnm5jlihyd4xgn465q4dqsch2p"
+   "commit": "c1e8d8b1e8bf9463c7b97f290a8307184a19c041",
+   "sha256": "05gniyrl3pffdaa6kbb5cssvmi0gjg6isnyk17zl3c23lf3s4mnf"
   }
  },
  {
@@ -90956,8 +90777,8 @@
   "repo": "meedstrom/org-node-fakeroam",
   "unstable": {
    "version": [
-    20241005,
-    1718
+    20241127,
+    1306
    ],
    "deps": [
     "compat",
@@ -90965,14 +90786,14 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "3e84dee8641191c87cc5a9e74999b2396db92972",
-   "sha256": "13pkrzldbbn1n5hc967baqhd2ncdfh1fdcw8f4107mbvbfh3g3v9"
+   "commit": "288d897e12713db7d15162ccf3bdc93147f00943",
+   "sha256": "1lrkqv5bkz2f15vp50j95nnffhl3ibbh47nq4mbl14wqil1bp89m"
   },
   "stable": {
    "version": [
     1,
-    2,
-    6
+    6,
+    4
    ],
    "deps": [
     "compat",
@@ -90980,8 +90801,8 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "3e84dee8641191c87cc5a9e74999b2396db92972",
-   "sha256": "13pkrzldbbn1n5hc967baqhd2ncdfh1fdcw8f4107mbvbfh3g3v9"
+   "commit": "288d897e12713db7d15162ccf3bdc93147f00943",
+   "sha256": "1lrkqv5bkz2f15vp50j95nnffhl3ibbh47nq4mbl14wqil1bp89m"
   }
  },
  {
@@ -91503,8 +91324,8 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20240916,
-    2325
+    20241107,
+    345
    ],
    "deps": [
     "compat",
@@ -91519,14 +91340,14 @@
     "transient",
     "ts"
    ],
-   "commit": "b6f8a315e966123fbfd1ac240d35da5c2b48d6ac",
-   "sha256": "0661v0rpiq2qa6kz8fl9h3i52idisf3azr8xmanqa3n339ib2z70"
+   "commit": "a5650e2be831ae130af8d9f5419bcb141e36b1d4",
+   "sha256": "1008hjqrlcc5pm6zw65p42ivf6gljj3mivvkinv8byyqkanrhklb"
   },
   "stable": {
    "version": [
     0,
     8,
-    9
+    10
    ],
    "deps": [
     "compat",
@@ -91541,8 +91362,8 @@
     "transient",
     "ts"
    ],
-   "commit": "81281350d44a3903a0866431342299f5f3c74beb",
-   "sha256": "1mw07y82r3b9brphx2j8gj95rbs4632fgq0b79824zqpwm8m291j"
+   "commit": "9c53c1bddfcbda3475ffd8810f012be6de07d963",
+   "sha256": "043m90flbmmcaiv1n5lfw6pd5hr978r9kqbhy34rgyzm0k34sk72"
   }
  },
  {
@@ -91815,8 +91636,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20240802,
-    1213
+    20241124,
+    2012
    ],
    "deps": [
     "avy",
@@ -91832,8 +91653,8 @@
     "request",
     "s"
    ],
-   "commit": "fd178abf12a85f8e12005d1df683564bdc534124",
-   "sha256": "0rdi1n4vay93xs7gwxxmivg3lq13sk10f0g505z0hagzcv2f48w7"
+   "commit": "a61fe2a76294dcf4b216c25f789c4dba15f5986d",
+   "sha256": "05fb0ihnflm14z4fhphjx3zfg172asmjl8lf602vgimyj28xbidy"
   },
   "stable": {
    "version": [
@@ -91942,11 +91763,11 @@
   "repo": "brabalan/org-review",
   "unstable": {
    "version": [
-    20230119,
-    1706
+    20241115,
+    701
    ],
-   "commit": "77211e40db8a9558b866f5660c7127922b459e6c",
-   "sha256": "1izm9aj8cqni8sjsxmlk5bbl4nn90476pa339jfxh812v5will1y"
+   "commit": "2d9c04776a58b94cfff790ed80a471a9e5b4873b",
+   "sha256": "19q8hw4cr01mfvh5bw4p3zjdc3sjfp0bsjw39l5m77jnkg35gjfn"
   }
  },
  {
@@ -92050,18 +91871,19 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20240826,
-    2002
+    20241130,
+    256
    ],
    "deps": [
+    "dash",
     "magit-section",
     "org-roam",
     "org-super-agenda",
     "s",
     "transient"
    ],
-   "commit": "9071426d97b329bb98bc54b5287a322dc3814d95",
-   "sha256": "1p6arv063z7vdx4x9s22xnna4iz7p599z5gp0x0mrwg9v6fvii7y"
+   "commit": "661e388bba2b71b2d8b3db287b7f77e400b452f6",
+   "sha256": "0l16gm93cyfvi9wcyrvrb20sdmgz6dgcrc2f2daxhdypkc4c3dzd"
   },
   "stable": {
    "version": [
@@ -92156,8 +91978,8 @@
  },
  {
   "ename": "org-ros",
-  "commit": "a7b6aff1afbd525b43a53229be4e6faf166c6968",
-  "sha256": "10jfdrrqqk0y43z32w0hsiih1l3rb6yafkqwxj64dgfd0iz4szsx",
+  "commit": "333bbda7a87518ef37b45a352b447b4e519b3926",
+  "sha256": "0cis880vq63z5zwnfan8sqimf8nc27yqh4w5z3ll1mdxif1kx87v",
   "fetcher": "github",
   "repo": "LionyxML/ros",
   "unstable": {
@@ -92752,14 +92574,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20241003,
-    221
+    20241109,
+    445
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "3b3f95b41c97abc9de3075419b9b30c754f749fc",
-   "sha256": "03s1rjm7yhc64jwxii9hj277x975b47nx99fcrbdmrqkcfp5ngff"
+   "commit": "4eb1b403a004daf20bb622c6b708d1c743bbc01a",
+   "sha256": "1hh3f63pf88x9jabwhjis6cpcm9h3rzzq6jjfgqa8vig4fzsa85z"
   }
  },
  {
@@ -92901,16 +92723,16 @@
   "repo": "ichernyshovvv/org-timeblock",
   "unstable": {
    "version": [
-    20240212,
-    649
+    20241027,
+    805
    ],
    "deps": [
     "compat",
     "org",
     "svg"
    ],
-   "commit": "b423b01712b9c25dff3e4203c7cde736225f62ef",
-   "sha256": "1q0271nli4yw01rwybkzdlqcj8ivqwh5r70yv9x0qqwxa955c9k9"
+   "commit": "e61e5734b49f933ed178029f804a0499f3308e1e",
+   "sha256": "1p0ry4kx98fp15zhfd3dpdw0k27x1w48ljwasnx2dgjz7bkkirrl"
   },
   "stable": {
    "version": [
@@ -93245,15 +93067,15 @@
   "repo": "unhammer/org-upcoming-modeline",
   "unstable": {
    "version": [
-    20231124,
-    1726
+    20241028,
+    1217
    ],
    "deps": [
     "org-ql",
     "ts"
    ],
-   "commit": "37634ddeeda85a0036987b056ac71199ac3bd03e",
-   "sha256": "1p1lphf50c71n0rp5k26kl37a02ahqxklpk1z133bwdmmnqi1ckm"
+   "commit": "66bfdbe847f398f87e8a05c0cf472eb673fac522",
+   "sha256": "1nmyrrqjmja3x318pjqcw208l2ir5v3fl9dhyvkah27nh0xxk11y"
   },
   "stable": {
    "version": [
@@ -93271,10 +93093,10 @@
  },
  {
   "ename": "org-variable-pitch",
-  "commit": "9632b7e98772b584d6420f8d0f9652d67118e05e",
-  "sha256": "1xci5zq1bpwnm3adlcsxzpskxywzalb1n3n14lvf787f77ib602c",
-  "fetcher": "github",
-  "repo": "cadadr/elisp",
+  "commit": "04fdd633207a28b91f0a6e64aa25d114ab229a13",
+  "sha256": "0v78akifa3mx2k42myr32swfdrijqjn7xwqqj4lx3ngib630k4wh",
+  "fetcher": "codeberg",
+  "repo": "kutuptiyini/elisp",
   "unstable": {
    "version": [
     20220220,
@@ -93411,28 +93233,28 @@
   "repo": "p-snow/org-web-track",
   "unstable": {
    "version": [
-    20241013,
-    820
+    20241110,
+    1121
    ],
    "deps": [
     "enlive",
     "request"
    ],
-   "commit": "3e41c415e932ab50fcbfadb3ae026c346cc3b35d",
-   "sha256": "1brcjznpiqvs9qg4k0pq8yhl1n55rd85rzgvr8z7snpkig8i1hw9"
+   "commit": "3e75df16ec05960e973f044966cdc0b9d1a0fa6d",
+   "sha256": "1r6ksxkph8r0i5vfw5z7bi0c0d5r9sg4lam580wy0aap9srsnwgq"
   },
   "stable": {
    "version": [
     0,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "enlive",
     "request"
    ],
-   "commit": "eff66fc207411d5a5265d4ee5232f13d268f252f",
-   "sha256": "18san6d7acfgz4fsjsv3w9bsbf41svf8p08jrc7rkqjp07h7hnwk"
+   "commit": "4371a177af1072076a5799a12bd37635b7e33942",
+   "sha256": "0c1rgz2harmp1si2fbdxiyfsxb6jnwkv58vzx28dh5v6ijf6hfd5"
   }
  },
  {
@@ -94264,14 +94086,14 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20241006,
-    13
+    20241122,
+    130
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e9db7161f62459d61518888bb7d4aadea15c7b1c",
-   "sha256": "1kpvbd31r6rp9nikbmab2g7ksd4llx3g5wpj50m3qmq1h293wqgn"
+   "commit": "6a2416dc4c3be22573cd9f5fb285df3f4bd6b6ea",
+   "sha256": "0cfwy4j5zv7axxkfg25cm4rs29d58w89gx58j4pprzf8pwxq6fvw"
   },
   "stable": {
    "version": [
@@ -94537,26 +94359,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20240824,
-    1650
+    20241129,
+    1654
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f515d0636426394af9c671bf58107091f9fac072",
-   "sha256": "14840nzs563syrdpdn6a44x8vg6rzszr4b6qb4hrh96k4hrz2smh"
+   "commit": "5f3894c031cd0900739e3cabb3eca3b6eb56f78f",
+   "sha256": "0jwmlqia3h2rb0j1qnlylslajqiz5g28ll3qy7h1mlbh4vb7bk24"
   },
   "stable": {
    "version": [
     3,
-    0,
+    1,
     1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "124de45328e2b8188d92c5221c922dd5e99756fe",
-   "sha256": "1m6m2jkq0bpclpbx067czzxqw0fp3r67ppq2kjwm7sn3xvh4mnvi"
+   "commit": "5f3894c031cd0900739e3cabb3eca3b6eb56f78f",
+   "sha256": "0jwmlqia3h2rb0j1qnlylslajqiz5g28ll3qy7h1mlbh4vb7bk24"
   }
  },
  {
@@ -94587,20 +94409,20 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20240830,
-    340
+    20241128,
+    1742
    ],
-   "commit": "77345373b5a5be4596b7f8826893bb787b82fb1f",
-   "sha256": "1n6k3cjacb9pqhykbxl75jli6770cb0cfc2gmjx8xkhj4yrhb5nn"
+   "commit": "7767c4a5393fcac626bfc29ceeba2f884b189aec",
+   "sha256": "1l1cpfqldrpxl7k2m0vad3yjmhsa3d9ni5lv1zv9ib8rgr8aagq9"
   },
   "stable": {
    "version": [
     1,
-    0,
-    6
+    1,
+    0
    ],
-   "commit": "77345373b5a5be4596b7f8826893bb787b82fb1f",
-   "sha256": "1n6k3cjacb9pqhykbxl75jli6770cb0cfc2gmjx8xkhj4yrhb5nn"
+   "commit": "86f1ea4be8a0fa1f498bf317dcf54467033fd75b",
+   "sha256": "0m27vinajmdaks0qc9is4329z97g0avgrj1324hp87j55r87kx56"
   }
  },
  {
@@ -95789,6 +95611,24 @@
   }
  },
  {
+  "ename": "ox-typst",
+  "commit": "468eb7d0c9aac3038c561659e69af0dc8ccc4456",
+  "sha256": "1hi1zhhzb4lwvcb8vs7zw3zzcdkrbsb15pj5yc5n0dq12v62fcrr",
+  "fetcher": "github",
+  "repo": "jmpunkt/ox-typst",
+  "unstable": {
+   "version": [
+    20241130,
+    1002
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "d00fc1d21657f925c7bd92e9b9cab51047bbcb2f",
+   "sha256": "1qqcajy5kssjrd49nf8cl5gg82scl77z341kwrci5kz5jjkpbhhd"
+  }
+ },
+ {
   "ename": "ox-wk",
   "commit": "0947993df2d9bee493c2c25760f1ac5bcc1136ac",
   "sha256": "0rb4xkkqb65ly01lb1gl3gyz4yj9hzv4ydbdzsbvmpj0hrdw5nv3",
@@ -96007,14 +95847,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20240930,
-    1924
+    20241123,
+    2136
    ],
    "deps": [
     "compat"
    ],
-   "commit": "af2dc7784df675cfca7b307e77ec2084ca5432f4",
-   "sha256": "1n2iyyjp4im6jhhm2rvphzifmjlrx31883a6a0l4mlkvkg4ffd3b"
+   "commit": "c1b276904278f0f89da2684f5e044760e3232c29",
+   "sha256": "0lwn4fd996lf4i4jmxfn09jn06k66k19ff76fzg6zzrs3hcsjg3j"
   },
   "stable": {
    "version": [
@@ -96049,14 +95889,14 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20240923,
-    1044
+    20241127,
+    1826
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "ae5491c511cb49ddb75d6dd4cd934bf71e47a2d5",
-   "sha256": "17m7wvaz7pyzqivkyg6wg2g2665xmd0vacbv2n847pxa8h2ayri1"
+   "commit": "0dee43756be149aac216cfa2794ba28f66137962",
+   "sha256": "1p3s7dl8gd54hyyvx0q7ficp60iiyim4js8195nksdqyb71df6vx"
   },
   "stable": {
    "version": [
@@ -96434,15 +96274,15 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20240920,
-    2210
+    20241109,
+    2313
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "3068a544fc2d1e2cdfd681f931e73f74d15be9ba",
-   "sha256": "13hg9qf64drpz7ak0sz13gj0dblgrfypjszx8iprf6z5kvh33zpk"
+   "commit": "db94e520f1ef228b94664ffb748150007af1f40d",
+   "sha256": "1qbh06lj19rxx138j6zj9lrfvfj95qi8fwa9l5g1wqbqlwixcl3v"
   },
   "stable": {
    "version": [
@@ -96482,10 +96322,10 @@
  },
  {
   "ename": "paper-theme",
-  "commit": "a7ea18a56370348715dec91f75adc162c800dd10",
-  "sha256": "1ph6c6g907cnxzl74byc754119qia8rs8y7wvaj8i6q3fz2658zr",
-  "fetcher": "github",
-  "repo": "cadadr/elisp",
+  "commit": "04fdd633207a28b91f0a6e64aa25d114ab229a13",
+  "sha256": "0vi17q1fbpmm69p0izksvb2cw8j5cdhzcbr5fw86rnq1i7s12jyz",
+  "fetcher": "codeberg",
+  "repo": "kutuptiyini/elisp",
   "unstable": {
    "version": [
     20230318,
@@ -96603,11 +96443,11 @@
   "url": "https://mumble.net/~campbell/git/paredit.git",
   "unstable": {
    "version": [
-    20230718,
-    2027
+    20241103,
+    2046
    ],
-   "commit": "037b9b8acbca75151f133b6c0f7f3ff97d9042e5",
-   "sha256": "0s3ia5yrhcl0wr4y7v70a68bhsvgkkfm3wvm3kmj37i84bb0nlrc"
+   "commit": "89e75b4cb21f525a6f4cabcd12f1bd4204e682ab",
+   "sha256": "1whjrk3g6ynpzl4i3x3fxvf0w3y6v7ww1pr8ckwr7as8vzxhhbyq"
   },
   "stable": {
    "version": [
@@ -96741,26 +96581,26 @@
   "repo": "justinbarclay/parinfer-rust-mode",
   "unstable": {
    "version": [
-    20240912,
-    2130
+    20241108,
+    1719
    ],
    "deps": [
     "track-changes"
    ],
-   "commit": "d617b2efd64695f3174f25e7d70e73e050efbfdc",
-   "sha256": "0pcqiq58fqx1n4xqyyby9zrpkzlpz80xm4vqfyk79hsda9430gyq"
+   "commit": "044c3fe8f68e3e69d1157359bbfb1cf95423fe26",
+   "sha256": "1p00m757maw6dxig0x45gry1l7vm9dm6wg1anfm2rwl6hw1f5q25"
   },
   "stable": {
    "version": [
     0,
     9,
-    2
+    3
    ],
    "deps": [
     "track-changes"
    ],
-   "commit": "a96c768e9dc4427c9ea18812a2f09e209a5e1a5e",
-   "sha256": "17kkyqkn0r3s2rbgc6v5jygrq5bm5jcw54byjfkhnif90zvdch0n"
+   "commit": "044c3fe8f68e3e69d1157359bbfb1cf95423fe26",
+   "sha256": "1p00m757maw6dxig0x45gry1l7vm9dm6wg1anfm2rwl6hw1f5q25"
   }
  },
  {
@@ -96840,19 +96680,19 @@
   "repo": "joostkremers/parsebib",
   "unstable": {
    "version": [
-    20230228,
-    1530
+    20241115,
+    2225
    ],
-   "commit": "ace9df707108b17759c004c7387655277122d4c1",
-   "sha256": "02h5sbg2bqkmksj1ap4z7301hnsp5ga6951jrnwy89ds0xvrbg6l"
+   "commit": "c0ee4d5f10bf801af03f633b6b73ced4a0ffead7",
+   "sha256": "1c6j45fvs8k8d5smyi4rd9n2rg79i7dv69n98md32qm8w2w7yi5x"
   },
   "stable": {
    "version": [
     4,
-    3
+    7
    ],
-   "commit": "819f6f269caf7569d0ca5814b8938f7a100b18b5",
-   "sha256": "0vcl2wvxwpr62c9ym0fm3qaxzhjcrpk4r6r0zaqhkvlf8qr3rg8y"
+   "commit": "26fb0fd165bacd160a5e89b966c6d080a740c4c4",
+   "sha256": "0rr1iy9j5s3m95j1kr2cqqk6mp5apva46g4zi3y07n120hz3ndw9"
   }
  },
  {
@@ -97791,10 +97631,10 @@
  },
  {
   "ename": "pelican-mode",
-  "commit": "aede5994c2e76c7fd860661c1e3252fb741f9228",
-  "sha256": "0z6w5j3qwb58pndqbmpsvy1l77w9jv90bss9qq9hicil8nlk4pvi",
-  "fetcher": "git",
-  "url": "https://git.korewanetadesu.com/pelican-mode.git",
+  "commit": "c238f6906d81b45acb30eea412fc5a5571f4c91c",
+  "sha256": "0mfhz1gyddqsd79y2b73kqq2knw7zhxv35jn9rkih1gcp07q870n",
+  "fetcher": "gitlab",
+  "repo": "joewreschnig/pelican-mode",
   "unstable": {
    "version": [
     20190124,
@@ -98131,25 +97971,25 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20240414,
-    359
+    20241030,
+    1848
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "ec48cb3bdda8c5ea12da89a12aa925ed1905a0b7",
-   "sha256": "1hg059nnyarnkx0wh1vl7qkdaqb2p7ifk9ciz35s6ffnc242jas5"
+   "commit": "e32d3ea731f6bc551ce196527b3cb0dc19d71151",
+   "sha256": "1vpjc9mk96siabl5j0k023bag00cwb852cpc9f89jyqhavm6011b"
   },
   "stable": {
    "version": [
     2,
-    18
+    19
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "8a69512639ae915c32c5055d1308ebf4b278266c",
-   "sha256": "1r026cw6p2ss5wg8mxgzf6iv1lb9pdnqyf6yrqb914aibkrvp9b6"
+   "commit": "e32d3ea731f6bc551ce196527b3cb0dc19d71151",
+   "sha256": "1vpjc9mk96siabl5j0k023bag00cwb852cpc9f89jyqhavm6011b"
   }
  },
  {
@@ -98262,16 +98102,16 @@
   "repo": "wyuenho/emacs-pet",
   "unstable": {
    "version": [
-    20240930,
-    2259
+    20241127,
+    2351
    ],
    "deps": [
     "f",
     "map",
     "seq"
    ],
-   "commit": "75b371ac4638cb8c6d7190f21a9c3ff257798d61",
-   "sha256": "16p91zwrp004hz6qndg3jiniy01ic24wd36hjfs2ksir83lsfg59"
+   "commit": "c2278f9bc1c3a5070021fe3251ed09b5a468d331",
+   "sha256": "0zr5vnbk3bgwx8nj563pbyv93rc0n7xmhqcdgv2nc8pdsvdd7sxi"
   },
   "stable": {
    "version": [
@@ -98320,25 +98160,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20241012,
-    1954
+    20241110,
+    1633
    ],
    "deps": [
     "peg"
    ],
-   "commit": "516f09df63d68b8bb1682e34ac8443f84ca9127d",
-   "sha256": "0l4z3a60s7mj3blxz26y5zfp927vx50k4i1b20hjnchn4cv6c92f"
+   "commit": "3e7917dfe17d40c08f0028917915682dbf576ee7",
+   "sha256": "12k4y52rv7fwg8yqniq4d3bmhcxdn75kgzvr1qxn56l80hxzfhvs"
   },
   "stable": {
    "version": [
     0,
-    42
+    44
    ],
    "deps": [
     "peg"
    ],
-   "commit": "c4b050c52a31aab0ca27d9c24bdb5eb71cd8764e",
-   "sha256": "1afyjzrb1q207as2vc9j3cjvr6f3d3zgajzisl3x3mv0kb0bk3jy"
+   "commit": "3e7917dfe17d40c08f0028917915682dbf576ee7",
+   "sha256": "12k4y52rv7fwg8yqniq4d3bmhcxdn75kgzvr1qxn56l80hxzfhvs"
   }
  },
  {
@@ -98647,26 +98487,26 @@
   "repo": "pivaldi/php-cs-fixer",
   "unstable": {
    "version": [
-    20240909,
-    1856
+    20241103,
+    1232
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fa21b0f3b9be8604345a5fd276477dff3c77e39f",
-   "sha256": "02cjlc4mkmp6ih6g24fs38wwa93vlls1da8wxv563a6g5g799yd1"
+   "commit": "710208cc2efc2e241d1e7421b3c2581d46a81a5c",
+   "sha256": "1681w4jsszcvva3xs9kj6a0crckwqhscy9lzsrk7zw8cjbb2q14b"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fa21b0f3b9be8604345a5fd276477dff3c77e39f",
-   "sha256": "02cjlc4mkmp6ih6g24fs38wwa93vlls1da8wxv563a6g5g799yd1"
+   "commit": "710208cc2efc2e241d1e7421b3c2581d46a81a5c",
+   "sha256": "1681w4jsszcvva3xs9kj6a0crckwqhscy9lzsrk7zw8cjbb2q14b"
   }
  },
  {
@@ -98692,11 +98532,11 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20240912,
-    2234
+    20241024,
+    1241
    ],
-   "commit": "3e8113c72a454f0f87a1593c22578b894549c53b",
-   "sha256": "0b2j2jcrqmanli2307yhj7b59p3dap2190iyk09b7dygk6p1niyr"
+   "commit": "31f702ee2de35d514fb633c0c37531cb648bff70",
+   "sha256": "0rz0qdi82swvvqmb44jdzwfkaz9xl4y4ic70i6i950rmrbz970pd"
   },
   "stable": {
    "version": [
@@ -98755,26 +98595,26 @@
   "repo": "emacs-php/php-runtime.el",
   "unstable": {
    "version": [
-    20230404,
-    1713
+    20241024,
+    1622
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ba64f30e716f89f9cf2c3bd44c5d00da69736868",
-   "sha256": "0642n7cf3vn90gm7a2bvy264mjq5ar20aw5lh79ls55i4mryvqnr"
+   "commit": "37beef404c70d7b80dc085b1ee1e13fd9c375fe6",
+   "sha256": "1sd65nhbcxr5r935z1ik3skz73kkpyr4r259nahn5gjvvww3if20"
   },
   "stable": {
    "version": [
     0,
     3,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ba64f30e716f89f9cf2c3bd44c5d00da69736868",
-   "sha256": "0642n7cf3vn90gm7a2bvy264mjq5ar20aw5lh79ls55i4mryvqnr"
+   "commit": "37beef404c70d7b80dc085b1ee1e13fd9c375fe6",
+   "sha256": "1sd65nhbcxr5r935z1ik3skz73kkpyr4r259nahn5gjvvww3if20"
   }
  },
  {
@@ -98804,8 +98644,8 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20240916,
-    1427
+    20241128,
+    1559
    ],
    "deps": [
     "async",
@@ -98813,8 +98653,8 @@
     "f",
     "php-runtime"
    ],
-   "commit": "8707094ac0da0564e7a0cc6874e3087ffc7e137a",
-   "sha256": "1nlaqwfd1klxplh6nwv6ci60mfl1d85i0dfnvcszbkn3nfmf0mnp"
+   "commit": "922a4339d796f16c393400ea273ddf61539edf82",
+   "sha256": "1dhss4qzllpgfp3xy2kdw2g2n70rzjzgz747rchx1rfb5vwhmwl8"
   },
   "stable": {
    "version": [
@@ -98838,16 +98678,16 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20240527,
-    2142
+    20241107,
+    408
    ],
    "deps": [
     "compat",
     "php-mode",
     "php-runtime"
    ],
-   "commit": "6f1c7bb357b1eb90b10a081f1831c1c548c40456",
-   "sha256": "1hnnhbma3mgbralp1f5c1gvm9pfswzf5xzi2nr22rs5d9r0zk2fj"
+   "commit": "b616f5fa5f8aff9aa220c7fe63b39df6d10588a5",
+   "sha256": "0xjr6vi158qm6rnrfvpcmh2grrlvixdd44kik333250298vc3nx3"
   },
   "stable": {
    "version": [
@@ -99033,11 +98873,11 @@
   "repo": "kljohann/pikchr-mode",
   "unstable": {
    "version": [
-    20210324,
-    2125
+    20241127,
+    2138
    ],
-   "commit": "5d424c5c97ac854cc44c369e654e4f906fcae3c8",
-   "sha256": "07qjz0mzl6cqgavv5sc9n1v7zq5q6f8is6nn126v0zk6rskp366q"
+   "commit": "27b5d06d6f55b4db45b9fc96d614f1dce8ee70fa",
+   "sha256": "00av07rn6pmds776nf18ypzg8ris4hwinjsl71k3pn9k3gv81qf7"
   }
  },
  {
@@ -99909,6 +99749,24 @@
    ],
    "commit": "8a2f465264c74e04524cc789cdad0190ace43f6c",
    "sha256": "0s34nbqqy6aqi113xj452pbmqp43046wfbfbbfv1xwhybgq0c1j1"
+  }
+ },
+ {
+  "ename": "plumber",
+  "commit": "5c2cf71d984e5ebe6baf4e17a187f94efa2097ad",
+  "sha256": "17xhncxabz6a4m8jpwb8zklykamrx8p4qcgdhkk626sa53g179za",
+  "fetcher": "github",
+  "repo": "8dcc/plumber.el",
+  "unstable": {
+   "version": [
+    20241110,
+    2234
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "7655ed6d6d69249488abf57a3b39fc762792be6f",
+   "sha256": "19p7jq1d9sy8fpby0m1lj6v6z8hr1cgr0jvkasgl5l1gjn12fxrl"
   }
  },
  {
@@ -100851,11 +100709,11 @@
   "repo": "karthink/popper",
   "unstable": {
    "version": [
-    20240325,
-    10
+    20241201,
+    110
    ],
-   "commit": "c6b78fdd546e19582fa2195cf51f6753c45e7c03",
-   "sha256": "121qil7y3n4p601y2j2sk077d8vzyb5ghdpj0f618pbw6pp8gyk4"
+   "commit": "faf155059e519fb036324af579c342365795dbbb",
+   "sha256": "17hgpyyr1p0501i8rqi83x8dhsfla8hy5pj7m73gs3aigcp173l5"
   },
   "stable": {
    "version": [
@@ -101116,11 +100974,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20240827,
-    654
+    20241023,
+    319
    ],
-   "commit": "570273bcf6c21641f02ccfcc9478607728f0a2a2",
-   "sha256": "1p1kfy0x8n1s2njfq70fix2jadfi6zb4m519scjmys51a7ahmy73"
+   "commit": "ac9f954ac4c546e68daf403f2ab2b5ad4397f26e",
+   "sha256": "0qq14z8qiwmx0dwbcz6nrhznj34jxkb47dcv1wf8v6qhnm4b7z2i"
   },
   "stable": {
    "version": [
@@ -101383,8 +101241,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20241014,
-    454
+    20241105,
+    1542
    ],
    "deps": [
     "ghub",
@@ -101392,8 +101250,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "e0488e7b1225e67a88ad5a2da5c17d524e007848",
-   "sha256": "1zls3bjp17fpkkird1h2v0gaz86nyxjkwj3jfzvfxyi3b9f8ciw6"
+   "commit": "bd9846fa0636bde8c6f9d88b9f2b9514903e82f8",
+   "sha256": "120ym24d2bccni9dwlk086sbqvfwmwj9kj61yfxh76j6dak28i9j"
   }
  },
  {
@@ -101779,15 +101637,15 @@
   "repo": "alphapapa/prism.el",
   "unstable": {
    "version": [
-    20240915,
-    1804
+    20241024,
+    40
    ],
    "deps": [
     "compat",
     "dash"
    ],
-   "commit": "646840f74ffa7c289426b54426f147e126812070",
-   "sha256": "01s751khsbnlqhx1jh62laimi1fpsqljh02hw3gdgd2ka25jcq24"
+   "commit": "2fa8eb5a9ca62a548d33befef4517e5d0266eb28",
+   "sha256": "1sp53s39vq3np3a0vs8wnckjj5b5i0giqdkzmah4h3yvhjbd4m9n"
   },
   "stable": {
    "version": [
@@ -102295,26 +102153,26 @@
   "repo": "TxGVNN/project-tasks",
   "unstable": {
    "version": [
-    20240903,
-    343
+    20241107,
+    330
    ],
    "deps": [
     "project"
    ],
-   "commit": "e5cc94cb65a18ea11aae7f65ee6f603a7808d4aa",
-   "sha256": "1gdq96296s4glylhh1yp3j6gn8j97b8f2acbh9xq5bk2y1vd7m04"
+   "commit": "404723d0b16dd46a3c0a63675d1f0ab9083799db",
+   "sha256": "16krbqz3x0cfvwcc6iiw6ly4n5v38d664gfa7bslv4xgr25s9sm3"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     0
    ],
    "deps": [
     "project"
    ],
-   "commit": "e5cc94cb65a18ea11aae7f65ee6f603a7808d4aa",
-   "sha256": "1gdq96296s4glylhh1yp3j6gn8j97b8f2acbh9xq5bk2y1vd7m04"
+   "commit": "ff1b159faae5e4f4756e5fc5f01b4a2a304ded13",
+   "sha256": "0fmppgiz7p4kc7rvs6m73gmcbvg44z30wfs79p1dqba3wsn7xp4j"
   }
  },
  {
@@ -102343,11 +102201,11 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20241009,
-    1152
+    20241102,
+    1410
    ],
-   "commit": "41f8a8e7bdc50467256af632108989b5c980cd56",
-   "sha256": "18sd8vim7pib5v13hk610l1fkndydv4sfhdmvxb3pb4p536xm6ch"
+   "commit": "9b466af28bac6d61fd0e717f1a4b0fcd2f18f37f",
+   "sha256": "1mbrvp1irjlsd3k2qajhlr44c2pc7sbbw57skisl3h2a5fbhygd1"
   },
   "stable": {
    "version": [
@@ -102608,8 +102466,8 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20241013,
-    1520
+    20241107,
+    2107
    ],
    "deps": [
     "compat",
@@ -102617,8 +102475,8 @@
     "project",
     "s"
    ],
-   "commit": "c2a5522e22b292c9ce94f1d5ece338c4e7117ddb",
-   "sha256": "1wbwkmf7fg1hamzidzf6wib2fbcjybh3ch9yr9y9l4946wxnca1h"
+   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
+   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
   }
  },
  {
@@ -102629,15 +102487,15 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20240325,
-    1931
+    20241107,
+    2107
    ],
    "deps": [
     "dape",
     "projection"
    ],
-   "commit": "68abb9dfab5e85daa31961be10362ca02effeeeb",
-   "sha256": "1zksskn924v4la718326gyafwgmlbrrj6k78wrv422a1n9wrq0s2"
+   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
+   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
   }
  },
  {
@@ -102648,15 +102506,15 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20240919,
-    2050
+    20241107,
+    2107
    ],
    "deps": [
     "compile-multi",
     "projection"
    ],
-   "commit": "c875330e69087f96ddbcb4b0f0e15b820adcc8ae",
-   "sha256": "13p1k2g6kciqhg4bhdxms9ifwx51vc8xh3wcm44ja3bhgi3ajlcs"
+   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
+   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
   }
  },
  {
@@ -102667,15 +102525,15 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20240803,
-    1509
+    20241107,
+    2107
    ],
    "deps": [
     "compile-multi-embark",
     "projection"
    ],
-   "commit": "719be9e5cda7324eed0a82ce14a92f88c8608080",
-   "sha256": "0jjpx3ckm99yn4izn922dcpc42zfs5p5ji2b2qaxl6mnzrg86mpg"
+   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
+   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
   }
  },
  {
@@ -102842,11 +102700,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20240912,
-    1558
+    20241126,
+    32
    ],
-   "commit": "1ffca70b2fcfd1c524f9b9e5ceebae07d3b745b6",
-   "sha256": "1kmgih45qkgqzas09bhy0xlvjssb187b1ki7a088za2kwcyw89hn"
+   "commit": "d6689469298b4140dc1f0f8b0ff7e8f937041ffe",
+   "sha256": "1d12z41rn5nh15qj4sf0w8xrbd9djxlrz0r6g38fiq63i7krbm4x"
   },
   "stable": {
    "version": [
@@ -102954,11 +102812,11 @@
   },
   "stable": {
    "version": [
-    28,
-    2
+    29,
+    0
    ],
-   "commit": "9fff46d7327c699ef970769d5c9fd0e44df08fc7",
-   "sha256": "1cd8hfszy6sqjwwwf95znvzic1nn3hd1ywij25m4hg8vddz2727s"
+   "commit": "2d4414f384dc499af113b5991ce3eaa9df6dd931",
+   "sha256": "0hrd4xm94nn4kazf86ca5wrmca4ss02m262zvm21i1dwq8pmmppf"
   }
  },
  {
@@ -103523,11 +103381,11 @@
   "repo": "smoeding/puppet-ts-mode",
   "unstable": {
    "version": [
-    20240626,
-    646
+    20241129,
+    1040
    ],
-   "commit": "9622188612f3be347bd92f5a195999b36f95f988",
-   "sha256": "0jrrmd77i5md8psxq313i8amw2f8hmmh518f1bsajm4wg46pfh3c"
+   "commit": "5dbce9c6785af03d47561329d38c436f0e18e3f3",
+   "sha256": "1zybz6ikz4i03glc4p659jr5n9i9cxb6yaamnsyavlq8lrjdbhkd"
   }
  },
  {
@@ -104779,11 +104637,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20230412,
-    53
+    20241129,
+    100
    ],
-   "commit": "d89b359d5a26234336487ab4e42eb5878ad3c5a5",
-   "sha256": "0632mh9yhs4cs8xzq7d86gyklvzvvlja729d6vlzam3nw6s89c4d"
+   "commit": "b4bbee3ef8cfa5f98fe141dfc61da77385da3b90",
+   "sha256": "1qsj9ng0zxpcqpdgmwkxi9v9p2hr0p6zya5qdjpnag2h2hzcdksv"
   }
  },
  {
@@ -105086,6 +104944,30 @@
   }
  },
  {
+  "ename": "quick-sdcv",
+  "commit": "b626190c9f6e709acb1f7bff7d72c13d447b507f",
+  "sha256": "1a3mnn903hgf5fpr3a189y69iwq1rvmfkq6yzb2k3k2bm651bh3n",
+  "fetcher": "github",
+  "repo": "jamescherti/quick-sdcv.el",
+  "unstable": {
+   "version": [
+    20241130,
+    2051
+   ],
+   "commit": "1f0a38c8de2ddea93f2e42b2201c8d642f300008",
+   "sha256": "0m14vzs4ds3f1d2gq1gc10sgcas67nq76w5a5qx1mfzknv54h3zn"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "ef24026f1f03d3df8ed999e5c75f5c3bbc70860e",
+   "sha256": "0z83fziijw6262i4iq4wd881ps3w1wd9f2x4966bjxgavd0ijfp7"
+  }
+ },
+ {
   "ename": "quick-shell-keybind",
   "commit": "e9bf4d78da24d88476545f97b2af0527dde73600",
   "sha256": "1f66wk2m0yykcbq6qbalgscpq8s53qshyyqdnimlmdi0g0glif1b",
@@ -105310,11 +105192,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20241001,
-    1458
+    20241129,
+    1353
    ],
-   "commit": "ec8b5142abaaef8335c23b98c18dee1f960b6e0b",
-   "sha256": "1q6vdp2rhb6r3s17vqy6qbq0kzbix8a4fd9ikxxlgj8gc4xg6dv5"
+   "commit": "986c9ad883a1b96076a0da6ae75761c75baaac09",
+   "sha256": "1952y4xjyfxw7m748lbcfkjyf0199ziskycmmqnbivqj2cv7c8wc"
   }
  },
  {
@@ -106189,15 +106071,15 @@
   "repo": "realgud/realgud-lldb",
   "unstable": {
    "version": [
-    20230201,
-    948
+    20241119,
+    209
    ],
    "deps": [
     "load-relative",
     "realgud"
    ],
-   "commit": "74d442abc8469bb6277702f9c60fa479848009b2",
-   "sha256": "150p7yk0x4apszvkh6sv9iwjv5amzjvlj9ydk9w46bxfypxr29p1"
+   "commit": "deacd070e8ab8830f4d577fee37136ad89183d13",
+   "sha256": "1yn51aavvz5v4l27afzqbmh77fi1gpqsb89l7ladlv1d6fbzh3z9"
   },
   "stable": {
    "version": [
@@ -106469,6 +106351,21 @@
    ],
    "commit": "00634eca420cc48657b81e40e599ff8548083985",
    "sha256": "1xh9nxqfg9abcl41ni69rnwjfgyfr0pbl55dzyxsbh6sb36r3h8z"
+  }
+ },
+ {
+  "ename": "recall",
+  "commit": "b42cd347f93cb1be86fc8171b90e4b3dc56042de",
+  "sha256": "18vdyfvyj8ciq4azixyi4jaljsla81szx2lj398ymq46ak5bqzi5",
+  "fetcher": "github",
+  "repo": "svaante/recall",
+  "unstable": {
+   "version": [
+    20241201,
+    2002
+   ],
+   "commit": "1921316d8ab02c735454b0d51153f1a657430bff",
+   "sha256": "001dgrdfmy3n2qyv7ai84129j463a62yqkdzcpar62iil0sq7n58"
   }
  },
  {
@@ -107282,8 +107179,8 @@
   "repo": "alhassy/repl-driven-development",
   "unstable": {
    "version": [
-    20231123,
-    1917
+    20241110,
+    1611
    ],
    "deps": [
     "bind-key",
@@ -107291,15 +107188,14 @@
     "devdocs",
     "eros",
     "f",
-    "hierarchy",
     "json-navigator",
     "lf",
     "peg",
     "pulsar",
     "s"
    ],
-   "commit": "05bd1cee8f298173010ed17a98ba2b94cb08d830",
-   "sha256": "1ladm2gmvmhhccly1l2m0c1389xy50dacqbjzk1rw6mdbscgjqlm"
+   "commit": "2ffa5368a6db602a9f220935cd985999c60845ba",
+   "sha256": "175mkhj2q8xcxab8q9czfc6kck30xgln2xdkxycv3x2q969ziag3"
   }
  },
  {
@@ -108055,15 +107951,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20241002,
-    2036
+    20241112,
+    1353
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "d727fe8466502e29975067adf6f2ca3e0618279c",
-   "sha256": "0kznbka5ssgs9cmdjbjlk8z7zl3vb294mvymy7nsm4w11phdz0w6"
+   "commit": "bd63cd3346fcabab0ff25e841e9d1ee56f5db705",
+   "sha256": "0j3vqnis4wgg9bf5b85xl9f3yrjyz1r5i64yc7ijfiin0cw8rgff"
   },
   "stable": {
    "version": [
@@ -108298,8 +108194,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20241003,
-    1750
+    20241106,
+    2056
    ],
    "deps": [
     "cl-lib",
@@ -108307,8 +108203,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "e5c5ffb57088aa7ec6b82a6ca3f9499294124954",
-   "sha256": "13n9rkwkza1n91k2n5saxyijm9qsjywj9hlx6la4z1d3lvr4r1cy"
+   "commit": "8837e4b86d3cef73079a3f4ad6d3c79885236aa5",
+   "sha256": "1s5hx4gp0g66mnjwvmb1f8g9r5m3frzhxj0qphky0mssbd62dh60"
   },
   "stable": {
    "version": [
@@ -108513,11 +108409,11 @@
   "repo": "jgkamat/rmsbolt",
   "unstable": {
    "version": [
-    20240622,
-    1704
+    20241030,
+    607
    ],
-   "commit": "484d9c06f0544532336ad2ac2ddf46a1a81272ef",
-   "sha256": "1sky9qvrycqjmhlhrd3jn2mpdgii3m9m6r48nb6m6s7pshwlydw3"
+   "commit": "c152a1c591108a5244026a7e193f053a8e58e135",
+   "sha256": "18mwmcm6d4ii91kyjcmynwypi0ksw7ww16am9pyzlnvlv1clmy9v"
   }
  },
  {
@@ -108630,11 +108526,11 @@
   "repo": "tad-lispy/roc-ts-mode",
   "unstable": {
    "version": [
-    20240820,
-    1737
+    20241202,
+    15
    ],
-   "commit": "8a85436227a9fdc07bce9ad773a46ba78cb3cdd0",
-   "sha256": "1vrhh6xa1v4qfraw888xrz3izkk6zshbrzqdf21x9dwyd4wlr0is"
+   "commit": "de6a523be86c5ec925b8c58c950dcebef233b09a",
+   "sha256": "0f7002bzckinq14s5q9f39ad3jmzjps9fm4v215zw2lzcd5knlg1"
   }
  },
  {
@@ -109530,11 +109426,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20240903,
-    1233
+    20241112,
+    438
    ],
-   "commit": "c87f6f82bd484fb1c15009c8a3518ebb62942605",
-   "sha256": "15nafhm0ssvqg1w55gpk91hsr7mq6ryswhnnhwmz007g8d6zc34q"
+   "commit": "542f1755d8929ca83564322d7030d558f3392fe1",
+   "sha256": "1a6p50hkw2qlgh2v1yivhbifp8l7ffsqs4712sd971scb00yv2r4"
   },
   "stable": {
    "version": [
@@ -109577,8 +109473,8 @@
   "repo": "emacs-rustic/rustic",
   "unstable": {
    "version": [
-    20241012,
-    1556
+    20241110,
+    729
    ],
    "deps": [
     "dash",
@@ -109592,8 +109488,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "34abafbd0ff921681d4ee6d84ce4787483f1e8d2",
-   "sha256": "0zh51a4gyp4hysha1phiyq9ray8s90iw9pfp1fkjnfsqx2gwaqbm"
+   "commit": "9fdf5c76b20cfc2985d518b3a4ae7b9634b39999",
+   "sha256": "0kwvvk2gx2dcm9y676n00jhaqicxlb0nf4kqwj3grwvhdjvr93wg"
   },
   "stable": {
    "version": [
@@ -109624,15 +109520,15 @@
   "repo": "ShuguangSun/rutils.el",
   "unstable": {
    "version": [
-    20220619,
-    1421
+    20241027,
+    1606
    ],
    "deps": [
     "ess",
     "transient"
    ],
-   "commit": "dd500ab8062ce40cb339ec8620bdfc63fdd28364",
-   "sha256": "1hzly8kxdhddz4b4i7cxafl54aqpk6q4ziwh1k92s1767mjqwg2d"
+   "commit": "e39ca3c953ef395f28176f740ebf500d62edb429",
+   "sha256": "1ld22yz85ds0syf9cyldhc40rg1fd993dza52i8dj49q1jnby2xc"
   }
  },
  {
@@ -110258,11 +110154,11 @@
   "repo": "KaranAhlawat/scala-ts-mode",
   "unstable": {
    "version": [
-    20240917,
-    933
+    20241027,
+    701
    ],
-   "commit": "a9faced661fddc76be9c8db8c2190309ec5eab3b",
-   "sha256": "09cypfgwia25lk2liaj5rly34kmfp95bsp9nd6jby71g5z76j5c5"
+   "commit": "039af6d4e353726245e60756667f0b7378840f6c",
+   "sha256": "0b4f9zax2rgg3zrlsg40mgiz7f5z9dq52adg7xrgwrc1k65mlxlf"
   }
  },
  {
@@ -110778,28 +110674,28 @@
   "repo": "sdm-lang/emacs-sdml-mode",
   "unstable": {
    "version": [
-    20240821,
-    1835
+    20241104,
+    1705
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent"
    ],
-   "commit": "86d2f30a0f49c2ca35e07382ce9620aeff7c9960",
-   "sha256": "1qlf1bcckw20y30iqxccscgdi1aqy3hiq5dh2ls0gg37q7ll8v8n"
+   "commit": "ec867931868b0bced385f9b7517a8b48cd146ac4",
+   "sha256": "0mzbllnpr6kqm7f3yr3yq6wr42k8kps7qrzw7023fb9kh3q1xg6g"
   },
   "stable": {
    "version": [
     0,
-    1,
-    8
+    2,
+    0
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent"
    ],
-   "commit": "105c0fd42269ba8a5c29fa71e617644fa385f68f",
-   "sha256": "1axpf0cs4sk9aa23dhpxal1vwfpff2k10fg54iiqqbw4yvlckp8y"
+   "commit": "1f59deffa3186a9eafe3921fdb793549a4629a03",
+   "sha256": "07fkws8359hjd7wcacr4k9mknacccc4qnyz5fcb6z8m0s7i93b8p"
   }
  },
  {
@@ -111062,14 +110958,14 @@
   "repo": "captainflasmr/selected-window-accent-mode",
   "unstable": {
    "version": [
-    20240831,
-    1100
+    20241019,
+    1342
    ],
    "deps": [
     "transient"
    ],
-   "commit": "f4c2e7fed2702072cc5a73f2c56a75624ea85cc1",
-   "sha256": "0f9xlgl37cvpbn5vmp9kk4h0gywxp9r9cghrzgg0xnjak7b35bfx"
+   "commit": "32c0dc7d2bfc66fff1487019c03d7277f2411fe4",
+   "sha256": "1kd1qv0bnq9gsgmqfi1w7c0lnzvf0yhk1dx9xgdj63dpk6243668"
   },
   "stable": {
    "version": [
@@ -111217,21 +111113,20 @@
  },
  {
   "ename": "semi",
-  "commit": "e78849c2d1df187b7f0ef4c34985a341e640ad3e",
-  "sha256": "01wk3lgln5lac65hp6v83d292bdk7544z23xa1v6a756nhybwv25",
+  "commit": "5e4ccfc8ab211349b577a06dea355ea59b3eb888",
+  "sha256": "0v9d73adgsb6wmy0da4bqjrf1jk8g9wy58bl6svg07gq065w8lv0",
   "fetcher": "github",
-  "repo": "wanderlust/semi",
+  "repo": "emacsmirror/semi",
   "unstable": {
    "version": [
-    20240606,
-    1327
+    20170314,
+    1219
    ],
    "deps": [
-    "apel",
     "flim"
    ],
-   "commit": "85a52b899ac89be504d9e38d8d406bba98f4b0b3",
-   "sha256": "13sfwv889i99l5zv10ibzm221wvwbp3m45nf4nsr0dhvln90zrjj"
+   "commit": "425098e6a57e7668ba2eeccba31f73e59c3d3a7f",
+   "sha256": "0b9cxz99l1wf9sw9d5aklvmmcklgb94njrrm6g6yp9yl07px46iw"
   }
  },
  {
@@ -111994,26 +111889,26 @@
  },
  {
   "ename": "shell-maker",
-  "commit": "c7f36f62391f888e2485c096890739de0c71305a",
-  "sha256": "0a03brzbasnamry39nxybdh0r71igpkva8b0svsvw96j0dc4chbc",
+  "commit": "bd7bfd8814e2e81d4022984f6b2baf2b1d1d0225",
+  "sha256": "1c8zixkkn7xl7z89x006q15qhq3j4hzlbgqcrnbq4xy9w3vcwmj7",
   "fetcher": "github",
-  "repo": "xenodium/chatgpt-shell",
+  "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20241011,
-    805
+    20241128,
+    934
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "d9330f283241142a13a11d5d83aca875c6796f88",
+   "sha256": "15v3hlcasfv6jzabhg9753hg0jhwfbjycsq75qg2q9vcf0ksacm6"
   },
   "stable": {
    "version": [
-    1,
-    8,
+    0,
+    72,
     1
    ],
-   "commit": "08c8a6dec6a5b1a23d4ae3f4312dc6c92d1a09a1",
-   "sha256": "04byw3zz06fr1g185p55pdaf5bqxj3mssldbh089pmx10qdmaxqi"
+   "commit": "d9330f283241142a13a11d5d83aca875c6796f88",
+   "sha256": "15v3hlcasfv6jzabhg9753hg0jhwfbjycsq75qg2q9vcf0ksacm6"
   }
  },
  {
@@ -112241,20 +112136,20 @@
   "repo": "redguardtoo/shenshou",
   "unstable": {
    "version": [
-    20230226,
-    320
+    20241015,
+    1227
    ],
-   "commit": "0a00b9f5a86a54324f88c7d27b603f136ee2fb0b",
-   "sha256": "0yr6pw3yglav07xg6l0dx1xc0dggcgv1xyfpds7y865iizvmc4i9"
+   "commit": "65163b449131ed0946ca6e817a660b4bbb7d35e9",
+   "sha256": "1d8462mrifp33pbkr5kgkb0m6fk98r6ysi6j9giyj83xih9rpxd5"
   },
   "stable": {
    "version": [
     0,
-    1,
-    2
+    2,
+    0
    ],
-   "commit": "0a00b9f5a86a54324f88c7d27b603f136ee2fb0b",
-   "sha256": "0yr6pw3yglav07xg6l0dx1xc0dggcgv1xyfpds7y865iizvmc4i9"
+   "commit": "65163b449131ed0946ca6e817a660b4bbb7d35e9",
+   "sha256": "1d8462mrifp33pbkr5kgkb0m6fk98r6ysi6j9giyj83xih9rpxd5"
   }
  },
  {
@@ -112820,14 +112715,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20240824,
-    2024
+    20241130,
+    1105
    ],
    "deps": [
     "ht"
    ],
-   "commit": "0994d4d78f79385e5830563d42a41118acc5a9ef",
-   "sha256": "100wb249bmcc4ikj6zm0rwcyczabd994nakjb1w1kk4rxj5p2qjf"
+   "commit": "63c913aeb5836f2376d1ad01580e67f9d1c56e0a",
+   "sha256": "11agf4mzydyksbh869s1rq7z2vi4jk4w0mkbs9xqw69lnasr2iyx"
   },
   "stable": {
    "version": [
@@ -112850,15 +112745,15 @@
   "repo": "emacs-sideline/sideline-blame",
   "unstable": {
    "version": [
-    20240906,
-    1906
+    20241130,
+    1118
    ],
    "deps": [
     "sideline",
     "vc-msg"
    ],
-   "commit": "48288bc77a90b58c7609598d0a129ba1638d0098",
-   "sha256": "17cnn5xga51j34z2m9c9mm6j9jgj9yqddk8g2idgli1sm9nv0mg4"
+   "commit": "24acacc766f7cc8ffb1a7dda695be6eb67ec5670",
+   "sha256": "18gvg5b89g88ijhx058lvdnwvwgm0jpkg6cnrrf86dj2sv2qzdcd"
   },
   "stable": {
    "version": [
@@ -112882,16 +112777,16 @@
   "repo": "emacs-sideline/sideline-flycheck",
   "unstable": {
    "version": [
-    20240629,
-    840
+    20241130,
+    1119
    ],
    "deps": [
     "flycheck",
     "ht",
     "sideline"
    ],
-   "commit": "4147f2754c353e0b7920caf385b8dccc5e6301f7",
-   "sha256": "1978b149d7mza2r2mknp01zvpf55sz49addaxd153fqdsmf8hxq8"
+   "commit": "1cc46a244d76027687136b3db0da1f5535d1352c",
+   "sha256": "0q16mblknwlvs9adg8vc919snr7m3qypz8xj2vbn2vf6m8prs0d3"
   },
   "stable": {
    "version": [
@@ -112915,14 +112810,14 @@
   "repo": "emacs-sideline/sideline-flymake",
   "unstable": {
    "version": [
-    20240509,
-    742
+    20241130,
+    1119
    ],
    "deps": [
     "sideline"
    ],
-   "commit": "06e84875022a5645ece8f4c2c8b56aa5f003c65d",
-   "sha256": "10gk7l93c13z8mpvd598x06bhv8zz21157madxdw1f7jarkssqh7"
+   "commit": "096b2fecfdb5a2192541e6099f761dde22b53aec",
+   "sha256": "0z8h403891swpprjfj5pvpnh129p9kmsn0hb7625k7iar6xnywc2"
   },
   "stable": {
    "version": [
@@ -112945,8 +112840,8 @@
   "repo": "emacs-sideline/sideline-lsp",
   "unstable": {
    "version": [
-    20240403,
-    2210
+    20241130,
+    1119
    ],
    "deps": [
     "dash",
@@ -112955,8 +112850,8 @@
     "s",
     "sideline"
    ],
-   "commit": "69aca6403509abb4f5c5ba8499e98f80f81ebc88",
-   "sha256": "0jh81bc7dl309v6bxfh2d39f9lbp61bsdanflym33lsvdyl59zrk"
+   "commit": "96fd13fa94fc7abfe84dbf1c966cdfe1b5273d94",
+   "sha256": "19jrhyyzsrc6vwj3kbpc9vh1wnyj81w46skk59dm91ws0isyvf6b"
   },
   "stable": {
    "version": [
@@ -113414,11 +113309,11 @@
   "repo": "laishulu/emacs-smart-input-source",
   "unstable": {
    "version": [
-    20231211,
-    1602
+    20241125,
+    217
    ],
-   "commit": "23f3fe8b95e0570b65aa21b9db57c906aa9f35fd",
-   "sha256": "1gc1z176nbc3hxx0wwid68bajbl1pwxllsmmsnpqx665zcn7qvnb"
+   "commit": "d55ea5c0271c9fb91cd1eeceadeb20f67b7cf5fb",
+   "sha256": "05c1fhvp29v76151l4pv1qkbxjlqkz4k60ps2yn2zlgmpygpzzkg"
   }
  },
  {
@@ -113429,8 +113324,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20240831,
-    2304
+    20241015,
+    1351
    ],
    "deps": [
     "compat",
@@ -113438,21 +113333,23 @@
     "llama",
     "magit"
    ],
-   "commit": "9999af565f313507c8255c6c143963c9e8682c26",
-   "sha256": "0szk06hf60s7c0vrrmbqmh61p3685spwms4jidmi3mclrz3ychvn"
+   "commit": "e6ec5d8687f34644b4d049a6be463269792c9fd6",
+   "sha256": "0kgx57liqqfdslxpzm7av1jj5yjpjbabdiijc95jqw47mvvnfj1b"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "compat",
+    "elx",
+    "llama",
     "magit"
    ],
-   "commit": "ff5447669a6d208983e3d9897a5b247d8c5a215b",
-   "sha256": "1nnb2l77bi58pg63w1sifxkj8hzzp14bzgldznk3q7b9hibjqlzd"
+   "commit": "e6ec5d8687f34644b4d049a6be463269792c9fd6",
+   "sha256": "0kgx57liqqfdslxpzm7av1jj5yjpjbabdiijc95jqw47mvvnfj1b"
   }
  },
  {
@@ -113674,25 +113571,28 @@
  },
  {
   "ename": "slack",
-  "commit": "f0258cc41de809b67811a5dde3d475c429df0695",
-  "sha256": "0mybjx08yskk9vi06ayiknl5ddyd8h0mnr8c0a3zr61p1x4s6anp",
+  "commit": "d2b2189ea2d354763dce759dcd5f6482e14024a7",
+  "sha256": "112r6nqcqgzjjbm3qd01vdirpkzb85qc5i27x4wq2gnzw559r4y4",
   "fetcher": "github",
-  "repo": "yuya373/emacs-slack",
+  "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20211129,
-    310
+    20241126,
+    6
    ],
    "deps": [
     "alert",
     "circe",
+    "dash",
     "emojify",
     "oauth2",
     "request",
+    "s",
+    "ts",
     "websocket"
    ],
-   "commit": "ff46d88726482211e3ac3d0b9c95dd4fdffe11c2",
-   "sha256": "15g4dmy4iqqpk8ivhkpsngzllbw0nc5d2sc9j36sdnhwkajzhidj"
+   "commit": "661041b5c398a1e7c226b2805aaffd4387ec3e94",
+   "sha256": "0h66mb4mfdrwmbsxr5yfsqv580ipyqq0gyzfyz0cw11qwpxnq0x0"
   }
  },
  {
@@ -113753,25 +113653,25 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20241013,
-    1008
+    20241201,
+    2103
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "b37aff4842ed51b14ee583ee51d044e3aedb395d",
-   "sha256": "1iz1a0i30fmw54h4y5kp52l8mnclwjb3nwzw6fvzy555f262r7k9"
+   "commit": "a71e133aa7d3c132bb3a00cedaeee3f76b5f17ab",
+   "sha256": "0rqjw2c5hzmrmvbf37l6fdx6pria6d360nvqka47qc74s4pw1hyi"
   },
   "stable": {
    "version": [
     2,
-    30
+    31
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "ef2af895a9e79306f0789e72b101aa39e960c900",
-   "sha256": "0qb7m65gq0mbxfrdppkh3k4jn13i14i07ziga4r8b3rmrxhrmlv0"
+   "commit": "a71e133aa7d3c132bb3a00cedaeee3f76b5f17ab",
+   "sha256": "0rqjw2c5hzmrmvbf37l6fdx6pria6d360nvqka47qc74s4pw1hyi"
   }
  },
  {
@@ -114005,11 +113905,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20240922,
-    1741
+    20241115,
+    1459
    ],
-   "commit": "98f0a9a124e46dd16683ff54208fee539945db46",
-   "sha256": "1ygi7j21hwf8j5340ciskcrkaaqcsw25c1qnjmqzgkkrrjyb4nxh"
+   "commit": "c6e7d4b5da6f1116b479c71d9c7fa0aca71d4030",
+   "sha256": "1xd8nd55dhdf1dx622x2618zj3xk196p2yr4123hk8hlqlb46h2d"
   }
  },
  {
@@ -114339,11 +114239,11 @@
   "repo": "victorteokw/smart-mark",
   "unstable": {
    "version": [
-    20150912,
-    210
+    20241104,
+    1311
    ],
-   "commit": "d179cdc3f53001a5ce99d5095f493cdf3a792567",
-   "sha256": "0kd3rh6idlaqand9i6sc44s1iahg5jdhqs9jpvivxlycj6z9p7m8"
+   "commit": "d326cc77495f57beb4bc85614804976f1ae06fb7",
+   "sha256": "0zym233mvf2m565ppb4qx9l7845gxzr82sv31pff8f76221awxh0"
   }
  },
  {
@@ -114858,14 +114758,14 @@
   "repo": "nverno/sml-ts-mode",
   "unstable": {
    "version": [
-    20241009,
-    528
+    20241015,
+    632
    ],
    "deps": [
     "sml-mode"
    ],
-   "commit": "649408a823f8aef23ea1697c5f897950e9b1cd9b",
-   "sha256": "08xz2bjfzz4vlainkzlhj139wxxy27j7m7lxpn68pbgvn9w9vzna"
+   "commit": "d2dabcc9d8f91eeee7048641e4c80fabb3583194",
+   "sha256": "0wvp8vps9f7xxlas3vcs7l40047v3vr6w2byh6bphj0p19w9461d"
   }
  },
  {
@@ -116058,11 +115958,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20240825,
-    1709
+    20241101,
+    1030
    ],
-   "commit": "9f3781430106adfe512790d55a9705568b58d968",
-   "sha256": "0q9rzih1c9r5bycvsr9iaimxz8fgh2r6z9wb4il69j3sbly81p12"
+   "commit": "6c74684c4d55713c8359bedf1936e429918a8c33",
+   "sha256": "0ijpgaa9p971r2gvrad0p52wz7x3ry2245g0vsmwds3lpahkyiwr"
   },
   "stable": {
    "version": [
@@ -116201,11 +116101,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20241011,
-    118
+    20241117,
+    126
    ],
-   "commit": "28ccd3a7df1a417874e9c5ce05e5d372d42f24b8",
-   "sha256": "0jvwm217maa9qcajqkc9s8hciw5jkh8iy0dxsxf01xmr6mmqxwqh"
+   "commit": "c036cfc6e6581b1c23d484d278e278c4d809fc23",
+   "sha256": "1isgv9fzdfgf2dn7nv5wypkm2g4yh508qxh1npgbfgwg38shpq1c"
   }
  },
  {
@@ -116838,11 +116738,11 @@
   "repo": "xenodium/sqlite-mode-extras",
   "unstable": {
    "version": [
-    20240319,
-    1312
+    20241017,
+    1030
    ],
-   "commit": "376aabe26607d40fbd572290296edaaafdf61bd3",
-   "sha256": "0xsk9b211nk2s6jxijvry5r75j64g3mazcd74iwkd21hq9hal5y8"
+   "commit": "2508fdd94b48517892a409a4cb725ece3bd015b6",
+   "sha256": "0fnd84fm37vkr64gvbdv6knaj2abmpl7p0h2w8ks26hbdb8g4wg0"
   }
  },
  {
@@ -116976,11 +116876,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20240924,
-    1924
+    20241121,
+    1857
    ],
-   "commit": "1dcf802700b39a078d970c2e18fcae91f674b0ff",
-   "sha256": "0pdizm62plhk4j26fszb93vy1ijq5wv1g5gi9sdav52rim3pdgfp"
+   "commit": "e9f6edb09d9cce461249ad54505911d71ca81a45",
+   "sha256": "0hkri3rmyj303lhi4wr6ydc3b553lczra6al9n5i9mcvx2i43gx8"
   },
   "stable": {
    "version": [
@@ -117108,11 +117008,11 @@
   "repo": "cjohansson/emacs-ssh-deploy",
   "unstable": {
    "version": [
-    20230702,
-    928
+    20241117,
+    1850
    ],
-   "commit": "95fb076c9b657c5f1bfad3ee5bf1f8691c50d428",
-   "sha256": "0iwciwnlkpbasnwdvvip5g39jq4qc8srfw0s07ljb3c3njg3jhsg"
+   "commit": "dc8882d1806c0fdd635bc625b109179dfa3c929c",
+   "sha256": "022q31z4ybcrvp1wa16h623nyp2qcn0xrsrlzi0djfm1rxg80dx3"
   },
   "stable": {
    "version": [
@@ -117291,11 +117191,11 @@
   "repo": "SFTtech/starlit-emacs",
   "unstable": {
    "version": [
-    20240223,
-    1728
+    20241130,
+    2124
    ],
-   "commit": "136bbc4fc4961c5b2cd0824eb0762e672322fbd1",
-   "sha256": "1kdk7gb3244z50yxk7wdkvrh1l50ygx5h1flajv9sxqmfivmybfd"
+   "commit": "5427867db973d91bccb35a75f819591610a81024",
+   "sha256": "178q0j2g6ql3ng0gfgdp5nn546a49aw0yc0440sga6mf1az65nkk"
   }
  },
  {
@@ -117519,11 +117419,11 @@
   "repo": "motform/stimmung-themes",
   "unstable": {
    "version": [
-    20240117,
-    1324
+    20241030,
+    823
    ],
-   "commit": "1a574973041cd5c318f39b95f6377b60337f2d6d",
-   "sha256": "1whzhbvi1kzvxw8ciqm46p911pcd7ynh9zgkshlyzrgg2dcvamrp"
+   "commit": "c7fbe9f06fff0fca2f2fc9a448865c6fc1e6ce8a",
+   "sha256": "0b5dn4f1cgldf7a5y22297p42xhhjgqy6gky1dnyj2b5jzyryxyd"
   }
  },
  {
@@ -118379,14 +118279,14 @@
   "repo": "rougier/svg-tag-mode",
   "unstable": {
    "version": [
-    20240828,
-    820
+    20241021,
+    1341
    ],
    "deps": [
     "svg-lib"
    ],
-   "commit": "91179d9576850312b00583910a55c798ba615382",
-   "sha256": "17z1zkgz1phhfp1avh37wzp31n8092xjq5fw1vyg4wjyx019444q"
+   "commit": "13e888b8bd9a0664d060149a44a751b2113331b6",
+   "sha256": "0fbq5gcr4rfddjdfy5qcnlk64lb15pibg1bbgdnyqvyvvv0biw48"
   }
  },
  {
@@ -118847,11 +118747,11 @@
   "repo": "dimitri/switch-window",
   "unstable": {
    "version": [
-    20220812,
-    2137
+    20241028,
+    314
    ],
-   "commit": "71ef2f54c97f3fd2e7ff7964d82e6562eb6282f7",
-   "sha256": "186100j93in5dm1h3xl1sg892yfz8nvssap2hsy5kh6aw1am412y"
+   "commit": "61e425e703bee66825c33f4be11fabac1a3d992a",
+   "sha256": "1wj9rm2yvl72irahq486h78caqqmlf7v1r17ysz69l2kwiqfjidv"
   },
   "stable": {
    "version": [
@@ -119098,8 +118998,8 @@
   "repo": "drym-org/symex.el",
   "unstable": {
    "version": [
-    20240920,
-    2329
+    20241126,
+    352
    ],
    "deps": [
     "evil",
@@ -119112,8 +119012,8 @@
     "tree-sitter",
     "tsc"
    ],
-   "commit": "6e9867002919576d8ab69d14c7d6095fe42d3a16",
-   "sha256": "08kxgzv22x2ysqmlwhzpvh6y2rfd83vnqks42g26a120r942zpqs"
+   "commit": "2a5ad0113a906aca9f4adade2776706657b314bc",
+   "sha256": "056c5n21xq0r82nysjn7m230h85pd3z1fiz38asabcpkd5cxbbir"
   },
   "stable": {
    "version": [
@@ -119199,20 +119099,20 @@
   "repo": "KeyWeeUsr/emacs-syncthing",
   "unstable": {
    "version": [
-    20240101,
-    2334
+    20241126,
+    247
    ],
-   "commit": "9f44d45a55b460b7eaeb9fb15d17d94e790705e0",
-   "sha256": "13s6gnjxf5g1688hs30ha65nmmby3gyyzpb2wb82hckwgm0g8rqp"
+   "commit": "70569dd11762125205015b0e59638c6b1683f0f5",
+   "sha256": "11jynl1wg13vysnzl0xakwl6h3kqvjbdjcxxvc0gq2qg73iz4am1"
   },
   "stable": {
    "version": [
-    2,
-    2,
+    3,
+    0,
     0
    ],
-   "commit": "9f44d45a55b460b7eaeb9fb15d17d94e790705e0",
-   "sha256": "13s6gnjxf5g1688hs30ha65nmmby3gyyzpb2wb82hckwgm0g8rqp"
+   "commit": "70569dd11762125205015b0e59638c6b1683f0f5",
+   "sha256": "11jynl1wg13vysnzl0xakwl6h3kqvjbdjcxxvc0gq2qg73iz4am1"
   }
  },
  {
@@ -119425,30 +119325,6 @@
   }
  },
  {
-  "ename": "system-packages",
-  "commit": "7d3c7af03e0bca3f834c32827cbcca29e29ef4db",
-  "sha256": "13nk3m8gw9kqjllk7hgkmpxsx9y5h03f0l7zydg388wc7cxsiy3l",
-  "fetcher": "gitlab",
-  "repo": "jabranham/system-packages",
-  "unstable": {
-   "version": [
-    20220409,
-    1023
-   ],
-   "commit": "c087d2c6e598f85fc2760324dce20104ea442fa3",
-   "sha256": "00idwy8jzvkgs8qzafiy6s344rgms452n8mxbjg6yszwp3y3hmq1"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "commit": "05add2fe051846e2ecb3c23ef22c41ecc59a1f36",
-   "sha256": "0n4qr5qqy6hbc1hg4wi1d2ckdl870v5mf9xhv5m9vrlwaphvnnjr"
-  }
- },
- {
   "ename": "system-specific-settings",
   "commit": "3f52c584d7435c836ba3c95c598306ba0f5c06da",
   "sha256": "1ydmxi8aw2lf78wv4m39yswbqkmcadqg0wmzg9s8b5h9bxxwvppp",
@@ -119656,6 +119532,35 @@
   }
  },
  {
+  "ename": "tab-line-nerd-icons",
+  "commit": "fcf5f86284a02746c2475522fbd73ae663b88239",
+  "sha256": "1hid372ja5r2j43944lbszm7d5ivss167i5cci1hn3jif0gwb3zl",
+  "fetcher": "github",
+  "repo": "lucius-martius/tab-line-nerd-icons",
+  "unstable": {
+   "version": [
+    20241125,
+    1048
+   ],
+   "deps": [
+    "nerd-icons"
+   ],
+   "commit": "7a49880f3ae39a8709d6887b26ec84ba2b92360c",
+   "sha256": "0iwxiixdhc5j4gx6mqplav4jcik1kvc0dnai84vdxiii7222zfq7"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "deps": [
+    "nerd-icons"
+   ],
+   "commit": "e44d16276f5df80a2d2b86e5fafb132f43bfd550",
+   "sha256": "0plmb9m8hpini73v2z1kcpwkm5jvdikbkadp8x6p78d9wi2iss78"
+  }
+ },
+ {
   "ename": "tabbar",
   "commit": "806420d75561cbeffbc1b387345a56c21cc20179",
   "sha256": "1y376nz1xmchwns4fz8dixbb7hbqh4mln78zvsh7y32il98wzvx9",
@@ -119771,8 +119676,24 @@
   "repo": "shuxiao9058/tabnine",
   "unstable": {
    "version": [
-    20240629,
-    1347
+    20241123,
+    715
+   ],
+   "deps": [
+    "dash",
+    "editorconfig",
+    "language-id",
+    "s",
+    "transient"
+   ],
+   "commit": "1f7e417eb18e097c0c08c9d151f40f476aa64608",
+   "sha256": "0vd43cj7fmrjig6abibz5nlag8f3m8qgdb4ncqygq81fl39f5sif"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
    ],
    "deps": [
     "dash",
@@ -119793,14 +119714,14 @@
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20240924,
-    1414
+    20241123,
+    1957
    ],
    "deps": [
     "project"
    ],
-   "commit": "49bd9508bade2962f72f4fab9ffc12ef31c271f7",
-   "sha256": "1cn0ccv65n4j6q1g17rgz3acrzg6w65x0zfrnpxbm8dfid4r6zr5"
+   "commit": "4fd52c33f4a215360e2b2e1b237115a217ae9bbe",
+   "sha256": "0k17vaflbqm5n7jcllpaz4idmvmy79njsaq9i4r5py367g85qa7z"
   }
  },
  {
@@ -119945,11 +119866,11 @@
   "repo": "juba/color-theme-tangotango",
   "unstable": {
    "version": [
-    20220714,
-    2034
+    20241117,
+    1143
    ],
-   "commit": "9036c4978965149ae9837bc0ad691b2ba9269052",
-   "sha256": "08qmc43m02hpy34mc7fynd9jvwc3idaawn2mq4357y56m7d38f3r"
+   "commit": "897c1643bd2cfd3c0b265a5f7599d1d04de0c304",
+   "sha256": "0a73196mhwjv72j4rkkzq8gdwp3igvkqgd14qv06z4a7d5phaxgz"
   }
  },
  {
@@ -119999,11 +119920,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20241007,
-    837
+    20241126,
+    1304
    ],
-   "commit": "eb3907798188f3117f24eec8f295b9490f6a0953",
-   "sha256": "1pkhlnykawxkv4zaghqb1ssiypg6j5pjc73f60gmjpsxwb8ki0xj"
+   "commit": "fff056c76220ea87eb45ee115f3a54a1abf1273e",
+   "sha256": "1hn2mfafkzbv8cwz3ch83by3x9nxq6m4ymx75chg0np55l9hmdxg"
   },
   "stable": {
    "version": [
@@ -120041,14 +119962,14 @@
   "repo": "phillord/tawny-owl",
   "unstable": {
    "version": [
-    20231117,
-    1644
+    20241104,
+    1432
    ],
    "deps": [
     "cider"
    ],
-   "commit": "b2708d693400a2010370df040d7571bc30fa4d75",
-   "sha256": "02p8gw7pzawzq2zzkgfx8wpp4l4zlz9zyw0f298yqrwp2zsrw5fx"
+   "commit": "0baa9c3e9aea40bcf9c11c9a009f0e26efbc366f",
+   "sha256": "1rn0lmn0pcsyvh55kfv1afhwmgxyks8knlmncj95a53ydra0qriv"
   },
   "stable": {
    "version": [
@@ -120190,16 +120111,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20240911,
-    638
+    20241118,
+    1404
    ],
    "deps": [
-    "rainbow-identifiers",
     "transient",
     "visual-fill-column"
    ],
-   "commit": "aa891d2a5a6cba18ab79b42d396795f7b61f2e9f",
-   "sha256": "04raas24bvrjsfk8div8822cgiyqy5n9bsqxwvrjjqy54jf2m2jp"
+   "commit": "f4f957253093a449c806397fd6157e19d84a7c02",
+   "sha256": "1v6v813lglgwcl8kv6jrvqjyqgp4crpbkv8qyckh9bhkjbmcgxma"
   },
   "stable": {
    "version": [
@@ -120330,14 +120250,14 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20240926,
-    925
+    20241115,
+    656
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7414b13cf9986f241f89149ccd2c39f1ec1d110c",
-   "sha256": "15wd5gh8pni9kyflz317pdl24cr3cq7hmxy0bhckz4lmvs91vv9i"
+   "commit": "3659036edbc332746dec556d0dec69ac4c52dcac",
+   "sha256": "14xw8sf5frws7qrpq4p08nphj1hflrnzlxa0bd78p6dkr86pjnij"
   },
   "stable": {
    "version": [
@@ -120359,14 +120279,14 @@
   "repo": "Crandel/tempel-collection",
   "unstable": {
    "version": [
-    20240903,
-    1136
+    20241107,
+    1417
    ],
    "deps": [
     "tempel"
    ],
-   "commit": "cb7367ac57e3ddec687e11d1567e8b3843e0d311",
-   "sha256": "18m9pxk9shwdr80h18kzy8sgr0ifa3sma6y4k5n59lcq4nkmlpg1"
+   "commit": "85f8e1d80963bc717abb8bf160274455093e3b6f",
+   "sha256": "0nc23339y09r8ngx154bdcnlx1kbz1pr4l0j28nli79zcvxb4akf"
   }
  },
  {
@@ -121509,21 +121429,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20241014,
-    1131
+    20241125,
+    830
    ],
-   "commit": "f2c4e6c61f8235d909f0af06ac0bb3043a2ce3a5",
-   "sha256": "07wz8di70q1cpb853rfkxa70bfqpkwidm31wmxxk8abar4zm0a3i"
+   "commit": "13a0cd43ea3f14bc58b7685dbb28bb5325c6a398",
+   "sha256": "126gb3z9y2jz74qx5hv4zpwlx9chhip996ihlzk7c8zcvyj86gdv"
   },
   "stable": {
    "version": [
     2024,
-    10,
-    7,
+    11,
+    25,
     0
    ],
-   "commit": "8d6d2cea014274c23db498400f1559e5a82995e7",
-   "sha256": "17nxbjab5kr2hyy34mys22k7h7wz4b8ha1yy05cvrryhiyi45gf7"
+   "commit": "13a0cd43ea3f14bc58b7685dbb28bb5325c6a398",
+   "sha256": "126gb3z9y2jz74qx5hv4zpwlx9chhip996ihlzk7c8zcvyj86gdv"
   }
  },
  {
@@ -121603,8 +121523,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20230620,
-    1444
+    20241019,
+    2101
    ],
    "deps": [
     "cl-lib",
@@ -121612,8 +121532,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "b38dfc3f8fb754e64e48e76fc92d472cb3d1a3dc",
-   "sha256": "0s1wfsn6z828zxydd0cmfy9c9nix77snx10cr2va8wdrsp0sy14s"
+   "commit": "6a35fe355f1442da34b976bf2decf008d6e4f991",
+   "sha256": "0sr7r7bbsj724s7k8g3a4sy462057n0v6l2wx512naxnzhkk56xq"
   },
   "stable": {
    "version": [
@@ -121936,19 +121856,19 @@
   "repo": "aimebertrand/timu-line",
   "unstable": {
    "version": [
-    20240405,
-    2022
+    20241107,
+    2145
    ],
-   "commit": "3957234a4a7618376dc9ef40272f6aeabdf48843",
-   "sha256": "0msa4c6h6y1kl1q5rqjbf7i1hkpgp7k9qif7ssjq7dj6dlhakmb1"
+   "commit": "cbb456f96f5a300d4705565660de7e6dbb225dbe",
+   "sha256": "0m6z0ckypp2lkh4s1yqlsq724axwh5spnx06jjcr0dcdv4rkj2sp"
   },
   "stable": {
    "version": [
-    0,
-    9
+    1,
+    0
    ],
-   "commit": "3957234a4a7618376dc9ef40272f6aeabdf48843",
-   "sha256": "0msa4c6h6y1kl1q5rqjbf7i1hkpgp7k9qif7ssjq7dj6dlhakmb1"
+   "commit": "9744c8ac9070ca8b744c0207a6f573d8eddf5adc",
+   "sha256": "0zlaqdzij0pfqyq7ln8zpk5r2rx0vvv98a29f2wwxccspikps0sj"
   }
  },
  {
@@ -122349,11 +122269,11 @@
   "repo": "justinlime/toggle-term.el",
   "unstable": {
    "version": [
-    20240804,
-    117
+    20241112,
+    635
    ],
-   "commit": "54605ed1d03dbfd324d9bec4ee314ab764a2a8dd",
-   "sha256": "15cmn2zwcypx17zxii3m39a7jwb4fsxm9ix8ykbmnxnjfl7kzxha"
+   "commit": "64f7022d214d5701c6babfe4a975baa60ec999c8",
+   "sha256": "0kw1pyd8vywlad4kkh8rw7l941jmc86y6ahs76l1xzxs4lgwsm2s"
   }
  },
  {
@@ -122394,11 +122314,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20231019,
-    947
+    20241114,
+    1637
    ],
-   "commit": "61c86fd2902b6342efe4463230dffdd185159d1c",
-   "sha256": "03n75dmsmlhpkra6scqpvanbcfplc08np8hzarn4jcnysybji0f4"
+   "commit": "fa495ad556079af8efff758d3705dbf22ca64ca1",
+   "sha256": "0abdvzww9lj20jjqygj6sp528dilry4368w2pc88j7whfv1wyp2i"
   }
  },
  {
@@ -122510,11 +122430,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20240922,
-    114
+    20241128,
+    1605
    ],
-   "commit": "83cdd101e8ff25e1fe6addd224ab726095616304",
-   "sha256": "1qj3yf1izk9qlnpmq39dfdf0r5sq8csy8ynrkb6ari3xi7w68y3p"
+   "commit": "a6f73ee3cafd580a8704f6d1a596dc19c783e31c",
+   "sha256": "01mfial0jh595pk6imn6z0g4r3mk15c508xnkkrsazs3614brwq8"
   },
   "stable": {
    "version": [
@@ -122782,6 +122702,35 @@
   }
  },
  {
+  "ename": "tp",
+  "commit": "67589f7b4bad6d14792364e5106cedd93cb3c86f",
+  "sha256": "0pyiphw9fidrx353dijf5k92jmqb2vj3aaxpg0zr6kajzlf03ljm",
+  "fetcher": "codeberg",
+  "repo": "martianh/tp.el",
+  "unstable": {
+   "version": [
+    20241031,
+    729
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "df6490d86f24fff22f5ea4f7d887fc60caed1163",
+   "sha256": "14vdn5syv7jghxvqlih9gvh82755r5gd8yxskq8bv6wkm4b0y0cs"
+  },
+  "stable": {
+   "version": [
+    0,
+    6
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "df6490d86f24fff22f5ea4f7d887fc60caed1163",
+   "sha256": "14vdn5syv7jghxvqlih9gvh82755r5gd8yxskq8bv6wkm4b0y0cs"
+  }
+ },
+ {
   "ename": "tql-mode",
   "commit": "6a7c3dec5d970a4e819c0166a4b9846d74484b08",
   "sha256": "0nrycix119vail6vk1kgqsli4l4cw8x49grc368n53w0xwngh0ns",
@@ -122965,11 +122914,11 @@
   "repo": "fosskers/transducers.el",
   "unstable": {
    "version": [
-    20240308,
-    843
+    20241103,
+    35
    ],
-   "commit": "2d452e4cdc3b5cfa29ee3d7a645ff53d4e993384",
-   "sha256": "1k17mxkk7mdv07ji30njxdpkzgyjpn4v45p0am72wn1k1kyq4vim"
+   "commit": "f8f46db6ddba6641669160fffb3f98213ab5b213",
+   "sha256": "1xdiyzzy2ld7xv2wd9aghivzm90cnjykm3hfaa1wr75006bsm88f"
   },
   "stable": {
    "version": [
@@ -123007,28 +122956,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20241008,
-    1824
+    20241201,
+    1616
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "8873c300b2cf8c648278210205c1d3234e387a30",
-   "sha256": "0q0jsvl9irhsp3blnl4yfnfwgafr13kc4i4xlxjccf2y3q75qlf5"
+   "commit": "37be15575a8e7618de59b6aec5a42ba5656dc36f",
+   "sha256": "1whz9zkzid34rz5753xxyvsxnhs24xcnbv31bvc6n8l1szdncfzi"
   },
   "stable": {
    "version": [
     0,
     7,
-    7
+    9
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "fc03c0b75826aa771b682137aa3f4e24130a9e3c",
-   "sha256": "0rdhjb2fcxwxpbr7lrjqqqdnag2zqs8l6g4yw59bkp4g7kxpmmar"
+   "commit": "00fabc76eb3dc75f742d8d2720c44e25e5772e8f",
+   "sha256": "17qhj3i57i6yz28bvznimls7z1y3f4mln0axk2782jcysz7f80bl"
   }
  },
  {
@@ -123401,16 +123350,16 @@
   "repo": "ShuguangSun/tree-sitter-ess-r",
   "unstable": {
    "version": [
-    20221012,
-    855
+    20241120,
+    1547
    ],
    "deps": [
     "ess",
     "tree-sitter",
     "tree-sitter-langs"
    ],
-   "commit": "9669c00f3d3463e6769725af74c392891e269eed",
-   "sha256": "083m21lqgic910fqbxc104fai0vh2hrb7s2nlln43l7hlb8939b4"
+   "commit": "5e5dbd4d1cf6417530bae2f620405d304fac7772",
+   "sha256": "12lami5z8ji19y79zpwvk1p15zzhnjawj1bp2i5gnr38r8h9k2qy"
   },
   "stable": {
    "version": [
@@ -123483,26 +123432,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20241006,
-    953
+    20241201,
+    1840
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "62e169d3122658761581105c91d8a6aad103fed5",
-   "sha256": "0ssf35m6ihbrh4gnp7ikv6jzbqarcpwarb9jbniiba378czas07h"
+   "commit": "c5ca30e1fa43ca1fdcb7f423ec4c97732ccb8753",
+   "sha256": "0cj6x17yc6j8byqvb7y0k8s2vpwzyq9myqbrj2jj5i38y7d6zcb8"
   },
   "stable": {
    "version": [
     0,
     12,
-    226
+    238
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "62e169d3122658761581105c91d8a6aad103fed5",
-   "sha256": "0ssf35m6ihbrh4gnp7ikv6jzbqarcpwarb9jbniiba378czas07h"
+   "commit": "c5ca30e1fa43ca1fdcb7f423ec4c97732ccb8753",
+   "sha256": "0cj6x17yc6j8byqvb7y0k8s2vpwzyq9myqbrj2jj5i38y7d6zcb8"
   }
  },
  {
@@ -123579,8 +123528,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20240815,
-    1227
+    20241113,
+    2139
    ],
    "deps": [
     "ace-window",
@@ -123592,8 +123541,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "488dfc0a3aa7c1d35802d4f89be058e761578663",
-   "sha256": "01gljyihn9wyishd39vxav8rdzy19wsp0jyd0kr7w7xv83rbm57n"
+   "commit": "2fd7745f1bc446fc590dc7ba2eb4e062a51fbb3e",
+   "sha256": "0pspxkja58zpic2gnprhg5jkdy49ydw09rgg9wpf6vjwr5zbxp5b"
   },
   "stable": {
    "version": [
@@ -123684,14 +123633,14 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20240131,
-    2042
+    20241017,
+    2046
    ],
    "deps": [
     "treemacs"
    ],
-   "commit": "bcba09c1581c4bd93ff0217d464aead04f6d26d4",
-   "sha256": "051x78qpzclzr8mic5z3rpr1j3f5a5apcnn9rhah1rnxg5z9gqa7"
+   "commit": "63e80d4b96c2a411da0beaee8a1e46f116e05e27",
+   "sha256": "1bibbphybx0qbc0w8lhr8zpc9fl9pfcn3721vmjmr3qkh0w695rk"
   },
   "stable": {
    "version": [
@@ -123941,11 +123890,11 @@
   "repo": "erickgnavar/treesit-ispell.el",
   "unstable": {
    "version": [
-    20240816,
-    145
+    20241104,
+    1520
    ],
-   "commit": "9e06b5a37945f3ff96a5cfbb79ea3e4c2986bd6a",
-   "sha256": "1fq5j8rx1crwdjxsg18i8l83m0fql9z2rnkfjgjxwc75p83b77hi"
+   "commit": "fd1598fb16fe99dc8d8245974641c3e474dc31d1",
+   "sha256": "18373figl9l9wshv5m8dbkpnjlbqciv28miah5zs21c6m344l6g5"
   }
  },
  {
@@ -123956,11 +123905,20 @@
   "repo": "tilmanrassy/emacs-treeview",
   "unstable": {
    "version": [
-    20230728,
-    2343
+    20241101,
+    115
    ],
-   "commit": "c6888e5f3aa0d72a7b4db625fcc2a847fd3bb1ce",
-   "sha256": "1jr9lw7hjwa2cajphy9y19gn3dlacdp1kggp823vpx5p1d5fsvgz"
+   "commit": "9a1a16f84fc3c368443641f7a71aa2407ad91d38",
+   "sha256": "1m1xxkhvd3pb6j2ljsf57jzksb2iap1ssnsy1l7amknnwfdk9hsi"
+  },
+  "stable": {
+   "version": [
+    1,
+    3,
+    0
+   ],
+   "commit": "f8b678ba1dd52171002585bfc13921a509658af3",
+   "sha256": "0blggaqzz7rwycpp6v0n0fig1d9prdp63w25cprnq59ymczr7w85"
   }
  },
  {
@@ -124618,20 +124576,20 @@
   "repo": "KeyWeeUsr/typewriter-roll-mode",
   "unstable": {
    "version": [
-    20240817,
-    928
+    20241127,
+    1742
    ],
-   "commit": "9ce34ea14616e478f10abc49727d9e9cee6c5dc3",
-   "sha256": "0kjqimpgm8awjav0m796w3bb0qrbvm2i85cn6b37fxbxa6dsxhql"
+   "commit": "821a0c6e13e160e9a6f02c6232449c163043f75b",
+   "sha256": "0ijihkx1lnl8hkbl5m6hn9n9bf3a0w90b00hz3xlsw1i32wriik3"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "9ce34ea14616e478f10abc49727d9e9cee6c5dc3",
-   "sha256": "0kjqimpgm8awjav0m796w3bb0qrbvm2i85cn6b37fxbxa6dsxhql"
+   "commit": "821a0c6e13e160e9a6f02c6232449c163043f75b",
+   "sha256": "0ijihkx1lnl8hkbl5m6hn9n9bf3a0w90b00hz3xlsw1i32wriik3"
   }
  },
  {
@@ -124977,11 +124935,11 @@
   "repo": "marktran/color-theme-ujelly",
   "unstable": {
    "version": [
-    20180214,
-    1624
+    20241111,
+    822
    ],
-   "commit": "bf724ce7806a738d2043544061e5f9bbfc56e674",
-   "sha256": "0pz26q5qfq4wiqcpfkq26f19q5gyiv8q71sq4k77hkss5a5b5fqg"
+   "commit": "7345ab821739aafa2ec079a71fa7de350a869f0e",
+   "sha256": "057nvr00siib76ar86n9dw50xkc4likk5l1nrnz60wnmgvri80h8"
   }
  },
  {
@@ -125561,14 +125519,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20241014,
-    1600
+    20241130,
+    1714
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "51f8096af29bc67ab6defedf3bf71e82e64e67c2",
-   "sha256": "04l48gaqyvsxfpvrgi412qjx95283yi30r6kcw9rldpx9hvqywwk"
+   "commit": "f9177e8b476db6f388ad4eac1a98b5d6129e7f61",
+   "sha256": "1vhan0dpxq7k5bi863hyb3fn8k8x7m6vidr4b4blj601bmdygk7k"
   }
  },
  {
@@ -126117,45 +126075,15 @@
   }
  },
  {
-  "ename": "use-package",
-  "commit": "570bde6b4b89eb74eaf47dda64004cd575f9d953",
-  "sha256": "0rlccqjdynh03ww9jqnnyvn86mr9cd4hlfni8hz2r7a726b70xf1",
-  "fetcher": "github",
-  "repo": "jwiegley/use-package",
-  "unstable": {
-   "version": [
-    20230426,
-    2324
-   ],
-   "deps": [
-    "bind-key"
-   ],
-   "commit": "b59b4dc2361c7b351238990d0c34eece8d79ecf0",
-   "sha256": "05995kr3chn918l0hywslqfvk0rbr2pzbdbfkdfij65hpmdjaznh"
-  },
-  "stable": {
-   "version": [
-    2,
-    4,
-    4
-   ],
-   "deps": [
-    "bind-key"
-   ],
-   "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
-   "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
-  }
- },
- {
   "ename": "use-package-chords",
-  "commit": "6240afa625290187785e4b7535ee7b0d7aad8969",
-  "sha256": "1217l0gpxcp8532p0d3g1xd2015qpx2g5xm0kwsbxdmffqqdaar3",
+  "commit": "6c1d8ed99c3769f6a789fb51dc37794b95f8bb37",
+  "sha256": "18av8gkz3nzyqigyd88ajvylsz2nswsfywxrk2w8d0ykc3p37ass",
   "fetcher": "github",
-  "repo": "jwiegley/use-package",
+  "repo": "waymondo/use-package-chords",
   "unstable": {
    "version": [
-    20221117,
-    1610
+    20241115,
+    2228
    ],
    "deps": [
     "bind-chord",
@@ -126163,8 +126091,8 @@
     "key-chord",
     "use-package"
    ],
-   "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
-   "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
+   "commit": "a2b16a1e64b19ae9428a6cd8f3e09b8159707a29",
+   "sha256": "0krskz087vy4iws01w5wxsn7b0pkncsn6s1vj9ywagn5i1z6a34x"
   },
   "stable": {
    "version": [
@@ -126176,38 +126104,6 @@
     "bind-chord",
     "bind-key",
     "key-chord",
-    "use-package"
-   ],
-   "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
-   "sha256": "03mqkv63ink2ysy86slac8ac7a5g22bi0pwvxyncfasm43q9d0sx"
-  }
- },
- {
-  "ename": "use-package-ensure-system-package",
-  "commit": "6240afa625290187785e4b7535ee7b0d7aad8969",
-  "sha256": "1cl61nwgsz5dh3v9rdiww8mq2k1sbx27gr6izb4ij4pnzjp7aaj6",
-  "fetcher": "github",
-  "repo": "jwiegley/use-package",
-  "unstable": {
-   "version": [
-    20221209,
-    2013
-   ],
-   "deps": [
-    "system-packages",
-    "use-package"
-   ],
-   "commit": "bcf0984cf55b70fe6896c6a15f61df92b24f8ffd",
-   "sha256": "0pmz5x7ghwsjyr4lhaqa53c7190bjqxaczljpsr62s60bn55fdsi"
-  },
-  "stable": {
-   "version": [
-    2,
-    4,
-    4
-   ],
-   "deps": [
-    "system-packages",
     "use-package"
    ],
    "commit": "9090080b15486c3e337be254226efe7e5fde4c99",
@@ -126305,15 +126201,30 @@
   "repo": "ushin/ushin-shapes.el",
   "unstable": {
    "version": [
-    20230702,
-    2210
+    20241022,
+    522
    ],
    "deps": [
+    "compat",
     "svg-lib",
     "svg-tag-mode"
    ],
-   "commit": "30171af499d8117a2dbc3e978473793eced49bcb",
-   "sha256": "1gxjj1f9jdh572sdfh60z3a056a4clzssbyx12kkh60vak5g0fg3"
+   "commit": "fd2c4289c7d336528f1f855eb9378615417f4483",
+   "sha256": "0gjnnlldv9vxysn7s2sbz2hswkj6674alkzcgv97205yii4kgqsd"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "compat",
+    "svg-lib",
+    "svg-tag-mode"
+   ],
+   "commit": "fd2c4289c7d336528f1f855eb9378615417f4483",
+   "sha256": "0gjnnlldv9vxysn7s2sbz2hswkj6674alkzcgv97205yii4kgqsd"
   }
  },
  {
@@ -126339,26 +126250,26 @@
   "repo": "diml/utop",
   "unstable": {
    "version": [
-    20240226,
-    1308
+    20241125,
+    1512
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "d4f6f5f7337eeeac9507801c8f147fff518f9d69",
-   "sha256": "03lagf6s7rsxcgrqk1nklnrbsjrng5gpw0h0rza510y08k77gw52"
+   "commit": "3322adaa5267b1188d14b15e85c802c21fe061cb",
+   "sha256": "0g5inax35v3m8bxvbrdvjv0zg1b7q4jk8xp5jwhgjp5n3w3hryy1"
   },
   "stable": {
    "version": [
     2,
-    14,
+    15,
     0
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "d4f6f5f7337eeeac9507801c8f147fff518f9d69",
-   "sha256": "03lagf6s7rsxcgrqk1nklnrbsjrng5gpw0h0rza510y08k77gw52"
+   "commit": "3322adaa5267b1188d14b15e85c802c21fe061cb",
+   "sha256": "0g5inax35v3m8bxvbrdvjv0zg1b7q4jk8xp5jwhgjp5n3w3hryy1"
   }
  },
  {
@@ -126587,11 +126498,11 @@
   "repo": "arthurgleckler/validate-html",
   "unstable": {
    "version": [
-    20210420,
-    2344
+    20241023,
+    2029
    ],
-   "commit": "748e874d50c3a95c61590ae293778e26de05c5f9",
-   "sha256": "0b2b5dm85jwgkqvga23r3vfya07vxv2n7a3a6r1pxpk8asqlw41c"
+   "commit": "4285c492d8a28025ffce7ee717e2aefc905bea66",
+   "sha256": "1h413p278g1yz88paj27azyljray31fm5fr6r2ql7zra9yc1dv91"
   }
  },
  {
@@ -127135,11 +127046,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20241012,
-    1924
+    20241021,
+    1914
    ],
-   "commit": "98934fef8cd2bc339f40abb36ee4a6776e50872d",
-   "sha256": "12fcji7q50w174fvmdyf7fxpp2yi3g7dn8z75ril7s9c3ajgfr67"
+   "commit": "c05263f8cad09b9bf13b03ad9198c40400f31483",
+   "sha256": "1dihjsyi7qi7znqai3r2fa9ggb7mggzsap3723bhj5pkl0gfq9ld"
   },
   "stable": {
    "version": [
@@ -127351,14 +127262,14 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20241004,
-    1350
+    20241105,
+    2131
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e826dfcb14af5e2cfd88ed110d0208ddc2d37788",
-   "sha256": "0f029jyjca1cis6mlj5ba4xn417q7sqxjdbp86am5nfvawglybqi"
+   "commit": "b0f9e7679be590b976576e4056b6af4b31212ab0",
+   "sha256": "0wsd1d5grrmpyywxl1fgfw2wd4i65fd6g5dml7a58i6fq44jr8r9"
   },
   "stable": {
    "version": [
@@ -127458,8 +127369,8 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20240917,
-    1142
+    20241016,
+    1217
    ],
    "deps": [
     "ag",
@@ -127471,14 +127382,14 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "ee05144a17fa319f6acc001ff990def0796d757a",
-   "sha256": "0qm3i1jicjjkivm46cwmqv5nl2dvnb7dass6r24d03xg624clrc9"
+   "commit": "28838b9722933889c8af4b9b543db07ccd2d2b66",
+   "sha256": "1fm42f0fhnychix1mzhlnrchnipi9qq5cl9sjlhmfxz0wflrbqij"
   },
   "stable": {
    "version": [
     0,
     5,
-    2
+    3
    ],
    "deps": [
     "ag",
@@ -127490,8 +127401,8 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "dee99805f375b5fc7f4821bf8fd6563fc53bf03e",
-   "sha256": "1fsgfwazvhvbp06hrfm0xzlvs92d4i0x24znfavrib0s25in8pcv"
+   "commit": "28838b9722933889c8af4b9b543db07ccd2d2b66",
+   "sha256": "1fm42f0fhnychix1mzhlnrchnipi9qq5cl9sjlhmfxz0wflrbqij"
   }
  },
  {
@@ -127744,11 +127655,11 @@
   "repo": "nverno/vimscript-ts-mode",
   "unstable": {
    "version": [
-    20240426,
-    818
+    20241020,
+    7
    ],
-   "commit": "e806f59f870e268bfe879bdc7b5134e641c42c0f",
-   "sha256": "0n5k0rl7panzbzjfaj6y3qcirr9c809fh0p9156v33ah3jl71a2l"
+   "commit": "8ebe7746172caaa88d463c58e0bfe76ec7fc971a",
+   "sha256": "132814w2751k7jh20lrjhqp758h41s78pyvsffk1xzk6cvb6xn80"
   }
  },
  {
@@ -127944,6 +127855,29 @@
    ],
    "commit": "a6420b25ec0fbba43bf57875827092e1196d8a9e",
    "sha256": "1isqa4ck6pm4ykcrkr0g1qj8664jkpcsrq0f8dlb0sksns2dqkwj"
+  }
+ },
+ {
+  "ename": "visual-replace",
+  "commit": "88e516cf57f8fda6d475039cf9cbd9dd59689c43",
+  "sha256": "0nvrx15a1pp7034fh5ca6gz8492ghvs91gfa0w4jdlbxsylfalwb",
+  "fetcher": "github",
+  "repo": "szermatt/visual-replace",
+  "unstable": {
+   "version": [
+    20241124,
+    1051
+   ],
+   "commit": "19544555e7b5bba624238217a295fd4c80c0ed1d",
+   "sha256": "1sqxwl8ahn4sm553chidh281nj46ppn2yhwlgfj4d0bv7ng0fj8r"
+  },
+  "stable": {
+   "version": [
+    1,
+    1
+   ],
+   "commit": "d9a89fa02c6170a1b417b3e71e85d481213f318b",
+   "sha256": "05s21qhq23mmv8in88qxfbq79h26j14vcw5pc112sjr1a4fl5306"
   }
  },
  {
@@ -128184,11 +128118,11 @@
   "repo": "jojojames/vscode-icon-emacs",
   "unstable": {
    "version": [
-    20230330,
-    2206
+    20241201,
+    2200
    ],
-   "commit": "3976bc2e7e2fe0068ae59c11d226f67e0e87aaea",
-   "sha256": "168hvmj3nlbi1p7w5m424sn6shn12kbgjd9spyj60pj1867jq7r1"
+   "commit": "27cbf4f178924de1e2a09b4d87f87b5fa67c8cf4",
+   "sha256": "1xbv2nih9lapxci1sqs0rg3k5mb447jlj1kl597pgh242r2xacgk"
   }
  },
  {
@@ -128199,11 +128133,11 @@
   "repo": "hardenedapple/vsh",
   "unstable": {
    "version": [
-    20240820,
-    1320
+    20241104,
+    1341
    ],
-   "commit": "40daabb4b05e1dce8bc9b68cb437d9aff3cfa7d0",
-   "sha256": "0bzl82dpga2nazpilrrih35mdqxp5ar360rbvk12b96xlas7lbnr"
+   "commit": "47b6190777be9e1c4c0efb94c166b29c83b10553",
+   "sha256": "1ywzd4mr3szcspv16k78cj4fn0m897sy6nx4cchy6bza92qw2k08"
   }
  },
  {
@@ -128214,11 +128148,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20240825,
-    133
+    20241118,
+    1627
    ],
-   "commit": "988279316fc89e6d78947b48513f248597ba969a",
-   "sha256": "1qk0fxzn3401b5kjb064bln199s6wn2abfdvfxgyswnygw1hdxav"
+   "commit": "fd50624723200f4ac261f122f6332f57796c782f",
+   "sha256": "0sfgpg6d4xj97sf3vsmxyh13vmdz9gsln1lcp05inkavyxz02xb1"
   }
  },
  {
@@ -128491,11 +128425,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20240712,
-    248
+    20241030,
+    52
    ],
-   "commit": "a3dd9b16224893ef1d75ee9bf0c2b088bc2a5d92",
-   "sha256": "1sb2p0gxb8z9im0h5pky0fhvcxjhajsyd1gicfnhl8cqxmjjf907"
+   "commit": "cce39eb257b27f737b4264f7b41c70ae70dc3906",
+   "sha256": "0zzc7p2b8nqqp8gn0px5jds3fj895gx1n2igvkwmz4v429p7wkgb"
   }
  },
  {
@@ -128750,22 +128684,22 @@
  },
  {
   "ename": "wanderlust",
-  "commit": "112fe41123b723cda52af773ebb161e5b189f68b",
-  "sha256": "0d2j2nvh53563q2753kxpb0skg6qd7r0sa7swq7r8vi8s02zfhi7",
+  "commit": "8fe101b6d26bc501d5dc3515f10f972a53078a46",
+  "sha256": "08ivrdcfj7zj01jndp4lr76q6cd29xsbjwgdfkhh9iz89hsm4y7q",
   "fetcher": "github",
-  "repo": "wanderlust/wanderlust",
+  "repo": "emacsmirror/wanderlust",
   "unstable": {
    "version": [
-    20240913,
-    818
+    20241125,
+    2206
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "8b413b33cdb5a1b715f99a3919573fde2cfb3053",
-   "sha256": "060mfriavciqb71c6gp3l6va7vr87r9lvn4z4h344mx287g502d8"
+   "commit": "dddd7d64f27747cfa546d6656beee6ec4e5c55cf",
+   "sha256": "0qd6d6yd2sr3mv8wb22py7yvnib6nk9jpqfj0fkib0x0w9anfxz8"
   }
  },
  {
@@ -129066,10 +129000,10 @@
    "version": [
     17,
     3,
-    13
+    20
    ],
-   "commit": "90502d9cd2b5bc9a13d2628e48fd66b78243e090",
-   "sha256": "0d4j97vywfqabc896w8d30niig19lg2q1bdd3kxyvz3b8027zn4g"
+   "commit": "0c83581d1e93d1d802c730a1d5e90cd1c740e1b2",
+   "sha256": "0lvixg4c5apwrpqljj11b3yrq8nklz4ky4njnh8y6h1j5bisx40p"
   }
  },
  {
@@ -129280,15 +129214,15 @@
   "repo": "etu/webpaste.el",
   "unstable": {
    "version": [
-    20241002,
-    536
+    20241125,
+    1418
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "5653e0994a10536db13b142b074e45894959d134",
-   "sha256": "09z8ihykv3hcq1ja7vigrgwks5657r8706c1yb7y12fm6xzhmcvd"
+   "commit": "e2a41530257f04b7ad2198d333adcf247a05277c",
+   "sha256": "1zxk0fgv7hmqs8sccj5bhd6il5l2k7ahwnwiycnmkcylsrkyqrc4"
   },
   "stable": {
    "version": [
@@ -129687,14 +129621,15 @@
   "repo": "SalOrak/whaler.el",
   "unstable": {
    "version": [
-    20240714,
-    1833
+    20241124,
+    1732
    ],
    "deps": [
+    "dash",
     "f"
    ],
-   "commit": "6909cc2280b9c0846255ca98b9f6420ec37efbc3",
-   "sha256": "1nrdyxfh7jidl9826gx20xvawmk63hqla80vgkyw0ab212sbv9k8"
+   "commit": "8de85180c2a66f999f3effeef88aa9468d1499eb",
+   "sha256": "01h4srxrrjcqxg7x103q76k2ckzbsxld20g272wlh315mxji8dix"
   }
  },
  {
@@ -130231,11 +130166,11 @@
   "repo": "kiwanami/emacs-window-layout",
   "unstable": {
    "version": [
-    20170215,
-    33
+    20241104,
+    900
    ],
-   "commit": "cd2e4f967b610c2bbef53182829e47250d027056",
-   "sha256": "0wgqi8r844lbx52fn6az8c1n8m681rp6dkfzd54wmdk1ka7zmvv6"
+   "commit": "277d0a8247adf13707703574cbbc16ddcff7c5fd",
+   "sha256": "101gab1xm3a4ildwzfysmjcpxrzxj3a1l9fa03nc88if9pcsxjb9"
   },
   "stable": {
    "version": [
@@ -130544,26 +130479,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20240831,
-    2230
+    20241201,
+    1419
    ],
    "deps": [
     "compat"
    ],
-   "commit": "77cb2403158cfea9d8bfb8adad81b84d1d6d7c6a",
-   "sha256": "1k86z7zjvs5mbxirxvn190ya7fj1vdzps5cm0659hh32373c1l7s"
+   "commit": "ca902ae02972bdd6919a902be2593d8cb6bd991b",
+   "sha256": "0h21qs60qihv4p72x5wbmc0xly4g74wc25qj8m9slfbc4am9mwys"
   },
   "stable": {
    "version": [
     3,
     4,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "77cb2403158cfea9d8bfb8adad81b84d1d6d7c6a",
-   "sha256": "1k86z7zjvs5mbxirxvn190ya7fj1vdzps5cm0659hh32373c1l7s"
+   "commit": "ca902ae02972bdd6919a902be2593d8cb6bd991b",
+   "sha256": "0h21qs60qihv4p72x5wbmc0xly4g74wc25qj8m9slfbc4am9mwys"
   }
  },
  {
@@ -130938,11 +130873,11 @@
   "repo": "martianh/wordreference.el",
   "unstable": {
    "version": [
-    20240318,
-    2135
+    20241020,
+    1145
    ],
-   "commit": "6cd9e43c809267fc37e21e99d49ded4e4731b48a",
-   "sha256": "06m17drciv9nxb7344ir0gm7a3krz24krh78v167vnyvzv72abfr"
+   "commit": "698fa410232830a8acb249a422be33a58dd4c6ee",
+   "sha256": "0cbvg9pgclkf2mwnslnvalnl6z9gznkmzpap83g8pvgrbjrjbgcc"
   }
  },
  {
@@ -131224,19 +131159,19 @@
   "repo": "lewang/ws-butler",
   "unstable": {
    "version": [
-    20201117,
-    1528
+    20241107,
+    519
    ],
-   "commit": "e3a38d93e01014cd47bf5af4924459bd145fd7c4",
-   "sha256": "1vcgg8wr5zpkn9ynyx8sad7srmd31dzkc40wnrzs8aan8nsah5bx"
+   "commit": "d3927f6131f215e9cd3e1f747be5a91e5be8ca9a",
+   "sha256": "17f73isx2wdwzjcxparyy7ngl4cha0g69da1d72b3yidzim1kh6h"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
-   "commit": "323b651dd70ee40a25accc940b8f80c3a3185205",
-   "sha256": "1a4b0lsmwq84qfx51c5xy4fryhb1ysld4fhgw2vr37izf53379sb"
+   "commit": "d3927f6131f215e9cd3e1f747be5a91e5be8ca9a",
+   "sha256": "17f73isx2wdwzjcxparyy7ngl4cha0g69da1d72b3yidzim1kh6h"
   }
  },
  {
@@ -131392,14 +131327,14 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20240801,
-    719
+    20241119,
+    1907
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d62e83f1041680df8de7bbfe19aaaa0f2dfa79b6",
-   "sha256": "0dbi5fwid24ilrvagj0s9v9gn1737889swycm20vggkdcij8fzh8"
+   "commit": "b4dc55ee6f9e22e6558fe72a0c350b2c3a771f66",
+   "sha256": "135pppf7xw1v8yzvxp0rdnimsr7jzz1scsb208xxq4s3x1g0vmax"
   }
  },
  {
@@ -132220,11 +132155,11 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20231211,
-    1501
+    20241129,
+    2114
    ],
-   "commit": "70c4fcead97e9bd6594e418c922ae769818f4245",
-   "sha256": "0qq9jr1ihk1b5wfvppyvb8c2pq2gma9wysggd22iln4nqz2mjc81"
+   "commit": "cd3edfc02cb12514426c00e07160b87bd8340f4a",
+   "sha256": "1018s84pdvr8s4dg1g827w0ss78fbs5xj41vglnm5p9np29gfafz"
   },
   "stable": {
    "version": [
@@ -132558,24 +132493,6 @@
   }
  },
  {
-  "ename": "yasnippet-lean",
-  "commit": "e1cdcf88a7ff90570d8b09901de8b8b8a153c52e",
-  "sha256": "0mhlg6ya4b232hgq5wh5w9h0ww35qi9br4501sc379zqwflvqcm7",
-  "fetcher": "github",
-  "repo": "leanprover-community/yasnippet-lean",
-  "unstable": {
-   "version": [
-    20220105,
-    2251
-   ],
-   "deps": [
-    "yasnippet"
-   ],
-   "commit": "c75485757cc8675ad4f36c1eb028d9d54dc21733",
-   "sha256": "0lki128rgk5nshpqkz2mndwvzl4a62nammy0xrm4m84ya4vb9mwi"
-  }
- },
- {
   "ename": "yasnippet-snippets",
   "commit": "42490bbdac871bce302fbc9a0488ff7de354627e",
   "sha256": "0daawvlw78ya38bbi95swjq8qk5jf5shsyv164m81y2gd8i5c183",
@@ -132776,14 +132693,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20241012,
-    758
+    20241022,
+    2200
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f73172433a944551558204554efae0e441388034",
-   "sha256": "0issjdi1j1cvapxjxbansbmdmfs9khxmr2k0cr6pqm0hfzak4c9s"
+   "commit": "d3437030bcd8d64b2e5a3bc579e2f2f0b4581d1f",
+   "sha256": "1szi2ghx67vrs76dnv3bfjx12rdhyskm6bf2yjkrlf03fy1r8api"
   },
   "stable": {
    "version": [
@@ -133023,16 +132940,16 @@
   "repo": "tuedachu/ytdl",
   "unstable": {
    "version": [
-    20230331,
-    1804
+    20241025,
+    1913
    ],
    "deps": [
     "async",
     "dash",
     "transient"
    ],
-   "commit": "2ea3daf2f6aa9d18b71fe3e15f05c30a56fca228",
-   "sha256": "0y62lkgsg19j05dpd6sp6zify8vq8xvpc8caqiy4rwi7p4ahacsf"
+   "commit": "309ad5ce95368ad2e35d1c1701a1f3c0043415a3",
+   "sha256": "1rmh302hm0w0fp796aiq69pm1ic2hl7jpybd3gd5rz4p6la4zys9"
   },
   "stable": {
    "version": [
@@ -133047,21 +132964,6 @@
    ],
    "commit": "23da64f5c38b8cb83dbbadf704171b86cc0fa937",
    "sha256": "010arhvibyw50lqhsr8bm0vj3pzry1h1vgcvxnmyryirk3dv40jl"
-  }
- },
- {
-  "ename": "ytel",
-  "commit": "f01e793028a76e9033dd2e1e55e1ad475685fb69",
-  "sha256": "0sg5bjv6zknwvdbklmai9ilisja97lv30dq8n9h3fp47kw19fhyf",
-  "fetcher": "github",
-  "repo": "manabiseijin/ytel",
-  "unstable": {
-   "version": [
-    20200725,
-    1056
-   ],
-   "commit": "d80c7964ec66589d5580fc13773e94f1834ab76f",
-   "sha256": "124pvj39lcv3dfz2m42qyydyab0xk6c5da54ffhrqbg8vri34w9w"
   }
  },
  {
@@ -133640,14 +133542,14 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20240416,
-    1636
+    20241104,
+    1624
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "b4170b747ae4c45d145ff8bcb7fafe095e17b4c6",
-   "sha256": "1zzi7xlhhrzaxrwy20ida561n3rdjn25k3pkjvvjl073cr35hmyw"
+   "commit": "f0b4a487530146f99230f4a5ff67e8d56c8f3f80",
+   "sha256": "1cm4wvddvqyjhlp7wngls1lapsiq1n14qgi1ygiq3w2vryg96s1v"
   }
  },
  {
@@ -133658,11 +133560,11 @@
   "repo": "meow_king/zig-ts-mode",
   "unstable": {
    "version": [
-    20241012,
-    627
+    20241026,
+    1427
    ],
-   "commit": "a1426d9f9d4d804aad452f6d902192505b061ee4",
-   "sha256": "0cf3njlnk5ysqpizlv2l59c80xdqgqbhmpk327lfi168rrkl9rlq"
+   "commit": "020500ac3c9ac2cadedccb5cd6c506eb38327443",
+   "sha256": "0kq29pw124bcir5fgnb6xkhas9xqzywzsciv85d0rh0nfbbnbjxy"
   }
  },
  {
@@ -133673,8 +133575,8 @@
   "repo": "WillForan/zim-wiki-mode",
   "unstable": {
    "version": [
-    20241012,
-    1711
+    20241020,
+    2315
    ],
    "deps": [
     "dokuwiki-mode",
@@ -133683,8 +133585,8 @@
     "link-hint",
     "pretty-hydra"
    ],
-   "commit": "fd43e6e8355a0943714aa3a1cd4dd3ccc8e665af",
-   "sha256": "1bfy6dwpmi4c7radn7a4x00fr3g7vh7wp3g2pxybi5sszcc47kkp"
+   "commit": "8afce06846b9b8c62e7eeb2ac874ee4f68f31616",
+   "sha256": "09qijra2pfy2lrjlx7pkpqd5z1ba3ck4i6nwbyfb7cq2q0irclpx"
   }
  },
  {
@@ -134026,20 +133928,20 @@
   "repo": "cyrus-and/zoom",
   "unstable": {
    "version": [
-    20220411,
-    1126
+    20241019,
+    2101
    ],
-   "commit": "2104abb074682db79b9ff3a748e8e2e760a4d8cf",
-   "sha256": "0wp7a1ibyqll8rpirsiazpf51lnd0q3yrya9pqvlx9ik5r41jp2m"
+   "commit": "f5f635e1fc5a8f606b7386286546bb6439e7124c",
+   "sha256": "1zzm8kchm5wwxras4bfl46flyfj44bf7qazc5yyahx9qr2ksfnhd"
   },
   "stable": {
    "version": [
     0,
-    2,
-    4
+    3,
+    0
    ],
-   "commit": "2104abb074682db79b9ff3a748e8e2e760a4d8cf",
-   "sha256": "0wp7a1ibyqll8rpirsiazpf51lnd0q3yrya9pqvlx9ik5r41jp2m"
+   "commit": "f5f635e1fc5a8f606b7386286546bb6439e7124c",
+   "sha256": "1zzm8kchm5wwxras4bfl46flyfj44bf7qazc5yyahx9qr2ksfnhd"
   }
  },
  {


### PR DESCRIPTION
emacs-overlay commit: https://github.com/nix-community/emacs-overlay/commit/d3342b2b1be90527b9cd54494e1c063613c6454c

There are four new build failures: https://hydra.nix-community.org/eval/171423?filter=x86_64-linux.unstable.packages.&compare=170614&full= .
- `emacsPackages.sdml-mode` and `emacsPackages.auto-virtualenv` are fixed.
- I will try to fix `emacsPackages.wanderlust` and `emacsPackages.semi` in the future.  Helps are welcome.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
