### PR TITLE
linuxPackages.nvidiaPackages.latest: 560.35.03 -> 565.77

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -23,12 +23,6 @@ let
     hash = "sha256-eZiQQp2S/asE7MfGvfe6dA/kdCvek9SYa/FFGp24dVg=";
   };
 
-  # Fixes framebuffer with linux 6.11
-  fbdev_linux_611_patch = fetchpatch {
-    url = "https://patch-diff.githubusercontent.com/raw/NVIDIA/open-gpu-kernel-modules/pull/692.patch";
-    hash = "sha256-OYw8TsHDpBE5DBzdZCBT45+AiznzO9SfECz5/uXN5Uc=";
-  };
-
   # Fixes drm device not working with linux 6.12
   # https://github.com/NVIDIA/open-gpu-kernel-modules/issues/712
   drm_fop_flags_linux_612_patch  = fetchpatch {
@@ -55,15 +49,12 @@ rec {
   };
 
   latest = selectHighestVersion production (generic {
-    version = "560.35.03";
-    sha256_64bit = "sha256-8pMskvrdQ8WyNBvkU/xPc/CtcYXCa7ekP73oGuKfH+M=";
-    sha256_aarch64 = "sha256-s8ZAVKvRNXpjxRYqM3E5oss5FdqW+tv1qQC2pDjfG+s=";
-    openSha256 = "sha256-/32Zf0dKrofTmPZ3Ratw4vDM7B+OgpC4p7s+RHUjCrg=";
-    settingsSha256 = "sha256-kQsvDgnxis9ANFmwIwB7HX5MkIAcpEEAHc8IBOLdXvk=";
-    persistencedSha256 = "sha256-E2J2wYYyRu7Kc3MMZz/8ZIemcZg68rkzvqEwFAL3fFs=";
-    patchesOpen = [ fbdev_linux_611_patch ];
-
-    broken = kernel.kernelAtLeast "6.12";
+    version = "565.77";
+    sha256_64bit = "sha256-CnqnQsRrzzTXZpgkAtF7PbH9s7wbiTRNcM0SPByzFHw=";
+    sha256_aarch64 = "sha256-LSAYUnhfnK3rcuPe1dixOwAujSof19kNOfdRHE7bToE=";
+    openSha256 = "sha256-Fxo0t61KQDs71YA8u7arY+503wkAc1foaa51vi2Pl5I=";
+    settingsSha256 = "sha256-VUetj3LlOSz/LB+DDfMCN34uA4bNTTpjDrb6C6Iwukk=";
+    persistencedSha256 = "sha256-wnDjC099D8d9NJSp9D0CbsL+vfHXyJFYYgU3CwcqKww=";
   });
 
   beta = selectHighestVersion latest (generic {


### PR DESCRIPTION
Highlights since R565 Beta Release, 565.57.01

- Fixed a bug in i2c handling that caused the OpenRGB Application to set incorrect LED colors on some NVIDIA GPUs. https://github.com/NVIDIA/open-gpu-kernel-modules/issues/41
- Changed the fallback preference from 10 BPC YUV422 to 8 BPC RGB + dithering when enabling HDR scanout with limited display bandwidth.
- Fixed a bug that could cause the nvidia-settings control panel to crash when using X11 forwarding on some systems.
- Added a new application profile key, "GLVidHeapReuseRatio", to control the amount of memory OpenGL may hold for later reuse, as well as some application profiles for several Wayland compositors using the new key to work around issues with excessive video memory usage.
- Fixed a bug that could lead to crashes when a Vulkan application waits on a VkFence created by importing a DRM syncobj. This solves some crashes observed with Unreal Engine and other applications on Wayland.
- Fixed a bug that could cause KDE Plasma 6 to crash when running as a Wayland compositor.
- Fixed a bug that would cause the driver stack to fail to load the correct state of a Quadro Sync board when GSP is enabled. This would lead to inaccuracies in reporting framelock state when using house sync or stereo signals.
- Updated the kernel module build process to use CONFIG_CC_VERSION_TEXT from the Linux kernel's Kconfig to detect the compiler used to build the kernel. This may help select the correct compiler on systems where the kernel was built with a compiler other than the default one.
- Fixed a bug that prevented kernel modules linked using precompiled kernel interface files from loading on recent Debian systems.
- Improved the ability of nvidia-modprobe to detect whether kernel modules are already loaded. This corrects an issue that prevented nvidia-persistenced from setting persistence mode on some systems.

Highlights from R565 Beta Release, 565.57.01

- Fixed a bug that could cause suspend/resume to fail when using the NVreg_PreserveVideoMemoryAllocations option: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/472
- Fixed a bug that caused the cursor image to be truncated on Gamescope: https://github.com/ValveSoftware/gamescope/issues/1099
- Re-enabled GLX_EXT_buffer_age on Xwayland. This extension had been previously disabled on Xwayland due to a bug which is now fixed.
- Added support for mmap of exported DMA-BUF objects.
- Reduced some cases of stutter with OpenGL syncing to vblank while using GSP firmware.
- Fixed a regression that could cause some applications to exit due to resource exhaustion on some GPUs while using GSP firmware.
- Added several new per-plane and per-CRTC vendor-specific properties to nvidia-drm. These properties may be used by Wayland compositors to program the GPU's color pipeline for HDR hardware acceleration.
- Introduced a driver optimization to mitigate the performance loss from the 'd3d9.floatEmulation' option in DXVK.
- Fixed a bug that caused FarCry 5 running through DXVK to display a black screen.
- Updated the framelock settings page of the nvidia-settings control panel to use the GTK3 theme text color rather than defaulting to white for the text color, improving legibility with some themes.
- Fixed some performance regressions that were observed with vkd3d-proton 2.9.
- Fixed a bug that could cause flickering in some applications when using Unified Back Buffer (UBB).
- Fixed a bug which could cause incorrect and/or washed out colors to be displayed with HDR scanout: https://bugs.kde.org/show_bug.cgi?id=482780
- Implemented support for VK_EXT_depth_clamp_control.
- Fixed a bug which could cause applications using GBM to crash when running with nvidia-drm.modeset=0.
- Fixed a bug that could cause kernel crashes upon attempting KMS operations through DRM when nvidia_drm was loaded with modeset=0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
