### PR TITLE
ungoogled-chromium: 131.0.6778.85-1 -> 131.0.6778.108-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -766,7 +766,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "131.0.6778.85",
+    "version": "131.0.6778.108",
     "deps": {
       "depot_tools": {
         "rev": "20b9bdcace7ed561d6a75728c85373503473cb6b",
@@ -777,16 +777,16 @@
         "hash": "sha256-a8yCdBsl0nBMPS+pCLwrkAvQNP/THx/z/GySyOgx4Jk="
       },
       "ungoogled-patches": {
-        "rev": "131.0.6778.85-1",
-        "hash": "sha256-mcSshjdfUEH4ur4z+0P0oWCjlV8EhFMc+7rdfIIPASI="
+        "rev": "131.0.6778.108-1",
+        "hash": "sha256-xFtxgZRbtG8qxvTyt++wa69dQvr61K29mTubkxoI1Y8="
       },
       "npmHash": "sha256-b1l8SwjAfoColoa3zhTMPEF/rRuxzT3ATHE77rWU5EA="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "3d81e41b6f3ac8bcae63b32e8145c9eb0cd60a2d",
-        "hash": "sha256-fREToEHVbTD0IVGx/sn7csSju4BYajWZ+LDCiKWV4cI=",
+        "rev": "3b014839fbc4fb688b2f5af512d6ce312ad208b1",
+        "hash": "sha256-ypzu3LveMFcOFm7+JlaERjzs3SK/n9+sfm5wOKB8/zw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -886,8 +886,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "7e742cac42c29a14ab7f54b134b2f17592711267",
-        "hash": "sha256-K2gwKNwonzCIu4hnlYuOaYyKaRV11hwDzF4oykiKsl0="
+        "rev": "740d2502dbbd719a76c5a8d3fb4dac1b5363f42e",
+        "hash": "sha256-R41YVv4uWCU6SsACXPRppeCDguTs+/NVJckvMGGTgJE="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1366,8 +1366,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "94631d9b9a10697325589e1642af63a0137cac94",
-        "hash": "sha256-SKKLOxjimQWt8W+Q3wlCJaUC/lxw6EIZDFBuVQKmnVY="
+        "rev": "f14f6b1ab7cf544c0190074488d17821281cfa4d",
+        "hash": "sha256-0p57otDuIShl6MngYs22XA1QYxptDVa3vCwJsH59H34="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1491,8 +1491,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "8445abdf8069cadcbd134369b70d0ebd436ef477",
-        "hash": "sha256-EitEjXNtm0gB9wtAwIYHBHkU7paHg5zvsTz171hRmK4="
+        "rev": "79aff54b0fa9238ce3518dd9eaf9610cd6f22e82",
+        "hash": "sha256-xkMnUduSG88EWiwq6PITN0KgAKjFd4QOis3dgxedK30="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1526,8 +1526,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "bd2671b973062afc614b852ec190524b80aaef8a",
-        "hash": "sha256-uq0CE7Chqzy2d+iifC3hV9RTnDVinpwjl1pOzyNGbSo="
+        "rev": "e38771cb283b9689683c5ac0b5831dd89f8ec690",
+        "hash": "sha256-csSDnepYxil0R3PD/LVxW7JBcasOKG4l6q6vj8zHV/I="
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/update.mjs
+++ b/pkgs/applications/networking/browsers/chromium/update.mjs
@@ -29,26 +29,31 @@ const flush_to_file_proxy = {
   },
 }
 const lockfile = new Proxy(structuredClone(lockfile_initial), flush_to_file_proxy)
-
+const ungoogled_rev = argv['ungoogled-chromium-rev']
 
 for (const attr_path of Object.keys(lockfile)) {
-  if (!argv[attr_path]) {
+  const ungoogled = attr_path === 'ungoogled-chromium'
+
+  if (!argv[attr_path] && !(ungoogled && ungoogled_rev)) {
     console.log(`[${attr_path}] Skipping ${attr_path}. Pass --${attr_path} as argument to update.`)
     continue
   }
 
-  const ungoogled = attr_path === 'ungoogled-chromium'
   const version_nixpkgs = !ungoogled ? lockfile[attr_path].version : lockfile[attr_path].deps['ungoogled-patches'].rev
-  const version_upstream = !ungoogled ? await get_latest_chromium_release() : await get_latest_ungoogled_release()
+  const version_upstream = !ungoogled ? await get_latest_chromium_release() :
+    ungoogled_rev ?? await get_latest_ungoogled_release()
 
   console.log(`[${attr_path}] ${chalk.red(version_nixpkgs)} (nixpkgs)`)
   console.log(`[${attr_path}] ${chalk.green(version_upstream)} (upstream)`)
 
-  if (version_greater_than(version_upstream, version_nixpkgs)) {
+  if (ungoogled_rev || version_greater_than(version_upstream, version_nixpkgs)) {
     console.log(`[${attr_path}] ${chalk.green(version_upstream)} from upstream is newer than our ${chalk.red(version_nixpkgs)}...`)
 
-    // unconditionally remove ungoogled-chromium's epoch/sub-version (e.g. 130.0.6723.116-1 -> 130.0.6723.116)
-    const version_chromium = version_upstream.split('-')[0]
+    let ungoogled_patches = ungoogled ? await fetch_ungoogled(version_upstream) : undefined
+
+    // For ungoogled-chromium we need to remove the patch revision (e.g. 130.0.6723.116-1 -> 130.0.6723.116)
+    // by just using the chromium_version.txt content from the patches checkout (to also work with commit revs).
+    const version_chromium = ungoogled_patches?.chromium_version ?? version_upstream
 
     const chromium_rev = await chromium_resolve_tag_to_rev(version_chromium)
 
@@ -58,7 +63,10 @@ for (const attr_path of Object.keys(lockfile)) {
       deps: {
         depot_tools: {},
         gn: {},
-        'ungoogled-patches': ungoogled ? await fetch_ungoogled(version_upstream) : undefined,
+        'ungoogled-patches': !ungoogled ? undefined : {
+          rev: ungoogled_patches.rev,
+          hash: ungoogled_patches.hash,
+        },
         npmHash: dummy_hash,
       },
       DEPS: {},
@@ -187,13 +195,19 @@ async function fetch_ungoogled(rev) {
   const expr = (hash) => [`(import ./. {}).fetchFromGitHub { owner = "ungoogled-software"; repo = "ungoogled-chromium"; rev = "${rev}"; hash = "${hash}"; }`]
   const hash = await prefetch_FOD('--expr', expr(''))
 
-  const checkout = await $nixpkgs`nix-build  --expr ${expr(hash)}`
+  const checkout = await $nixpkgs`nix-build --expr ${expr(hash)}`
+  const checkout_path = checkout.stdout.trim()
 
-  await fs.copy(`${checkout.stdout.trim()}/flags.gn`, './ungoogled-flags.toml')
+  await fs.copy(path.join(checkout_path, 'flags.gn'), './ungoogled-flags.toml')
+
+  const chromium_version = (await fs.readFile(path.join(checkout_path, 'chromium_version.txt'))).toString().trim()
+
+  console.log(`[ungoogled-chromium] ${chalk.green(rev)} patch revision resolves to chromium version ${chalk.green(chromium_version)}`)
 
   return {
     rev,
     hash,
+    chromium_version,
   }
 }
 


### PR DESCRIPTION
Same underlying changes as #361530

https://chromereleases.googleblog.com/2024/12/stable-channel-update-for-desktop.html

This update includes 4 security fixes.

CVEs:
CVE-2024-12053

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
