### PR TITLE
[Backport release-24.11] zulip: build package from source

### DIFF
--- a/pkgs/by-name/zu/zulip/package.nix
+++ b/pkgs/by-name/zu/zulip/package.nix
@@ -74,7 +74,7 @@ buildNpmPackage rec {
     homepage = "https://zulip.com";
     license = licenses.asl20;
     maintainers = with maintainers; [ andersk ];
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
     mainProgram = "zulip";
   };
 }

--- a/pkgs/by-name/zu/zulip/package.nix
+++ b/pkgs/by-name/zu/zulip/package.nix
@@ -1,34 +1,73 @@
 { lib
-, fetchurl
-, appimageTools
+, fetchFromGitHub
+, buildNpmPackage
+, electron_32
+, makeDesktopItem
+, makeShellWrapper
+, copyDesktopItems
 }:
 
-let
+buildNpmPackage rec {
   pname = "zulip";
   version = "5.11.1";
 
-  src = fetchurl {
-    url = "https://github.com/zulip/zulip-desktop/releases/download/v${version}/Zulip-${version}-x86_64.AppImage";
-    hash = "sha256-t5qBm5+kTdeRMvcHpNbS5mp184UG/IqgJrtj7Ntcbb0=";
-    name="${pname}-${version}.AppImage";
+  src = fetchFromGitHub {
+    owner = "zulip";
+    repo = "zulip-desktop";
+    rev = "v${version}";
+    hash = "sha256-ELuQ/K5QhtS4QiTR35J9VtYNe1qBrS56Ay6mtcGL+FI=";
   };
 
-  appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
+  npmDepsHash = "sha256-13Rlqa7TC2JUq6q1b2U5X3EXpOJGZ62IeF163/mTo68=";
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
   };
 
-in appimageTools.wrapType2 {
-  inherit pname version src;
+  nativeBuildInputs = [
+    makeShellWrapper
+    copyDesktopItems
+  ];
 
-  runScript = "appimage-exec.sh -w ${appimageContents} -- \${NIXOS_OZONE_WL:+\${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}";
+  dontNpmBuild = true;
+  buildPhase = ''
+    runHook preBuild
 
-  extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/zulip.desktop $out/share/applications/zulip.desktop
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/zulip.png \
-      $out/share/icons/hicolor/512x512/apps/zulip.png
-    substituteInPlace $out/share/applications/zulip.desktop \
-      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+    npm run pack -- \
+      -c.electronDist=${electron_32}/libexec/electron \
+      -c.electronVersion=${electron_32.version}
+
+    runHook postBuild
   '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/lib/zulip"
+    cp -r dist/*-unpacked/resources/app.asar* "$out/share/lib/zulip/"
+
+    install -m 444 -D app/resources/zulip.png $out/share/icons/hicolor/512x512/apps/zulip.png
+
+    makeShellWrapper '${lib.getExe electron_32}' "$out/bin/zulip" \
+      --add-flags "$out/share/lib/zulip/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-wayland-ime=true}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zulip";
+      exec = "zulip %U";
+      icon = "zulip";
+      desktopName = "Zulip";
+      comment = "Zulip Desktop Client for Linux";
+      categories = [ "Chat" "Network" "InstantMessaging" ];
+      startupWMClass = "Zulip";
+      terminal = false;
+    })
+  ];
 
   meta = with lib; {
     description = "Desktop client for Zulip Chat";


### PR DESCRIPTION
This is the manual backport of #279545, automatic backport of which failed due to #358620.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
