### PR TITLE
python312Packages.langgraph*: 20241206 update

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
@@ -36,6 +36,9 @@ buildPythonPackage rec {
     langgraph-checkpoint
   ];
 
+  # Checkpoint clients are lagging behind langgraph-checkpoint
+  pythonRelaxDeps = [ "langgraph-checkpoint" ];
+
   pythonImportsCheck = [ "langgraph.checkpoint.duckdb" ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/checkpointduckdb==${version}";
+    tag = "checkpointduckdb==${version}";
     hash = "sha256-wSrlFBfTcTgyE46uwv9GCyxRT1xVafgWyP2g87KUTAU=";
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -3,12 +3,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   langgraph-checkpoint,
+  langgraph-sdk,
   orjson,
   psycopg,
   psycopg-pool,
-  langgraph-sdk,
   poetry-core,
   pythonOlder,
+  pgvector,
   postgresql,
   postgresqlTestHook,
   pytestCheckHook,
@@ -18,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "2.0.2";
+  version = "2.0.8";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -27,12 +28,13 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpointpostgres==${version}";
-    hash = "sha256-E3gdHWUYelR/xI3Cv3T2uVwsyt+tOkw9MjX7I2RAuiQ=";
+    hash = "sha256-yHLkFUp+q/XOt9Y9Dog2Tgs/K2CU7Bfkkucdr9vAKSg=";
   };
 
   postgresqlTestSetupPost = ''
     substituteInPlace tests/conftest.py \
-      --replace-fail "DEFAULT_URI = \"postgres://postgres:postgres@localhost:5441/postgres?sslmode=disable\"" "DEFAULT_URI = \"postgres:///$PGDATABASE\""
+      --replace-fail "DEFAULT_URI = \"postgres://postgres:postgres@localhost:5441/postgres?sslmode=disable\"" "DEFAULT_URI = \"postgres:///$PGDATABASE\"" \
+      --replace-fail "DEFAULT_POSTGRES_URI = \"postgres://postgres:postgres@localhost:5441/\"" "DEFAULT_POSTGRES_URI = \"postgres:///\""
   '';
 
   sourceRoot = "${src.name}/libs/checkpoint-postgres";
@@ -50,14 +52,33 @@ buildPythonPackage rec {
 
   doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
 
-  pythonImportsCheck = [ "langgraph.checkpoint.postgres" ];
-
   nativeCheckInputs = [
-    postgresql
-    postgresqlTestHook
     pytest-asyncio
     pytestCheckHook
+    (postgresql.withPackages (p: with p; [ pgvector ]))
+    postgresqlTestHook
   ];
+
+  preCheck = ''
+    export postgresqlTestUserOptions = "LOGIN SUPERUSER"
+  '';
+
+  disabledTests = [
+    # psycopg.errors.FeatureNotSupported: extension "vector" is not available
+    # /nix/store/...postgresql-and-plugins-16.4/share/postgresql/extension/vector.control": No such file or directory.
+    "test_embed_with_path"
+    "test_embed_with_path_sync"
+    "test_scores"
+    "test_search_sorting"
+    "test_vector_store_initialization"
+    "test_vector_insert_with_auto_embedding"
+    "test_vector_update_with_embedding"
+    "test_vector_search_with_filters"
+    "test_vector_search_pagination"
+    "test_vector_search_edge_cases"
+  ];
+
+  pythonImportsCheck = [ "langgraph.checkpoint.postgres" ];
 
   passthru = {
     updateScript = langgraph-sdk.updateScript;

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/checkpointpostgres==${version}";
+    tag = "checkpointpostgres==${version}";
     hash = "sha256-yHLkFUp+q/XOt9Y9Dog2Tgs/K2CU7Bfkkucdr9vAKSg=";
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -48,7 +48,10 @@ buildPythonPackage rec {
     psycopg-pool
   ];
 
-  pythonRelaxDeps = [ "psycopg-pool" ];
+  pythonRelaxDeps = [
+    "langgraph-checkpoint"
+    "psycopg-pool"
+  ];
 
   doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
 
@@ -60,7 +63,7 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    export postgresqlTestUserOptions = "LOGIN SUPERUSER"
+    export postgresqlTestUserOptions="LOGIN SUPERUSER"
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
     langgraph-checkpoint
   ];
 
+  # Checkpoint clients are lagging behind langgraph-checkpoint
+  pythonRelaxDeps = [ "langgraph-checkpoint" ];
+
   pythonImportsCheck = [ "langgraph.checkpoint.sqlite" ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/checkpointsqlite==${version}";
+    tag = "checkpointsqlite==${version}";
     hash = "sha256-dh+cjcOp6rGFntz82VNfVyetcrQBdBFdXk5xFb0aR5c=";
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/checkpoint==${version}";
+    tag = "checkpoint==${version}";
     hash = "sha256-obDK6wn+oo8zDQsidogwKTIgT5wuUH/l4y+12cttkd0=";
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "2.0.2";
+  version = "2.0.8";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpoint==${version}";
-    hash = "sha256-Mjo6NJ6vYb2E7nk0D/2M7jzr39xRvRRhUZE4tP247to=";
+    hash = "sha256-obDK6wn+oo8zDQsidogwKTIgT5wuUH/l4y+12cttkd0=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/cli==${version}";
+    tag = "cli==${version}";
     hash = "sha256-zTBeDJB1Xu/rWsvEC/L4BRzxyh04lPYV7HQNHoJcskk=";
   };
 

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.35";
+  version = "0.1.43";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/sdk==${version}";
-    hash = "sha256-HWUGRoe5S0HPfOEbqUnFYLVrHe3SJtk3U8cy1JON050=";
+    hash = "sha256-mG04V36Aa5Df5pUgr+xWej8i2XYx+O/N61sSzxwN9Go=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";
@@ -36,6 +36,8 @@ buildPythonPackage rec {
     httpx-sse
     orjson
   ];
+
+  disabledTests = [ "test_aevaluate_results" ]; # Compares execution time to magic number
 
   pythonImportsCheck = [ "langgraph_sdk" ];
 

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/sdk==${version}";
+    tag = "sdk==${version}";
     hash = "sha256-mG04V36Aa5Df5pUgr+xWej8i2XYx+O/N61sSzxwN9Go=";
   };
 

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.2.43";
+  version = "0.2.56";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/${version}";
-    hash = "sha256-8xTjWBq6GSl6X2IId3roS3ZNM/h76EGPitS08YQ4e7Y=";
+    hash = "sha256-X/IMNEmggu9bSJFUaTohbFYxGZBguf+eFb3ObmQGplk=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-X/IMNEmggu9bSJFUaTohbFYxGZBguf+eFb3ObmQGplk=";
   };
 


### PR DESCRIPTION
## Changes

1. Bump to latest releases
 - `langgraph`: 0.2.43 -> 0.2.56
 - `langgraph-sdk`: 0.1.35 -> 0.1.43
 - `langgraph-checkpoint`: 2.0.2 -> 2.0.8
 - `langgraph-checkpoint-postgres`: 2.0.2 -> 2.0.8
2. Update `langgraph-checkpoint-postgres` derivation to work with newly revised unit tests.
3. Update `langgraph-checkpoint-{sqlite,postgresql,duckdb}` clients to accept current `langgraph-checkpoint`. (Sqlite and duckdb adaptors haven't been updated in a while.)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
