### PR TITLE
Cinnamon updates 2024-12-05

### DIFF
--- a/pkgs/by-name/bu/bulky/package.nix
+++ b/pkgs/by-name/bu/bulky/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "3.4";
+  version = "3.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    hash = "sha256-YByzRDL/LuI/VwBHLRZ3+S2VnttYeuMgJpRLPhR/NCA=";
+    hash = "sha256-yGW2vEYGmd0FawbgB0lJoi5sId8MG9gNQa71wF1XupQ=";
   };
 
   nativeBuildInputs = [
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    (python3.withPackages (p: with p; [ pygobject3 magic setproctitle ]))
+    (python3.withPackages (p: with p; [ pygobject3 magic setproctitle unidecode ]))
     gsettings-desktop-schemas
     gtk3
     glib

--- a/pkgs/by-name/ci/cinnamon-common/package.nix
+++ b/pkgs/by-name/ci/cinnamon-common/package.nix
@@ -73,13 +73,13 @@ in
 # TODO (after 25.05 branch-off): Rename to pkgs.cinnamon
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "6.4.1";
+  version = "6.4.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-xkM6t1AiFpfAJOUEP2eeWBtYLQa36FNxrpPiRgHot3w=";
+    hash = "sha256-r5cSm/a+xtHwwAHQmdgviDAN3nnMAnXGY/p+ER1/gbk=";
   };
 
   patches = [

--- a/pkgs/by-name/ci/cinnamon-control-center/package.nix
+++ b/pkgs/by-name/ci/cinnamon-control-center/package.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "6.4.0";
+  version = "6.4.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-hS1vFrwMYUinFLWx33nnlcXwcMkqDCivElI1HaZsSSE=";
+    hash = "sha256-1Z+kXvBmENNXIqdZgPDx7ZSwJMFAm2oMih6eFFAsA/A=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ci/cinnamon-translations/package.nix
+++ b/pkgs/by-name/ci/cinnamon-translations/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "6.4.0";
+  version = "6.4.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-aR1O/NaEJcu4W3bGMWVeaIVGeuMYTrQrPfeS1V+4Nmk=";
+    hash = "sha256-MMUXh8HFvISPZzu6+m/rm0/svLLml4OweZ7c4H9IHco=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -7,14 +7,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "folder-color-switcher";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # They don't really do tags, this is just a named commit.
-    rev = "ba8ea15a48a1a31f318676f4079789af20bdf099";
-    hash = "sha256-jbfc831wTA3NMa905ZzMnV0dyzzqZxOzrRPdgS7E2ZU=";
+    rev = "208e66285ec33a078205a221af579c79bc8cad01";
+    hash = "sha256-t38eEFgbrFsZ+vy+axIeL8j6todPLg4NqS6DM20iIxQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.0.7";
+  version = "2.0.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-ZsbX4xB6sLpZH6vaVFlkC7hAhPLZa1T+FlPANqBQTOg=";
+    sha256 = "sha256-NkQ2oPtTN/x5uCGubcBOwOXZCwzW1RRbBwdmeytqaF4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -32,13 +32,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "6.4.2";
+  version = "6.4.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-J7GQV+T5Lsmu1eELQJE9C3uLI6SoTJNPp648MYqEHvo=";
+    hash = "sha256-3FALXfW0PzWuirX7bxP8BFkIRyQzvg3xBQCdddSpmOg=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/pix/package.nix
+++ b/pkgs/by-name/pi/pix/package.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.4.3";
+  version = "3.4.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-WL9EW7oKeQwufw1VYDigbqAt52GQTpc5RgDEmnKO6vc=";
+    hash = "sha256-BasS0Z8fj7vxFnMZ6KOd5LkvSvTaw6+DDfcRFrdus7A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/sticky/package.nix
+++ b/pkgs/by-name/st/sticky/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sticky";
-  version = "1.22";
+  version = "1.23";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-JrzBME1d4qvGjF2zdiqCX7h+sFadLsRQqZKnQj7elHs=";
+    hash = "sha256-vNS2p3cmuQB+wusx9VSi81ZyGmUYgVXlMjIMkrnvyrI=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/wa/warpinator/package.nix
+++ b/pkgs/by-name/wa/warpinator/package.nix
@@ -36,13 +36,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "warpinator";
-  version = "1.8.6";
+  version = "1.8.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-GJp2iRB3F42pSfYd2FLpmDTZ1zqt8thdRPAHu9/ns5E=";
+    hash = "sha256-EgTz0i7Dui74xYFShkLox6ITAEAF8yYATEcQ51pc7gA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.6";
+  version = "3.4.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-J1IlgHKyNGJTn1sIU3q02eTgWqyeRm2leFIhtKPIdhg=";
+    hash = "sha256-hRX+vSotjhoQ/fyFdCelr9IHZGUM8xaYHNfX2vD3nq0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is mostly just translation updates.

<!--

sticky: 1.22 -> 1.23
lightdm-slick-greeter: 2.0.7 -> 2.0.8
xviewer: 3.4.6 -> 3.4.7
warpinator: 1.8.6 -> 1.8.7
pix: 3.4.3 -> 3.4.4
nemo: 6.4.2 -> 6.4.3
folder-color-switcher: 1.6.5 -> 1.6.6
cinnamon-translations: 6.4.0 -> 6.4.1
cinnamon-control-center: 6.4.0 -> 6.4.1
cinnamon-common: 6.4.1 -> 6.4.2
bulky: 3.4 -> 3.5

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

