### PR TITLE
python312Packages.wheel: 0.44.0 -> 0.45.1, fix poetry2nix

### DIFF
--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.44.0";
-  format = "pyproject";
+  version = "0.45.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "wheel";
     rev = "refs/tags/${version}";
-    hash = "sha256-IFJ411H5nItR8gA5R0AYXFs3n6e1SLo2VoMOqgvDnnk=";
+    hash = "sha256-tgueGEWByS5owdA5rhXGn3qh1Vtf0HGYC6+BHfrnGAs=";
     postFetch = ''
       cd $out
       mv tests/testdata/unicode.dist/unicodedist/åäö_日本語.py \


### PR DESCRIPTION
Since the beginning/mid of September, some python packages like PyYAML fail to build with poetry2nix using nixpkgs master and release-24.11. The issue we're encountering is https://github.com/pypa/setuptools/issues/4683. I believe the root cause is the update of setuptools to 75.1.1 in 6b98b10a65e77b7bc2f19de33a4f93d5e88546fe.

We are encountering this for instance in the authentik-nix flake. The issue can be reliably fixed by bumping wheel to 0.45.0 but the override is a bit ugly, see https://github.com/fpletz/authentik-nix/commit/24907f67ee4850179e46c19ce89334568d2b05c6.

This issue is solely related to poetry2nix builds and not for python packages in nixpkgs itself. I haven't investigated deeply what poetry2nix is doing differently under the hood than the python packaging in nixpkgs. Maybe some of our python maintainers can enlighten me here. Since it's a poetry2nix issue, I would prefer a fix in poetry2nix itself but it's [abandonware](https://github.com/nix-community/poetry2nix/issues/1865) yet still used by lots of people until the pyproject-nix tooling is ready for primetime. Putting the wheel package bump into poetry2nix is IMHO also not an ideal solution. A fix in nixpkgs (this PR) would also fix the issue but needs to be backported to 24.11 and is a mass-rebuild.

The fix for setuptools in https://github.com/pypa/setuptools/pull/4684 was released with 75.2.0. The fix for wheel in https://github.com/pypa/wheel/pull/638 was released in 0.45.0. I'm not entirely sure which of the two packages we should bump but I've chosen wheel for this PR.

Further ideas or solutions to fix the situation are appreciated.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
