### PR TITLE
gruvbox-material-gtk-theme: init at 0-unstable-2024-08-09

### DIFF
--- a/pkgs/by-name/gr/gruvbox-material-gtk-theme/package.nix
+++ b/pkgs/by-name/gr/gruvbox-material-gtk-theme/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  gtk-engine-murrine,
+  lib,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "gruvbox-material-gtk-theme";
+  version = "0-unstable-2024-08-09";
+
+  src = fetchFromGitHub {
+    owner = "TheGreatMcPain";
+    repo = "gruvbox-material-gtk";
+    rev = "808959bcfe8b9409b49a7f92052198f0882ae8bc";
+    hash = "sha256-NHjE/HI/BJyjrRfoH9gOKIU8HsUIBPV9vyvuW12D01M=";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/"{themes,icons}
+    for i in "icons" "themes"; do
+      cp -a "$i/"* "$out/share/$i"
+    done
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GTK Theme based off of the Gruvbox Material colour palette";
+    homepage = "https://github.com/TheGreatMcPain/gruvbox-material-gtk";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadaluzia ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## What have I done?
I have added the Gruvbox Material GTK Theme by TheGreatMcPain

This theme provides the colouring of Gruvbox Material to GTK.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
