### PR TITLE
buildBazelPackage: use same bazel for deps & build

### DIFF
--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -40,8 +40,8 @@ buildBazelPackage rec {
   fetchAttrs = {
     hash =
       {
-        aarch64-linux = "sha256-E4VHjDa0qkHmKUNpTBfJi7dhMLcd1z5he+p31/XvUl8=";
-        x86_64-linux = "sha256-M7xhAIhTcVLCUkmy4giGxbr7DgHrXbg0e8D/bL6yZWU=";
+        aarch64-linux = lib.fakeHash;
+        x86_64-linux = lib.fakeHash;
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -40,8 +40,8 @@ buildBazelPackage rec {
   fetchAttrs = {
     hash =
       {
-        aarch64-linux = lib.fakeHash;
-        x86_64-linux = lib.fakeHash;
+        aarch64-linux = "sha256-L3zoUCIvWwqVEtvlJWLeSHBx27nJ+vv5IgiNY6FYTuc=";
+        x86_64-linux = "sha256-AZE8WIEFGioD3eCZIzA7L3Gp6KQ/4KjQM/HYCRWAqdQ=";
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -37,8 +37,8 @@ let
   # these need to be updated for any changes to fetchAttrs
   depsHash =
     {
-      x86_64-linux = "sha256-LkDNPFT7UUCsGPG1dMnwzdIw0lzc5+3JYDoblF5oZVk=";
-      aarch64-linux = "sha256-DkibjmY1YND9Q2aQ41bhNdch0SKM5ghY2mjYSQfV30M=";
+      x86_64-linux = lib.fakeHash;
+      aarch64-linux = lib.fakeHash;
     }
     .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 in

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -37,8 +37,8 @@ let
   # these need to be updated for any changes to fetchAttrs
   depsHash =
     {
-      x86_64-linux = lib.fakeHash;
-      aarch64-linux = lib.fakeHash;
+      x86_64-linux = "sha256-yi9lYmdWcUApRSwwSFR8KhAckQYncvXPSQrISVYapv8=";
+      aarch64-linux = "sha256-qyayZqdtiBWyoqVc6kmMmxi6SSEqvj4RQfKoF6CDDa8=";
     }
     .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 in

--- a/pkgs/by-name/fc/fcitx5-mozc/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mozc/package.nix
@@ -62,7 +62,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/fcitx5
     '';
 
-    sha256 = "sha256-rrRp/v1pty7Py80/6I8rVVQvkeY72W+nlixUeYkjp+o=";
+    sha256 = lib.fakeHash;
   };
 
   preConfigure = ''

--- a/pkgs/by-name/fc/fcitx5-mozc/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mozc/package.nix
@@ -62,7 +62,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/fcitx5
     '';
 
-    sha256 = lib.fakeHash;
+    sha256 = "sha256-xF6XEUqEbEyoklJM98RUHKMEtsTpVCOLqgPAHCBQuUk=";
   };
 
   preConfigure = ''

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -45,7 +45,7 @@ buildBazelPackage rec {
   inherit bazel;
 
   fetchAttrs = {
-    sha256 = lib.fakeHash;
+    sha256 = "sha256-le3ZidXmjw1cXlCNYXpz3Oem1O6C5WGf99gp8mk4Oy8=";
 
     # remove references of buildInputs and zip code files
     preInstall = ''

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -45,7 +45,7 @@ buildBazelPackage rec {
   inherit bazel;
 
   fetchAttrs = {
-    sha256 = "sha256-+N7AhSemcfhq6j0IUeWZ0DyVvr1l5FbAkB+kahTy3pM=";
+    sha256 = lib.fakeHash;
 
     # remove references of buildInputs and zip code files
     preInstall = ''

--- a/pkgs/by-name/pe/perf_data_converter/package.nix
+++ b/pkgs/by-name/pe/perf_data_converter/package.nix
@@ -38,8 +38,8 @@ buildBazelPackage rec {
   fetchAttrs = {
     hash =
       {
-        aarch64-linux = lib.fakeHash;
-        x86_64-linux = lib.fakeHash;
+        aarch64-linux = "sha256-GK5UB5Om0hGsgyiipyRjDG8LymLtThvUd9Cjt97+ue8=";
+        x86_64-linux = "sha256-udo3EmbbZFmZ0L60htocXdFA3fo8MflsKC9ZXSUJkXc=";
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/pe/perf_data_converter/package.nix
+++ b/pkgs/by-name/pe/perf_data_converter/package.nix
@@ -38,8 +38,8 @@ buildBazelPackage rec {
   fetchAttrs = {
     hash =
       {
-        aarch64-linux = "sha256-F4fYZfdCmDzJRR+z1rCLsculP9y9B8H8WHNQbFZEv+s=";
-        x86_64-linux = "sha256-rjlquK0WcB7Te2uUKKVOrL7+6PtcWQImUWTVafIsbHY=";
+        aarch64-linux = lib.fakeHash;
+        x86_64-linux = lib.fakeHash;
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -19,7 +19,7 @@ buildBazelPackage rec {
 
   LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
-  fetchAttrs.hash = lib.fakeHash;
+  fetchAttrs.hash = "sha256-F1xVqpMNEn8iDNy5zWm1PPa83TT3/4X74Z29sIuIuys=";
 
   buildAttrs.installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -19,7 +19,7 @@ buildBazelPackage rec {
 
   LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
-  fetchAttrs.hash = "sha256-WOBlZ0XNrl5UxIaSDxZeOfzS2a8ZkrKdTLKHBDC9UNQ=";
+  fetchAttrs.hash = lib.fakeHash;
 
   buildAttrs.installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/te/tensorflow-lite/package.nix
+++ b/pkgs/by-name/te/tensorflow-lite/package.nix
@@ -10,11 +10,11 @@ let
   pythonEnv = buildPackages.python3.withPackages (ps: with ps; [ distutils numpy ]);
   bazelDepsSha256ByBuildAndHost = {
     x86_64-linux = {
-      x86_64-linux = lib.fakeHash;
-      aarch64-linux = lib.fakeHash;
+      x86_64-linux = "sha256-AQlQH3Cd7VSqMUTO7f1I2MVAbTiKxYJwEQrmyA8fclk=";
+      aarch64-linux = "sha256-69D037FQr2QmLG28QEiGhPdTNIO/4uiZ+KQLFMrdJnY=";
     };
     aarch64-linux = {
-      aarch64-linux = lib.fakeHash;
+      aarch64-linux = "sha256-4rmvxF6X3dTGNdM2P/xWiNUyLnw5kUzsBbQqOnHxTqg=";
     };
   };
   bazelHostConfigName.aarch64-linux = "elinux_aarch64";

--- a/pkgs/by-name/te/tensorflow-lite/package.nix
+++ b/pkgs/by-name/te/tensorflow-lite/package.nix
@@ -10,11 +10,11 @@ let
   pythonEnv = buildPackages.python3.withPackages (ps: with ps; [ distutils numpy ]);
   bazelDepsSha256ByBuildAndHost = {
     x86_64-linux = {
-      x86_64-linux = "sha256-61qmnAB80syYhURWYJOiOnoGOtNa1pPkxfznrFScPAo=";
-      aarch64-linux = "sha256-sOIYpp98wJRz3RGvPasyNEJ05W29913Lsm+oi/aq/Ag=";
+      x86_64-linux = lib.fakeHash;
+      aarch64-linux = lib.fakeHash;
     };
     aarch64-linux = {
-      aarch64-linux = "sha256-MJU4y9Dt9xJWKgw7iKW+9Ur856rMIHeFD5u05s+Q7rQ=";
+      aarch64-linux = lib.fakeHash;
     };
   };
   bazelHostConfigName.aarch64-linux = "elinux_aarch64";

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -40,7 +40,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    hash = lib.fakeHash;
+    hash = "sha256-1971ZjIz/6PTihwsSa3ccog3p06aDU+5YC9twASRWr4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -40,7 +40,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    hash = "sha256-bKASgc5KftCWtMvJkGA4nweBAtgdnyC9uXIJxPjKYS0=";
+    hash = lib.fakeHash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -385,11 +385,11 @@ let
       sha256 =
         (
           if cudaSupport then
-            { x86_64-linux = "sha256-Uf0VMRE0jgaWEYiuphWkWloZ5jMeqaWBl3lSvk2y1HI="; }
+            { x86_64-linux = lib.fakeHash; }
           else
             {
-              x86_64-linux = "sha256-NzJJg6NlrPGMiR8Fn8u4+fu0m+AulfmN5Xqk63Um6sw=";
-              aarch64-linux = "sha256-Ro3qzrUxSR+3TH6ROoJTq+dLSufrDN/9oEo2MRkx7wM=";
+              x86_64-linux = lib.fakeHash;
+              aarch64-linux = lib.fakeHash;
             }
         ).${effectiveStdenv.system} or (throw "jaxlib: unsupported system: ${effectiveStdenv.system}");
 

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -385,11 +385,11 @@ let
       sha256 =
         (
           if cudaSupport then
-            { x86_64-linux = lib.fakeHash; }
+            { x86_64-linux = "sha256-3ITBU7DplS7xXs1ndbGxzpczik9umuTkmnOo36Bhs3M="; }
           else
             {
-              x86_64-linux = lib.fakeHash;
-              aarch64-linux = lib.fakeHash;
+              x86_64-linux = "sha256-3ITBU7DplS7xXs1ndbGxzpczik9umuTkmnOo36Bhs3M=";
+              aarch64-linux = "sha256-5fJHpXF7vvKOzoPc6rGNU/udPgnYrRoBO73dWQQXNJs=";
             }
         ).${effectiveStdenv.system} or (throw "jaxlib: unsupported system: ${effectiveStdenv.system}");
 

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -66,7 +66,7 @@ let
     LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
     fetchAttrs = {
-      sha256 = "sha256-TbWcWYidyXuAMgBnO2/k0NKCzc4wThf2uUeC3QxdBJY=";
+      sha256 = lib.fakeHash;
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -66,7 +66,7 @@ let
     LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
     fetchAttrs = {
-      sha256 = lib.fakeHash;
+      sha256 = "sha256-1VVrKARZsWg/UT9K8rcGjl5A91Sif+DgoeAu+oeaFV8=";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -521,16 +521,8 @@ let
     fetchAttrs = {
       sha256 =
         {
-          x86_64-linux =
-            if cudaSupport then
-              lib.fakeHash
-            else
-              lib.fakeHash;
-          aarch64-linux =
-            if cudaSupport then
-              lib.fakeHash
-            else
-              lib.fakeHash;
+          x86_64-linux = if cudaSupport then lib.fakeHash else lib.fakeHash;
+          aarch64-linux = if cudaSupport then lib.fakeHash else lib.fakeHash;
           x86_64-darwin = lib.fakeHash;
           aarch64-darwin = lib.fakeHash;
         }

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -523,16 +523,16 @@ let
         {
           x86_64-linux =
             if cudaSupport then
-              "sha256-5VFMNHeLrUxW5RTr6EhT3pay9nWJ5JkZTGirDds5QkU="
+              lib.fakeHash
             else
-              "sha256-KzgWV69Btr84FdwQ5JI2nQEsqiPg1/+TWdbw5bmxXOE=";
+              lib.fakeHash;
           aarch64-linux =
             if cudaSupport then
-              "sha256-ty5+51BwHWE1xR4/0WcWTp608NzSAS/iiyN+9zx7/wI="
+              lib.fakeHash
             else
-              "sha256-9btXrNHqd720oXTPDhSmFidv5iaZRLjCVX8opmrMjXk=";
-          x86_64-darwin = "sha256-gqb03kB0z2pZQ6m1fyRp1/Nbt8AVVHWpOJSeZNCLc4w=";
-          aarch64-darwin = "sha256-WdgAaFZU+ePwWkVBhLzjlNT7ELfGHOTaMdafcAMD5yo=";
+              lib.fakeHash;
+          x86_64-darwin = lib.fakeHash;
+          aarch64-darwin = lib.fakeHash;
         }
         .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
     };


### PR DESCRIPTION
It should make more sense to use same `bazel` to produce & consume the deps.

Produced deps tarball seems to be currently the same if build
with or without `enableNixHacks`, at least have verified it for `fcitx5-mozc`.

Since we also start using `bazelForBuild.name` for version string it
will invalidate the deps, which sounds like a good thing to do on
`buildBazelPackage` changes. This will cause a rebuild but relatively
few packages are affected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
