### PR TITLE
Update NixOS Module evremap

### DIFF
--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -7,6 +7,8 @@
 let
   cfg = config.services.evremap;
   format = pkgs.formats.toml { };
+  settings = lib.attrsets.filterAttrs (n: v: v != null) cfg.settings;
+  configFile = format.generate "evremap.toml" settings;
 
   key = lib.types.strMatching "(BTN|KEY)_[[:upper:]]+" // {
     description = "key ID prefixed with BTN_ or KEY_";
@@ -68,10 +70,10 @@ in
             default = null;
             example = "usb-0000:07:00.3-2.1.1/input0";
             description = ''
-              If you have multiple devices with the same name, you can optionally
-              specify this attribute.
+              The physical device name to listen on.
 
-              If available, the value will be printed when running `evremap list-devices` with elevated permissions.
+              This attribute may be specified to disambiguate multiple devices with the same device name.
+              The physical device names of each device can be obtained by running `evremap list-devices` with elevated permissions.
             '';
           };
 
@@ -129,9 +131,7 @@ in
       description = "evremap - keyboard input remapper";
       wantedBy = [ "multi-user.target" ];
 
-      script = "${lib.getExe pkgs.evremap} remap ${
-        format.generate "evremap.toml" (lib.attrsets.filterAttrs (n: v: v != null) cfg.settings)
-      }";
+      script = "${lib.getExe pkgs.evremap} remap ${configFile}";
 
       serviceConfig = {
         DynamicUser = true;

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -8,8 +8,8 @@ let
   cfg = config.services.evremap;
   format = pkgs.formats.toml { };
 
-  key = lib.types.strMatching "KEY_[[:upper:]]+" // {
-    description = "key ID prefixed with KEY_";
+  key = lib.types.strMatching "(BTN|KEY)_[[:upper:]]+" // {
+    description = "key ID prefixed with BTN_ or KEY_";
   };
 
   mkKeyOption =

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -70,7 +70,7 @@ in
             description = ''
               If you have multiple devices with the same name, you can optionally
               specify this attribute.
-              
+
               If available, the value will be printed when running `evremap list-devices` with elevated permissions.
             '';
           };
@@ -129,7 +129,9 @@ in
       description = "evremap - keyboard input remapper";
       wantedBy = [ "multi-user.target" ];
 
-      script = "${lib.getExe pkgs.evremap} remap ${format.generate "evremap.toml" (lib.attrsets.filterAttrs (n: v: v != null) cfg.settings)}";
+      script = "${lib.getExe pkgs.evremap} remap ${
+        format.generate "evremap.toml" (lib.attrsets.filterAttrs (n: v: v != null) cfg.settings)
+      }";
 
       serviceConfig = {
         DynamicUser = true;

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -129,7 +129,7 @@ in
       description = "evremap - keyboard input remapper";
       wantedBy = [ "multi-user.target" ];
 
-      script = "${lib.getExe pkgs.evremap} remap ${format.generate "evremap.toml" cfg.settings}";
+      script = "${lib.getExe pkgs.evremap} remap ${format.generate "evremap.toml" (lib.attrsets.filterAttrs (n: v: v != null) cfg.settings)}";
 
       serviceConfig = {
         DynamicUser = true;

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -63,6 +63,18 @@ in
             '';
           };
 
+          phys = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "usb-0000:07:00.3-2.1.1/input0";
+            description = ''
+              If you have multiple devices with the same name, you can optionally
+              specify this attribute.
+              
+              If available, the value will be printed when running `evremap list-devices` with elevated permissions.
+            '';
+          };
+
           dual_role = lib.mkOption {
             type = lib.types.listOf dualRoleModule;
             default = [ ];

--- a/nixos/modules/services/misc/evremap.nix
+++ b/nixos/modules/services/misc/evremap.nix
@@ -7,6 +7,8 @@
 let
   cfg = config.services.evremap;
   format = pkgs.formats.toml { };
+  settings = lib.attrsets.filterAttrs (n: v: v != null) cfg.settings;
+  configFile = format.generate "evremap.toml" settings;
 
   key = lib.types.strMatching "(BTN|KEY)_[[:upper:]]+" // {
     description = "key ID prefixed with BTN_ or KEY_";
@@ -60,6 +62,18 @@ in
               The name of the device that should be remapped.
 
               You can get a list of devices by running `evremap list-devices` with elevated permissions.
+            '';
+          };
+
+          phys = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "usb-0000:07:00.3-2.1.1/input0";
+            description = ''
+              The physical device name to listen on.
+
+              This attribute may be specified to disambiguate multiple devices with the same device name.
+              The physical device names of each device can be obtained by running `evremap list-devices` with elevated permissions.
             '';
           };
 
@@ -117,7 +131,7 @@ in
       description = "evremap - keyboard input remapper";
       wantedBy = [ "multi-user.target" ];
 
-      script = "${lib.getExe pkgs.evremap} remap ${format.generate "evremap.toml" cfg.settings}";
+      script = "${lib.getExe pkgs.evremap} remap ${configFile}";
 
       serviceConfig = {
         DynamicUser = true;


### PR DESCRIPTION
I have updated the NixOS Module evremap.
I expanded the type for remappable keys to include `BTN`.
I added the optional `phys` attribute, which can be used if multiple devices share the same name. As toml doesn't support `null` values, I added a filter function to the toml generation.

When testing the `phys` attribute, an error occurs that prevents the service to start if you try to switch to the new generation without a reboot. The software wants to create a uinput device but some permissions were not set immediately. After rebooting the same config worked. I'm unsure if this is something to include in the description of the attribute.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
