### PR TITLE
update-python-libraries: migrate git revs to tag

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -157,6 +157,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 # Python-related code and docs
 /doc/languages-frameworks/python.section.md   @mweinelt @natsukium
 /maintainers/scripts/update-python-libraries  @mweinelt @natsukium
+/pkgs/by-name/up/update-python-libraries      @mweinelt @natsukium
 /pkgs/development/interpreters/python         @mweinelt @natsukium
 /pkgs/top-level/python-packages.nix                     @natsukium
 /pkgs/top-level/release-python.nix                      @natsukium

--- a/maintainers/scripts/update-python-libraries
+++ b/maintainers/scripts/update-python-libraries
@@ -1,3 +1,3 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=channel:nixpkgs-unstable -i bash -p "python3.withPackages (ps: with ps; [ packaging requests ])" -p nix-prefetch-git
-exec python3 pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py $@
+exec python3 pkgs/by-name/up/update-python-libraries/update-python-libraries.py $@

--- a/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
+++ b/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
@@ -486,7 +486,7 @@ def _update_package(path, target):
     if fetcher == "fetchFromGitHub":
         # in the case of fetchFromGitHub, it's common to see `rev = version;` or `rev = "v${version}";`
         # in which no string value is meant to be substituted. However, we can just overwrite the previous value.
-        regex = r"(rev\s+=\s+[^;]*;)"
+        regex = r"((?:rev|tag)\s+=\s+[^;]*;)"
         regex = re.compile(regex)
         matches = regex.findall(text)
         n = len(matches)
@@ -496,7 +496,7 @@ def _update_package(path, target):
         else:
             # forcefully rewrite rev, incase tagging conventions changed for a release
             match = matches[0]
-            text = text.replace(match, f'rev = "refs/tags/{prefix}${{version}}";')
+            text = text.replace(match, f'tag = "{prefix}${{version}}";')
             # incase there's no prefix, just rewrite without interpolation
             text = text.replace('"${version}";', "version;")
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
