### PR TITLE
nixos/networking: don't add extra names to ::1

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -163,8 +163,6 @@ in
         ++ lib.optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
     in {
       "127.0.0.2" = hostnames;
-    } // lib.optionalAttrs cfg.enableIPv6 {
-      "::1" = hostnames;
     };
 
     networking.hostFiles = let

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -62,6 +62,8 @@ let
             fqdn_and_host_name
             == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2,$3}'").strip()
         )
+
+        assert "${fqdn}" == machine.succeed("getent hosts ${hostName} | awk '{print $2}'").strip()
       '';
     };
 


### PR DESCRIPTION
From hosts(5):

> For each host a single line should be present with the following
> information:
>
>               IP_address canonical_hostname [aliases...]

With lines like "::1 localhost ahost.adomin ahost", we were saying that the canonical name for "ahost" was "localhost", the opposite of a canonical name.  This is why a second loopback address (127.0.0.2) is used for hostnames with IPv4 — if they were put after "localhost" on the 127.0.0.1 line, the same thing would happen.  With IPv6 we can't do the same thing as there's only a single loopback address, so instead the right thing to do is to simply not list the hostnames in /etc/hosts, and rely on the myhostname NSS plugin, which will handle this correctly.

(Note that the examples in hosts(5) also do not include IPv6 FQDN or hostname entries.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
