### PR TITLE
python312Packages.argcomplete: add patch to fix downstream issues

### DIFF
--- a/pkgs/development/python-modules/argcomplete/default.nix
+++ b/pkgs/development/python-modules/argcomplete/default.nix
@@ -21,6 +21,13 @@ buildPythonPackage rec {
     hash = "sha256-um8iFzEHExTRV1BAl86/XKLc7vmf2Ws1dB83agfvoec=";
   };
 
+  patches = [
+    # fixes issues with python3Packages.traitlets tests
+    # https://git.launchpad.net/ubuntu/+source/python-argcomplete/tree/debian/patches/python-3.13-compat.patch?h=ubuntu/plucky
+    # https://github.com/kislyuk/argcomplete/pull/513
+    ./python-3.13-compat.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/argcomplete/python-3.13-compat.patch
+++ b/pkgs/development/python-modules/argcomplete/python-3.13-compat.patch
@@ -1,0 +1,49 @@
+From 7438d1fa962eb736af9754669f200f29c5b6025d Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Mon, 18 Nov 2024 16:12:54 -0700
+Subject: [PATCH] Preliminary Python 3.13 compatibility
+
+---
+ argcomplete/packages/_argparse.py | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/argcomplete/packages/_argparse.py b/argcomplete/packages/_argparse.py
+index d10cf01..10ed00c 100644
+--- a/argcomplete/packages/_argparse.py
++++ b/argcomplete/packages/_argparse.py
+@@ -5,6 +5,7 @@
+ 
+ # This file contains argparse introspection utilities used in the course of argcomplete execution.
+ 
++import sys
+ from argparse import (
+     ONE_OR_MORE,
+     OPTIONAL,
+@@ -15,6 +16,7 @@
+     Action,
+     ArgumentError,
+     ArgumentParser,
++    Namespace,
+     _get_action_name,
+     _SubParsersAction,
+ )
+@@ -75,6 +77,19 @@ class IntrospectiveArgumentParser(ArgumentParser):
+     except for the lines that contain the string "Added by argcomplete".
+     '''
+ 
++    def _parse_known_args2(self, args, namespace, intermixed):
++        if args is None:
++            # args default to the system args
++            args = sys.argv[1:]
++        else:
++            # make sure that args are mutable
++            args = list(args)
++
++        # default Namespace built from parser defaults
++        if namespace is None:
++            namespace = Namespace()
++        return self._parse_known_args(args, namespace)
++
+     def _parse_known_args(self, arg_strings, namespace):
+         _num_consumed_args.clear()  # Added by argcomplete
+         self._argcomplete_namespace = namespace


### PR DESCRIPTION
https://git.launchpad.net/ubuntu/+source/python-argcomplete/tree/debian/patches/python-3.13-compat.patch?h=ubuntu/plucky 
https://bugs.launchpad.net/ubuntu/+source/python-argcomplete/+bug/2088928

fixes checkPhase of python3Packages.traitlets
https://hydra.nixos.org/build/281237249

https://github.com/kislyuk/argcomplete/pull/513

https://github.com/NixOS/nixpkgs/pull/361878

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
