### PR TITLE
Revert "splice.nix: make `pkgs` `splicedPackages`"

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -1,6 +1,7 @@
-{ lib, pkgs, erlang }:
+{ lib, __splicedPackages, erlang }:
 
 let
+  pkgs = __splicedPackages;
   inherit (lib) makeExtensible;
 
   lib' = pkgs.callPackage ./lib.nix { };

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,5 +1,8 @@
-{ pkgs, lib }:
+{ __splicedPackages, lib }:
 
+let
+  pkgs = __splicedPackages;
+in
 rec {
 
   /* Similar to callPackageWith/callPackage, but without makeOverridable

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -19,7 +19,11 @@ let
         # - adds spliced package sets to the package set
         ({ stdenv, pkgs, perl, callPackage, makeScopeWithSplicing' }: let
           perlPackagesFun = callPackage ../../../top-level/perl-packages.nix {
-            inherit stdenv pkgs;
+            # allow 'perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig; }; }' like in python3Packages
+            # most perl packages aren't called with callPackage so it's not possible to override their arguments individually
+            # the conditional is because the // above won't be applied to __splicedPackages and hopefully no one is doing that when cross-compiling
+            pkgs = if stdenv.buildPlatform != stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
+            inherit stdenv;
             perl = self;
           };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5393,7 +5393,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });
+  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins {
+    pkgs = pkgs.__splicedPackages;
+  });
 
   tokei = callPackage ../development/tools/misc/tokei {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -5754,7 +5756,7 @@ with pkgs;
 
   yarn-berry = callPackage ../development/tools/yarn-berry { };
 
-  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea/yarn2nix { };
+  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea/yarn2nix { pkgs = pkgs.__splicedPackages; };
 
   inherit (yarn2nix-moretea)
     yarn2nix
@@ -6461,6 +6463,7 @@ with pkgs;
 
   idrisPackages = dontRecurseIntoAttrs (callPackage ../development/idris-modules {
     idris-no-deps = haskellPackages.idris;
+    pkgs = pkgs.__splicedPackages;
   });
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
@@ -16944,7 +16947,8 @@ with pkgs;
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
   openraPackages_2019 = import ../games/openra_2019 {
-    inherit lib pkgs;
+    inherit lib;
+    pkgs = pkgs.__splicedPackages;
   };
 
   openra_2019 = openraPackages_2019.engines.release;

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -151,8 +151,6 @@ in
 
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
-  pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;
-
   # prefill 2 fields of the function for convenience
   makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
   makeScopeWithSplicing' = lib.makeScopeWithSplicing' { inherit splicePackages; inherit (pkgs) newScope; };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#349316

```
       … in the right operand of the update (//) operator
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:32:59:
           31|         # Other pkgs sets
           32|         pkgsBuildBuild // pkgsBuildTarget // pkgsHostHost // pkgsTargetTarget
             |                                                           ^
           33|         # The same pkgs sets one probably intends

       … in the left operand of the update (//) operator
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:34:9:
           33|         # The same pkgs sets one probably intends
           34|         // pkgsBuildHost // pkgsHostTarget;
             |         ^
           35|       merge = name: {

       … from call site
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:79:32:
           78|             pkgsHostTarget = getOutputs valueHostTarget;
           79|             pkgsTargetTarget = tryGetOutputs valueTargetTarget;
             |                                ^
           80|             # Just recur on plain attrsets

       … while calling 'tryGetOutputs'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:62:29:
           61|             # on {}
           62|             tryGetOutputs = value0:
             |                             ^
           63|               let

       … from call site
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:66:15:
           65|               in
           66|               getOutputs (lib.optionalAttrs success value);
             |               ^
           67|             getOutputs = value: lib.genAttrs

       … while calling 'getOutputs'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:67:26:
           66|               getOutputs (lib.optionalAttrs success value);
           67|             getOutputs = value: lib.genAttrs
             |                          ^
           68|               (value.outputs or (lib.optional (value ? out) "out"))

       … from call site
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:67:33:
           66|               getOutputs (lib.optionalAttrs success value);
           67|             getOutputs = value: lib.genAttrs
             |                                 ^
           68|               (value.outputs or (lib.optional (value ? out) "out"))

       … while calling 'genAttrs'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/lib/attrsets.nix:1246:5:
         1245|     names:
         1246|     f:
             |     ^
         1247|     listToAttrs (map (n: nameValuePair n (f n)) names);

       … while calling the 'listToAttrs' builtin
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/lib/attrsets.nix:1247:5:
         1246|     f:
         1247|     listToAttrs (map (n: nameValuePair n (f n)) names);
             |     ^
         1248|

       … while calling the 'map' builtin
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/lib/attrsets.nix:1247:18:
         1246|     f:
         1247|     listToAttrs (map (n: nameValuePair n (f n)) names);
             |                  ^
         1248|

       … from call site
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:66:27:
           65|               in
           66|               getOutputs (lib.optionalAttrs success value);
             |                           ^
           67|             getOutputs = value: lib.genAttrs

       … while calling 'optionalAttrs'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/lib/attrsets.nix:1351:5:
         1350|     cond:
         1351|     as:
             |     ^
         1352|     if cond then as else {};

       … while evaluating a branch condition
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/lib/attrsets.nix:1352:5:
         1351|     as:
         1352|     if cond then as else {};
             |     ^
         1353|

       … while calling the 'tryEval' builtin
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/splice.nix:64:26:
           63|               let
           64|                 inherit (builtins.tryEval value0) success value;
             |                          ^
           65|               in

       … while evaluating the attribute 'gcc13Stdenv'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/all-packages.nix:6065:3:
         6064|   gcc12Stdenv = overrideCC gccStdenv buildPackages.gcc12;
         6065|   gcc13Stdenv = overrideCC gccStdenv buildPackages.gcc13;
             |   ^
         6066|   gcc14Stdenv = overrideCC gccStdenv buildPackages.gcc14;

       … from call site
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/all-packages.nix:6065:17:
         6064|   gcc12Stdenv = overrideCC gccStdenv buildPackages.gcc12;
         6065|   gcc13Stdenv = overrideCC gccStdenv buildPackages.gcc13;
             |                 ^
         6066|   gcc14Stdenv = overrideCC gccStdenv buildPackages.gcc14;

       … while calling 'overrideCC'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/stdenv/adapters.nix:35:24:
           34|   # Override the compiler in stdenv for specific packages.
           35|   overrideCC = stdenv: cc: stdenv.override {
             |                        ^
           36|     allowedRequisites = null;

       … while evaluating a branch condition
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/all-packages.nix:6051:5:
         6050|   gccStdenv =
         6051|     if stdenv.cc.isGNU
             |     ^
         6052|     then stdenv

       … while evaluating the attribute 'cc.isGNU'
         at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/stdenv/generic/default.nix:168:15:
          167|
          168|       inherit cc hasCC;
             |               ^
          169|

       error: infinite recursion encountered
       at /nix/store/3h4h1w28dnzwn4x7ldj17kdnnkhh09m0-source/pkgs/top-level/all-packages.nix:6051:8:
         6050|   gccStdenv =
         6051|     if stdenv.cc.isGNU
             |        ^
         6052|     then stdenv
         ```
         
         https://github.com/NixOS/nixpkgs/actions/runs/12202727756/job/34044092263