### PR TITLE
gnomeExtensions: auto-update

### DIFF
--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -20,8 +20,16 @@
     "batterytime@typeof.pw",
     "batime@martin.zurowietz.de"
   ],
+  "nepali-calendar": [
+    "nepali-date@biplab",
+    "nepali-calendar-gs-extension@subashghimire.info.np"
+  ],
   "power-profile-indicator": [
     "power-profile-indicator@laux.wtf",
     "power-profile@fthx"
+  ],
+  "fullscreen-to-empty-workspace": [
+    "fullscreen-to-empty-workspace@aiono.dev",
+    "fullscreen-to-empty-workspace2@corgijan.dev"
   ]
 }

--- a/pkgs/desktops/gnome/extensions/extensionRenames.nix
+++ b/pkgs/desktops/gnome/extensions/extensionRenames.nix
@@ -20,8 +20,14 @@
   "batterytime@typeof.pw" = "battery-time-2";
   "batime@martin.zurowietz.de" = "battery-time";
 
+  "nepali-date@biplab" = "nepali-calendar";
+  "nepali-calendar-gs-extension@subashghimire.info.np" = "nepali-calendar-2";
+
   "power-profile-indicator@laux.wtf" = "power-profile-indicator";
   "power-profile@fthx" = "power-profile-indicator-2";
+
+  "fullscreen-to-empty-workspace@aiono.dev" = "fullscreen-to-empty-workspace";
+  "fullscreen-to-empty-workspace2@corgijan.dev" = "fullscreen-to-empty-workspace-2";
 
   # ############################################################################
   # These extensions no longer collide. We preserve the old attribute name for backwards compatibility.


### PR DESCRIPTION
@wrenix https://github.com/NixOS/nixpkgs/pull/346261#issuecomment-2508727078
```console
> grep -i 'hass-gshell@geoph9-on-github' pkgs/desktops/gnome/extensions/extensions.json
, {"uuid": "hass-gshell@geoph9-on-github", "name": "Home Assistant Extension", "pname": "home-assistant-extension", "description": "A simple gnome shell extension for Home Assistant. Check the README on github for additional help!\n\nMain points:\n- You need to provide the url of your hass, a long live access token obtained from your profile page (on your hass web instance) and the entity ids of the entities you want to have as togglable.\n- In order to add some local temperature/humidity sensor, you may also provide a temperature and/or a humidity entity id (which should match the corresponding ids of your hass instance).", "link": "https://extensions.gnome.org/extension/4170/home-assistant-extension/", "shell_version_map": {
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
