### PR TITLE
xash3d: init at unstable-2024-12-04

### DIFF
--- a/pkgs/by-name/xa/xash3d/package.nix
+++ b/pkgs/by-name/xa/xash3d/package.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  stdenv,
+  SDL2,
+  buildPackages,
+  bzip2,
+  ensureNewerSourcesForZipFilesHook,
+  fetchFromGitHub,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  libglvnd,
+  libogg,
+  libopus,
+  libvorbis,
+  llvmPackages,
+  opusfile,
+  pkg-config,
+  python3,
+  unstableGitUpdater,
+  waf,
+  dedicatedServer ? false,
+  gameDir ? "valve",
+  lowMemoryMode ? null,
+  withAsyncResolve ? true,
+  withBsp2 ? false,
+  withCustomSwap ? false,
+  withEngineFuzz ? false,
+  withEngineTests ? true,
+  withFFmpeg ? false,
+  withFbdev ? false,
+  withFuzzer ? false,
+  withGL ? true,
+  withGL4ES ? false,
+  withGLES1 ? false,
+  withGLES2 ? false,
+  withGLES3Compat ? false,
+  withHL25ExtendedStructs ? false,
+  withMdlDec ? true,
+  withNull ? false,
+  withSoft ? true,
+  withUtils ? false,
+  withXar ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xash3d";
+  version = "unstable-2024-12-04";
+
+  src = fetchFromGitHub {
+    owner = "FWGS";
+    repo = "xash3d-fwgs";
+    rev = "614b9113ad34b3bc9bc87de3cdb8b1914c0633ef";
+    hash = "sha256-sfxRFYKJh6PbB0QkTDFjfCLpjb4OVv5yeJHNlY2wwXg=";
+    fetchSubmodules = true;
+  };
+
+  # Make sure we're using our own libopus
+  #
+  # Help the launcher find libxash
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace-fail 'opus = 1.4' 'opus = ${libopus.version}'
+
+    substituteInPlace game_launch/game.cpp \
+      --replace-fail '#define XASHLIB "libxash." OS_LIB_EXT' '#define XASHLIB "${placeholder "out"}/lib/xash3d/libxash${stdenv.hostPlatform.extensions.sharedLibrary}"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    ensureNewerSourcesForZipFilesHook
+    pkg-config
+    python3
+    waf.hook
+  ];
+
+  buildInputs =
+    lib.optionals (!dedicatedServer) [
+      SDL2
+      bzip2
+      fontconfig
+      freetype
+      libglvnd
+      libogg
+      libopus
+      libvorbis
+      opusfile
+    ]
+    ++ lib.optional (withEngineFuzz || withFuzzer) llvmPackages.compiler-rt
+    ++ lib.optional withFFmpeg ffmpeg;
+
+  wafConfigureFlags =
+    [
+      (lib.enableFeature true "packaging")
+
+      "--build-type"
+      "release"
+
+      "--gamedir"
+      gameDir
+    ]
+    ++ lib.optional finalAttrs.finalPackage.doCheck (lib.enableFeature true "tests")
+    ++ lib.optionals stdenv.hostPlatform.isStatic (
+      map (lib.enableFeature true) [
+        "static-gl"
+        "static-binary"
+      ]
+    )
+    ++ lib.optional stdenv.hostPlatform.is64bit "--64bits"
+    ++ lib.optionals (stdenv.hostPlatform.isWindows && !dedicatedServer) [
+      "--sdl2"
+      (lib.getLib SDL2)
+    ]
+    ++ lib.optional (!withAsyncResolve) (lib.enableFeature withAsyncResolve "async-resolve")
+    ++ lib.optional (!withGL) (lib.enableFeature withGL "gl")
+    ++ lib.optional (!withMdlDec) (lib.enableFeature withMdlDec "utils-mdldec")
+    ++ lib.optional (!withSoft) (lib.enableFeature withSoft "soft")
+    ++ lib.optional (lowMemoryMode != null) "--low-memory-mode ${toString lowMemoryMode}"
+    ++ lib.optional dedicatedServer "--dedicated"
+    ++ lib.optional withBsp2 (lib.enableFeature withBsp2 "bsp2")
+    ++ lib.optional withCustomSwap (lib.enableFeature withCustomSwap "custom-swap")
+    ++ lib.optional withEngineFuzz (lib.enableFeature withEngineFuzz "engine-fuzz")
+    ++ lib.optional withEngineTests (lib.enableFeature withEngineTests "engine-tests")
+    ++ lib.optional withFFmpeg (lib.enableFeature withFFmpeg "ffmpeg")
+    ++ lib.optional withFbdev (lib.enableFeature withFbdev "fbdev")
+    ++ lib.optional withFuzzer (lib.enableFeature withFuzzer "fuzzer")
+    ++ lib.optional withGL4ES (lib.enableFeature withGL4ES "gl4es")
+    ++ lib.optional withGLES1 (lib.enableFeature withGLES1 "gles1")
+    ++ lib.optional withGLES2 (lib.enableFeature withGLES2 "gles2")
+    ++ lib.optional withGLES3Compat (lib.enableFeature withGLES3Compat "gles3compat")
+    ++ lib.optional withHL25ExtendedStructs (
+      lib.enableFeature withHL25ExtendedStructs "hl25-extended-structs"
+    )
+    ++ lib.optional withNull (lib.enableFeature withNull "null")
+    ++ lib.optional withUtils (lib.enableFeature withUtils "utils")
+    ++ lib.optional withXar (lib.enableFeature withXar "xar");
+
+  wafInstallFlags = [ "--destdir=/" ];
+
+  # TODO: Use emulator to run engine tests
+  doCheck = stdenv.hostPlatform.emulatorAvailable buildPackages;
+
+  postInstall = ''
+    mkdir -p $out/share/pixmaps
+    install -Dm644 game_launch/icon-xash-material.png $out/share/pixmaps/xash3d.png
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "Game engine aimed to provide compatibility with Half-Life Engine and extend it";
+    longDescription = ''
+      Xash3D FWGS is a game engine, aimed to provide compatibility with Half-Life Engine and extend it, as well as to give game developers well known workflow.
+
+      Xash3D FWGS is a heavily modified fork of an original Xash3D Engine by Unkle Mike.
+    '';
+    homepage = "https://github.com/FWGS/xash3d-fwgs";
+    # This has a lot of licensing issues...best to play it safe
+    # see https://github.com/FWGS/xash3d-fwgs/issues/63
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ getchoo ];
+    platforms = lib.intersectLists lib.platforms.x86 (lib.platforms.linux ++ lib.platforms.windows);
+  };
+})


### PR DESCRIPTION
(Hopefully) supersedes https://github.com/NixOS/nixpkgs/pull/166081 & https://github.com/NixOS/nixpkgs/pull/238392 

Draft until https://github.com/NixOS/nixpkgs/pull/361114

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
