### PR TITLE
nixos/kanidm: fix startup failure

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -194,7 +194,7 @@ let
 
     count=0
     while [[ ! "$(health_check)" =~ 'true' ]]; do
-      if [ $((count++)) -ge 15 ]; then
+      if [ $((count++)) -ge 30 ]; then
         echo "Giving up after at least $count seconds ..."
         exit 1
       fi

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -125,6 +125,7 @@ let
       "@system-service"
       "~@privileged @resources @setuid @keyring"
     ];
+    TimeoutStartSec = 30;
     # Does not work well with the temporary root
     #UMask = "0066";
   };
@@ -192,12 +193,7 @@ let
         ${cfg.provision.instanceUrl}/status
     }
 
-    count=0
     while [[ ! "$(health_check)" =~ 'true' ]]; do
-      if [ $((count++)) -ge 30 ]; then
-        echo "Giving up after at least $count seconds ..."
-        exit 1
-      fi
       echo "Waiting for kanidm to start ..."
       sleep 1
     done


### PR DESCRIPTION
This PR only affects the systemd service postStart script

Observed behavior: systemd service kanidm quits after 60 seconds.
  One cause/symptom is that the kanidm process receives a SIGTERM+3 signal
  exactly 60 seconds after starting. Which is odd because the
  postStart is designed to quit after 30 seconds if the service
  is not healthy. I wasn't sure what sent that signal, but I determined
  that the service was in fact healthy, and the logic for checking
  whether the kanidm process had started was failing.

Fixes:
- curl was not using system-installed ca certs and failed TLS negotiation. Fix: add --cacert parm using tls_certs configuration setting. Also, isolated health_check into separate function for clarity.
- the bash variable 'count' for checking time elapsed was not incrementing. ( `count=$((count++))` reset the value to zero each iteration) Fix: allow count to increment
- curl was checking the main service url `http<s>://idm.example.com`, but there's a recommended health check url that returns "true". Fix: append '/status' to the url and verify the output contains "true"
- moved `set -euo pipefail` to after the curl checks because we expect curl might fail and handle that condition.

Tested:
- tested on x86_64-linux
- nixos-unstable (as of 2024-12-05)
- kanidm 1.4.3
- kanidm 1.4.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html)). 
    - (not applicable)

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes] 
    - (not applicable)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
