### PR TITLE
mir: 2.18.3 -> 2.19.2

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -30,18 +30,25 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.7";
 
   src = fetchFromGitHub {
-    owner = "mattkae";
+    owner = "miracle-wm-org";
     repo = "miracle-wm";
     rev = "v${finalAttrs.version}";
     hash = "sha256-31S7Mfz3LIOAmDUl6jbr3kSP2BdLaM0M4xMZ8FHhLH0=";
   };
 
   patches = [
-    # Remove when https://github.com/mattkae/miracle-wm/pull/211 merged & in release
+    # Remove when version > 0.3.7
     (fetchpatch {
-      name = "0001-miracle-wm-Dont-ignore-PKG_CONFIG_PATH.patch";
-      url = "https://github.com/mattkae/miracle-wm/commit/a9fe6ed1e7dc605f72e18cdc2d19afb3c187be3a.patch";
-      hash = "sha256-zzOwqUjyZGYIy/3BvOiedfCubrqaeglvsAzTXyq3wYU=";
+      name = "0001-miracle-wm-Dont-override-PKG_CONFIG_PATH.patch";
+      url = "https://github.com/miracle-wm-org/miracle-wm/commit/0a8809d4362e1d3abbea6e29fd1234c8fa981bfb.patch";
+      hash = "sha256-Fy/fDmV1uXRt4omxccpFkZb0vE8iHYSS9A7E+PEFBOM=";
+    })
+
+    # Remove when version > 0.3.7
+    (fetchpatch {
+      name = "0002-miracle-wm-Fix-mir-2.19-support.patch";
+      url = "https://github.com/miracle-wm-org/miracle-wm/commit/a9db8b539a5396e9df6f6f009cbabcbb053f2b05.patch";
+      hash = "sha256-VxUVpwBSHuLzs0yEQ7gStpMnHRJJtZ/Shmjb2un3qI0=";
     })
   ];
 

--- a/pkgs/by-name/mi/miriway/package.nix
+++ b/pkgs/by-name/mi/miriway/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miriway";
-  version = "24.10.1";
+  version = "24.11.1";
 
   src = fetchFromGitHub {
     owner = "Miriway";
     repo = "Miriway";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-jpXsvr2HnfMCJh851oS+IiQLSmL9C1bnaG6IPSq5xrA=";
+    hash = "sha256-DphzqU0jT2NE2dSDuQf6BQIjXTwJuPiOjfxk9N9YmaQ=";
   };
 
   postPatch = ''

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.18.3";
-    hash = "sha256-2PwLTWQeaVR80slZ6/BPr23gVahiDWXulFtdjc9ZUCs=";
+    version = "2.19.2";
+    hash = "sha256-E6+FjYJUIgejpat1Kyl0B1JL+mnQd4rXjSQAPTX31qc=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
- mir: https://github.com/canonical/mir/releases/tag/v2.19.0 (.1 and .2 are just forgotten ABI bumps)
- miracle-wm: Fetch https://github.com/miracle-wm-org/miracle-wm/commit/a9db8b539a5396e9df6f6f009cbabcbb053f2b05 to fix compat with new Mir
- miriway: https://github.com/Miriway/Miriway/releases/tag/v24.11 makes use of a new 2.19 feature, .1 is a bugfix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
