### PR TITLE
chromium: remove ofborg maintainer ping workaround, use CODEOWNERS

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -207,8 +207,8 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 
 # Browsers
 /pkgs/applications/networking/browsers/firefox @mweinelt
-/pkgs/applications/networking/browsers/chromium @emilylange
-/nixos/tests/chromium.nix @emilylange
+/pkgs/applications/networking/browsers/chromium @emilylange @networkException
+/nixos/tests/chromium.nix @emilylange @networkException
 
 # Certificate Authorities
 pkgs/data/misc/cacert/ @ajs124 @lukegb @mweinelt

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -84,6 +84,8 @@ mkChromiumDerivation (base: rec {
     homepage = if ungoogled
       then "https://github.com/ungoogled-software/ungoogled-chromium"
       else "https://www.chromium.org/";
+    # Maintainer pings for this derivation are highly unreliable.
+    # If you add yourself as maintainer here, please also add yourself as CODEOWNER.
     maintainers = with lib.maintainers; if ungoogled
       then [ networkexception emilylange ]
       else [ networkexception emilylange ];

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -663,12 +663,7 @@ let
     } // lib.optionalAttrs (!isElectron) {
       inherit chromiumDeps npmDeps;
     };
-  }
-  # overwrite `version` with the exact same `version` from the same source,
-  # except it internally points to `upstream-info.nix` for
-  # `builtins.unsafeGetAttrPos`, which is used by ofborg to decide
-  # which maintainers need to be pinged.
-  // builtins.removeAttrs upstream-info (builtins.filter (e: e != "version") (builtins.attrNames upstream-info));
+  };
 
 # Remove some extraAttrs we supplied to the base attributes already.
 in stdenv.mkDerivation (base // removeAttrs extraAttrs [

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -178,9 +178,3 @@ in stdenv.mkDerivation {
     inherit sandboxExecutableName;
   };
 }
-# the following is a complicated and long-winded variant of
-# `inherit (chromium.browser) version`, with the added benefit
-# that it keeps the pointer to upstream-info.nix for
-# builtins.unsafeGetAttrPos, which is what ofborg uses to
-# decide which maintainers need to be pinged.
-// builtins.removeAttrs chromium.browser (builtins.filter (e: e != "version") (builtins.attrNames chromium.browser))


### PR DESCRIPTION
The workaround to have ofborg ping `chromium` and `ungoogled-chromium` maintainers when a change was only made to the upstream-info relied on string context.

That string context was provided by the upstream-info being a nix file, not a json file, and then holding on to that string context using awkward attribute merges.

It was intended as a quick fix until the handling of this would improve in ofborg itself and worked great.

That was until very recently when we switched from the chromium release tarball to git source fetching in #357371 (8dd2f1add978a4747a5962f2874b8ad20f86b01c).

Part of that change included going back from `upstream-info.nix` to `upstream-info.json` and with that losing the string context and the base on which this workaround used to work.

But this is fine. A lot has happened in the meantime.

CODEOWNERS was reimplemented and no longer requires every user listed in it to have write permissions to the repository (commit bit).

Meaning we can accept that ofborg pings no longer work and instead rely on CODEOWNERS exclusively.

It should, however, be noted that CODEOWNERS provide less granularity than ofborg, meaning we can no longer differentiate between `ungoogled-chromium` and `chromium` or even `chromedriver`.

Previously, implementing the workaround that is now essentially reverted: #245762 (68c59791fb6644ac733d99d0147b09bce4cb8319)

This is a no-op.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
