### PR TITLE
nixos/web-servers: remove "reload" services in favor of ACME postRun

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -66,6 +66,8 @@
 
 - `gkraken` software and `hardware.gkraken.enable` option have been removed, use `coolercontrol` via `programs.coolercontrol.enable` option instead.
 
+- `{httpd,nginx,pomerium}-config-reload.service` have been removed in favor of using `security.acme.certs.*.reloadServices` for the relevant certs.
+
 - `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
 - `containerd` has been updated to v2, which contains breaking changes. See the [containerd

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -381,7 +381,7 @@ let
             rm renewed
             ${data.postRun}
             ${lib.optionalString (data.reloadServices != [])
-                "systemctl --no-block try-reload-or-restart ${lib.escapeShellArgs data.reloadServices}"
+                "systemctl --no-block try-reload-or-restart ${lib.escapeShellArgs (lib.unique data.reloadServices)}"
             }
           fi
         '');

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -645,7 +645,7 @@ in
     ] ++ map (name: mkCertOwnershipAssertion {
       cert = config.security.acme.certs.${name};
       groups = config.users.groups;
-      services = [ config.systemd.services.httpd ] ++ lib.optional (vhostCertNames != []) config.systemd.services.httpd-config-reload;
+      services = [ config.systemd.services.httpd ];
     }) vhostCertNames;
 
     warnings =
@@ -665,10 +665,9 @@ in
       wwwrun.gid = config.ids.gids.wwwrun;
     };
 
-    security.acme.certs = let
-      acmePairs = map (hostOpts: let
+    security.acme.certs = lib.mkMerge (map (hostOpts: let
         hasRoot = hostOpts.acmeRoot != null;
-      in nameValuePair hostOpts.hostName {
+      in { ${hostOpts.hostName} = {
         group = mkDefault cfg.group;
         # if acmeRoot is null inherit config.security.acme
         # Since config.security.acme.certs.<cert>.webroot's own default value
@@ -680,9 +679,14 @@ in
         # Use the vhost-specific email address if provided, otherwise let
         # security.acme.email or security.acme.certs.<cert>.email be used.
         email = mkOverride 2000 (if hostOpts.adminAddr != null then hostOpts.adminAddr else cfg.adminAddr);
+      };
       # Filter for enableACME-only vhosts. Don't want to create dud certs
-      }) (filter (hostOpts: hostOpts.useACMEHost == null) acmeEnabledVhosts);
-    in listToAttrs acmePairs;
+    }) (filter (vhostConfig: vhostConfig.useACMEHost == null) acmeEnabledVhosts)
+    ++ map (certName: {
+      ${certName} = {
+        reloadServices = [ "httpd.service" ];
+      };
+    }) vhostCertNames);
 
     # httpd requires a stable path to the configuration file for reloads
     environment.etc."httpd/httpd.conf".source = cfg.configFile;
@@ -747,7 +751,7 @@ in
         ];
 
     systemd.services.httpd = {
-        description = "Apache HTTPD";
+        description = "Apache HTTP Daemon";
         wantedBy = [ "multi-user.target" ];
         wants = concatLists (map (certName: [ "acme-finished-${certName}.target" ]) vhostCertNames);
         after = [ "network.target" ]
@@ -787,33 +791,5 @@ in
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         };
       };
-
-    # postRun hooks on cert renew can't be used to restart Apache since renewal
-    # runs as the unprivileged acme user. sslTargets are added to wantedBy + before
-    # which allows the acme-finished-$cert.target to signify the successful updating
-    # of certs end-to-end.
-    systemd.services.httpd-config-reload = let
-      sslServices = map (certName: "acme-${certName}.service") vhostCertNames;
-      sslTargets = map (certName: "acme-finished-${certName}.target") vhostCertNames;
-    in mkIf (vhostCertNames != []) {
-      wantedBy = sslServices ++ [ "multi-user.target" ];
-      # Before the finished targets, after the renew services.
-      # This service might be needed for HTTP-01 challenges, but we only want to confirm
-      # certs are updated _after_ config has been reloaded.
-      before = sslTargets;
-      after = sslServices;
-      restartTriggers = [ cfg.configFile ];
-      # Block reloading if not all certs exist yet.
-      # Happens when config changes add new vhosts/certs.
-      unitConfig.ConditionPathExists = map (certName: certs.${certName}.directory + "/fullchain.pem") vhostCertNames;
-      serviceConfig = {
-        Type = "oneshot";
-        TimeoutSec = 60;
-        ExecCondition = "/run/current-system/systemd/bin/systemctl -q is-active httpd.service";
-        ExecStartPre = "${pkg}/bin/httpd -f /etc/httpd/httpd.conf -t";
-        ExecStart = "/run/current-system/systemd/bin/systemctl reload httpd.service";
-      };
-    };
-
   };
 }

--- a/nixos/modules/services/web-servers/pomerium.nix
+++ b/nixos/modules/services/web-servers/pomerium.nix
@@ -111,24 +111,9 @@ in
       };
     };
 
-    # postRun hooks on cert renew can't be used to restart Nginx since renewal
-    # runs as the unprivileged acme user. sslTargets are added to wantedBy + before
-    # which allows the acme-finished-$cert.target to signify the successful updating
-    # of certs end-to-end.
-    systemd.services.pomerium-config-reload = mkIf (cfg.useACMEHost != null) {
-      # TODO(lukegb): figure out how to make config reloading work with credentials.
-
-      wantedBy = [ "acme-finished-${cfg.useACMEHost}.target" "multi-user.target" ];
-      # Before the finished targets, after the renew services.
-      before = [ "acme-finished-${cfg.useACMEHost}.target" ];
-      after = [ "acme-${cfg.useACMEHost}.service" ];
-      # Block reloading if not all certs exist yet.
-      unitConfig.ConditionPathExists = [ "${config.security.acme.certs.${cfg.useACMEHost}.directory}/fullchain.pem" ];
-      serviceConfig = {
-        Type = "oneshot";
-        TimeoutSec = 60;
-        ExecCondition = "/run/current-system/systemd/bin/systemctl -q is-active pomerium.service";
-        ExecStart = "/run/current-system/systemd/bin/systemctl --no-block restart pomerium.service";
+    security.acme.certs = mkIf (cfg.useACMEHost != null) {
+      ${cfg.useACMEHost} = {
+        reloadServices = [ "pomerium.service" ];
       };
     };
   });

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -126,12 +126,18 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         webserver.fail(
             "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
         )
-        webserver.succeed("[[ $(systemctl is-failed nginx-config-reload) == failed ]]")
-        webserver.succeed("[[ $(systemctl is-failed nginx) == active ]]")
-        # just to make sure operation is idempotent. During development I had a situation
-        # when first time it shows error, but stops showing it on subsequent rebuilds
-        webserver.fail(
-            "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
-        )
+        webserver.succeed("[[ $(systemctl is-active nginx) == active ]]")
+        webserver.fail("systemctl reload nginx.service")
+        webserver.succeed("[[ $(systemctl is-active nginx) == active ]]")
+
+        # TODO: make `reloadTriggers` idempotent
+        #       Would be a change to `switch-to-configuration[-ng]` so it taints services
+        #       who's reload failed, and retries on next activation if the service didn't
+        #       change (in addition to normal reload/restart logic).
+        # # just to make sure operation is idempotent. During development I had a situation
+        # # when first time it shows error, but stops showing it on subsequent rebuilds
+        # webserver.succeed(
+        #     "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
+        # )
   '';
 })


### PR DESCRIPTION
Use `reloadServices` instead of custom logic. Avoids reloading when certs didn't change.
Also fixes issue I had with reload timing out on system rebuild, which I didn't fully investigate.

I've been running this since late August with no issues to report. Didn't open a PR before since other things were already stuck in flight, but it's relevant now following [discussion on another PR](https://github.com/NixOS/nixpkgs/pull/336412#discussion_r1864708992).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
