### PR TITLE
calibre: add image optimization programs

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -16,6 +16,8 @@
   libstemmer,
   libuchardet,
   libusb1,
+  libwebp,
+  optipng,
   piper-tts,
   pkg-config,
   podofo,
@@ -190,6 +192,13 @@ stdenv.mkDerivation (finalAttrs: {
         wrapProgram $program \
           ''${qtWrapperArgs[@]} \
           ''${gappsWrapperArgs[@]} \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              libjpeg
+              libwebp
+              optipng
+            ]
+          } \
           ${if popplerSupport then popplerArgs else ""}
       done
     '';

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
       ps:
       with ps;
       [
-        (apsw.overrideAttrs (oldAttrs: {
+        (apsw.overrideAttrs (_oldAttrs: {
           setupPyBuildFlags = [ "--enable=load_extension" ];
         }))
         beautifulsoup4
@@ -138,10 +138,10 @@ stdenv.mkDerivation (finalAttrs: {
             # does not support by simply omitting qtwebengine.
             pyqt6-webengine
           ]
-      ++ lib.optional (unrarSupport) unrardll
+      ++ lib.optional unrarSupport unrardll
     ))
     xdg-utils
-  ] ++ lib.optional (speechSupport) speechd-minimal;
+  ] ++ lib.optional speechSupport speechd-minimal;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Calibre uses `cwebp`, `jpegtran`, and `optipng` to losslessly optimize images with its `polish-ebook` tool. This adds these utilities in Calibre's `PATH`. The source code file where these utilities are used is [here](https://github.com/kovidgoyal/calibre/blob/master/src/calibre/utils/img.py).

Fixes #362529.

Can be verified by running this:

```
result/bin/ebook-polish --compress-images my-book-with-images.epub
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
