### PR TITLE
materialious-desktop: init at 1.6.23

### DIFF
--- a/pkgs/by-name/ma/materialious-desktop/package.nix
+++ b/pkgs/by-name/ma/materialious-desktop/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  makeDesktopItem,
+  nix-update-script,
+}:
+
+let
+  pname = "materialious-desktop";
+  version = "1.6.23";
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/Materialious/Materialious/${version}/branding/Materialious.png";
+    sha256 = "sha256-VmuBAfhpNO3UdhdEQ7cZV/FI8jJgg4mNyLvIY3slIoY=";
+  };
+
+  desktopItem = makeDesktopItem {
+    inherit icon;
+    name = pname;
+    exec = pname;
+    desktopName = "Materialious";
+    genericName = "Invidious Frontend";
+  };
+
+  dist =
+    {
+      aarch64-linux = {
+        arch = "arm64";
+        sha256 = "sha256-1qwJWrRJLdKAKTSDq7m0OWgQ3I1/aBJJwi1rW3TxhQM=";
+      };
+
+      x86_64-linux = {
+        arch = "x86_64";
+        sha256 = "sha256-2a75l7/aVkyi0NXkyGYZiRTKGvzQ9evk7hC+JTBgPZk=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+appimageTools.wrapType2 {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://github.com/Materialious/Materialious/releases/download/${version}/Materialious-${version}-linux-${dist.arch}.AppImage";
+    hash = dist.sha256;
+  };
+
+  extraInstallCommands = ''
+    mkdir "$out/share"
+    ln -s "${desktopItem}/share/applications" "$out/share/"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern material design desktop app for Invidious";
+    homepage = "https://materialio.us";
+    license = [ lib.licenses.agpl3Plus ];
+    maintainers = with lib.maintainers; [ romner-set ];
+    mainProgram = "materialious-desktop";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
A privacy respecting frontend for YouTube built on top of Invidious.

https://materialio.us/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
