### PR TITLE
foomatic-db: update & fix version numbers

### DIFF
--- a/pkgs/by-name/fo/foomatic-db-engine/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-engine/package.nix
@@ -17,7 +17,7 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "foomatic-db-engine";
-  version = "unstable-2024-02-10";
+  version = "0-unstable-2024-02-10";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,

--- a/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-db-nonfree";
-  version = "unstable-2015-06-05";
+  version = "0-unstable-2015-06-05";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -13,15 +13,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-db";
-  version = "0-unstable-2024-08-13";
+  version = "0-unstable-2024-12-05";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db";
-    rev = "359508733741039b65c86e7a1318a89862e03b13";
-    hash = "sha256-DSduuSC9XX2+fS2XOQ4/FrmBzOu7rgfNDeLzpcBplsY=";
+    rev = "9a7a08318598fea569cf073489709899c9af6143";
+    hash = "sha256-7vvJPhUa4oDe101Iv897LoChNIcdTa4LviLUndHxWtw=";
   };
 
   buildInputs = [ cups cups-filters ghostscript gnused perl ];

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-db";
-  version = "unstable-2024-08-13";
+  version = "0-unstable-2024-08-13";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,


### PR DESCRIPTION
*   Change version numbers of all `foomatic-db*` packages so that they start with a digit, as mandated by https://github.com/NixOS/nixpkgs/tree/nixos-unstable/pkgs#versioning .  (I guess this broke long ago when `name` got split up into `pname` and `version` and the substring "unstable" got part of `version`.)
*   Update `foomatic-db` to latest upstream repo commit.  This [merely adds one Oki printer](https://github.com/OpenPrinting/foomatic-db/commit/9a7a08318598fea569cf073489709899c9af6143).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>foomatic-db</li>
    <li>foomatic-db-engine</li>
    <li>foomatic-db-nonfree</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>ptouch-driver</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc