### PR TITLE
libbladeRF: gcc-14 fixes

### DIFF
--- a/pkgs/by-name/li/libbladeRF/gcc-14-calloc-fixes.diff
+++ b/pkgs/by-name/li/libbladeRF/gcc-14-calloc-fixes.diff
@@ -1,0 +1,26 @@
+diff --git a/host/utilities/bladeRF-fsk/c/src/fir_filter.c b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+index 59f34f0..7def697 100644
+--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.c
++++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+@@ -213,18 +213,18 @@ int main(int argc, char *argv[])
+         return EXIT_FAILURE;
+     }
+ 
+-    inbuf = calloc(2*sizeof(int16_t), chunk_size);
++    inbuf = calloc(chunk_size, 2*sizeof(int16_t));
+     if (!inbuf) {
+         perror("calloc");
+         goto out;
+     }
+-    tempbuf = calloc(2*sizeof(int16_t), chunk_size);
++    tempbuf = calloc(chunk_size, 2*sizeof(int16_t));
+     if (!tempbuf) {
+         perror("calloc");
+         goto out;
+     }
+ 
+-    outbuf = calloc(sizeof(struct complex_sample), chunk_size);
++    outbuf = calloc(chunk_size, sizeof(struct complex_sample));
+     if (!outbuf) {
+         perror("calloc");
+         goto out;

--- a/pkgs/by-name/li/libbladeRF/package.nix
+++ b/pkgs/by-name/li/libbladeRF/package.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # https://github.com/Nuand/bladeRF/issues/994
+    ./gcc-14-calloc-fixes.diff
+  ];
+
   nativeBuildInputs = [ cmake pkg-config git doxygen help2man ];
   # ncurses used due to https://github.com/Nuand/bladeRF/blob/ab4fc672c8bab4f8be34e8917d3f241b1d52d0b8/host/utilities/bladeRF-cli/CMakeLists.txt#L208
   buildInputs = [ tecla libusb1 ]


### PR DESCRIPTION
fix build for gcc-14

> host/utilities/bladeRF-fsk/c/src/fir_filter.c:227:28:
error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument
  227 |     outbuf = calloc(sizeof(struct complex_sample), chunk_size);

https://cache.nixos.org/log/hsg1v3cl1hk9ca77rgkng6n6dabz1bi3-libbladeRF-2.5.0.drv

https://github.com/Nuand/bladeRF/issues/994
https://github.com/NixOS/nixpkgs/pull/361878

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
