### PR TITLE
dotnet: wrapper improvements

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -52,8 +52,7 @@
     {
       name = "dotnet-fixup-hook";
       substitutions = {
-        # this is used for DOTNET_ROOT, so we need unwrapped
-        dotnetRuntime = if (dotnet-runtime != null) then dotnet-runtime.unwrapped else null;
+        dotnetRuntime = if (dotnet-runtime != null) then dotnet-runtime else null;
         wrapperPath = lib.makeBinPath [ which coreutils ];
       };
     }

--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -32,7 +32,7 @@
 let
   dyalogHome = "$out/lib/dyalog";
 
-  makeWrapperArgs = lib.optional dotnetSupport "--set DOTNET_ROOT ${dotnet-sdk_8.unwrapped}/share/dotnet";
+  makeWrapperArgs = lib.optional dotnetSupport "--set DOTNET_ROOT ${dotnet-sdk_8}/share/dotnet";
 
   licenseUrl = "https://www.dyalog.com/uploads/documents/Developer_Software_Licence.pdf";
 

--- a/pkgs/by-name/ne/netcoredbg/package.nix
+++ b/pkgs/by-name/ne/netcoredbg/package.nix
@@ -36,7 +36,7 @@ let
 
     cmakeFlags = [
       "-DCORECLR_DIR=${coreclr-src}/src/coreclr"
-      "-DDOTNET_DIR=${dotnet-sdk.unwrapped}/share/dotnet"
+      "-DDOTNET_DIR=${dotnet-sdk}/share/dotnet"
       "-DBUILD_MANAGED=0"
     ];
   };

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -93,7 +93,7 @@ buildPythonApplication rec {
              VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1 LANG=en_US.UTF-8
 
       # Resolve `.NET location: Not found` errors for dotnet tests
-      export DOTNET_ROOT="${dotnet-sdk.unwrapped}/share/dotnet"
+      export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"
 
       export HOME=$(mktemp -d)
 

--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -20,7 +20,7 @@ assert lib.assertMsg ((builtins.length dotnetPackages) > 0) ''
          ];`'';
 (buildEnv {
   name = "dotnet-core-combined";
-  paths = map (x: x.unwrapped) dotnetPackages;
+  paths = dotnetPackages;
   pathsToLink = map (x: "/share/dotnet/${x}") [
     "host"
     "packs"
@@ -34,7 +34,7 @@ assert lib.assertMsg ((builtins.length dotnetPackages) > 0) ''
   postBuild =
     ''
       mkdir -p "$out"/share/dotnet
-      cp "${cli.unwrapped}"/share/dotnet/dotnet $out/share/dotnet
+      cp "${cli}"/share/dotnet/dotnet $out/share/dotnet
       cp -R "${cli}"/nix-support "$out"/
       mkdir "$out"/bin
       ln -s "$out"/share/dotnet/dotnet "$out"/bin/dotnet

--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -4,6 +4,7 @@ dotnetPackages:
   makeWrapper,
   lib,
   symlinkJoin,
+  callPackage,
 }:
 # TODO: Rethink how we determine and/or get the CLI.
 #       Possible options raised in #187118:
@@ -12,14 +13,15 @@ dotnetPackages:
 #         3. Something else?
 let
   cli = builtins.head dotnetPackages;
+  mkWrapper = callPackage ./wrapper.nix { };
 in
 assert lib.assertMsg ((builtins.length dotnetPackages) > 0) ''
   You must include at least one package, e.g
         `with dotnetCorePackages; combinePackages [
             sdk_6_0 aspnetcore_7_0
          ];`'';
-(buildEnv {
-  name = "dotnet-core-combined";
+mkWrapper "sdk" (buildEnv {
+  name = "dotnet-combined";
   paths = dotnetPackages;
   pathsToLink = map (x: "/share/dotnet/${x}") [
     "host"
@@ -43,6 +45,8 @@ assert lib.assertMsg ((builtins.length dotnetPackages) > 0) ''
       ln -s ${cli.man} $man
     '';
   passthru = {
+    pname = "dotnet";
+    version = "combined";
     inherit (cli) icu;
 
     versions = lib.catAttrs "version" dotnetPackages;
@@ -53,9 +57,4 @@ assert lib.assertMsg ((builtins.length dotnetPackages) > 0) ''
   };
 
   inherit (cli) meta;
-}).overrideAttrs
-  ({
-    outputs = [
-      "out"
-    ] ++ lib.optional (cli ? man) "man";
-  })
+})

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -46,8 +46,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p "$out"/bin "$out"/share/dotnet
+    mkdir -p "$out"/bin "$out"/share
     ln -s "$src"/bin/* "$out"/bin
+    ln -s "$src"/share/dotnet "$out"/share
     runHook postInstall
   '';
 
@@ -125,8 +126,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               )
               (
                 lib.optionalString (runtime != null) ''
-                  # TODO: use runtime here
-                  export DOTNET_ROOT=${runtime.unwrapped}/share/dotnet
+                  export DOTNET_ROOT=${runtime}/share/dotnet
                 ''
                 + run
               );

--- a/pkgs/test/dotnet/use-dotnet-from-env/default.nix
+++ b/pkgs/test/dotnet/use-dotnet-from-env/default.nix
@@ -21,7 +21,7 @@ let
       removeReferencesTo
     ];
     postFixup = (oldAttrs.postFixup or "") + ''
-      remove-references-to -t ${dotnet-runtime.unwrapped} "$out/bin/Application"
+      remove-references-to -t ${dotnet-runtime} "$out/bin/Application"
     '';
   });
 
@@ -46,7 +46,7 @@ in
   use-dotnet-root-env = testers.testEqualContents {
     assertion = "buildDotnetModule uses DOTNET_ROOT from environment in wrapper";
     expected = runtimeVersionFile;
-    actual = runCommand "use-dotnet-from-env-root-test" { env.DOTNET_ROOT = "${dotnet-runtime.unwrapped}/share/dotnet"; } ''
+    actual = runCommand "use-dotnet-from-env-root-test" { env.DOTNET_ROOT = "${dotnet-runtime}/share/dotnet"; } ''
       ${appWithoutFallback}/bin/Application >"$out"
     '';
   };


### PR DESCRIPTION
This makes it so wrappers contain a symlink to `DOTNET_ROOT` in `/usr/share/dotnet`, so you don't have to use `unwrapped`.

I think the potential for breakage is pretty low.  You'd have to depend on the symlink not existing, or use a wrapper in an environment in a way that conflicts with an unwrapped SDK.

Cc: @NixOS/dotnet 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
