### PR TITLE
splice.nix: make pkgs splicedPackages when required

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -1,7 +1,6 @@
-{ lib, __splicedPackages, erlang }:
+{ lib, pkgs, erlang }:
 
 let
-  pkgs = __splicedPackages;
   inherit (lib) makeExtensible;
 
   lib' = pkgs.callPackage ./lib.nix { };

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,8 +1,5 @@
-{ __splicedPackages, lib }:
+{ pkgs, lib }:
 
-let
-  pkgs = __splicedPackages;
-in
 rec {
 
   /* Similar to callPackageWith/callPackage, but without makeOverridable

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -19,11 +19,7 @@ let
         # - adds spliced package sets to the package set
         ({ stdenv, pkgs, perl, callPackage, makeScopeWithSplicing' }: let
           perlPackagesFun = callPackage ../../../top-level/perl-packages.nix {
-            # allow 'perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig; }; }' like in python3Packages
-            # most perl packages aren't called with callPackage so it's not possible to override their arguments individually
-            # the conditional is because the // above won't be applied to __splicedPackages and hopefully no one is doing that when cross-compiling
-            pkgs = if stdenv.buildPlatform != stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
-            inherit stdenv;
+            inherit stdenv pkgs;
             perl = self;
           };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5432,9 +5432,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins {
-    pkgs = pkgs.__splicedPackages;
-  });
+  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });
 
   tokei = callPackage ../development/tools/misc/tokei {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -5799,7 +5797,7 @@ with pkgs;
 
   yarn-berry = callPackage ../development/tools/yarn-berry { };
 
-  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea/yarn2nix { pkgs = pkgs.__splicedPackages; };
+  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea/yarn2nix { };
 
   inherit (yarn2nix-moretea)
     yarn2nix
@@ -6506,7 +6504,6 @@ with pkgs;
 
   idrisPackages = dontRecurseIntoAttrs (callPackage ../development/idris-modules {
     idris-no-deps = haskellPackages.idris;
-    pkgs = pkgs.__splicedPackages;
   });
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
@@ -17036,8 +17033,7 @@ with pkgs;
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
   openraPackages_2019 = import ../games/openra_2019 {
-    inherit lib;
-    pkgs = pkgs.__splicedPackages;
+    inherit lib pkgs;
   };
 
   openra_2019 = openraPackages_2019.engines.release;

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -151,6 +151,8 @@ in
 
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
+  pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;
+
   # prefill 2 fields of the function for convenience
   makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
   makeScopeWithSplicing' = lib.makeScopeWithSplicing' { inherit splicePackages; inherit (pkgs) newScope; };


### PR DESCRIPTION
Take 2 of https://github.com/NixOS/nixpkgs/pull/349316

This will make `pkgs` used in `callPackage`, and `pkgsCross.X.pkgs` have
packages with `__spliced`.

https://www.github.com/NixOS/nixpkgs/blob/3029741718f4c765fbc5ebf76bea3d6c8ff15fe5/pkgs/development/interpreters/python/passthrufun.nix#L37

https://www.github.com/NixOS/nixpkgs/blob/d2bd9a39dec88eddd5c192abee69939e67f43d12/pkgs/top-level/python-packages.nix#L10720

```
nix-repl> pkgsCross.aarch64-multiplatform.python3Packages.protobuf4.protobuf.__spliced
error:
       … while evaluating the attribute 'aarch64-multiplatform.python3Packages.protobuf4.protobuf.__spliced'
         at /home/artturin/nixgits/my-nixpkgs/.worktree/1/pkgs/development/python-modules/protobuf/4.nix:119:13:
          118|   passthru = {
          119|     inherit protobuf;
             |             ^
          120|   };

       error: attribute '__spliced' missing
       at «string»:1:1:
            1| pkgsCross.aarch64-multiplatform.python3Packages.protobuf4.protobuf.__spliced
             | ^
```

to

```
nix-repl> pkgsCross.aarch64-multiplatform.python3Packages.protobuf4.protobuf.__spliced
{
  buildBuild = «derivation /nix/store/s7da5mfvx4h1n86j78knaj9cprglxqz6-protobuf-25.4.drv»;
  buildHost = «derivation /nix/store/s7da5mfvx4h1n86j78knaj9cprglxqz6-protobuf-25.4.drv»;
  buildTarget = «repeated»;
  hostHost = «derivation /nix/store/mszvybzs4zxh43awyrjnybsfcb265n9r-protobuf-aarch64-unknown-linux-gnu-25.4.drv»;
  hostTarget = «repeated»;
}
```<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
