### PR TITLE
nixos/zfs: skip scrub if one is in progress

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -887,13 +887,24 @@ in
           Type = "simple";
         };
         script = ''
-          # shellcheck disable=SC2046
-          ${cfgZfs.package}/bin/zpool scrub -w ${
+          PATH="$PATH:${cfgZfs.package}/bin"
+          export PATH
+
+          zpoolsToScrub=${
             if cfgScrub.pools != [] then
-              (lib.concatStringsSep " " cfgScrub.pools)
+              "( " + (lib.strings.concatStringsSep " " cfgScrub.pools) + " )"
             else
-              "$(${cfgZfs.package}/bin/zpool list -H -o name)"
-            }
+              "( $(zpool list -H -o name) )"
+          }
+
+          for zpoolToScrub in "''${zpoolsToScrub[@]}"; do
+              if zpool status "''${zpoolToScrub}" | grep -q 'scrub in progress'; then
+                  echo "The zpool ''${zpoolToScrub} is already being scrubbed at the moment."
+                  continue
+              else
+                  zpool scrub -w "''${zpoolToScrub}"
+              fi
+          done
         '';
       };
 


### PR DESCRIPTION
The `zpool-scrub` command has only one non-zero return code and that is for everything: failed to initiate a scrub for _some_ reason, but not for which reason. Since that doesn't exist, we can check the output of the `zpool-status` command and see if a scrub is in progress. If it is, we skip scrubbing the zpool because doing so would do nothing but cause the `zpool-scrub` command to erroneously exit.

A `for` loop was added to iterate over multiple zpools, in case there are more than one zpool that the user hasn't specified in the NixOS configuration.

Fixes #361952.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
