### PR TITLE
GNOME updates 2024-12-07

### DIFF
--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -18,16 +18,15 @@
 , ninja
 , pkg-config
 , rustc
-, rustPlatform
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Vg7kIWfB7SKCZhjmHYPkkUDbW/R6Zam6js4s1z0qSqg=";
+    hash = "sha256-Qccr4eybpV2pDIL8GFc7dC3/WCsJr8N7RWXEfpnMj/Q=";
   };
 
   patches = [
@@ -45,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     rustc
-    rustPlatform.bindgenHook # for libheif-sys
   ];
 
   buildInputs = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -74,11 +74,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "47.1.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BR/UBXFX9LIzcBP778luPRKWVOP8lg1ISdNUJSQAvnc=";
+    hash = "sha256-Q0oyLcN0OFi4nYFl2J+J3AWWi2t740AJRM7UJxJQ0+k=";
   };
 
   patches = [
@@ -151,9 +151,6 @@ stdenv.mkDerivation (finalAttrs: {
     # For animations in Mouse panel.
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
-    # vp9alphadecodebin, observed from GST_DEBUG="*:3" warnings.
-    # https://github.com/NixOS/nixpkgs/pull/333911#issuecomment-2409233470
-    gst_all_1.gst-plugins-bad
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-initial-setup";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-initial-setup/${lib.versions.major finalAttrs.version}/gnome-initial-setup-${finalAttrs.version}.tar.xz";
-    hash = "sha256-KTeKVkQG7Lzn8IzzklqA3TCCWoQ/kfzwWF45mecDUw0=";
+    hash = "sha256-T00Y61YnXMVqGZOlofTRPVpkJoad5nCWuS8rKcryIjw=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-music/package.nix
+++ b/pkgs/by-name/gn/gnome-music/package.nix
@@ -31,13 +31,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "47.0";
+  version = "47.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-music/${lib.versions.major version}/gnome-music-${version}.tar.xz";
-    hash = "sha256-o1Qjz1IgX9cDfLCpprVw9uwvHjQubiDtfn2A2NyGpyY=";
+    hash = "sha256-Zm8XX1YKGtnLq2HqDzA5PKL+0pRrpG5cAOrqEX28cNA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.52.1";
+  version = "3.52.2";
 
   outputs = [ "out" "dev" ] ++ lib.optionals enableBackend [ "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-N8dSL/lFT4NxtahyW7p27XQwyVsfnvx/66YmjwUtHrc=";
+    hash = "sha256-+0E/SN7vu5/DACqRV53ulHzu7UH0nC9RMXr3SJtnb2c=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -31,11 +31,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-BG0Py4m4jQskaczTUGPbW0KkUfkHEbU/H6OrFJGsGN4=";
+    hash = "sha256-k1HdjDns5wUMlny9zr4WYrwmuP2pJPioCpsqMS0H9HE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -42,11 +42,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-8qrL5V+jjocIWD7sCmZRBJ5TfrUFo+0s4Lqk6bZCRtE=";
+    hash = "sha256-HrdYhi6Ij1WghpGTCH8c+8x6EWNlTmMAmf9DQt0/alo=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6UOMxdOfmHXf0E6gq7UeWWLqrVwgJ0EjJDsWEgmLOoU=";
+    hash = "sha256-3XdKApFYSRer3oi7xOzPkkQXjjwmnOBhjQSVF3wSZS0=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -70,7 +70,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "47.1";
+  version = "47.2";
 
   outputs = [
     "out"
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-tGdXX4wVnSBVclhRfw3Wjf0BR9EbSNl6uOH3CbxSKmM=";
+    hash = "sha256-QYTQGhq4LLQh0couK8zgKSzrRsTHSeYbC95LdQBNLgA=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "47.0";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-0G2H/NcmqQ7QOhcMq0XUcIlJkeMSkS/FCL3g37yDz9o=";
+    hash = "sha256-2b8IuabChNHgT2/pI3pt7trRYeDlungQv/7PKF4rzd8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-share/package.nix
+++ b/pkgs/by-name/gn/gnome-user-share/package.nix
@@ -20,11 +20,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-share";
-  version = "47.0";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-share/${lib.versions.major finalAttrs.version}/gnome-user-share-${finalAttrs.version}.tar.xz";
-    hash = "sha256-yELzUv5/Dw6hj/kYa6lIK2yQ0vazZau1sR1oyQbbpJA=";
+    hash = "sha256-H6wbuIAN+kitnD4ZaQ9+EOZ6T5lNnLF8rh0b3/yRRLo=";
   };
 
   preConfigure = ''

--- a/pkgs/by-name/gt/gtranslator/package.nix
+++ b/pkgs/by-name/gt/gtranslator/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtranslator";
-  version = "47.0";
+  version = "47.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-duEEHF77Coi6GHZOpFiLThll+lAxTgGhc/o+oBUOHNU=";
+    hash = "sha256-yRwCZLmpnjCR75EfcxqP9tCahKK8115WUZcdprvqYiI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lo/localsearch/package.nix
+++ b/pkgs/by-name/lo/localsearch/package.nix
@@ -49,11 +49,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "localsearch";
-  version = "3.8.0";
+  version = "3.8.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/localsearch/${lib.versions.majorMinor finalAttrs.version}/localsearch-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5Og6Ha67UmORW0W3GXMeP3BB2VnL1jfqKa++kQySu/k=";
+    hash = "sha256-p7JKTweAXfdUOk3QI2hPzeXuaZygDrWwkSOgSdOuzNg=";
   };
 
   patches = [

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-9gNWmpThcwHy2sNLAsEsbY48pq65vmq1uYM5P5Ve2Ho=";
+    hash = "sha256-bgRu/k965X7idI1S0dBzVsdEnSBKPTHQtCNnqAGXShU=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -1,6 +1,5 @@
 {
   fetchurl,
-  fetchpatch,
   runCommand,
   lib,
   stdenv,
@@ -69,7 +68,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "47.1";
+  version = "47.3";
 
   outputs = [
     "out"
@@ -80,22 +79,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-kFR0oyzZmzQ0LNaedLsBlxs4fi+iI2G22ZrdEJQJ3ck=";
+    hash = "sha256-dkIa9vkFCc/fGrhR1e5YJx4n6Uqo99tSHVqgba6mxWA=";
   };
-
-  patches = [
-    # Fix cursor positioning
-    # https://gitlab.gnome.org/GNOME/mutter/-/issues/3696
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/5bcaa7c80b7640e2da6135cdff83eba77c202407.patch";
-      hash = "sha256-+LDTZRagBltarGvHtTI94mA70DrkonuqA+ibLkjvZ50=";
-    })
-  ];
 
   mesonFlags = [
     "-Degl_device=true"
     "-Dinstalled_tests=false" # TODO: enable these
     "-Dtests=disabled"
+    # For NVIDIA proprietary driver up to 470.
+    # https://src.fedoraproject.org/rpms/mutter/pull-request/49
     "-Dwayland_eglstream=true"
     "-Dprofiler=true"
     "-Dxwayland_path=${lib.getExe xwayland}"


### PR DESCRIPTION
- In case you review upstream changelogs from the [GitHub mirror](https://github.com/GNOME/), the GitLab -> GitHub sync is down (?) after the [migration](https://discourse.gnome.org/t/scheduled-maintenance-gitlab-gitlab-pages-04th-of-december-2024-at-2-pm-utc/25271) so the Mutter 47.3 tag is only available on gitlab.g.o
- I keep seeing downstream fixes for https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7836 I think it will be an annoying task for us when we need to do GTK 4.18 bump



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@jtojnar