### PR TITLE
netris: fix gcc-14 build

### DIFF
--- a/pkgs/by-name/ne/netris/configure-fixes-for-gcc-14.patch
+++ b/pkgs/by-name/ne/netris/configure-fixes-for-gcc-14.patch
@@ -1,0 +1,63 @@
+From 9f82b88e17f5e04929eff96c673dac5810006c87 Mon Sep 17 00:00:00 2001
+From: Reno Dakota <paparodeo@proton.me>
+Date: Thu, 5 Dec 2024 09:49:40 +0000
+Subject: [PATCH] configure fixes for gcc-14
+
+---
+ Configure | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/Configure b/Configure
+index fbc57a8..e8cea16 100755
+--- a/Configure
++++ b/Configure
+@@ -76,7 +76,7 @@ done
+ CFLAGS="$COPT $CEXTRA"
+ 
+ echo "Checking for libraries"
+-echo 'main(){}' > test.c
++echo 'int main(void){ return 0; }' > test.c
+ LFLAGS=""
+ for lib in -lcurses -lncurses; do
+ 	if $CC $CFLAGS $LEXTRA test.c $lib > /dev/null 2>&1; then
+@@ -91,8 +91,9 @@ done
+ 
+ echo "Checking for on_exit()"
+ cat << END > test.c
++#include <stdlib.h>
+ void handler(void) {}
+-main() { on_exit(handler, (void *)0); }
++int main(void) { on_exit(handler, (void *)0); return 0; }
+ END
+ if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
+ 	HAS_ON_EXIT=true
+@@ -103,7 +104,7 @@ fi
+ echo "Checking for sigprocmask()"
+ cat << END > test.c
+ #include <signal.h>
+-main() { sigset_t set; sigprocmask(SIG_BLOCK, &set, &set); }
++int main(void) { sigset_t set; sigprocmask(SIG_BLOCK, &set, &set); return 0; }
+ END
+ if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
+ 	HAS_SIGPROCMASK=true
+@@ -114,7 +115,7 @@ fi
+ echo "Checking for getopt.h"
+ cat << END > test.c
+ #include <getopt.h>
+-main(){}
++int main(void){ return 0; }
+ END
+ 
+ if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
+@@ -126,7 +127,7 @@ fi
+ echo "Checking for memory.h"
+ cat << END > test.c
+ #include <memory.h>
+-main(){}
++int main(void){ return 0; }
+ END
+ 
+ if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
+-- 
+2.47.0
+

--- a/pkgs/by-name/ne/netris/package.nix
+++ b/pkgs/by-name/ne/netris/package.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation {
     sha256 = "0gmxbpn50pnffidwjchkzph9rh2jm4wfq7hj8msp5vhdq5h0z9hm";
   };
 
+  patches = [
+    # https://github.com/naclander/netris/pull/1
+    ./configure-fixes-for-gcc-14.patch
+  ];
+
   buildInputs = [
     ncurses
   ];

--- a/pkgs/by-name/ne/netris/package.nix
+++ b/pkgs/by-name/ne/netris/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation {
   configureScript = "./Configure";
   dontAddPrefix = true;
 
+  configureFlags = [
+    "--cc" "${stdenv.cc.targetPrefix}cc"
+  ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp ./netris $out/bin
@@ -33,6 +37,6 @@ stdenv.mkDerivation {
     mainProgram = "netris";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ patryk27 ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/ne/netris/package.nix
+++ b/pkgs/by-name/ne/netris/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--cc" "${stdenv.cc.targetPrefix}cc"
+    "-O2"
   ];
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
fix build on gcc-14 as well as non-gcc builds

https://github.com/NixOS/nixpkgs/pull/361878
https://github.com/naclander/netris/pull/1
https://hydra.nixos.org/build/281261450

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
