### PR TITLE
crystal: add fish completions

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -25,6 +25,7 @@
 , pcre2
 , pcre
 , pkg-config
+, installShellFiles
 , readline
 , tzdata
 , which
@@ -166,7 +167,7 @@ let
 
 
       strictDeps = true;
-      nativeBuildInputs = [ binary makeWrapper which pkg-config llvmPackages.llvm ];
+      nativeBuildInputs = [ binary makeWrapper which pkg-config llvmPackages.llvm installShellFiles ];
       buildInputs = [
         boehmgc
         (if lib.versionAtLeast version "1.8" then pcre2 else pcre)
@@ -218,17 +219,18 @@ let
         cp -r docs/* $out/share/doc/crystal/api/
         cp -r samples $out/share/doc/crystal/
 
-        install -Dm644 etc/completion.bash $out/share/bash-completion/completions/crystal
-        install -Dm644 etc/completion.zsh $out/share/zsh/site-functions/_crystal
-        # fish completion was introduced since 1.6.0
-        test -f etc/completion.fish && install -Dm644 etc/completion.fish $out/share/fish/vendor_completions.d/crystal.fish
+        installShellCompletion --cmd ${finalAttrs.meta.mainProgram} etc/completion.*
 
-        install -Dm644 man/crystal.1 $out/share/man/man1/crystal.1
+        installManPage man/crystal.1
 
         install -Dm644 -t $out/share/licenses/crystal LICENSE README.md
 
         mkdir -p $out
         ln -s $bin/bin $out/bin
+        ln -s $bin/share/bash-completion $out/share/bash-completion
+        ln -s $bin/share/zsh $out/share/zsh
+        # fish completion was introduced in 1.6.0
+        test -f etc/completion.fish && ln -s $bin/share/fish $out/share/fish
         ln -s $lib $out/lib
 
         runHook postInstall

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -220,6 +220,8 @@ let
 
         install -Dm644 etc/completion.bash $out/share/bash-completion/completions/crystal
         install -Dm644 etc/completion.zsh $out/share/zsh/site-functions/_crystal
+        # fish completion was introduced since 1.6.0
+        test -f etc/completion.fish && install -Dm644 etc/completion.fish $out/share/fish/vendor_completions.d/crystal.fish
 
         install -Dm644 man/crystal.1 $out/share/man/man1/crystal.1
 


### PR DESCRIPTION
fish completion was introduced in version 1.6.0
so this guard is required, this package is also supporting 1.2.2

https://github.com/crystal-lang/crystal/commit/98a15ee1ab90c2590d43529ea527c6ffc0ce318d
https://github.com/crystal-lang/crystal/blob/0e80a60f0826f6e5031edbd55ee3c3edd9891c18/Makefile#L183-L184

```console
# pkgs.crystal (crystal_1_14)
> tree ./result/share/*sh*
./result/share/bash-completion
└── completions
    └── crystal
./result/share/fish
└── vendor_completions.d
    └── crystal.fish
./result/share/zsh
└── site-functions
    └── _crystal
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
