### PR TITLE
python3Packages.nidaqmx: 0.5.7 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/hightime/default.nix
+++ b/pkgs/development/python-modules/hightime/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "hightime";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ni";
+    repo = "hightime";
+    rev = "v${version}";
+    hash = "sha256-P/ZP5smKyNg18YGYWpm/57YGFY3MrX1UIVDU5RsF+rA=";
+  };
+
+  disabled = pythonOlder "3.7";
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  # Test incompatible with datetime's integer type requirements
+  disabledTests = [
+    "test_datetime_arg_wrong_value"
+  ];
+
+  pythonImportsCheck = [ "hightime" ];
+
+  meta = {
+    changelog = "https://github.com/ni/hightime/releases/tag/v${version}";
+    description = "Hightime Python API";
+    homepage = "https://github.com/ni/hightime";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fsagbuya ];
+  };
+}

--- a/pkgs/development/python-modules/nidaqmx/default.nix
+++ b/pkgs/development/python-modules/nidaqmx/default.nix
@@ -1,54 +1,85 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  six,
+  poetry-core,
+  pythonOlder,
   numpy,
-  pytestCheckHook,
-  pykka,
-  pythonAtLeast,
+  deprecation,
+  hightime,
+  tzlocal,
+  python-decouple,
+  click,
+  distro,
+  requests,
+  sphinx,
+  sphinx-rtd-theme,
+  grpcio,
+  protobuf,
+  toml,
 }:
-
-# Note we currently do not patch the path to the drivers
-# because those are not available in Nixpkgs.
-# https://github.com/NixOS/nixpkgs/pull/74980
 
 buildPythonPackage rec {
   pname = "nidaqmx";
-  version = src.rev;
-  format = "setuptools";
-
-  # 3.10 is not supported, upstream inactive
-  disabled = pythonAtLeast "3.10";
+  version = "1.0.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ni";
     repo = "nidaqmx-python";
-    rev = "0.5.7";
-    sha256 = "19m9p99qvdmvvqbwmqrqm6b50x7czgrj07gdsxbbgw04shf5bhrs";
+    rev = "${version}";
+    hash = "sha256-rf5cGq3Iv6ucURSUFuFANQzaGeufBZ+adjKlg4B5DRY=";
   };
 
-  propagatedBuildInputs = [
-    numpy
-    six
-  ];
+  disabled = pythonOlder "3.8";
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    pykka
-  ];
+  build-system = [ poetry-core ];
 
-  dontUseSetuptoolsCheck = true;
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
 
-  # Older pytest is needed
-  # https://github.com/ni/nidaqmx-python/issues/80
-  # Fixture "x_series_device" called directly. Fixtures are not meant to be called directly
+    substituteInPlace pyproject.toml \
+      --replace-fail '["poetry>=1.2"]' '["poetry-core>=1.0.0"]'
+  '';
+
+  dependencies =
+    [
+      numpy
+      deprecation
+      hightime
+      tzlocal
+      python-decouple
+      click
+      requests
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      distro
+    ];
+
+  passthru.optional-dependencies = {
+    docs = [
+      sphinx
+      sphinx-rtd-theme
+      toml
+    ];
+    grpc = [
+      grpcio
+      protobuf
+    ];
+  };
+
+  # Tests require hardware
   doCheck = false;
 
-  pythonImportsCheck = [ "nidaqmx.task" ];
+  pythonImportsCheck = [ "nidaqmx" ];
 
   meta = {
+    changelog = "https://github.com/ni/nidaqmx-python/releases/tag/v${version}";
     description = "API for interacting with the NI-DAQmx driver";
-    license = [ lib.licenses.mit ];
+    homepage = "https://github.com/ni/nidaqmx-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fsagbuya ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5818,6 +5818,8 @@ self: super: with self; {
 
   highspy = callPackage ../development/python-modules/highspy { };
 
+  hightime = callPackage ../development/python-modules/hightime { };
+
   hid = callPackage ../development/python-modules/hid {
     inherit (pkgs) hidapi;
   };


### PR DESCRIPTION
- Update `nidaqmx` for `python >3.12`
- package additional dependency `hightime` 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
