### PR TITLE
bazel_8: init at 8.1.1

### DIFF
--- a/pkgs/by-name/ba/bazel_8/bazel_rc.patch
+++ b/pkgs/by-name/ba/bazel_8/bazel_rc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/cpp/option_processor.cc b/src/main/cpp/option_processor.cc
+index 8f8f15685f..a7ae52d1e4 100644
+--- a/src/main/cpp/option_processor.cc
++++ b/src/main/cpp/option_processor.cc
+@@ -56,7 +56,7 @@ OptionProcessor::OptionProcessor(
+     : workspace_layout_(workspace_layout),
+       startup_options_(std::move(default_startup_options)),
+       parse_options_called_(false),
+-      system_bazelrc_path_(BAZEL_SYSTEM_BAZELRC_PATH) {}
++      system_bazelrc_path_("@bazelSystemBazelRCPath@") {}
+ 
+ OptionProcessor::OptionProcessor(
+     const WorkspaceLayout* workspace_layout,

--- a/pkgs/by-name/ba/bazel_8/darwin_hacks/BlazeModule.java
+++ b/pkgs/by-name/ba/bazel_8/darwin_hacks/BlazeModule.java
@@ -1,0 +1,7 @@
+package com.google.devtools.build.lib.runtime;
+
+// We only need to capture enough details from Bazel source code
+// to make our modules compile and be binary-compatible.
+// This BlazeModule won't be injected into Bazel classpath.
+public abstract class BlazeModule {
+}

--- a/pkgs/by-name/ba/bazel_8/darwin_hacks/SleepPreventionModule.java
+++ b/pkgs/by-name/ba/bazel_8/darwin_hacks/SleepPreventionModule.java
@@ -1,0 +1,9 @@
+package com.google.devtools.build.lib.platform;
+
+import com.google.devtools.build.lib.runtime.BlazeModule;
+
+// This class can fail in Nix sandbox on Darwin so we replace
+// it with a stub version
+public final class SleepPreventionModule extends BlazeModule {
+  // do nothing
+}

--- a/pkgs/by-name/ba/bazel_8/darwin_hacks/SystemSuspensionModule.java
+++ b/pkgs/by-name/ba/bazel_8/darwin_hacks/SystemSuspensionModule.java
@@ -1,0 +1,15 @@
+package com.google.devtools.build.lib.platform;
+
+import com.google.devtools.build.lib.runtime.BlazeModule;
+
+// This class can fail in Nix sandbox on Darwin so we replace
+// it with a stub version
+public final class SystemSuspensionModule extends BlazeModule {
+  // do nothing
+
+  // this method is part of module interface
+  synchronized void suspendCallback(int reason) {
+    // do nothing
+  }
+}
+

--- a/pkgs/by-name/ba/bazel_8/darwin_hacks/default.nix
+++ b/pkgs/by-name/ba/bazel_8/darwin_hacks/default.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  buildJdk,
+  runJdk,
+  version,
+  writeScript,
+}:
+let
+  fakeBazelModules = stdenv.mkDerivation {
+    pname = "fakeBazelModules";
+    inherit version;
+    dontUnpack = true;
+    buildPhase = "
+      # Java file name needs to match class name so we need to copy
+      cp ${./BlazeModule.java} ./BlazeModule.java
+      cp ${./SystemSuspensionModule.java} ./SystemSuspensionModule.java
+      cp ${./SleepPreventionModule.java} ./SleepPreventionModule.java
+
+      # compile all sources
+      ${buildJdk}/bin/javac -d . BlazeModule.java SystemSuspensionModule.java SleepPreventionModule.java
+
+      # don't package BlazeModule.class as we want to use real base class, but a stub compatible version was needed to make
+      # fake modules compile
+      ${buildJdk}/bin/jar cf output.jar ./com/google/devtools/build/lib/platform/{SystemSuspension,SleepPrevention}Module.class
+    ";
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/
+      install -Dm755 output.jar $out/output.jar
+
+      runHook postInstall
+    '';
+
+  };
+  # bin/java wrapper that injects fake modules into classpath
+  jvmInterceptSh = writeScript "java" ''
+    #!/usr/bin/env bash
+
+    # replaces
+    # .. -jar foo.jar ..
+    # with
+    # .. -cp ..overrides..:foo.jar MainClass ..
+    # to inject fake modules classes into Bazel
+
+    for (( i=2; i <= "$#"; i++ )); do
+      if [[ "''${!i}" == "-jar" ]]; then
+        prev=$(( i - 1 ))
+        jar=$(( i + 1 ))
+        MAIN_CLASS=$(unzip -qc "''${!jar}" META-INF/MANIFEST.MF | grep "^Main-Class: " | cut -d " " -f 2- | tr -d "\r")
+        next=$(( jar + 1 ))
+        exec "${runJdk}/bin/java" "''${@:1:prev}" -cp "${fakeBazelModules}/output.jar:''${!jar}" "$MAIN_CLASS" "''${@:next}"
+      fi
+    done
+
+    echo "Failed to find -jar argument in: $@" >&2
+    exit 1
+  '';
+in
+{
+  jvmIntercept = stdenv.mkDerivation {
+    pname = "jvmIntercept";
+    inherit version;
+    dontUnpack = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      install -Dm755 ${jvmInterceptSh} $out/bin/java
+
+      runHook postInstall
+    '';
+  };
+
+}

--- a/pkgs/by-name/ba/bazel_8/darwin_sleep.patch
+++ b/pkgs/by-name/ba/bazel_8/darwin_sleep.patch
@@ -1,0 +1,56 @@
+diff --git a/src/main/native/darwin/sleep_prevention_jni.cc b/src/main/native/darwin/sleep_prevention_jni.cc
+index 67c35b201e..e50a58320e 100644
+--- a/src/main/native/darwin/sleep_prevention_jni.cc
++++ b/src/main/native/darwin/sleep_prevention_jni.cc
+@@ -33,31 +33,13 @@ static int g_sleep_state_stack = 0;
+ static IOPMAssertionID g_sleep_state_assertion = kIOPMNullAssertionID;
+ 
+ int portable_push_disable_sleep() {
+-  std::lock_guard<std::mutex> lock(g_sleep_state_mutex);
+-  BAZEL_CHECK_GE(g_sleep_state_stack, 0);
+-  if (g_sleep_state_stack == 0) {
+-    BAZEL_CHECK_EQ(g_sleep_state_assertion, kIOPMNullAssertionID);
+-    CFStringRef reasonForActivity = CFSTR("build.bazel");
+-    IOReturn success = IOPMAssertionCreateWithName(
+-        kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, reasonForActivity,
+-        &g_sleep_state_assertion);
+-    BAZEL_CHECK_EQ(success, kIOReturnSuccess);
+-  }
+-  g_sleep_state_stack += 1;
+-  return 0;
++  // Unreliable, disable for now
++  return -1;
+ }
+ 
+ int portable_pop_disable_sleep() {
+-  std::lock_guard<std::mutex> lock(g_sleep_state_mutex);
+-  BAZEL_CHECK_GT(g_sleep_state_stack, 0);
+-  g_sleep_state_stack -= 1;
+-  if (g_sleep_state_stack == 0) {
+-    BAZEL_CHECK_NE(g_sleep_state_assertion, kIOPMNullAssertionID);
+-    IOReturn success = IOPMAssertionRelease(g_sleep_state_assertion);
+-    BAZEL_CHECK_EQ(success, kIOReturnSuccess);
+-    g_sleep_state_assertion = kIOPMNullAssertionID;
+-  }
+-  return 0;
++  // Unreliable, disable for now
++  return -1;
+ }
+ 
+ }  // namespace blaze_jni
+diff --git a/src/main/native/darwin/system_suspension_monitor_jni.cc b/src/main/native/darwin/system_suspension_monitor_jni.cc
+index 3483aa7935..51782986ec 100644
+--- a/src/main/native/darwin/system_suspension_monitor_jni.cc
++++ b/src/main/native/darwin/system_suspension_monitor_jni.cc
+@@ -83,10 +83,7 @@ void portable_start_suspend_monitoring() {
+     // Register to receive system sleep notifications.
+     // Testing needs to be done manually. Use the logging to verify
+     // that sleeps are being caught here.
+-    suspend_state.connect_port = IORegisterForSystemPower(
+-        &suspend_state, &notifyPortRef, SleepCallBack, &notifierObject);
+-    BAZEL_CHECK_NE(suspend_state.connect_port, MACH_PORT_NULL);
+-    IONotificationPortSetDispatchQueue(notifyPortRef, queue);
++    // XXX: Unreliable, disable for now
+ 
+     // Register to deal with SIGCONT.
+     // We register for SIGCONT because we can't catch SIGSTOP.

--- a/pkgs/by-name/ba/bazel_8/java_toolchain.patch
+++ b/pkgs/by-name/ba/bazel_8/java_toolchain.patch
@@ -1,0 +1,30 @@
+diff --git a/tools/jdk/BUILD.tools b/tools/jdk/BUILD.tools
+index a8af76e90c..7f8b030f63 100644
+--- a/tools/jdk/BUILD.tools
++++ b/tools/jdk/BUILD.tools
+@@ -146,6 +146,25 @@ py_test(
+     ],
+ )
+ 
++##### Nonprebuilt toolchains definitions for NixOS and nix build sandboxes ####
++
++load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain", "NONPREBUILT_TOOLCHAIN_CONFIGURATION")
++
++[
++    default_java_toolchain(
++        name = "nonprebuilt_toolchain_java" + str(version),
++        configuration = NONPREBUILT_TOOLCHAIN_CONFIGURATION,
++        java_runtime = "@local_jdk//:jdk",
++        source_version = str(version),
++        target_version = str(version),
++    )
++    # Ideally we would only define toolchains for the java versions that the
++    # local jdk supports. But we cannot access this information in a BUILD
++    # file, and this is a hack anyway, so just pick a large enough upper bound.
++    # At the current pace, java <= 30 should cover all realeases until 2028.
++    for version in range(8, 31)
++]
++
+ #### Aliases to rules_java to keep backward-compatibility (begin) ####
+ 
+ TARGET_NAMES = [

--- a/pkgs/by-name/ba/bazel_8/nix-build-bazel-package-hacks.patch
+++ b/pkgs/by-name/ba/bazel_8/nix-build-bazel-package-hacks.patch
@@ -1,0 +1,47 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+index 53e6494656..22261cd268 100644
+--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
++++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+@@ -55,6 +55,7 @@ import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
+ import com.google.devtools.build.skyframe.SkyKey;
+ import com.google.devtools.build.skyframe.SkyValue;
+ import java.io.IOException;
++import java.util.Collections;
+ import java.util.Map;
+ import java.util.Optional;
+ import java.util.TreeMap;
+@@ -193,16 +194,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
+       }
+ 
+       if (shouldUseCachedRepos(env, handler, repoRoot, rule)) {
+-        // Make sure marker file is up-to-date; correctly describes the current repository state
+-        byte[] markerHash = digestWriter.areRepositoryAndMarkerFileConsistent(handler, env);
+-        if (env.valuesMissing()) {
+-          return null;
+-        }
+-        if (markerHash != null) { // repo exist & up-to-date
++        {
++          // Nix hack: Always consider cached dirs as up-to-date
+           return RepositoryDirectoryValue.builder()
+               .setPath(repoRoot)
+-              .setDigest(markerHash)
+-              .setExcludeFromVendoring(excludeRepoFromVendoring)
++              .setDigest(digestWriter.writeMarkerFile(Collections.emptyMap()))
+               .build();
+         }
+       }
+
+
+diff --git a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+index 649647c5f2..64d05b530c 100644
+--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
++++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+@@ -158,7 +158,6 @@ public class JavaSubprocessFactory implements SubprocessFactory {
+     ProcessBuilder builder = new ProcessBuilder();
+     builder.command(Lists.transform(params.getArgv(), StringEncoding::internalToPlatform));
+     if (params.getEnv() != null) {
+-      builder.environment().clear();
+       params
+           .getEnv()
+           .forEach(
+ 

--- a/pkgs/by-name/ba/bazel_8/package.nix
+++ b/pkgs/by-name/ba/bazel_8/package.nix
@@ -1,0 +1,836 @@
+{
+  stdenv,
+  # nix tooling and utilities
+  lib,
+  fetchurl,
+  fetchpatch,
+  makeWrapper,
+  writeTextFile,
+  writeScript,
+  substituteAll,
+  writeShellApplication,
+  makeBinaryWrapper,
+  autoPatchelfHook,
+  buildFHSEnv,
+  # native build inputs
+  runtimeShell,
+  zip,
+  unzip,
+  bash,
+  coreutils,
+  which,
+  gawk,
+  gnused,
+  gnutar,
+  gnugrep,
+  gzip,
+  findutils,
+  diffutils,
+  gnupatch,
+  file,
+  installShellFiles,
+  lndir,
+  python3,
+  # Apple dependencies
+  cctools,
+  libcxx,
+  libtool,
+  sigtool,
+  CoreFoundation,
+  CoreServices,
+  Foundation,
+  IOKit,
+  # Allow to independently override the jdks used to build and run respectively
+  buildJdk,
+  runJdk,
+  # Toggle for hacks for running bazel under buildBazelPackage:
+  # Always assume all markers valid (this is needed because we remove markers; they are non-deterministic).
+  # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
+  enableNixHacks ? false,
+  version ? "8.1.1",
+  # bazel codebase isn't guaranteed to be buildable by itself, but rather by .bazelversion bazel
+  # https://github.com/bazelbuild/bazel/issues/24583#issuecomment-2523198843
+  bootstrapVersion ? "8.0.1",
+}:
+
+let
+  sourceRoot = ".";
+
+  src = fetchurl {
+    url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
+    hash = "sha256-TJSHoW94QRUAkvB9k6ZyfWbyxBM6YX1zncqOyD+wCZw=";
+  };
+
+  defaultShellUtils =
+    # Keep this list conservative. For more exotic tools, prefer to use
+    # @rules_nixpkgs to pull in tools from the nix repository. Example:
+    #
+    # WORKSPACE:
+    #
+    #     nixpkgs_git_repository(
+    #         name = "nixpkgs",
+    #         revision = "def5124ec8367efdba95a99523dd06d918cb0ae8",
+    #     )
+    #
+    #     # This defines an external Bazel workspace.
+    #     nixpkgs_package(
+    #         name = "bison",
+    #         repositories = { "nixpkgs": "@nixpkgs//:default.nix" },
+    #     )
+    #
+    # some/BUILD.bazel:
+    #
+    #     genrule(
+    #        ...
+    #        cmd = "$(location @bison//:bin/bison) -other -args",
+    #        tools = [
+    #            ...
+    #            "@bison//:bin/bison",
+    #        ],
+    #     )
+    [
+      bash
+      coreutils
+      diffutils
+      file
+      findutils
+      gawk
+      gnugrep
+      gnupatch
+      gnused
+      gnutar
+      gzip
+      python3
+      unzip
+      which
+      zip
+      makeWrapper
+    ];
+
+  # Bootstrap an existing Bazel so we can vendor deps with vendor mode
+  bazelBootstrap = stdenv.mkDerivation rec {
+    name = "bazelBootstrap";
+
+    src =
+      {
+        x86_64-linux = fetchurl {
+          url = "https://github.com/bazelbuild/bazel/releases/download/${bootstrapVersion}/bazel_nojdk-${bootstrapVersion}-linux-x86_64";
+          hash = "sha256-KLejW8XcVQ3xD+kP9EGCRrODmHZwX7Sq3etdrVBNXHI=";
+        };
+        aarch64-linux = fetchurl {
+          url = "https://github.com/bazelbuild/bazel/releases/download/${bootstrapVersion}/bazel_nojdk-${bootstrapVersion}-linux-arm64";
+          hash = "sha256-+4GTKurt1KBkdyfC2hOLI31gBDOm1wTn91+kDX1di9M=";
+        };
+        x86_64-darwin = fetchurl {
+          url = "https://github.com/bazelbuild/bazel/releases/download/${bootstrapVersion}/bazel-${bootstrapVersion}-darwin-x86_64";
+          hash = "sha256-MsqLv4ZssUGQv7AZzhrEp9YbjLs/B3ETeXTo0OXN8es=";
+        };
+        aarch64-darwin = fetchurl {
+          url = "https://github.com/bazelbuild/bazel/releases/download/${bootstrapVersion}/bazel-${bootstrapVersion}-darwin-arm64";
+          hash = "sha256-0QrGSIVQxSEa7SAIT0Dft39jZ+IpsVoc8ocFeUHZMys=";
+        };
+      }
+      .${stdenv.hostPlatform.system};
+
+    nativeBuildInputs = defaultShellUtils;
+    buildInputs = [
+      stdenv.cc.cc
+    ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
+
+    dontUnpack = true;
+    dontPatch = true;
+    dontBuild = true;
+    dontStrip = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      install -Dm755 $src $out/bin/bazel
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      wrapProgram $out/bin/bazel \
+        --prefix PATH : ${lib.makeBinPath nativeBuildInputs}
+    '';
+
+    meta.sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+  # A FOD that vendors the Bazel dependencies using Bazel's new vendor mode.
+  # See https://bazel.build/versions/7.4.1/external/vendor for details.
+  # Note that it may be possible to vendor less than the full set of deps in
+  # the future, as this is approximately 1GB.
+  bazelVendorDeps =
+    let
+      bazelForDeps = bazelBootstrap;
+      # Bootstrap Bazel isn't reliably working on MacOS, under sandbox=true
+      # it may fail to make power management tweaks
+      # but we can hack out those modules with classpath manipilations
+      #
+      # Note that those stubs don't affect bazelVendorDeps outputs and aren't
+      # applied for bazel build step either, they are only needed to prevent
+      # build failures in sandbox
+      serverJavabase =
+        if stdenv.hostPlatform.isDarwin then
+          let
+            hacks = (import ./darwin_hacks/default.nix) {
+              inherit
+                stdenv
+                buildJdk
+                runJdk
+                version
+                writeScript
+                ;
+            };
+          in
+          hacks.jvmIntercept
+        else
+          runJdk;
+    in
+    stdenv.mkDerivation {
+      name = "bazelVendorDeps";
+      inherit src version;
+      sourceRoot = ".";
+      patches = [
+        # The repo rule that creates a manifest of the bazel source for testing
+        # the cli is not reproducible. This patch ensures that it is by sorting
+        # the results in the repo rule rather than the downstream genrule.
+        ./test_source_sort.patch
+      ];
+      patchFlags = [
+        "--no-backup-if-mismatch"
+        "-p1"
+      ];
+      nativeBuildInputs = [
+        unzip
+        runJdk
+        bazelForDeps
+        stdenv.cc.cc
+      ] ++ lib.optional (stdenv.hostPlatform.isDarwin) libtool;
+      buildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
+      configurePhase = ''
+        runHook preConfigure
+
+        mkdir bazel_src
+        shopt -s dotglob extglob
+        mv !(bazel_src) bazel_src
+        mkdir vendor_dir
+
+        runHook postConfigure
+      '';
+      dontFixup = true;
+      buildPhase = ''
+        runHook preBuild
+
+        export HOME=$(mktemp -d)
+        export JAVA_HOME=${runJdk.home}
+
+        cd bazel_src
+
+        ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+          # process-wrapper links against libstdc++.so.6 so we need to apply patchelf to
+          # it and any other potential unpacked tools
+          export INSTALL_BASE=$(${bazelForDeps}/bin/bazel --batch info install_base)
+
+          # Bazel checks integrity of unpacked files by setting timestamp into future
+          # and then comparing it, so we should preserve the timestamps
+          touch -r $INSTALL_BASE/process-wrapper save_time
+
+          autoPatchelf "$INSTALL_BASE"
+
+          find $INSTALL_BASE -exec touch -r save_time '{}' \;
+        ''}
+
+        # note: --host_jvm_args is a workaround for https://github.com/bazelbuild/bazel/issues/25479
+        # FATAL: bazel crashed due to an internal error. Printing stack trace:
+        # java.lang.IllegalAccessError: class com.google.devtools.build.lib.util.Blocker (in unnamed module @0x57fa26b7) cannot access class jdk.internal.misc.Blocker (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x57fa26b7
+        ${bazelForDeps}/bin/bazel \
+        --server_javabase=${serverJavabase} \
+        --host_jvm_args="--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED" \
+        --batch \
+        vendor src:bazel_nojdk \
+        --curses=no \
+        --vendor_dir ../vendor_dir \
+        --verbose_failures \
+        --experimental_strict_java_deps=off \
+        --strict_proto_deps=off \
+        --tool_java_runtime_version=local_jdk_21 \
+        --java_runtime_version=local_jdk_21 \
+        --tool_java_language_version=21 \
+        --java_language_version=21
+
+        cd ..
+
+        # Some post-fetch fixup is necessary, because the deps come with some
+        # baggage that is not reproducible. Luckily, this baggage does not factor
+        # into the final product, so removing it is enough.
+
+        # .pyc files are poisonous
+        find vendor_dir -name "*.pyc" -type f -delete
+
+        # those symlinks point to locations under bazel_src/
+        find vendor_dir -name imported_maven_install.json -exec rm '{}' \;
+
+        # bazel-external is auto-generated and should be removed
+        # see https://bazel.build/external/vendor#vendor-symlinks for more details
+        rm vendor_dir/bazel-external
+
+        # patch for
+        # > ERROR: noBrokenSymlinks: the symlink /nix/store/awkpn1zndcmx59n3d1khqsbyy1m2s9f3-bazelDeps/vendor_dir/rules_python++python+python_3_11_x86_64-unknown-linux-gnu/python points to a missing target: /nix/store/awkpn1zndcmx59n3d1khqsbyy1m2s9f3-bazelDeps/vendor_dir/bazel-external/rules_python++python+python_3_11_x86_64-unknown-linux-gnu/bin/python3
+        find vendor_dir -name python -type l -exec rm '{}' \;
+
+        # .marker files seem to make Nix unhappy with FOD output on MacOS
+        # and make "store path invalid"
+        find vendor_dir -name "*.marker" -exec rm '{}' \;
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        mkdir -p $out/vendor_dir
+        cp -r --reflink=auto vendor_dir/* $out/vendor_dir
+      '';
+
+      outputHashMode = "recursive";
+      outputHash =
+        {
+          x86_64-linux = "sha256-UbQboDfQHOiaPfhd5YvZsUzq/8sUiKsIt0XdRkJ8aBY=";
+          aarch64-linux = "sha256-q4gGFhyKJSS9BbU52uYeZJFzl0IUmr8lvsId6S0OHAk=";
+          aarch64-darwin = "sha256-7k0GIdWXL2VeRbffQ5UO/Uo4gCaaNXycrwTo1+LEdVc=";
+          x86_64-darwin = "sha256-gKCvg22K0CMfxE5t/jqGguOY6nbaJY6eldEKcXJgJ/I=";
+        }
+        .${stdenv.hostPlatform.system};
+      outputHashAlgo = "sha256";
+
+    };
+  declareSedVerbose = ''
+    function sedVerbose() {
+      local path=$1; shift;
+      sed -i".bak-nix" "$path" "$@"
+      diff -U0 "$path.bak-nix" "$path" | sed "s/^/  /" || true
+      rm -f "$path.bak-nix"
+    }
+  '';
+
+  # bazelVendorDeps have some references to "/usr/bin/env python3" that
+  # need to be replaced.
+  #
+  # Note that it can't easily be combined with bazelVendorDeps FOD because
+  # it produces output with references to Nix store and those aren't allowed
+  # by default for FOD, also listing all allowed references isn't as easy as
+  # just listing "python3" as allowed reference.
+  # So we add this extra non-FOD derivation.
+  bazelDeps = stdenv.mkDerivation {
+    name = "bazelDeps";
+    inherit version;
+
+    dontUnpack = true;
+
+    buildPhase =
+      declareSedVerbose
+      + ''
+        cp -r ${bazelVendorDeps} $out
+        chmod -R +w $out
+
+        ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+          sed -i -e 's;"/usr/bin/libtool";_find_generic(repository_ctx, "libtool", "LIBTOOL", overriden_tools);g' $out/vendor_dir/rules_cc+/cc/private/toolchain/unix_cc_configure.bzl
+          wrappers=( $out/vendor_dir/rules_cc+/cc/private/toolchain/osx_cc_wrapper.sh.tpl )
+          for wrapper in "''${wrappers[@]}"; do
+            sedVerbose $wrapper \
+              -e "s,/usr/bin/xcrun install_name_tool,${cctools}/bin/install_name_tool,g"
+          done
+        ''}
+        # https://github.com/bazelbuild/bazel/issues/25124
+        ${lib.optionalString stdenv.hostPlatform.isDarwin ''patch -d $out/vendor_dir/rules_java++toolchains+remote_java_tools/java_tools/zlib/ -p1 < ${
+          fetchpatch {
+            url = "https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9.patch";
+            hash = "sha256-qEwNnZjtU2Bq5cy3YKWq36gnYDy8NQtYBlo8pH4m8ds=";
+          }
+        }''}
+
+        echo
+        echo "Substituting /usr/bin/env hardcoded paths"
+        # Prefilter the files with grep for speed
+        grep -rlZ /bin/ $out \
+        | while IFS="" read -r -d "" path; do
+          # If you add more replacements here, you must change the grep above!
+          # Only files containing /bin/ are taken into account.
+          sedVerbose "$path" \
+            -e 's!/usr/bin/env python3!${python3}/bin/python!g'
+        done
+
+      '';
+  };
+
+  defaultShellPath = lib.makeBinPath defaultShellUtils;
+
+  bashWithDefaultShellUtilsSh = writeShellApplication {
+    name = "bash";
+    runtimeInputs = defaultShellUtils;
+    text = ''
+      if [[ "$PATH" == "/no-such-path" ]]; then
+        export PATH=${defaultShellPath}
+      fi
+      exec ${bash}/bin/bash "$@"
+    '';
+  };
+
+  # Script-based interpreters in shebangs aren't guaranteed to work,
+  # especially on MacOS. So let's produce a binary
+  bashWithDefaultShellUtils = stdenv.mkDerivation {
+    name = "bash";
+    src = bashWithDefaultShellUtilsSh;
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      makeWrapper ${bashWithDefaultShellUtilsSh}/bin/bash $out/bin/bash
+    '';
+  };
+
+  platforms = lib.platforms.linux ++ lib.platforms.darwin;
+
+  inherit (stdenv.hostPlatform) isDarwin isAarch64;
+
+  system = if isDarwin then "darwin" else "linux";
+
+  # on aarch64 Darwin, `uname -m` returns "arm64"
+  arch = with stdenv.hostPlatform; if isDarwin && isAarch64 then "arm64" else parsed.cpu.name;
+
+  bazelRC = writeTextFile {
+    name = "bazel-rc";
+    text = ''
+      startup --server_javabase=${runJdk}
+
+      # Register nix-specific nonprebuilt java toolchains
+      build --extra_toolchains=@bazel_tools//tools/jdk:all
+      # and set bazel to use them by default
+      build --tool_java_runtime_version=local_jdk
+      build --java_runtime_version=local_jdk
+
+      # load default location for the system wide configuration
+      try-import /etc/bazel.bazelrc
+    '';
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "bazel";
+  inherit version src;
+  inherit sourceRoot;
+
+  patches =
+    [
+      # Remote java toolchains do not work on NixOS because they download binaries,
+      # so we need to use the @local_jdk//:jdk
+      # It could in theory be done by registering @local_jdk//:all toolchains,
+      # but these java toolchains still bundle binaries for ijar and stuff. So we
+      # need a nonprebult java toolchain (where ijar and stuff is built from
+      # sources).
+      # There is no such java toolchain, so we introduce one here.
+      # By providing no version information, the toolchain will set itself to the
+      # version of $JAVA_HOME/bin/java, just like the local_jdk does.
+      # To ensure this toolchain gets used, we can set
+      # --{,tool_}java_runtime_version=local_jdk and rely on the fact no java
+      # toolchain registered by default uses the local_jdk, making the selection
+      # unambiguous.
+      # This toolchain has the advantage that it can use any ambiant java jdk,
+      # not only a given, fixed version. It allows bazel to work correctly in any
+      # environment where JAVA_HOME is set to the right java version, like inside
+      # nix derivations.
+      # However, this patch breaks bazel hermeticity, by picking the ambiant java
+      # version instead of the more hermetic remote_jdk prebuilt binaries that
+      # rules_java provide by default. It also requires the user to have a
+      # JAVA_HOME set to the exact version required by the project.
+      # With more code, we could define java toolchains for all the java versions
+      # supported by the jdk as in rules_java's
+      # toolchains/local_java_repository.bzl, but this is not implemented here.
+      # To recover vanilla behavior, non NixOS users can set
+      # --{,tool_}java_runtime_version=remote_jdk, effectively reverting the
+      # effect of this patch and the fake system bazelrc.
+      ./java_toolchain.patch
+
+      # Bazel integrates with apple IOKit to inhibit and track system sleep.
+      # Inside the darwin sandbox, these API calls are blocked, and bazel
+      # crashes. It seems possible to allow these APIs inside the sandbox, but it
+      # feels simpler to patch bazel not to use it at all. So our bazel is
+      # incapable of preventing system sleep, which is a small price to pay to
+      # guarantee that it will always run in any nix context.
+      #
+      # See also ./bazel_darwin_sandbox.patch in bazel_5. That patch uses
+      # NIX_BUILD_TOP env var to conditionnally disable sleep features inside the
+      # sandbox.
+      #
+      # If you want to investigate the sandbox profile path,
+      # IORegisterForSystemPower can be allowed with
+      #
+      #     propagatedSandboxProfile = ''
+      #       (allow iokit-open (iokit-user-client-class "RootDomainUserClient"))
+      #     '';
+      #
+      # I do not know yet how to allow IOPMAssertion{CreateWithName,Release}
+      ./darwin_sleep.patch
+
+      # Fix DARWIN_XCODE_LOCATOR_COMPILE_COMMAND by removing multi-arch support.
+      # Nixpkgs toolcahins do not support that (yet?) and get confused.
+      # Also add an explicit /usr/bin prefix that will be patched below.
+      ./xcode_locator.patch
+
+      # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
+      # This is breaking the build of any C target. This patch removes the last
+      # argument if it's found to be an empty string.
+      ./trim-last-argument-to-gcc-if-empty.patch
+
+      # --experimental_strict_action_env (which may one day become the default
+      # see bazelbuild/bazel#2574) hardcodes the default
+      # action environment to a non hermetic value (e.g. "/usr/local/bin").
+      # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
+      # So we are replacing this bazel paths by defaultShellPath,
+      # improving hermeticity and making it work in nixos.
+      (substituteAll {
+        src = ./strict_action_env.patch;
+        strictActionEnvPatch = defaultShellPath;
+      })
+
+      # bazel reads its system bazelrc in /etc
+      # override this path to a builtin one
+      (substituteAll {
+        src = ./bazel_rc.patch;
+        bazelSystemBazelRCPath = bazelRC;
+      })
+    ]
+    # https://github.com/bazelbuild/bazel/issues/25124
+    ++ lib.optional stdenv.hostPlatform.isDarwin (fetchpatch {
+      url = "https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9.patch";
+      hash = "sha256-wlZY0/XqND5Fk+SJkUCUj7XhGVwUJw/VqVGAlDdqOhs=";
+      stripLen = 1;
+      extraPrefix = "third_party/zlib/";
+    })
+    # See enableNixHacks argument above.
+    ++ lib.optional enableNixHacks ./nix-build-bazel-package-hacks.patch;
+
+  postPatch =
+    let
+      darwinPatches = ''
+        bazelLinkFlags () {
+          eval set -- "$NIX_LDFLAGS"
+          local flag
+          for flag in "$@"; do
+            printf ' -Wl,%s' "$flag"
+          done
+        }
+
+        # Explicitly configure gcov since we don't have it on Darwin, so autodetection fails
+        export GCOV=${coreutils}/bin/false
+
+        # Framework search paths aren't added by bintools hook
+        # https://github.com/NixOS/nixpkgs/pull/41914
+        export NIX_LDFLAGS+=" -F${CoreFoundation}/Library/Frameworks -F${CoreServices}/Library/Frameworks -F${Foundation}/Library/Frameworks -F${IOKit}/Library/Frameworks"
+
+        # libcxx includes aren't added by libcxx hook
+        # https://github.com/NixOS/nixpkgs/pull/41589
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+        # for CLang 16 compatibility in external/upb dependency
+        export NIX_CFLAGS_COMPILE+=" -Wno-gnu-offsetof-extensions"
+
+        # This variable is used by bazel to propagate env vars for homebrew,
+        # which is exactly what we need too.
+        export HOMEBREW_RUBY_PATH="foo"
+
+        # don't use system installed Xcode to run clang, use Nix clang instead
+        sed -i -E \
+          -e "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \
+          -e "s;/usr/bin/codesign;CODESIGN_ALLOCATE=${cctools}/bin/${cctools.targetPrefix}codesign_allocate ${sigtool}/bin/codesign;" \
+          scripts/bootstrap/compile.sh \
+          tools/osx/BUILD
+
+        # nixpkgs's libSystem cannot use pthread headers directly, must import GCD headers instead
+        sed -i -e "/#include <pthread\/spawn.h>/i #include <dispatch/dispatch.h>" src/main/cpp/blaze_util_darwin.cc
+      '';
+
+      genericPatches = ''
+        # unzip builtins_bzl.zip so the contents get patched
+        builtins_bzl=src/main/java/com/google/devtools/build/lib/bazel/rules/builtins_bzl
+        unzip ''${builtins_bzl}.zip -d ''${builtins_bzl}_zip >/dev/null
+        rm ''${builtins_bzl}.zip
+        builtins_bzl=''${builtins_bzl}_zip/builtins_bzl
+
+        # md5sum is part of coreutils
+        sed -i 's|/sbin/md5|md5sum|g' src/BUILD third_party/ijar/test/testenv.sh
+
+        echo
+        echo "Substituting */bin/* hardcoded paths in src/main/java/com/google/devtools"
+        # Prefilter the files with grep for speed
+        grep -rlZ /bin/ \
+          src/main/java/com/google/devtools \
+          src/main/starlark/builtins_bzl/common/python \
+          tools \
+        | while IFS="" read -r -d "" path; do
+          # If you add more replacements here, you must change the grep above!
+          # Only files containing /bin are taken into account.
+          sedVerbose "$path" \
+            -e 's!/usr/local/bin/bash!${bashWithDefaultShellUtils}/bin/bash!g' \
+            -e 's!/usr/bin/bash!${bashWithDefaultShellUtils}/bin/bash!g' \
+            -e 's!/bin/bash!${bashWithDefaultShellUtils}/bin/bash!g' \
+            -e 's!/usr/bin/env bash!${bashWithDefaultShellUtils}/bin/bash!g' \
+            -e 's!/usr/bin/env python3!${python3}/bin/python!g' \
+            -e 's!/usr/bin/env python2!${python3}/bin/python!g' \
+            -e 's!/usr/bin/env python!${python3}/bin/python!g' \
+            -e 's!/usr/bin/env!${coreutils}/bin/env!g' \
+            -e 's!/bin/true!${coreutils}/bin/true!g'
+        done
+
+        # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
+        sedVerbose scripts/bootstrap/compile.sh \
+          -e 's!/bin/bash!${bashWithDefaultShellUtils}/bin/bash!g' \
+          -e 's!shasum -a 256!sha256sum!g'
+
+        # Add required flags to bazel command line.
+        # XXX: It would suit a bazelrc file better, but I found no way to pass it.
+        #      It seems that bazel bootstrapping ignores it.
+        #      Passing EXTRA_BAZEL_ARGS is tricky due to quoting.
+        sedVerbose compile.sh \
+          -e "/bazel_build /a\  --verbose_failures \\\\" \
+          -e "/bazel_build /a\  --curses=no \\\\" \
+          -e "/bazel_build /a\  --toolchain_resolution_debug=.* \\\\" \
+          -e "/bazel_build /a\  --tool_java_runtime_version=local_jdk_21 \\\\" \
+          -e "/bazel_build /a\  --java_runtime_version=local_jdk_21 \\\\" \
+          -e "/bazel_build /a\  --tool_java_language_version=21 \\\\" \
+          -e "/bazel_build /a\  --java_language_version=21 \\\\" \
+          -e "/bazel_build /a\  --extra_toolchains=@bazel_tools//tools/jdk:all \\\\" \
+          -e "/bazel_build /a\  --vendor_dir=../vendor_dir \\\\" \
+          -e "/bazel_build /a\  --repository_disable_download \\\\" \
+          -e "/bazel_build /a\  --announce_rc \\\\" \
+          -e "/bazel_build /a\  --nobuild_python_zip \\\\" \
+          -e "/bazel_build /a\  --features=-module_maps --host_features=-module_maps \\\\" \
+
+        # Aligned allocation should only be available on MacOS 10.13+
+        # For some reason with darwinMinVersion >= 10.13 build still fails with default cxxopt
+        ${lib.optionalString
+          (stdenv.hostPlatform.isDarwin # && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13"
+          )
+          ''
+            sedVerbose compile.sh \
+              -e "/bazel_build /a\  --cxxopt=-fno-aligned-allocation --host_cxxopt=-fno-aligned-allocation \\\\" \
+          ''
+        }
+
+        # Also build parser_deploy.jar with bootstrap bazel
+        # TODO: Turn into a proper patch
+        sedVerbose compile.sh \
+          -e 's!bazel_build !bazel_build src/tools/execlog:parser_deploy.jar !' \
+          -e 's!clear_log!cp $(get_bazel_bin_path)/src/tools/execlog/parser_deploy.jar output\nclear_log!'
+
+        # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
+        echo "PATH=\$PATH:${defaultShellPath}" >> runfiles.bash.tmp
+        cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
+        mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
+
+        # reconstruct the now patched builtins_bzl.zip
+        pushd src/main/java/com/google/devtools/build/lib/bazel/rules/builtins_bzl_zip &>/dev/null
+          zip ../builtins_bzl.zip $(find builtins_bzl -type f) >/dev/null
+          rm -rf builtins_bzl
+        popd &>/dev/null
+        rmdir src/main/java/com/google/devtools/build/lib/bazel/rules/builtins_bzl_zip
+
+        patchShebangs . >/dev/null
+      '';
+    in
+    declareSedVerbose + lib.optionalString stdenv.hostPlatform.isDarwin darwinPatches + genericPatches;
+
+  meta = with lib; {
+    homepage = "https://github.com/bazelbuild/bazel/";
+    description = "Build tool that builds code quickly and reliably";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
+    license = licenses.asl20;
+    maintainers = lib.teams.bazel.members;
+    inherit platforms;
+  };
+
+  # Bazel starts a local server and needs to bind a local address.
+  __darwinAllowLocalNetworking = true;
+
+  buildInputs = [
+    buildJdk
+    bashWithDefaultShellUtils
+  ] ++ defaultShellUtils;
+
+  # when a command can’t be found in a bazel build, you might also
+  # need to add it to `defaultShellPath`.
+  nativeBuildInputs =
+    [
+      installShellFiles
+      makeWrapper
+      python3
+      unzip
+      which
+      zip
+      python3.pkgs.absl-py # Needed to build fish completion
+    ]
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) stdenv.cc # Needed for execlog
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+      cctools
+      libcxx
+      Foundation
+      CoreFoundation
+      CoreServices
+    ];
+
+  # Bazel makes extensive use of symlinks in the WORKSPACE.
+  # This causes problems with infinite symlinks if the build output is in the same location as the
+  # Bazel WORKSPACE. This is why before executing the build, the source code is moved into a
+  # subdirectory.
+  # Failing to do this causes "infinite symlink expansion detected"
+  preBuildPhases = [ "preBuildPhase" ];
+  preBuildPhase = ''
+    mkdir bazel_src
+    shopt -s dotglob extglob
+    mv !(bazel_src) bazel_src
+    # Augment bundled repository_cache with our extra paths
+    mkdir vendor_dir
+    ${lndir}/bin/lndir -silent ${bazelDeps}/vendor_dir vendor_dir
+    rm vendor_dir/VENDOR.bazel
+    find vendor_dir -maxdepth 1 -type d -printf "pin(\"@@%P\")\n" > vendor_dir/VENDOR.bazel
+  '';
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$(mktemp -d)
+
+    # If EMBED_LABEL isn't set, it'd be auto-detected from CHANGELOG.md
+    # and `git rev-parse --short HEAD` which would result in
+    # "3.7.0- (@non-git)" due to non-git build and incomplete changelog.
+    # Actual bazel releases use scripts/release/common.sh which is based
+    # on branch/tag information which we don't have with tarball releases.
+    # Note that .bazelversion is always correct and is based on bazel-*
+    # executable name, version checks should work fine
+    export EMBED_LABEL="${version}- (@non-git)"
+
+    echo "Stage 1 - Running bazel bootstrap script"
+    ${bash}/bin/bash ./bazel_src/compile.sh
+
+    # XXX: get rid of this, or move it to another stage.
+    # It is plain annoying when builds fail.
+    echo "Stage 2 - Generate bazel completions"
+    ${bash}/bin/bash ./bazel_src/scripts/generate_bash_completion.sh \
+        --bazel=./bazel_src/output/bazel \
+        --output=./bazel_src/output/bazel-complete.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-header.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-template.bash
+    ${python3}/bin/python3 ./bazel_src/scripts/generate_fish_completion.py \
+        --bazel=./bazel_src/output/bazel \
+        --output=./bazel_src/output/bazel-complete.fish
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel if
+    # it can’t find something in tools, it calls
+    # $out/bin/bazel-{version}-{os_arch} The binary _must_ exist with this
+    # naming if your project contains a .bazelversion file.
+    cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
+    versionned_bazel="$out/bin/bazel-${version}-${system}-${arch}"
+    mv ./bazel_src/output/bazel "$versionned_bazel"
+    wrapProgram "$versionned_bazel" --suffix PATH : ${defaultShellPath}
+
+    mkdir $out/share
+    cp ./bazel_src/output/parser_deploy.jar $out/share/parser_deploy.jar
+    cat <<EOF > $out/bin/bazel-execlog
+    #!${runtimeShell} -e
+    ${runJdk}/bin/java -jar $out/share/parser_deploy.jar \$@
+    EOF
+    chmod +x $out/bin/bazel-execlog
+
+    # shell completion files
+    installShellCompletion --bash \
+      --name bazel.bash \
+      ./bazel_src/output/bazel-complete.bash
+    installShellCompletion --zsh \
+      --name _bazel \
+      ./bazel_src/scripts/zsh_completion/_bazel
+    installShellCompletion --fish \
+      --name bazel.fish \
+      ./bazel_src/output/bazel-complete.fish
+  '';
+
+  installCheckPhase = ''
+    export TEST_TMPDIR=$(pwd)
+
+    hello_test () {
+      $out/bin/bazel test \
+        --test_output=errors \
+        examples/cpp:hello-success_test \
+        examples/java-native/src/test/java/com/example/myproject:hello
+    }
+
+    cd ./bazel_src
+
+    # If .bazelversion file is present in dist files and doesn't match `bazel` version
+    # running `bazel` command within bazel_src will fail.
+    # Let's remove .bazelversion within the test, if present it is meant to indicate bazel version
+    # to compile bazel with, not version of bazel to be built and tested.
+    rm -f .bazelversion
+
+    # test whether $WORKSPACE_ROOT/tools/bazel works
+
+    mkdir -p tools
+    cat > tools/bazel <<"EOF"
+    #!${runtimeShell} -e
+    exit 1
+    EOF
+
+    chmod +x tools/bazel
+
+    # first call should fail if tools/bazel is used
+    ! hello_test
+
+    cat > tools/bazel <<"EOF"
+    #!${runtimeShell} -e
+    exec "$BAZEL_REAL" "$@"
+    EOF
+
+    # second call succeeds because it defers to $out/bin/bazel-{version}-{os_arch}
+    hello_test
+
+    ## Test that the GSON serialisation files are present
+    gson_classes=$(unzip -l $(bazel info install_base)/A-server.jar | grep GsonTypeAdapter.class | wc -l)
+    if [ "$gson_classes" -lt 10 ]; then
+      echo "Missing GsonTypeAdapter classes in A-server.jar. Lockfile generation will not work"
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+
+  # Save paths to hardcoded dependencies so Nix can detect them.
+  # This is needed because the templates get tar’d up into a .jar.
+  postFixup =
+    ''
+      mkdir -p $out/nix-support
+      echo "${defaultShellPath}" >> $out/nix-support/depends
+      # The string literal specifying the path to the bazel-rc file is sometimes
+      # stored non-contiguously in the binary due to gcc optimisations, which leads
+      # Nix to miss the hash when scanning for dependencies
+      echo "${bazelRC}" >> $out/nix-support/depends
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      echo "${cctools}" >> $out/nix-support/depends
+    '';
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  passthru = {
+    # TODO add some tests to cover basic functionality, and also tests for enableNixHacks=true (buildBazelPackage tests)
+    # tests = ...
+
+    # For ease of debugging
+    inherit bazelVendorDeps bazelDeps;
+  };
+}

--- a/pkgs/by-name/ba/bazel_8/strict_action_env.patch
+++ b/pkgs/by-name/ba/bazel_8/strict_action_env.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+index a70b5559bc..10bdffe961 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -466,7 +466,7 @@ public class BazelRuleClassProvider {
+       // Note that --action_env does not propagate to the host config, so it is not a viable
+       // workaround when a genrule is itself built in the host config (e.g. nested genrules). See
+       // #8536.
+-      return "/bin:/usr/bin:/usr/local/bin";
++      return "@strictActionEnvPatch@";
+     }
+
+     String newPath = "";

--- a/pkgs/by-name/ba/bazel_8/test_source_sort.patch
+++ b/pkgs/by-name/ba/bazel_8/test_source_sort.patch
@@ -1,0 +1,15 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 14fc32418c..a22d39233e 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -368,10 +368,6 @@ rbe_preconfig(
+     toolchain = "ubuntu2004",
+ )
+ 
+-list_source_repository = use_repo_rule("//src/test/shell/bazel:list_source_repository.bzl", "list_source_repository")
+-
+-list_source_repository(name = "local_bazel_source_list")
+-
+ winsdk_configure = use_repo_rule("//src/main/res:winsdk_configure.bzl", "winsdk_configure")
+ 
+ winsdk_configure(name = "local_config_winsdk")

--- a/pkgs/by-name/ba/bazel_8/trim-last-argument-to-gcc-if-empty.patch
+++ b/pkgs/by-name/ba/bazel_8/trim-last-argument-to-gcc-if-empty.patch
@@ -1,0 +1,37 @@
+From 177b4720d6fbaa7fdd17e5e11b2c79ac8f246786 Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Thu, 27 Jun 2019 21:08:51 -0700
+Subject: [PATCH] Trim last argument to gcc if empty, on Darwin
+
+On Darwin, the last argument to GCC is coming up as an empty string.
+This is breaking the build of proto_library targets. However, I was not
+able to reproduce with the example cpp project[0].
+
+This commit removes the last argument if it's an empty string. This is
+not a problem on Linux.
+
+[0]: https://github.com/bazelbuild/examples/tree/master/cpp-tutorial/stage3
+---
+ tools/cpp/osx_cc_wrapper.sh.tpl | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tools/cpp/osx_cc_wrapper.sh.tpl b/tools/cpp/osx_cc_wrapper.sh.tpl
+index 4c85cd9b6b..6c611e3d25 100644
+--- a/tools/cpp/osx_cc_wrapper.sh.tpl
++++ b/tools/cpp/osx_cc_wrapper.sh.tpl
+@@ -53,7 +53,11 @@ done
+ %{env}
+ 
+ # Call the C++ compiler
+-%{cc} "$@"
++if [[ ${*: -1} = "" ]]; then
++    %{cc} "${@:0:$#}"
++else
++    %{cc} "$@"
++fi
+ 
+ function get_library_path() {
+     for libdir in ${LIB_DIRS}; do
+-- 
+2.19.2
+

--- a/pkgs/by-name/ba/bazel_8/xcode_locator.patch
+++ b/pkgs/by-name/ba/bazel_8/xcode_locator.patch
@@ -1,0 +1,13 @@
+--- a/tools/osx/BUILD
++++ b/tools/osx/BUILD
+@@ -28,8 +28,8 @@ exports_files([
+ 
+ DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
+   /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
+-      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
++      -framework Foundation                          -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
+-  env -i codesign --identifier $@ --force --sign - $@
++  /usr/bin/env -i /usr/bin/codesign --identifier $@ --force --sign - $@
+ """
+ 
+ genrule(

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7546,6 +7546,16 @@ with pkgs;
     bazel_self = bazel_7;
   };
 
+  bazel_8 = darwin.apple_sdk_11_0.callPackage ../by-name/ba/bazel_8/package.nix {
+    inherit (darwin) sigtool;
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation CoreServices Foundation IOKit;
+    buildJdk = jdk21_headless;
+    runJdk = jdk21_headless;
+    stdenv = if stdenv.hostPlatform.isDarwin then darwin.apple_sdk_11_0.stdenv
+      else if stdenv.cc.isClang then llvmPackages.stdenv
+      else stdenv;
+  };
+
   buildifier = bazel-buildtools;
   buildozer = bazel-buildtools;
   unused_deps = bazel-buildtools;


### PR DESCRIPTION
Started with copying `bazel_7` and adapted it, notable changes:
- `bazelDeps` now builds on Darwin in `sandbox=true` which was previously failing on power management tweaks
- using `lndir -silent` for less build logs
- had to disable `module_deps` feature to avoid getting `.. does not depend on a module exporting ..` errors on clang/macos importing intrinsics
- on macos adding `-fno-aligned-allocation` on sdk <10.13 to avoid build error saying it isn't supported on <10.13
- placing under `pkgs/by-name` to pass CI, but still calling from `pkgs/top-level/all-packages.nix` as not sure how to pass darwin sdk and other settings in by-name way

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
