### PR TITLE
nixos/cinnamon: Add x-cinnamon-mimeapps.list

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -135,6 +135,17 @@ in
       };
 
       environment.systemPackages = with pkgs; ([
+        # Teach nemo-desktop how to launch file browser.
+        # https://github.com/linuxmint/nemo/blob/6.4.0/src/nemo-desktop-application.c#L398
+        (writeTextFile {
+          name = "x-cinnamon-mimeapps";
+          destination = "/share/applications/x-cinnamon-mimeapps.list";
+          text = ''
+            [Default Applications]
+            inode/directory=nemo.desktop
+          '';
+        })
+
         desktop-file-utils
 
         # common-files


### PR DESCRIPTION
This is specifically for https://github.com/linuxmint/nemo/blob/6.4.0/src/nemo-desktop-application.c#L398.

The same thing is already done in the GNOME module. Otherwise when you e.g try "Downloads" -> "Show in Folder"
in Firefox, it will just do nothing, this is probably not a good experience.

ref: https://salsa.debian.org/cinnamon-team/cinnamon-desktop/-/blob/debian/6.2.0-1/debian/x-cinnamon-mimeapps.list
ref: https://src.fedoraproject.org/rpms/cinnamon-desktop/blob/f41/f/x-cinnamon-mimeapps.list

https://github.com/NixOS/nixpkgs/blob/608bb54d5005f1003f0a6d00f864166c52f48b62/nixos/modules/services/x11/desktop-managers/gnome.nix#L10-L17


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

