### PR TITLE
sidplayfp: 2.11.0 -> 2.12.0

### DIFF
--- a/pkgs/by-name/si/sidplayfp/package.nix
+++ b/pkgs/by-name/si/sidplayfp/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sidplayfp";
-  version = "2.11.0";
+  version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "sidplayfp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-X2ds7pYglxvwLOHXfCULwSeWAS9l2Y3PUdSxcuugwHs=";
+    hash = "sha256-78NlRBZ2GlZWhnZiefNIgRNv6bnJaHH94WsxEhP9rAk=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/si/sidplayfp/package.nix
+++ b/pkgs/by-name/si/sidplayfp/package.nix
@@ -1,17 +1,18 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, nix-update-script
-, alsaSupport ? stdenv.hostPlatform.isLinux
-, alsa-lib
-, autoreconfHook
-, pulseSupport ? stdenv.hostPlatform.isLinux
-, libpulseaudio
-, libsidplayfp
-, out123Support ? stdenv.hostPlatform.isDarwin
-, mpg123
-, perl
-, pkg-config
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  alsa-lib,
+  autoreconfHook,
+  pulseSupport ? stdenv.hostPlatform.isLinux,
+  libpulseaudio,
+  libsidplayfp,
+  out123Support ? stdenv.hostPlatform.isDarwin,
+  mpg123,
+  perl,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,15 +34,19 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = [
-    libsidplayfp
-  ] ++ lib.optionals alsaSupport [
-    alsa-lib
-  ] ++ lib.optionals pulseSupport [
-    libpulseaudio
-  ] ++ lib.optionals out123Support [
-    mpg123
-  ];
+  buildInputs =
+    [
+      libsidplayfp
+    ]
+    ++ lib.optionals alsaSupport [
+      alsa-lib
+    ]
+    ++ lib.optionals pulseSupport [
+      libpulseaudio
+    ]
+    ++ lib.optionals out123Support [
+      mpg123
+    ];
 
   configureFlags = [
     (lib.strings.withFeature out123Support "out123")
@@ -50,15 +55,19 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = gitUpdater { rev-prefix = "v"; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "SID player using libsidplayfp";
     homepage = "https://github.com/libsidplayfp/sidplayfp";
-    license = with licenses; [ gpl2Plus ];
+    changelog = "https://github.com/libsidplayfp/sidplayfp/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "sidplayfp";
-    maintainers = with maintainers; [ dezgeg OPNA2608 ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [
+      dezgeg
+      OPNA2608
+    ];
+    platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
https://github.com/libsidplayfp/sidplayfp/releases/tag/v2.12.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
