### PR TITLE
flirt: init at 0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -537,6 +537,13 @@
     githubId = 749381;
     name = "Adam Tulinius";
   };
+  adda = {
+    email = "chocholaty.david@protonmail.com";
+    matrix = "@adda0:matrix.org";
+    github = "adda0";
+    githubId = 52529234;
+    name = "David Chocholatý";
+  };
   addict3d = {
     email = "nickbathum@gmail.com";
     matrix = "@nbathum:matrix.org";

--- a/pkgs/by-name/fl/flirt/package.nix
+++ b/pkgs/by-name/fl/flirt/package.nix
@@ -1,0 +1,29 @@
+{
+  rustPlatform,
+  fetchFromSourcehut,
+  lib,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "flirt";
+  version = "0.2";
+
+  src = fetchFromSourcehut {
+    owner = "~hadronized";
+    repo = "flirt";
+    rev = "v${version}";
+    hash = "sha256-NV6UP7fPTcn0WrZwIfe1zuZW6hJDuxrfATM2Gpx0yr0=";
+  };
+
+  cargoHash = "sha256-gVtRU+tjwf3rTei/TjUFYSMvLB9g6gNeGYO+9NBxgYQ=";
+
+  meta = {
+    description = "FiLe InteRacT, the file interaction tool for your command line";
+    homepage = "https://git.sr.ht/~hadronized/flirt";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      adda
+    ];
+    mainProgram = "flirt";
+  };
+}


### PR DESCRIPTION
This PR adds `flirt`, [FiLe InteRacT, the file interaction tool for your command line](https://git.sr.ht/~hadronized/flirt). This is a small program that starts an interactive file selection process from your current pwd and allows you to select relative files, returning them to your command line once you are done.

Since the project is new, I will not add an automatic update script right from the start. First, I want to see what the typical development cycle will look like and act accordingly based on the behaviour. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
