### PR TITLE
ghostscript: support SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/pkgs/by-name/gh/ghostscript/package.nix
+++ b/pkgs/by-name/gh/ghostscript/package.nix
@@ -2,6 +2,7 @@
 , stdenv
 , lib
 , fetchurl
+, fetchpatch2
 , pkg-config
 , zlib
 , expat
@@ -72,6 +73,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
+
+    # Support SOURCE_DATE_EPOCH for reproducible builds
+    (fetchpatch2 {
+      url = "https://salsa.debian.org/debian/ghostscript/-/raw/01e895fea033cc35054d1b68010de9818fa4a8fc/debian/patches/2010_add_build_timestamp_setting.patch";
+      hash = "sha256-XTKkFKzMR2QpcS1YqoxzJnyuGk/l/Y2jdevsmbMtCXA=";
+    })
   ];
 
   outputs = [ "out" "man" "doc" "fonts" ];


### PR DESCRIPTION
Without this patch, it is impossible to generate PDF documents in a reproducible way using Ghostscript, as CreationDate and ModDate are included in the PDF, which are based on the current time. I ran into this problem while using the LATEX command `\includegraphics` with an `.eps` graphic.
The Ghostscript developers are not interested in fixing this and rejected the patch, see https://bugs.ghostscript.com/show_bug.cgi?id=696765#c28. This is also where I download the patch from.
[Arch Linux carries the same patch](https://gitlab.archlinux.org/archlinux/packaging/packages/ghostscript/-/commit/426e6bf6f290c1acf1816c032c630d921b626c95), as does [Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794004).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
