### PR TITLE
python312: fix memory exhaustion vulnerability in asyncio.protocols

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.12/CVE-2024-12254.patch
+++ b/pkgs/development/interpreters/python/cpython/3.12/CVE-2024-12254.patch
@@ -1,0 +1,45 @@
+From e991ac8f2037d78140e417cc9a9486223eb3e786 Mon Sep 17 00:00:00 2001
+From: "J. Nick Koston" <nick@koston.org>
+Date: Thu, 5 Dec 2024 22:33:03 -0600
+Subject: [PATCH] gh-127655: Ensure `_SelectorSocketTransport.writelines`
+ pauses the protocol if needed (#127656)
+
+Ensure `_SelectorSocketTransport.writelines` pauses the protocol if it reaches the high water mark as needed.
+
+Co-authored-by: Kumar Aditya <kumaraditya@python.org>
+
+diff --git a/Lib/asyncio/selector_events.py b/Lib/asyncio/selector_events.py
+index f94bf10b4225e7..f1ab9b12d69a5d 100644
+--- a/Lib/asyncio/selector_events.py
++++ b/Lib/asyncio/selector_events.py
+@@ -1175,6 +1175,7 @@ def writelines(self, list_of_data):
+         # If the entire buffer couldn't be written, register a write handler
+         if self._buffer:
+             self._loop._add_writer(self._sock_fd, self._write_ready)
++            self._maybe_pause_protocol()
+ 
+     def can_write_eof(self):
+         return True
+diff --git a/Lib/test/test_asyncio/test_selector_events.py b/Lib/test/test_asyncio/test_selector_events.py
+index aaeda33dd0c677..efca30f37414f9 100644
+--- a/Lib/test/test_asyncio/test_selector_events.py
++++ b/Lib/test/test_asyncio/test_selector_events.py
+@@ -805,6 +805,18 @@ def test_writelines_send_partial(self):
+         self.assertTrue(self.sock.send.called)
+         self.assertTrue(self.loop.writers)
+ 
++    def test_writelines_pauses_protocol(self):
++        data = memoryview(b'data')
++        self.sock.send.return_value = 2
++        self.sock.send.fileno.return_value = 7
++
++        transport = self.socket_transport()
++        transport._high_water = 1
++        transport.writelines([data])
++        self.assertTrue(self.protocol.pause_writing.called)
++        self.assertTrue(self.sock.send.called)
++        self.assertTrue(self.loop.writers)
++
+     @unittest.skipUnless(selector_events._HAS_SENDMSG, 'no sendmsg')
+     def test_write_sendmsg_full(self):
+         data = memoryview(b'data')

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -294,6 +294,8 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (pythonOlder "3.12") [
     # https://github.com/python/cpython/issues/90656
     ./loongarch-support.patch
+  ] ++ optionals (pythonAtLeast "3.12") [
+    ./3.12/CVE-2024-12254.patch
   ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.13") [
     # backport fix for https://github.com/python/cpython/issues/95855
     ./platform-triplet-detection.patch


### PR DESCRIPTION
https://mail.python.org/archives/list/security-announce@python.org/thread/H4O3UBAOAQQXGT4RE3E4XQYR5XLROORB/

Fixes:CVE-2024-12254


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (python312, python313, python314)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
