### PR TITLE
hugo: enable doCheck with skipping failing tests

### DIFF
--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -23,7 +23,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-qhiCZMSLRnLbyHplcaPn/BGJ3Lv8O8eEvCuIHwA4sMs=";
 
-  doCheck = false;
+  checkFlags = [
+    # Workaround for "failed to load modules"
+    "-skip=TestCommands/mod"
+  ];
 
   proxyVendor = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same motivation of #194829. cc: @Et7f3 I sent this PR because your prior work is from 2 years ago and now it is conflicting. I can close this PR if you want to continue with it. 🙏

<details>

<summary>Just enabling the flag makes this error</summary>


```plaintext
Running phase: checkPhase
@nix { "action": "setPhase", "phase": "checkPhase" }
go: downloading github.com/bep/helpers v0.5.0
--- FAIL: TestCommands (0.00s)
    --- FAIL: TestCommands/mod_npm (0.06s)
        testscript.go:584: # Test mod npm. (0.059s)
            > dostounix golden/package.json
            > hugo mod npm pack
            [stderr]
            go: no module dependencies to download
            go: github.com/gohugoio/hugoTestModule2@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/d2f91cdfc76314648077ca39b736383f6f0c08314f7cec8ae977d44a738e2220: exec: "git": executable file not found in $PATH
            failed to load modules: failed to get ["github.com/gohugoio/hugoTestModule2@upgrade"]: failed to execute 'go [get github.com/gohugoio/hugoTestModule2@upgrade]': failed to execute binary "go" with args [get github.com/gohugoio/hugoTestModule2@upgrade]: go: github.com/gohugoio/hugoTestModule2@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/d2f91cdfc76314648077ca39b736383f6f0c08314f7cec8ae977d44a738e2220: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod_npm.txt:6: unexpected command failure
            
    --- FAIL: TestCommands/mod_vendor (0.05s)
        testscript.go:584: > dostounix golden/vendor.txt
            > hugo mod vendor
            [stderr]
            go: github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml@v1.0.0: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
            failed to load modules: failed to download modules: failed to execute 'go [mod download -modcacherw]': failed to execute binary "go" with args [mod download -modcacherw]: go: github.com/gohugoio/hugo-mod-integrationtests/withconfigtoml@v1.0.0: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod_vendor.txt:3: unexpected command failure
            
    --- FAIL: TestCommands/mod_get (0.05s)
        testscript.go:584: > hugo mod get
            [stderr]
            go: no module dependencies to download
            go: github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
            failed to load modules: failed to get ["github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade"]: failed to execute 'go [get github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade]': failed to execute binary "go" with args [get github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade]: go: github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod_get.txt:1: unexpected command failure
            
    --- FAIL: TestCommands/mod_npm_withexisting (0.06s)
        testscript.go:584: # Test mod npm. (0.054s)
            > dostounix golden/package.json
            > hugo mod npm pack
            [stderr]
            go: no module dependencies to download
            go: github.com/gohugoio/hugoTestModule2@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/d2f91cdfc76314648077ca39b736383f6f0c08314f7cec8ae977d44a738e2220: exec: "git": executable file not found in $PATH
            failed to load modules: failed to get ["github.com/gohugoio/hugoTestModule2@upgrade"]: failed to execute 'go [get github.com/gohugoio/hugoTestModule2@upgrade]': failed to execute binary "go" with args [get github.com/gohugoio/hugoTestModule2@upgrade]: go: github.com/gohugoio/hugoTestModule2@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/d2f91cdfc76314648077ca39b736383f6f0c08314f7cec8ae977d44a738e2220: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod_npm_withexisting.txt:5: unexpected command failure
            
    --- FAIL: TestCommands/mod_get_u (0.05s)
        testscript.go:584: > hugo mod get -u
            [stderr]
            go: github.com/gohugoio/hugo-mod-integrationtests/commonmod@v0.0.0-20230823103305-919cefe8a425: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
            failed to load modules: failed to download modules: failed to execute 'go [mod download -modcacherw]': failed to execute binary "go" with args [mod download -modcacherw]: go: github.com/gohugoio/hugo-mod-integrationtests/commonmod@v0.0.0-20230823103305-919cefe8a425: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod_get_u.txt:1: unexpected command failure
            
    --- FAIL: TestCommands/mod__disable (0.06s)
        testscript.go:584: > hugo mod graph
            [stderr]
            go: no module dependencies to download
            go: github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
            failed to load modules: failed to get ["github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade"]: failed to execute 'go [get github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade]': failed to execute binary "go" with args [get github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade]: go: github.com/gohugoio/hugo-mod-integrationtests/withhugotoml@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/8f5ec6733c5d652c17c6fd03ad313cad85e51ef49f37890684774ecb4c4f2487: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod__disable.txt:1: unexpected command failure
            
    --- FAIL: TestCommands/mod (0.06s)
        testscript.go:584: # Test the hugo mod commands. (0.060s)
            > dostounix golden/vendor.txt
            > dostounix golden/go.mod.testsubmod
            > hugo mod graph
            [stderr]
            go: no module dependencies to download
            go: github.com/bep/empty-hugo-module@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/ff61a5b25b1734af8f64548a7c04d6f92ac2f179a2db8a5ea278d6a7157ebad7: exec: "git": executable file not found in $PATH
            failed to load modules: failed to get ["github.com/bep/empty-hugo-module@upgrade"]: failed to execute 'go [get github.com/bep/empty-hugo-module@upgrade]': failed to execute binary "go" with args [get github.com/bep/empty-hugo-module@upgrade]: go: github.com/bep/empty-hugo-module@upgrade: git init --bare in $WORK/hugocache/modules/filecache/modules/pkg/mod/cache/vcs/ff61a5b25b1734af8f64548a7c04d6f92ac2f179a2db8a5ea278d6a7157ebad7: exec: "git": executable file not found in $PATH
             *errors.errorString
            [exit status 1]
            FAIL: testscripts/commands/mod.txt:6: unexpected command failure
            
FAIL
FAIL    github.com/gohugoio/hugo        5.543s
FAIL
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
