### PR TITLE
megacmd: add ffmpeg and freeimage support; add darwin support

### DIFF
--- a/pkgs/by-name/me/megacmd/fix-darwin.patch
+++ b/pkgs/by-name/me/megacmd/fix-darwin.patch
@@ -1,0 +1,49 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -25,6 +25,11 @@ AM_CPPFLAGS = \
+ 
+ AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/sdk/include
+ 
++if DARWIN
++AM_LIBTOOLFLAGS="--tag=CXX"
++AM_CPPFLAGS+=-I$(top_srcdir)/include/mega/osx -I$(top_srcdir)/sdk/include/mega/osx
++endif
++
+ if WIN32
+ AM_CPPFLAGS+=-I$(top_srcdir)/sdk/include/mega/win32
+ else
+--- a/src/megacmdshell/megacmdshellcommunications.cpp
++++ b/src/megacmdshell/megacmdshellcommunications.cpp
+@@ -306,10 +306,6 @@ SOCKET MegaCmdShellCommunications::createSocket(int number, bool initializeserve
+         #endif
+                     const char executable2[] = "./mega-cmd-server";
+     #else
+-        #ifdef __MACH__
+-                    const char executable[] = "/Applications/MEGAcmd.app/Contents/MacOS/mega-cmd";
+-                    const char executable2[] = "./mega-cmd";
+-        #else
+                     const char executable[] = "mega-cmd-server";
+             #ifdef __linux__
+                     char executable2[PATH_MAX];
+@@ -317,7 +313,6 @@ SOCKET MegaCmdShellCommunications::createSocket(int number, bool initializeserve
+             #else
+                     const char executable2[] = "./mega-cmd-server";
+             #endif
+-        #endif
+     #endif
+ 
+                     std::vector<char*> argsVector{
+--- a/sdk/Makefile.am
++++ b/sdk/Makefile.am
+@@ -27,6 +27,11 @@ AM_CPPFLAGS = \
+ 
+ include m4/aminclude.am
+ 
++if DARWIN
++AM_LIBTOOLFLAGS="--tag=CXX"
++AM_CPPFLAGS+=-I$(top_srcdir)/include/mega/osx
++endif
++
+ if WIN32
+ AM_CPPFLAGS+=-I$(top_srcdir)/include/mega/win32
+ else

--- a/pkgs/by-name/me/megacmd/fix-ffmpeg.patch
+++ b/pkgs/by-name/me/megacmd/fix-ffmpeg.patch
@@ -1,0 +1,29 @@
+--- a/sdk/src/gfx/freeimage.cpp
++++ b/sdk/src/gfx/freeimage.cpp
+@@ -216,11 +216,13 @@ bool GfxProviderFreeImage::readbitmapFreeimage(const LocalPath& imagePath, int s
+ 
+ #ifdef HAVE_FFMPEG
+ 
++#if LIBAVCODEC_VERSION_MAJOR < 60
+ #ifdef AV_CODEC_CAP_TRUNCATED
+ #define CAP_TRUNCATED AV_CODEC_CAP_TRUNCATED
+ #else
+ #define CAP_TRUNCATED CODEC_CAP_TRUNCATED
+ #endif
++#endif
+ 
+ const char *GfxProviderFreeImage::supportedformatsFfmpeg()
+ {
+@@ -323,10 +325,12 @@ bool GfxProviderFreeImage::readbitmapFfmpeg(const LocalPath& imagePath, int size
+ 
+     // Force seeking to key frames
+     formatContext->seek2any = false;
++#if LIBAVCODEC_VERSION_MAJOR < 60
+     if (decoder->capabilities & CAP_TRUNCATED)
+     {
+         codecContext->flags |= CAP_TRUNCATED;
+     }
++#endif
+ 
+     AVPixelFormat sourcePixelFormat = static_cast<AVPixelFormat>(codecParm->format);
+     AVPixelFormat targetPixelFormat = AV_PIX_FMT_BGR24; //raw data expected by freeimage is in this format

--- a/pkgs/by-name/me/megacmd/package.nix
+++ b/pkgs/by-name/me/megacmd/package.nix
@@ -1,29 +1,33 @@
-{ lib
-, stdenv
-, autoreconfHook
-, c-ares
-, cryptopp
-, curl
-, fetchFromGitHub
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  c-ares,
+  cryptopp,
+  curl,
+  fetchFromGitHub,
   # build fails with latest ffmpeg, see https://github.com/meganz/MEGAcmd/issues/523.
   # to be re-enabled when patch available
-  # , ffmpeg
-, gcc-unwrapped
-, icu
-, libmediainfo
-, libraw
-, libsodium
-, libuv
-, libzen
-, pcre-cpp
-, pkg-config
-, readline
-, sqlite
+  # ffmpeg,
+  gcc-unwrapped,
+  icu,
+  libmediainfo,
+  libraw,
+  libsodium,
+  libuv,
+  libzen,
+  pcre-cpp,
+  pkg-config,
+  readline,
+  sqlite,
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "megacmd";
   version = "1.7.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "meganz";
@@ -34,7 +38,10 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   buildInputs = [
     c-ares
@@ -71,11 +78,17 @@ stdenv.mkDerivation rec {
     "--with-termcap"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "MEGA Command Line Interactive and Scriptable Application";
     homepage = "https://mega.io/cmd";
-    license = with licenses; [ bsd2 gpl3Only ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ lunik1 ];
+    license = with lib.licenses; [
+      bsd2
+      gpl3Only
+    ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with lib.maintainers; [ lunik1 ];
   };
 }

--- a/pkgs/by-name/me/megacmd/package.nix
+++ b/pkgs/by-name/me/megacmd/package.nix
@@ -6,9 +6,8 @@
   cryptopp,
   curl,
   fetchFromGitHub,
-  # build fails with latest ffmpeg, see https://github.com/meganz/MEGAcmd/issues/523.
-  # to be re-enabled when patch available
-  # ffmpeg,
+  ffmpeg,
+  freeimage,
   gcc-unwrapped,
   icu,
   libmediainfo,
@@ -20,6 +19,7 @@
   pkg-config,
   readline,
   sqlite,
+  withFreeImage ? false, # default to false because freeimage is insecure
 }:
 
 let
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     c-ares
     cryptopp
     curl
-    # ffmpeg
+    ffmpeg
     icu
     gcc-unwrapped
     libmediainfo
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
     pcre-cpp
     readline
     sqlite
-  ];
+  ] ++ lib.optionals withFreeImage [ freeimage ];
 
   configureFlags = [
     "--disable-curl-checks"
@@ -66,8 +66,7 @@ stdenv.mkDerivation {
     "--with-cares"
     "--with-cryptopp"
     "--with-curl"
-    # "--with-ffmpeg"
-    "--without-freeimage" # disabled as freeimage is insecure
+    "--with-ffmpeg"
     "--with-icu"
     "--with-libmediainfo"
     "--with-libuv"
@@ -76,6 +75,10 @@ stdenv.mkDerivation {
     "--with-readline"
     "--with-sodium"
     "--with-termcap"
+  ] ++ (if withFreeImage then [ "--with-freeimage" ] else [ "--without-freeimage" ]);
+
+  patches = [
+    ./fix-ffmpeg.patch # https://github.com/meganz/sdk/issues/2635#issuecomment-1495405085
   ];
 
   meta = {
@@ -89,6 +92,9 @@ stdenv.mkDerivation {
       "i686-linux"
       "x86_64-linux"
     ];
-    maintainers = with lib.maintainers; [ lunik1 ];
+    maintainers = with lib.maintainers; [
+      lunik1
+      ulysseszhan
+    ];
   };
 }

--- a/pkgs/by-name/me/megacmd/package.nix
+++ b/pkgs/by-name/me/megacmd/package.nix
@@ -25,17 +25,29 @@
 let
   pname = "megacmd";
   version = "1.7.0";
+  srcOptions =
+    if stdenv.isLinux then
+      {
+        tag = "${version}_Linux";
+        hash = "sha256-UlSqwM8GQKeG8/K0t5DbM034NQOeBg+ujNi/MMsVCuM=";
+      }
+    else
+      {
+        tag = "${version}_macOS";
+        hash = "sha256-UlSqwM8GQKeG8/K0t5DbM034NQOeBg+ujNi/MMsVCuM=";
+      };
 in
 stdenv.mkDerivation {
   inherit pname version;
 
-  src = fetchFromGitHub {
-    owner = "meganz";
-    repo = "MEGAcmd";
-    rev = "${version}_Linux";
-    hash = "sha256-UlSqwM8GQKeG8/K0t5DbM034NQOeBg+ujNi/MMsVCuM=";
-    fetchSubmodules = true;
-  };
+  src = fetchFromGitHub (
+    srcOptions
+    // {
+      owner = "meganz";
+      repo = "MEGAcmd";
+      fetchSubmodules = true;
+    }
+  );
 
   enableParallelBuilding = true;
   nativeBuildInputs = [
@@ -43,25 +55,26 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  buildInputs = [
-    c-ares
-    cryptopp
-    curl
-    ffmpeg
-    icu
-    gcc-unwrapped
-    libmediainfo
-    libraw
-    libsodium
-    libuv
-    libzen
-    pcre-cpp
-    readline
-    sqlite
-  ] ++ lib.optionals withFreeImage [ freeimage ];
+  buildInputs =
+    lib.optionals stdenv.isLinux [ gcc-unwrapped ] # fix: ld: cannot find lib64/libstdc++fs.a
+    ++ [
+      c-ares
+      cryptopp
+      curl
+      ffmpeg
+      icu
+      libmediainfo
+      libraw
+      libsodium
+      libuv
+      libzen
+      pcre-cpp
+      readline
+      sqlite
+    ]
+    ++ lib.optionals withFreeImage [ freeimage ];
 
   configureFlags = [
-    "--disable-curl-checks"
     "--disable-examples"
     "--with-cares"
     "--with-cryptopp"
@@ -77,8 +90,14 @@ stdenv.mkDerivation {
     "--with-termcap"
   ] ++ (if withFreeImage then [ "--with-freeimage" ] else [ "--without-freeimage" ]);
 
+  # On darwin, some macros defined in AssertMacros.h (from apple-sdk) are conflicting.
+  postConfigure = ''
+    echo '#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0' >> sdk/include/mega/config.h
+  '';
+
   patches = [
     ./fix-ffmpeg.patch # https://github.com/meganz/sdk/issues/2635#issuecomment-1495405085
+    ./fix-darwin.patch # fix: libtool tag not found; MacFileSystemAccess not declared; server cannot init
   ];
 
   meta = {
@@ -88,10 +107,7 @@ stdenv.mkDerivation {
       bsd2
       gpl3Only
     ];
-    platforms = [
-      "i686-linux"
-      "x86_64-linux"
-    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       lunik1
       ulysseszhan


### PR DESCRIPTION
Add FFmpeg support via a patch. Add FreeImage support optionally (user can risk the insecurity by overriding an argument). Add Darwin support.

Closes #297586.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
