### PR TITLE
timeshift: format expressions and sort dependencies alphabetically

### DIFF
--- a/pkgs/applications/backup/timeshift/default.nix
+++ b/pkgs/applications/backup/timeshift/default.nix
@@ -1,13 +1,14 @@
-{ callPackage
-, timeshift-unwrapped
-, rsync
-, coreutils
-, mount
-, umount
-, psmisc
-, cron
-, btrfs-progs
-, grubPackage
+{
+  callPackage,
+  timeshift-unwrapped,
+  rsync,
+  coreutils,
+  mount,
+  umount,
+  psmisc,
+  cron,
+  btrfs-progs,
+  grubPackage,
 }:
 let
   timeshift-wrapper = callPackage ./wrapper.nix { };
@@ -21,12 +22,15 @@ in
   cron
   btrfs-progs
   grubPackage
-])).overrideAttrs (oldAttrs: {
-  meta = oldAttrs.meta // {
-    description = oldAttrs.meta.description;
-    longDescription = oldAttrs.meta.longDescription + ''
-      This package comes with runtime dependencies of command utilities provided by rsync, coreutils, mount, umount, psmisc, cron and btrfs.
-      If you want to use the commands provided by the system, use timeshift-minimal instead.
-    '';
-  };
-})
+])).overrideAttrs
+  (oldAttrs: {
+    meta = oldAttrs.meta // {
+      description = oldAttrs.meta.description;
+      longDescription =
+        oldAttrs.meta.longDescription
+        + ''
+          This package comes with runtime dependencies of command utilities provided by rsync, coreutils, mount, umount, psmisc, cron and btrfs.
+          If you want to use the commands provided by the system, use timeshift-minimal instead.
+        '';
+    };
+  })

--- a/pkgs/applications/backup/timeshift/default.nix
+++ b/pkgs/applications/backup/timeshift/default.nix
@@ -1,28 +1,28 @@
 {
   callPackage,
-  timeshift-unwrapped,
-  rsync,
-  coreutils,
-  mount,
-  umount,
-  psmisc,
-  cron,
   btrfs-progs,
+  coreutils,
+  cron,
   grubPackage,
+  mount,
+  psmisc,
+  rsync,
+  timeshift-unwrapped,
+  umount,
 }:
 let
   timeshift-wrapper = callPackage ./wrapper.nix { };
 in
-(timeshift-wrapper timeshift-unwrapped ([
-  rsync
-  coreutils
-  mount
-  umount
-  psmisc
-  cron
+(timeshift-wrapper timeshift-unwrapped [
   btrfs-progs
+  coreutils
+  cron
   grubPackage
-])).overrideAttrs
+  mount
+  psmisc
+  rsync
+  umount
+]).overrideAttrs
   (oldAttrs: {
     meta = oldAttrs.meta // {
       description = oldAttrs.meta.description;

--- a/pkgs/applications/backup/timeshift/minimal.nix
+++ b/pkgs/applications/backup/timeshift/minimal.nix
@@ -1,5 +1,6 @@
-{ callPackage
-, timeshift-unwrapped
+{
+  callPackage,
+  timeshift-unwrapped,
 }:
 let
   timeshift-wrapper = callPackage ./wrapper.nix { };
@@ -7,9 +8,11 @@ in
 (timeshift-wrapper timeshift-unwrapped [ ]).overrideAttrs (oldAttrs: {
   meta = oldAttrs.meta // {
     description = oldAttrs.meta.description + " (without runtime dependencies)";
-    longDescription = oldAttrs.meta.longDescription + ''
-      This package is a wrapped version of timeshift-unwrapped
-      without runtime dependencies of command utilities.
-    '';
+    longDescription =
+      oldAttrs.meta.longDescription
+      + ''
+        This package is a wrapped version of timeshift-unwrapped
+        without runtime dependencies of command utilities.
+      '';
   };
 })

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -1,18 +1,19 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, gettext
-, help2man
-, meson
-, ninja
-, pkg-config
-, vala
-, gtk3
-, json-glib
-, libgee
-, util-linux
-, vte
-, xapp
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gettext,
+  help2man,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  gtk3,
+  json-glib,
+  libgee,
+  util-linux,
+  vte,
+  xapp,
 }:
 
 stdenv.mkDerivation rec {
@@ -65,6 +66,9 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linuxmint/timeshift";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ShamrockLee bobby285271 ];
+    maintainers = with maintainers; [
+      ShamrockLee
+      bobby285271
+    ];
   };
 }

--- a/pkgs/applications/backup/timeshift/wrapper.nix
+++ b/pkgs/applications/backup/timeshift/wrapper.nix
@@ -1,14 +1,14 @@
-{ stdenvNoCC
-, lib
-, wrapGAppsHook3
-, gdk-pixbuf
-, librsvg
-, xorg
-, shared-mime-info
+{
+  stdenvNoCC,
+  lib,
+  wrapGAppsHook3,
+  gdk-pixbuf,
+  librsvg,
+  xorg,
+  shared-mime-info,
 }:
 
-timeshift-unwrapped:
-runtimeDeps:
+timeshift-unwrapped: runtimeDeps:
 stdenvNoCC.mkDerivation {
   inherit (timeshift-unwrapped) pname version;
 
@@ -34,7 +34,13 @@ stdenvNoCC.mkDerivation {
     )
     gappsWrapperArgs+=(
       # Thumbnailers
-      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ gdk-pixbuf librsvg shared-mime-info ]}"
+      --prefix XDG_DATA_DIRS : "${
+        lib.makeSearchPath "share" [
+          gdk-pixbuf
+          librsvg
+          shared-mime-info
+        ]
+      }"
       "''${makeWrapperArgs[@]}"
     )
     wrapProgram "$out/bin/timeshift" "''${makeWrapperArgs[@]}"

--- a/pkgs/applications/backup/timeshift/wrapper.nix
+++ b/pkgs/applications/backup/timeshift/wrapper.nix
@@ -15,8 +15,8 @@ stdenvNoCC.mkDerivation {
   dontUnpack = true;
 
   nativeBuildInputs = [
-    xorg.lndir
     wrapGAppsHook3
+    xorg.lndir
   ];
 
   installPhase = ''


### PR DESCRIPTION
Format the Nix expressions and sort `nativeBuildInputs, `buildInputs`, `runtimeDeps`, etc., alphabetically.

This makes subsequent refactoring easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
