### PR TITLE
python312Packages.pyiceberg: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -1,0 +1,251 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  poetry-core,
+  setuptools,
+
+  # dependencies
+  cachetools,
+  click,
+  fsspec,
+  mmh3,
+  pydantic,
+  pyparsing,
+  ray,
+  requests,
+  rich,
+  sortedcontainers,
+  strictyaml,
+  tenacity,
+  zstandard,
+
+  # optional-dependencies
+  adlfs,
+  # getdaft,
+  duckdb,
+  pyarrow,
+  boto3,
+  gcsfs,
+  mypy-boto3-glue,
+  thrift,
+  pandas,
+  s3fs,
+  python-snappy,
+  psycopg2-binary,
+  sqlalchemy,
+
+  # tests
+  azure-core,
+  azure-storage-blob,
+  fastavro,
+  moto,
+  pyspark,
+  pytestCheckHook,
+  pytest-lazy-fixture,
+  pytest-mock,
+  pytest-timeout,
+  requests-mock,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "iceberg-python";
+  version = "0.8.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "iceberg-python";
+    tag = "pyiceberg-${version}";
+    hash = "sha256-L3YlOtzJv9R4TLeJGzfMQ+0nYtQEsqmgNZpW9B6vVAI=";
+  };
+
+  patches = lib.optionals (pythonOlder "3.12") [
+    # Build script fails to build the cython extension on python 3.11 (no issues with python 3.12):
+    # distutils.errors.DistutilsSetupError: each element of 'ext_modules' option must be an Extension instance or 2-tuple
+    # This error vanishes if Cython and setuptools imports are swapped
+    # https://stackoverflow.com/a/53356077/11196710
+    ./reorder-imports-in-build-script.patch
+  ];
+
+  build-system = [
+    cython
+    poetry-core
+    setuptools
+  ];
+
+  # Prevents the cython build to fail silently
+  env.CIBUILDWHEEL = "1";
+
+  dependencies = [
+    cachetools
+    click
+    fsspec
+    mmh3
+    pydantic
+    pyparsing
+    ray
+    requests
+    rich
+    sortedcontainers
+    strictyaml
+    tenacity
+    zstandard
+  ];
+
+  optional-dependencies = {
+    adlfs = [
+      adlfs
+    ];
+    daft = [
+      # getdaft
+    ];
+    duckdb = [
+      duckdb
+      pyarrow
+    ];
+    dynamodb = [
+      boto3
+    ];
+    gcsfs = [
+      gcsfs
+    ];
+    glue = [
+      boto3
+      mypy-boto3-glue
+    ];
+    hive = [
+      thrift
+    ];
+    pandas = [
+      pandas
+      pyarrow
+    ];
+    pyarrow = [
+      pyarrow
+    ];
+    ray = [
+      pandas
+      pyarrow
+      ray
+    ];
+    s3fs = [
+      s3fs
+    ];
+    snappy = [
+      python-snappy
+    ];
+    sql-postgres = [
+      psycopg2-binary
+      sqlalchemy
+    ];
+    sql-sqlite = [
+      sqlalchemy
+    ];
+    zstandard = [
+      zstandard
+    ];
+  };
+
+  pythonImportsCheck = [
+    "pyiceberg"
+    # Compiled avro decoder (cython)
+    "pyiceberg.avro.decoder_fast"
+  ];
+
+  nativeCheckInputs = [
+    azure-core
+    azure-storage-blob
+    boto3
+    fastavro
+    moto
+    mypy-boto3-glue
+    pandas
+    pyarrow
+    pyspark
+    pytest-lazy-fixture
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+    requests-mock
+    s3fs
+    sqlalchemy
+    thrift
+  ] ++ moto.optional-dependencies.server;
+
+  disabledTestPaths = [
+    # Several errors:
+    # - FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/...-python3.12-pyspark-3.5.3/lib/python3.12/site-packages/pyspark/./bin/spark-submit'
+    # - requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8181): Max retries exceeded with url: /v1/config
+    # - thrift.transport.TTransport.TTransportException: Could not connect to any of [('127.0.0.1', 9083)]
+    "tests/integration"
+  ];
+
+  disabledTests = [
+    # botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL
+    "test_checking_if_a_file_exists"
+    "test_closing_a_file"
+    "test_fsspec_file_tell"
+    "test_fsspec_getting_length_of_file"
+    "test_fsspec_pickle_round_trip_s3"
+    "test_fsspec_raise_on_opening_file_not_found"
+    "test_fsspec_read_specified_bytes_for_file"
+    "test_fsspec_write_and_read_file"
+    "test_writing_avro_file"
+
+    # Require unpackaged gcsfs
+    "test_fsspec_converting_an_outputfile_to_an_inputfile_gcs"
+    "test_fsspec_new_input_file_gcs"
+    "test_fsspec_new_output_file_gcs"
+    "test_fsspec_pickle_roundtrip_gcs"
+
+    # Timeout (network access)
+    "test_fsspec_converting_an_outputfile_to_an_inputfile_adls"
+    "test_fsspec_new_abfss_output_file_adls"
+    "test_fsspec_new_input_file_adls"
+    "test_fsspec_pickle_round_trip_aldfs"
+
+    # TypeError: pyarrow.lib.large_list() takes no keyword argument
+    # From tests/io/test_pyarrow_stats.py:
+    "test_bounds"
+    "test_column_metrics_mode"
+    "test_column_sizes"
+    "test_metrics_mode_counts"
+    "test_metrics_mode_full"
+    "test_metrics_mode_non_default_trunc"
+    "test_metrics_mode_none"
+    "test_null_and_nan_counts"
+    "test_offsets"
+    "test_read_missing_statistics"
+    "test_record_count"
+    "test_value_counts"
+    "test_write_and_read_stats_schema"
+    # From tests/io/test_pyarrow.py:
+    "test_list_type_to_pyarrow"
+    "test_projection_add_column"
+    "test_projection_list_of_structs"
+    "test_read_list"
+    "test_schema_compatible_missing_nullable_field_nested"
+    "test_schema_compatible_nested"
+    "test_schema_mismatch_missing_required_field_nested"
+    "test_schema_to_pyarrow_schema_exclude_field_ids"
+    "test_schema_to_pyarrow_schema_include_field_ids"
+    # From tests/io/test_pyarrow_visitor.py
+    "test_round_schema_conversion_nested"
+
+    # Hangs forever (from tests/io/test_pyarrow.py)
+    "test_getting_length_of_file_gcs"
+  ];
+
+  meta = {
+    description = "Python library for programmatic access to Apache Iceberg";
+    homepage = "https://github.com/apache/iceberg-python";
+    changelog = "https://github.com/apache/iceberg-python/releases/tag/pyiceberg-${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pyiceberg/reorder-imports-in-build-script.patch
+++ b/pkgs/development/python-modules/pyiceberg/reorder-imports-in-build-script.patch
@@ -1,0 +1,17 @@
+diff --git a/build-module.py b/build-module.py
+index d91375e..4d307e8 100644
+--- a/build-module.py
++++ b/build-module.py
+@@ -23,10 +23,10 @@ allowed_to_fail = os.environ.get("CIBUILDWHEEL", "0") != "1"
+ 
+ 
+ def build_cython_extensions() -> None:
+-    import Cython.Compiler.Options
+-    from Cython.Build import build_ext, cythonize
+     from setuptools import Extension
+     from setuptools.dist import Distribution
++    import Cython.Compiler.Options
++    from Cython.Build import build_ext, cythonize
+ 
+     Cython.Compiler.Options.annotate = True
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11752,6 +11752,8 @@ self: super: with self; {
 
   pyialarm = callPackage ../development/python-modules/pyialarm { };
 
+  pyiceberg = callPackage ../development/python-modules/pyiceberg { };
+
   pyicloud = callPackage ../development/python-modules/pyicloud { };
 
   pyicu = callPackage ../development/python-modules/pyicu { };


### PR DESCRIPTION
## Things done

Add [pyiceberg](https://github.com/apache/iceberg-python), a python library for programmatic access to Apache Iceberg.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
