### PR TITLE
nixos/podman: add systemd to extraPackages

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -6,10 +6,10 @@ let
   inherit (lib) mkOption types;
 
   podmanPackage = pkgs.podman.override {
-    extraPackages = cfg.extraPackages
-      # setuid shadow
-      ++ [ "/run/wrappers" ]
-      ++ lib.optional (config.boot.supportedFilesystems.zfs or false) config.boot.zfs.package;
+    extraPackages = cfg.extraPackages ++ [
+        "/run/wrappers" # setuid shadow
+        config.systemd.package # To allow systemd-based container healthchecks
+      ] ++ lib.optional (config.boot.supportedFilesystems.zfs or false) config.boot.zfs.package;
     extraRuntimes = [ pkgs.runc ]
       ++ lib.optionals (config.virtualisation.containers.containersConf.settings.network.default_rootless_network_cmd or "" == "slirp4netns") (with pkgs; [
       slirp4netns


### PR DESCRIPTION
Podman [uses `systemd-run`](https://github.com/containers/podman/blob/26605568a139ff7d4a1c5d80453fc206dab317b9/libpod/healthcheck_linux.go#L55-L56) to generate transient `service` and `timer` definitions for container health checks in runtime. If `podman` is running in an environment with limited `PATH` (like a systemd service) it fails to create those units. Adding `systemd` to `extraPackages` fixes it.

<details>
  <summary>Example fail logs</summary>

```
Dec 05 12:11:08 geekomA5 authentik-server[2867767]: time="2024-12-05T12:11:08+09:00" level=debug msg="creating systemd-transient files: systemd-run [--property LogLevelMax=notice --setenv=PATH=/nix/store/9r7b1760x9hql8jnhsb6jd02si0395cj-fuse-overlayfs-1.14/bin:/nix/store/4wj2h8f0npnf7slsdgy1hy985pxpj4lx-util-linux-2.39.4-bin/bin:/nix/store/1f1nkj7wn1sh8jza118n8kza8yk2lz03-iptables-1.8.10/bin:/nix/store/nm1mkbxw0a0j2qsjg3m7l89q61r6b1qv-iproute2-6.11.0/bin:/run/wrappers/bin --unit 8a6f807f1477e24f4283c077e2a46b413216e91b63a64b745e027d0657434e46-7d7e481dea95779e --on-unit-inactive=30s --timer-property=AccuracySec=1s /nix/store/gx9xv5wwm9r9wbrxihs2l3yr2pibra25-podman-5.3.0/bin/.podman-wrapped --log-level=debug --syslog healthcheck run 8a6f807f1477e24f4283c077e2a46b413216e91b63a64b745e027d0657434e46]"
Dec 05 12:11:08 geekomA5 authentik-server[2867767]: time="2024-12-05T12:11:08+09:00" level=error
```

</details>

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
