### PR TITLE
Frida-tools update + frida-python update

### DIFF
--- a/pkgs/by-name/fr/frida-tools/package.nix
+++ b/pkgs/by-name/fr/frida-tools/package.nix
@@ -1,4 +1,8 @@
-{ lib, fetchPypi, python3Packages }:
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "frida-tools";
@@ -14,6 +18,7 @@ python3Packages.buildPythonApplication rec {
     prompt-toolkit
     colorama
     frida-python
+    websockets
   ];
 
   meta = {

--- a/pkgs/development/python-modules/frida-python/default.nix
+++ b/pkgs/development/python-modules/frida-python/default.nix
@@ -1,67 +1,36 @@
 {
   lib,
-  stdenv,
-  fetchurl,
   fetchPypi,
   buildPythonPackage,
-  typing-extensions,
-  darwin,
 }:
-let
-  version = "16.0.19";
-  format = "setuptools";
 
-  devkit = {
-    aarch64-darwin = fetchurl {
-      url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-arm64.tar.xz";
-      hash = "sha256-5VAZnpHQ5wjl7IM96GhIKOfFYHFDKKOoSjN1STna2UA=";
-    };
-
-    x86_64-linux = fetchurl {
-      url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
-      hash = "sha256-yNXNqv8eCbpdQKFShpAh6rUCEuItrOSNNLOjESimPdk=";
-    };
-  }.${stdenv.hostPlatform.system}
-    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-
-in
 buildPythonPackage rec {
   pname = "frida-python";
-  inherit version;
+  version = "16.5.7";
+  format = "wheel";
 
   src = fetchPypi {
     pname = "frida";
-    inherit version;
-    hash = "sha256-rikIjjn9wA8VL/St/2JJTcueimn+q/URbt9lw/+nalY=";
+    inherit version format;
+    hash = "sha256-+2P+Be7xDWBHesqcGupt6gGdUmda0zIp8HkyJqzGgio=";
+    platform = "manylinux1_x86_64";
+    abi = "abi3";
+    python = "cp37";
+    dist = "cp37";
   };
 
-  postPatch = ''
-    mkdir assets
-    pushd assets
-    tar xvf ${devkit}
-    export FRIDA_CORE_DEVKIT=$PWD
-    popd
-  '';
-
-  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AppKit";
-
-  propagatedBuildInputs = [ typing-extensions ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.AppKit
+  pythonImportsCheck = [
+    "frida"
+    "frida._frida"
   ];
-
-  pythonImportsCheck = [ "frida" ];
-
-  passthru = {
-    inherit devkit;
-  };
 
   meta = {
     description = "Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers (Python bindings)";
     homepage = "https://www.frida.re";
     license = lib.licenses.wxWindows;
     maintainers = with lib.maintainers; [ s1341 ];
-    platforms = [ "aarch64-darwin" "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+    ];
   };
 }


### PR DESCRIPTION
Frida is currently broken on master, because of upstream changes to the build system.
We really do not want to build Frida from source, based on the amount of vendored pieces of software that's used, and where the build system is completely changed to use Meson instead (might be easier than I think, maybe??)

Therefore, we just use the wheel files provided on Pypi instead.

I've tested this, and it works fine. Unsure if people without `nix-ld` will have issues however, but it can't be worse than it currently  is.

This does NOT have Mac support, and I have no way to test it, or add it, etc. And it could easily be done in a future PR, as stated, the current thing in master does not work.

Fixes https://github.com/NixOS/nixpkgs/issues/353295

Fixes https://github.com/NixOS/nixpkgs/issues/316092

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
