### PR TITLE
python3Packages.django-mfa3: Enable failing test

### DIFF
--- a/pkgs/development/python-modules/django-mfa3/default.nix
+++ b/pkgs/development/python-modules/django-mfa3/default.nix
@@ -8,6 +8,7 @@
   fido2,
   qrcode,
   python,
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
@@ -21,6 +22,16 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-O8po7VevqyHlP2isnNnLbpgfs1p4sFezxIZKMTgnwuY=";
   };
+
+  patches = [
+    # Fix for tests.tests.FIDO2Test.test_origin_https
+    # https://github.com/xi/django-mfa3/issues/24
+    (fetchpatch {
+      url = "https://github.com/xi/django-mfa3/commit/49003746783e32cd60e55c4593bef5d7e709c4bd.patch";
+      hash = "sha256-D3fPURAB+RC16fSd2COpCIcmjZW/1h92GOOhRczSVec=";
+      name = "test_origin_https_fix.patch";
+    })
+  ];
 
   build-system = [ setuptools ];
 
@@ -36,9 +47,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "qrcode" ];
 
   checkPhase = ''
-    # Disable failing test test_origin_https
-    # https://github.com/xi/django-mfa3/issues/24
-    ${python.interpreter} -m django test --settings tests.settings -k "not test_origin_https"
+    ${python.interpreter} -m django test --settings tests.settings
   '';
 
   meta = {


### PR DESCRIPTION
Fix failing test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
