### PR TITLE
yao-pkg: init at 6.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16488,6 +16488,12 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  onahp = {
+    name = "Setephano Noovao";
+    email = "onahp@pm.me";
+    github = "onahp";
+    githubId = 54986259;
+  };
   ondt = {
     name = "Ondrej Telka";
     email = "nix@ondt.dev";

--- a/pkgs/by-name/ya/yao-pkg/package.nix
+++ b/pkgs/by-name/ya/yao-pkg/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fixup-yarn-lock,
+  makeWrapper,
+  nodejs,
+  yarn,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yao-pkg";
+  version = "6.1.1";
+
+  src = fetchFromGitHub {
+    owner = "yao-pkg";
+    repo = "pkg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AQ+PVIWYgrflDsauxCfmvo40imlTAOW3vXhMtN+eKq4=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-7jIrhIuuHSkfQCnjifgYCEIHi169np78NLhuw6iZRyU=";
+  };
+
+  nativeBuildInputs = [
+    fixup-yarn-lock
+    makeWrapper
+    nodejs
+    yarn
+    yarnBuildHook
+    yarnConfigHook
+    yarnInstallHook
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror ${finalAttrs.offlineCache}
+    fixup-yarn-lock yarn.lock
+    yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline prepare
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn --offline --production install
+
+    mkdir -p "$out/lib/node_modules/pkg"
+    cp -r . "$out/lib/node_modules/pkg"
+
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/pkg" \
+      --add-flags "$out/lib/node_modules/pkg/lib-es5/bin.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Package your Node.js project into an executable";
+    longDescription = ''
+      This command line interface enables you to package your Node.js project into
+      an executable that can be run even on devices without Node.js installed.
+      This is also the most active and updated fork of the original vercel/pkg project.
+      It packages your Node.js project into standalone executables, making it easy to
+      distribute without requiring Node.js to be installed on the target system.
+    '';
+    mainProgram = "pkg";
+    homepage = "https://github.com/yao-pkg/pkg";
+    license = lib.licenses.mit;
+    inherit (nodejs.meta) platforms;
+    maintainers = with lib.maintainers; [ onahp ];
+  };
+})


### PR DESCRIPTION
Adding [yao-pkg](https://github.com/yao-pkg) on nixos for packaging nodejs projects into standalone executables. Have done tests on local machines regarding:

- Local derivations
- Fork of the repository with imported package with the `$NIXPKGS` export
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
