### PR TITLE
elan: fix for Lean >= 4.16.0

### DIFF
--- a/pkgs/by-name/el/elan/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/by-name/el/elan/0001-dynamically-patchelf-binaries.patch
@@ -2,7 +2,7 @@ diff --git a/src/elan-dist/src/component/package.rs b/src/elan-dist/src/componen
 index c51e76d..ae8159e 100644
 --- a/src/elan-dist/src/component/package.rs
 +++ b/src/elan-dist/src/component/package.rs
-@@ -56,6 +56,37 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
+@@ -56,6 +56,52 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
          entry
              .unpack(&full_path)
              .chain_err(|| ErrorKind::ExtractingPackage)?;
@@ -14,13 +14,12 @@ index c51e76d..ae8159e 100644
 +
 +fn nix_patch_if_needed(dest_path: &Path) -> Result<()> {
 +    let is_bin = matches!(dest_path.parent(), Some(p) if p.ends_with("bin"));
-+    if is_bin {
-+        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
-+            .arg("--set-interpreter")
-+            .arg("@dynamicLinker@")
-+            .arg(dest_path)
-+            .output();
-+    }
++    if !is_bin { return Ok(()) }
++    let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++        .arg("--set-interpreter")
++        .arg("@dynamicLinker@")
++        .arg(dest_path)
++        .output();
 +
 +    if dest_path.file_name() == Some(::std::ffi::OsStr::new("leanc")) {
 +        use std::os::unix::fs::PermissionsExt;
@@ -32,11 +31,27 @@ index c51e76d..ae8159e 100644
 +LEAN_CC="${LEAN_CC:-@cc@}" exec -a "$0" "$dir/leanc.orig" "$@" -L"$dir/../lib"
 +"#)?;
 +        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
-+    }
++    } else if dest_path.file_name() == Some(::std::ffi::OsStr::new("lake")) {
++        // since Lean 4.16.0, `lake` calls `LEAN_CC` directly instead of through `leanc`
++        use std::os::unix::fs::PermissionsExt;
++        ::std::fs::write(dest_path.with_file_name("cc"), r#"#! @shell@
++dir="$(dirname "${BASH_SOURCE[0]}")"
++# use bundled libraries, but not bundled compiler that doesn't know about NIX_LDFLAGS
++exec "@cc@" "$@" -L"$dir/../lib"
++"#)?;
++        ::std::fs::set_permissions(dest_path.with_file_name("cc"), ::std::fs::Permissions::from_mode(0o755))?;
 +
-+    if dest_path.file_name() == Some(::std::ffi::OsStr::new("llvm-ar")) {
++        let new_path = dest_path.with_extension("orig");
++        ::std::fs::rename(dest_path, &new_path)?;
++        ::std::fs::write(dest_path, r#"#! @shell@
++dir="$(dirname "${BASH_SOURCE[0]}")"
++# use custom `cc`
++LEAN_CC="${LEAN_CC:-"$dir/cc"}" exec -a "$0" "$dir/lake.orig" "$@"
++"#)?;
++        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
++    } else if dest_path.file_name() == Some(::std::ffi::OsStr::new("llvm-ar")) {
 +        ::std::fs::remove_file(dest_path)?;
 +        ::std::os::unix::fs::symlink("@ar@", dest_path)?;
      }
- 
+
      Ok(())


### PR DESCRIPTION
Since Lean 4.16.0, `lake` does not call `leanc` anymore, so we create a `cc` wrapper for it instead (thus no change for older toolchains).