### PR TITLE
luci-go: init at 0-unstable-2024-10-31

### DIFF
--- a/pkgs/by-name/lu/luci-go/package.nix
+++ b/pkgs/by-name/lu/luci-go/package.nix
@@ -1,0 +1,50 @@
+{
+  buildGoModule,
+  fetchFromGitiles,
+  lib,
+}:
+let
+  commit = "500493c154652d6986a34b341e98df244ae1ad0d";
+  git-repo = "https://chromium.googlesource.com/infra/luci/luci-go";
+in
+buildGoModule {
+  pname = "luci-go";
+  version = "0-unstable-2024-10-31";
+
+  src = fetchFromGitiles {
+    url = git-repo;
+    rev = commit;
+    hash = "sha256-HP4Aizt5FJA3IAlqs7gylw8/xUbBwsmReGaR8jIkmrk=";
+  };
+
+  vendorHash = "sha256-FMqbEls6MivPeReZTADrfcAvxo8o0Gy7bq9xG6WN38k=";
+
+  checkFlags =
+    let
+      skippedTests = [
+        # require network access
+        "TestDownloadInputs"
+        "TestInstallCipd"
+        "TestIsLocalAddr"
+        "TestGenerateSignedURL"
+
+        # require filesystem access
+        "TestPythonBasic"
+        "TestPythonFromPath"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  meta = {
+    description = "LUCI services and tools in Go";
+    longDescription = ''
+      LUCI services and tools in Go. This is part of Chromium infra and
+      provides facilities useful for packaging software from the Chromium
+      ecosystem.
+    '';
+    homepage = "${git-repo}/";
+    changelog = "${git-repo}/+log?s=${commit}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ gm6k ];
+  };
+}


### PR DESCRIPTION
packaging: LUCI services and tools in Go

This is part of the chromium infrastructure and contains tools like `cipd` useful for packagers of chromium packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
