### PR TITLE
zed-open-capture: init at unstable-2023-24-19, use in rtabmap, add myself as rtabmap maintainer

### DIFF
--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -1,25 +1,28 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, pkg-config
-, cmake
-, opencv
-, pcl
-, libusb1
-, eigen
-, wrapQtAppsHook
-, qtbase
-, g2o
-, ceres-solver
-, octomap
-, freenect
-, libdc1394
-, libGL
-, libGLU
-, vtkWithQt5
-, wrapGAppsHook3
-, liblapack
-, xorg
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  opencv,
+  pcl,
+  libusb1,
+  eigen,
+  wrapQtAppsHook,
+  qtbase,
+  g2o,
+  ceres-solver,
+  zed-open-capture,
+  hidapi,
+  octomap,
+  freenect,
+  libdc1394,
+  libGL,
+  libGLU,
+  vtkWithQt5,
+  wrapGAppsHook3,
+  liblapack,
+  xorg,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,7 +36,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-y/p1uFSxVQNXO383DLGCg4eWW7iu1esqpWlyPMF3huk=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+    wrapGAppsHook3
+  ];
   buildInputs = [
     ## Required
     opencv
@@ -57,6 +65,8 @@ stdenv.mkDerivation rec {
     libGL
     libGLU
     vtkWithQt5
+    zed-open-capture
+    hidapi
   ];
 
   # Disable warnings that are irrelevant to us as packagers
@@ -66,7 +76,7 @@ stdenv.mkDerivation rec {
     description = "Real-Time Appearance-Based 3D Mapping";
     homepage = "https://introlab.github.io/rtabmap/";
     license = licenses.bsd3;
-    maintainers = [ ];
+    maintainers = with maintainers; [ marius851000 ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/by-name/ze/zed-open-capture/package.nix
+++ b/pkgs/by-name/ze/zed-open-capture/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  libusb1,
+  hidapi,
+  opencv,
+  cmake,
+  pkg-config,
+  fetchFromGitHub,
+  withExamples ? false,
+}:
+
+stdenv.mkDerivation {
+  pname = "zed-open-capture";
+  version = "0.5.0-unstable-2023-24-19";
+
+  src = fetchFromGitHub {
+    owner = "stereolabs";
+    repo = "zed-open-capture";
+    rev = "5cf66ff777175776451b9b59ecc6231d730fa202";
+    sha256 = "sha256-ZjgJkCRbvLT7jjOcA8REiEpTg0Jh57du2aMwRk/OKLI=";
+  };
+
+  buildInputs = [
+    libusb1
+    hidapi
+    opencv
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  # all but one example require opencv with UI support, so disable it.
+  # The input OpenCV can be overriden with (opencv.override { enableGtk3 = true; })
+  cmakeFlags = lib.optionals (!withExamples) [
+    "-DBUILD_EXAMPLES=OFF"
+  ];
+
+  meta = with lib; {
+    description = "Platform-agnostic camera and sensor capture API for the ZED 2, ZED 2i, and ZED Mini stereo cameras";
+    homepage = "https://github.com/stereolabs/zed-open-capture";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added zed-open-capture, and added it as a dependancy of rtabmap, allowing use of some ZED model of 3D camera (like the ZED Mini I just bought). I hit the rtabmap issue of https://github.com/introlab/rtabmap/issues/1400 , but that was solved by using LANG=C (I’ll submit a fix upstream later)

I also added myself as a maintainers of rtabmap. I experiment with this software since a while (using data exported from a PHAB2PRO mobile phone)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) Only tested the main rtabmap binary.
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
