### PR TITLE
nixos/grub: Add extraEntriesAtEnd

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -84,7 +84,7 @@ let
       inherit (cfg)
         extraConfig extraPerEntryConfig extraEntries forceInstall useOSProber
         extraGrubInstallArgs
-        extraEntriesBeforeNixOS extraPrepareConfig configurationLimit copyKernels
+        extraEntriesBeforeNixOS extraEntriesAtEnd extraPrepareConfig configurationLimit copyKernels
         default fsIdentifier efiSupport efiInstallAsRemovable gfxmodeEfi gfxmodeBios gfxpayloadEfi gfxpayloadBios
         users
         timeoutStyle
@@ -401,6 +401,26 @@ in
         type = types.bool;
         description = ''
           Whether extraEntries are included before the default option.
+        '';
+      };
+
+      extraEntriesAtEnd = mkOption {
+        default = "";
+        type = types.lines;
+        example = ''
+          # GRUB 2 example
+          menuentry "Windows 7" {
+            chainloader (hd0,4)+1
+          }
+
+          # GRUB 2 with UEFI example, chainloading another distro
+          menuentry "Fedora" {
+            set root=(hd1,1)
+            chainloader /efi/fedora/grubx64.efi
+          }
+        '';
+        description = ''
+          Any additional entries you want added to the GRUB boot menu at the end after NixOS and NixOS All Generations.
         '';
       };
 

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -67,6 +67,7 @@ my $extraPrepareConfig = get("extraPrepareConfig");
 my $extraPerEntryConfig = get("extraPerEntryConfig");
 my $extraEntries = get("extraEntries");
 my $extraEntriesBeforeNixOS = get("extraEntriesBeforeNixOS") eq "true";
+my $extraEntriesAtEnd = get("extraEntriesAtEnd");
 my $splashImage = get("splashImage");
 my $splashMode = get("splashMode");
 my $entryOptions = get("entryOptions");
@@ -661,6 +662,14 @@ if (get("useOSProber") eq "true") {
     my $targetpackage = ($efiTarget eq "no") ? $grub : $grubEfi;
     system(get("shell"), "-c", "pkgdatadir=$targetpackage/share/grub $targetpackage/etc/grub.d/30_os-prober >> $tmpFile");
 }
+
+## Append the extraEntriesAtEnd
+# rewrite the $conf variable from $tmpFile
+$conf = read_file($tmpFile);
+$conf .= "\n$extraEntriesAtEnd\n";
+
+#rewrite the tmp file
+writeFile($tmpFile, $conf);
 
 # Atomically switch to the new config
 rename $tmpFile, $confFile or die "cannot rename $tmpFile to $confFile: $!\n";


### PR DESCRIPTION
I have created a PR few months ago, but the reviewer I was assigned haven't been online for months, he didn't do any comment or rejected my PR for 6 months, I hope he is fine, so this is my second time creating another PR, after 6 months of waiting, I hope this time this PR will get someone who is active and isn't offline for months.

This option allows the user to specify a list of extra entries to be added to the end of the grub menu.

## Description of changes

I added this new option as boot.loader.grub.extraEntriesAtEnd, This option adds entries at the end of grub, The normal extraEntries option adds entries in the middle of NixOS and NixOS-Generations entry.

I wanted to add shutdown and reboot entries and end, but that old option was never designed to do that, so I created this new option which runs after OS Prober, and after OS Prober adds those entries then from this option entries are taken.

## Things done

I added an option with its description.
I added that option in the Perl file, after the line where OS Prober entries are loaded.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## My Message
I have never worked with Perl, but I am a student studying software engineering, and I used GitHub Copilot, so it may or may not contain bugs, please check it, I want this option as I am frustrated with the old option and it's arrangement, so please add it.