### PR TITLE
doc: include nixdoc for `lib.fetchers`

### DIFF
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -49,6 +49,10 @@
       description = "path functions";
     }
     {
+      name = "fetchers";
+      description = "functions which can be reused across [fetchers](#chap-pkgs-fetchers)";
+    }
+    {
       name = "filesystem";
       description = "filesystem functions";
     }

--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -50,7 +50,7 @@
     }
     {
       name = "fetchers";
-      description = "functions which can be reused across [fetchers](#chap-pkgs-fetchers)";
+      description = "functions which can be reused across fetchers";
     }
     {
       name = "filesystem";

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -155,6 +155,9 @@
   "sec-functions-library-cli": [
     "index.html#sec-functions-library-cli"
   ],
+  "sec-functions-library-fetchers": [
+    "index.html#sec-functions-library-fetchers"
+  ],
   "sec-functions-library-generators": [
     "index.html#sec-functions-library-generators"
   ],


### PR DESCRIPTION
Add `lib.fetchers` to the `libset` in `lib-function-docs.nix`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] `nix-build doc`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
