### PR TITLE
flutter: discourage use of 'flutter' with unpinned version

### DIFF
--- a/pkgs/by-name/cw/cwtch-ui/package.nix
+++ b/pkgs/by-name/cw/cwtch-ui/package.nix
@@ -1,7 +1,7 @@
 {
   cwtch,
   fetchgit,
-  flutter,
+  flutter329,
   lib,
   tor,
 }:
@@ -10,7 +10,7 @@ let
     tor
   ];
 in
-flutter.buildFlutterApplication rec {
+flutter329.buildFlutterApplication rec {
   pname = "cwtch-ui";
   version = "1.15.5";
   # This Gitea instance has archive downloads disabled, so: fetchgit

--- a/pkgs/by-name/fi/finamp/package.nix
+++ b/pkgs/by-name/fi/finamp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  flutter,
+  flutter329,
   mpv-unwrapped,
   patchelf,
   fetchFromGitHub,
@@ -11,7 +11,7 @@
 let
   version = "0.9.15-beta";
 in
-flutter.buildFlutterApplication {
+flutter329.buildFlutterApplication {
   inherit version;
   pname = "finamp";
   src = fetchFromGitHub {

--- a/pkgs/by-name/fi/firmware-updater/package.nix
+++ b/pkgs/by-name/fi/firmware-updater/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  writeText,
-  flutter,
+  flutter329,
   fetchFromGitHub,
 }:
 
-flutter.buildFlutterApplication rec {
+flutter329.buildFlutterApplication rec {
   pname = "firmware-updater";
   version = "0-unstable-2024-20-11";
 

--- a/pkgs/by-name/ho/hover/package.nix
+++ b/pkgs/by-name/ho/hover/package.nix
@@ -13,7 +13,7 @@
   makeWrapper,
   gcc,
   go,
-  flutter,
+  flutter329,
 }:
 
 let
@@ -94,7 +94,7 @@ buildFHSEnv {
     [
       binutils
       dejavu_fonts
-      flutter
+      flutter329
       gcc
       go
       hover

--- a/pkgs/by-name/qu/quickgui/package.nix
+++ b/pkgs/by-name/qu/quickgui/package.nix
@@ -3,10 +3,10 @@
   makeDesktopItem,
   copyDesktopItems,
   lib,
-  flutter,
+  flutter329,
   quickemu,
 }:
-flutter.buildFlutterApplication rec {
+flutter329.buildFlutterApplication rec {
   pname = "quickgui";
   version = "1.2.10";
   src = fetchFromGitHub {

--- a/pkgs/desktops/expidus/calculator/default.nix
+++ b/pkgs/desktops/expidus/calculator/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  flutter,
+  flutter329,
   fetchFromGitHub,
 }:
-flutter.buildFlutterApplication rec {
+flutter329.buildFlutterApplication rec {
   pname = "expidus-calculator";
   version = "0.1.1-alpha";
 

--- a/pkgs/desktops/expidus/file-manager/default.nix
+++ b/pkgs/desktops/expidus/file-manager/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  flutter,
+  flutter329,
   fetchFromGitHub,
 }:
-flutter.buildFlutterApplication rec {
+flutter329.buildFlutterApplication rec {
   pname = "expidus-file-manager";
   version = "0.2.1";
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -630,6 +630,7 @@ mapAliases {
   flatbuffers_2_0 = flatbuffers; # Added 2022-05-12
   flatcam = throw "flatcam has been removed because it is unmaintained since 2022 and doesn't support Python > 3.10"; # Added 2025-01-25
   flow-editor = flow-control; # Added 2025-03-05
+  flutter = flutterPackages.stable; # preserve, reason: discouraged to pin version but still valid to use
   flutter313 = throw "flutter313 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-10-05
   flutter316 = throw "flutter316 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-10-05
   flutter319 = throw "flutter319 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2024-12-03

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5951,7 +5951,8 @@ with pkgs;
     callPackage ../development/compilers/flutter { useNixpkgsEngine = true; }
   );
   flutterPackages = flutterPackages-bin;
-  flutter = flutterPackages.stable;
+  # This is moved to aliases.nix to avoid unpinned use in-tree
+  # flutter = flutterPackages.stable;
   flutter329 = flutterPackages.v3_29;
   flutter327 = flutterPackages.v3_27;
   flutter326 = flutterPackages.v3_26;


### PR DESCRIPTION
Building flutter applications with different major flutter versions is
prone to build failure and more hidden UI glitches. Therefore, we do not
recommend using the unpinned flutter version anymore. This has been
stated in the documentation before, but from now on we will disallow
in-tree use. Use cases out of Nixpkgs should evaluate the rationale of
unpinned version by themselves.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
