### PR TITLE
qcp: init at 0.9.0

### DIFF
--- a/pkgs/by-name/qc/qcp/package.nix
+++ b/pkgs/by-name/qc/qcp/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "qcp";
+  version = "0.8.1";
+
+  # Tags required to fix the binary version
+  GITHUB_REF_TYPE = "tag";
+  GITHUB_REF_NAME = finalAttrs.version;
+
+  src = fetchFromGitHub {
+    owner = "crazyscot";
+    repo = "qcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PdbzBegBTwgI4L0aP9Bf4yQO6zJkNCh7pWcaB+SZHXE=";
+  };
+
+  cargoHash = "sha256-wHsxOFq1RIuvS5sSxIbNiyRQdXdkXMTnumUz4ii9b/g=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  __structuredAttrs = true;
+
+  postInstall = ''
+    installManPage $src/qcp/misc/generated/qcp.1 $src/qcp/misc/generated/qcp_config.5
+    install -Dm644 $src/qcp/misc/20-qcp.conf $out/etc/sysctl.d/20-qcp.conf
+    install -Dm644 $src/qcp/misc/qcp.conf $out/etc/qcp.conf
+  '';
+
+  checkFlags = [
+    # SSH home directory tests will not work in nix sandbox
+    "--skip=config::ssh::includes::test::home_dir"
+    "--skip=control::process::test::ssh_no_such_host"
+    # Attempts to reach outside of the nix sandbox
+    "--skip=os::unix::test::config_paths"
+    # Permission checks in the sandbox appear to always fail
+    "--skip=session::get::test::permission_denied"
+    # Multiple network tests will fail in sanbox
+    "--skip=client::main_loop::test::endpoint_create_close"
+    "--skip=util::dns::tests::ipv4"
+    "--skip=util::dns::tests::ipv6"
+    # Tracing attempts to access stdout and angers the sandbox
+    "--skip=util::tracing::test::test_create_layers_with_invalid_level"
+  ]
+  ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    # Skip unix tests on darwin
+    "--skip=control::channel::test::happy_path"
+    "--skip=os::unix::test::test_buffers_gigantic_err"
+    "--skip=os::unix::test::test_buffers_small_ok"
+    "--skip=os::windows::test::test_buffers_gigantic_err"
+    "--skip=os::windows::test::test_buffers_small_ok"
+    "--skip=session::put::test::write_fail_dest_dir_missing"
+    "--skip=session::put::test::write_fail_io_error"
+    "--skip=session::put::test::write_fail_permissions"
+    "--skip=util::socket::test::bind_ipv6"
+    "--skip=util::socket::test::bind_range"
+    "--skip=util::socket::test::set_socket_bufsize_direct"
+    "--skip=util::socket::test::set_udp_buffer_sizes_large_fails"
+    "--skip=util::socket::test::set_udp_buffer_sizes_small_succeeds"
+  ];
+  checkType = "debug";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Experimental high-performance remote file copy utility for long-distance internet connections";
+    homepage = "https://github.com/crazyscot/qcp";
+    changelog = "https://github.com/crazyscot/qcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "qcp";
+  };
+})

--- a/pkgs/by-name/qc/qcp/package.nix
+++ b/pkgs/by-name/qc/qcp/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "qcp";
+  version = "0.9.0";
+
+  # Tags required to fix the binary version
+  GITHUB_REF_TYPE = "tag";
+  GITHUB_REF_NAME = finalAttrs.version;
+
+  src = fetchFromGitHub {
+    owner = "crazyscot";
+    repo = "qcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mPpYLYflCt2izNelD2R9FF66dNCiFmOVsTPgpgI7LzQ=";
+  };
+
+  cargoHash = "sha256-iP0A3ycaCwhhxOsz1Ze/z0voZ2m/Py/zHBgaLAcrdaw=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  __structuredAttrs = true;
+
+  postInstall = ''
+    installManPage $src/qcp/misc/generated/qcp.1 $src/qcp/misc/generated/qcp_config.5
+    install -Dm644 $src/qcp/misc/20-qcp.conf $out/etc/sysctl.d/20-qcp.conf
+    install -Dm644 $src/qcp/misc/qcp.conf $out/etc/qcp.conf
+  '';
+
+  checkFlags = [
+    # SSH home directory tests will not work in nix sandbox
+    "--skip=config::ssh::includes::test::home_dir"
+    "--skip=control::process::test::ssh_no_such_host"
+    # Attempts to reach outside of the nix sandbox
+    "--skip=os::unix::test::config_paths"
+    # Permission checks in the sandbox appear to always fail
+    "--skip=session::get::test::permission_denied"
+    # Multiple network tests will fail in sanbox
+    "--skip=client::main_loop::test::endpoint_create_close"
+    "--skip=util::dns::tests::ipv4"
+    "--skip=util::dns::tests::ipv6"
+    # Tracing attempts to access stdout and angers the sandbox
+    "--skip=util::tracing::test::test_create_layers_with_invalid_level"
+  ]
+  ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    # Skip unix tests on darwin
+    "--skip=control::channel::test::happy_path"
+    "--skip=os::unix::test::test_buffers_gigantic_err"
+    "--skip=os::unix::test::test_buffers_small_ok"
+    "--skip=os::windows::test::test_buffers_gigantic_err"
+    "--skip=os::windows::test::test_buffers_small_ok"
+    "--skip=session::put::test::write_fail_dest_dir_missing"
+    "--skip=session::put::test::write_fail_io_error"
+    "--skip=session::put::test::write_fail_permissions"
+    "--skip=util::socket::test::bind_ipv6"
+    "--skip=util::socket::test::bind_range"
+    "--skip=util::socket::test::set_socket_bufsize_direct"
+    "--skip=util::socket::test::set_udp_buffer_sizes_large_fails"
+    "--skip=util::socket::test::set_udp_buffer_sizes_small_succeeds"
+  ];
+  checkType = "debug";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Experimental high-performance remote file copy utility for long-distance internet connections";
+    homepage = "https://github.com/crazyscot/qcp";
+    changelog = "https://github.com/crazyscot/qcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "qcp";
+  };
+})


### PR DESCRIPTION
Adds the `qcp` package. This package is an experimental high-performance remote file copy utility used for long-distance transfers.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
