### PR TITLE
gtk-engine-murrine: func prototypes for gcc-14

### DIFF
--- a/pkgs/by-name/gt/gtk-engine-murrine/missing-prototypes.diff
+++ b/pkgs/by-name/gt/gtk-engine-murrine/missing-prototypes.diff
@@ -1,0 +1,33 @@
+diff --git a/src/murrine_rc_style.h b/src/murrine_rc_style.h
+index 8e3d7a8..2823e7a 100644
+--- a/src/murrine_rc_style.h
++++ b/src/murrine_rc_style.h
+@@ -154,5 +154,6 @@ struct _MurrineRcStyleClass
+ };
+ 
+ GType murrine_rc_style_get_type	(void);
++void murrine_rc_style_register_types (GTypeModule *module);
+ 
+ #endif /* MURRINE_RC_STYLE_H */
+diff --git a/src/murrine_style.h b/src/murrine_style.h
+index 33ae51c..1646e6d 100644
+--- a/src/murrine_style.h
++++ b/src/murrine_style.h
+@@ -102,5 +102,6 @@ struct _MurrineStyleClass
+ };
+ 
+ GType murrine_style_get_type (void);
++void murrine_style_register_types (GTypeModule *module);
+ 
+ #endif /* MURRINE_STYLE_H */
+diff --git a/src/support.h b/src/support.h
+index e141067..4bf824e 100644
+--- a/src/support.h
++++ b/src/support.h
+@@ -149,4 +149,6 @@ G_GNUC_INTERNAL void murrine_get_notebook_tab_position (GtkWidget *widget,
+                                                         gboolean  *start,
+                                                         gboolean  *end);
+ 
++gboolean murrine_widget_is_ltr (GtkWidget *widget);
++gboolean murrine_object_is_a (const GObject * object, const gchar * type_name);
+ #endif /* SUPPORT_H */

--- a/pkgs/by-name/gt/gtk-engine-murrine/package.nix
+++ b/pkgs/by-name/gt/gtk-engine-murrine/package.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "129cs5bqw23i76h3nmc29c9mqkm9460iwc8vkl7hs4xr07h8mip9";
   };
 
+  patches = [
+    # add prototypes to fix gcc-14 implicit-function-declaration errors
+    ./missing-prototypes.diff
+  ];
+
   strictDeps = true;
   nativeBuildInputs = [ pkg-config intltool ];
   buildInputs = [ gtk2 ];


### PR DESCRIPTION
add function prototypes to various include files to fix implicit-function-declaration errors on gcc-14

repo is archived: https://gitlab.gnome.org/Archive/murrine

https://hydra.nixos.org/build/281131898

https://github.com/NixOS/nixpkgs/pull/361878
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
