### PR TITLE
idris2Packages.pack: fix runtime building of Idris2 versions

### DIFF
--- a/pkgs/development/compilers/idris2/pack.nix
+++ b/pkgs/development/compilers/idris2/pack.nix
@@ -2,6 +2,12 @@
   lib,
   idris2Packages,
   fetchFromGitHub,
+  clang,
+  chez,
+  gmp,
+  zsh,
+  makeBinaryWrapper,
+  stdenv,
 }:
 let
   inherit (idris2Packages) idris2Api buildIdris;
@@ -41,6 +47,28 @@ let
       toml
       filepath
     ];
+
+    nativeBuildInputs = [ makeBinaryWrapper ];
+
+    buildInputs = [
+      gmp
+      clang
+      chez
+    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ zsh ];
+
+    postInstall = ''
+      wrapProgram $out/bin/pack \
+        --suffix C_INCLUDE_PATH : ${lib.makeIncludePath [ gmp ]} \
+        --suffix PATH : ${
+          lib.makeBinPath (
+            [
+              clang
+              chez
+            ]
+            ++ lib.optionals stdenv.hostPlatform.isDarwin [ zsh ]
+          )
+        }
+    '';
 
     meta = {
       description = "An Idris2 Package Manager with Curated Package Collections";


### PR DESCRIPTION
It was pointed out to me by someone trying to use Pack that you quickly hit problems at runtime given Pack's desire to build specific versions of the Idris2 compiler for itself -- these problems are fixed by making sure Pack has Idris2's requirements in its PATH/C_INCLUDE_PATH at runtime. We don't explicitly reference the `idris2` derivation's `nativeBuildInputs` because Pack doesn't need e.g. `makeWrapper` at runtime to build Idris2.

## Things done

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>idris2Packages.pack</li>
  </ul>
</details>

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>idris2Packages.pack</li>
  </ul>
</details>

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
