### PR TITLE
[staging-next] chromium: libgbm -> mesa

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -37,7 +37,7 @@
 , bison, gperf, libkrb5
 , glib, gtk3, dbus-glib
 , libXScrnSaver, libXcursor, libXtst, libxshmfence, libGLU, libGL
-, libgbm
+, mesa
 , pciutils, protobuf, speechd-minimal, libXdamage, at-spi2-core
 , pipewire
 , libva
@@ -246,7 +246,7 @@ let
       util-linux alsa-lib
       libkrb5
       glib gtk3 dbus-glib
-      libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL libgbm
+      libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL mesa
       pciutils protobuf speechd-minimal libXdamage at-spi2-core
       pipewire
       libva
@@ -273,7 +273,7 @@ let
       util-linux alsa-lib
       libkrb5
       glib gtk3 dbus-glib
-      libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL libgbm
+      libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL mesa
       pciutils protobuf speechd-minimal libXdamage at-spi2-core
       pipewire
       libva


### PR DESCRIPTION
Regression from #342794

Otherwise chromium complains about not finding the "dri" package. Let me know if there is a better way to fix this error.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).