### PR TITLE
typora: fix

### DIFF
--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -60,6 +60,7 @@ let
       pango
       cairo
       mesa
+      libGL
       expat
       libxkbcommon
     ]) ++ (with pkgs.xorg; [
@@ -73,7 +74,7 @@ let
       libxcb
     ]);
     runScript = ''
-      Typora $*
+      Typora "$@"
     '';
   };
 

--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -16,6 +16,7 @@
 , expat
 , alsa-lib
 , buildFHSEnv
+, writeTextFile
 }:
 
 let
@@ -78,6 +79,31 @@ let
     '';
   };
 
+  launchScript = writeTextFile {
+  name = "typora-launcher";
+  executable = true;
+  text = ''
+    #!${stdenv.shell}
+
+    # Configuration directory setup
+    XDG_CONFIG_HOME=''${XDG_CONFIG_HOME:-~/.config}
+    TYPORA_CONFIG_DIR="$XDG_CONFIG_HOME/Typora"
+    TYPORA_DICT_DIR="$TYPORA_CONFIG_DIR/typora-dictionaries"
+
+    # Create config directories with proper permissions
+    mkdir -p "$TYPORA_DICT_DIR"
+    chmod 755 "$TYPORA_CONFIG_DIR"
+    chmod 755 "$TYPORA_DICT_DIR"
+
+    # Read user flags if they exist
+    if [ -f "$XDG_CONFIG_HOME/typora-flags.conf" ]; then
+      TYPORA_USER_FLAGS="$(sed 's/#.*//' "$XDG_CONFIG_HOME/typora-flags.conf" | tr '\n' ' ')"
+    fi
+
+    exec ${typoraFHS}/bin/typora-fhs "$@" $TYPORA_USER_FLAGS
+  '';
+  };
+
 in stdenv.mkDerivation {
   inherit pname version;
 
@@ -88,7 +114,7 @@ in stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    ln -s ${typoraFHS}/bin/typora-fhs $out/bin/typora
+    ln -s ${launchScript} $out/bin/typora
     ln -s ${typoraBase}/share/ $out
     runHook postInstall
   '';


### PR DESCRIPTION
Fix partially : https://github.com/NixOS/nixpkgs/issues/362022
- Fix open .md files
- Fix LibGL issue
- Add Launcher (Inspired by AUR)

Launcher add possibility to set : 

```
# ~/.config/typora-flags.conf
--disable-gpu
--no-sandbox
```

Only is missing spell support : 
https://support.typora.io/Spellcheck/
https://github.com/typora/dictionaries

If you have idea for fix this ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
