### PR TITLE
nixos-container: add support for --private-users

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -115,6 +115,16 @@ let
         extraFlags+=("--private-network")
       fi
 
+      NIX_BIND_OPT=""
+      if [ -n "$PRIVATE_USERS" ]; then
+        extraFlags+=("--private-users=$PRIVATE_USERS")
+        if [ "$PRIVATE_USERS" = "pick" ] || ( [ "$PRIVATE_USERS" != "identity" ] && [ "$PRIVATE_USERS" -gt 0 ] ); then
+          # when user namespacing is enabled, we use `idmap` mount option
+          # so that bind mounts under /nix get proper owner (and not nobody/nogroup).
+          NIX_BIND_OPT=":idmap"
+        fi
+      fi
+
       if [ -n "$HOST_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS" ] ||
          [ -n "$HOST_ADDRESS6" ] || [ -n "$LOCAL_ADDRESS6" ]; then
         extraFlags+=("--network-veth")
@@ -171,13 +181,14 @@ let
         $EXTRA_NSPAWN_FLAGS \
         --notify-ready=yes \
         --kill-signal=SIGRTMIN+3 \
-        --bind-ro=/nix/store \
-        --bind-ro=/nix/var/nix/db \
-        --bind-ro=/nix/var/nix/daemon-socket \
-        --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles" \
-        --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots" \
+        --bind-ro=/nix/store:/nix/store$NIX_BIND_OPT \
+        --bind-ro=/nix/var/nix/db:/nix/var/nix/db$NIX_BIND_OPT \
+        --bind-ro=/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket$NIX_BIND_OPT \
+        --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles$NIX_BIND_OPT" \
+        --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots$NIX_BIND_OPT" \
         ${optionalString (!cfg.ephemeral) "--link-journal=try-guest"} \
         --setenv PRIVATE_NETWORK="$PRIVATE_NETWORK" \
+        --setenv PRIVATE_USERS="$PRIVATE_USERS" \
         --setenv HOST_BRIDGE="$HOST_BRIDGE" \
         --setenv HOST_ADDRESS="$HOST_ADDRESS" \
         --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
@@ -650,6 +661,27 @@ in
               '';
             };
 
+            privateUsers = mkOption {
+              type = types.either types.ints.u32 (types.enum [ "no" "identity" "pick" ]);
+              default = "no";
+              description = ''
+                Whether to give the container its own private UIDs/GIDs space (user namespacing).
+                Disabled by default (`no`).
+
+                If set to a number (usually above host's UID/GID range: 65536),
+                user namespacing is enabled and the container UID/GIDs will start at that number.
+
+                If set to `identity`, mostly equivalent to `0`, this will only provide
+                process capability isolation (no UID/GID isolation, as they are the same as host).
+
+                If set to `pick`, user namespacing is enabled and the UID/GID range is automatically chosen,
+                so that no overlapping UID/GID ranges are assigned to multiple containers.
+                This is the recommanded option as it enhances container security massively and operates fully automatically in most cases.
+
+                See https://www.freedesktop.org/software/systemd/man/latest/systemd-nspawn.html#--private-users= for details.
+              '';
+            };
+
             interfaces = mkOption {
               type = types.listOf types.str;
               default = [];
@@ -862,6 +894,13 @@ in
                 additionalCapabilities = cfg.additionalCapabilities
                   ++ [ "CAP_NET_ADMIN" ];
               }
+            ) // (
+            optionalAttrs (!cfg.enableTun && cfg.privateNetwork
+              && (cfg.privateUsers == "pick" || (builtins.isInt cfg.privateUsers && cfg.privateUsers > 0 )))
+              {
+                allowedDevices = cfg.allowedDevices
+                  ++ [ { node = "/dev/net/tun"; modifier = "rwm"; } ];
+              }
             );
           in
             recursiveUpdate unit {
@@ -923,6 +962,7 @@ in
               ${optionalString (cfg.networkNamespace != null) ''
                 NETWORK_NAMESPACE_PATH=${cfg.networkNamespace}
               ''}
+              PRIVATE_USERS=${toString cfg.privateUsers}
               INTERFACES="${toString cfg.interfaces}"
               MACVLANS="${toString cfg.macvlans}"
               ${optionalString cfg.autoStart ''

--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -364,7 +364,7 @@ sub restartContainer {
 sub runInContainer {
     my @args = @_;
     my $leader = getLeader;
-    exec($nsenter, "-t", $leader, "-m", "-u", "-i", "-n", "-p", "--", @args);
+    exec($nsenter, "--all", "-t", $leader, "--", @args);
     die "cannot run ‘nsenter’: $!\n";
 }
 


### PR DESCRIPTION
 imply bind mounts with idmap option when user namespacing is enabled,
 so that /nix/store and friends are correctly own by root user.

doc: https://www.freedesktop.org/software/systemd/man/latest/systemd-nspawn.html#--private-users=

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
