### PR TITLE
Fix kodi crosscompile

### DIFF
--- a/pkgs/applications/video/kodi/jsonschemabuilder.nix
+++ b/pkgs/applications/video/kodi/jsonschemabuilder.nix
@@ -1,0 +1,29 @@
+{
+  stdenv, lib, fetchFromGitHub,
+  cmake, makeWrapper, which, pkg-config,
+  buildPackages
+}:
+
+stdenv.mkDerivation(finalAttrs: {
+  pname = "kodi-jsonSchemaBuilder";
+  version = "21.0";
+  kodiReleaseName = "Omega";
+
+  src = fetchFromGitHub {
+    owner = "xbmc";
+    repo  = "xbmc";
+    rev   = "${finalAttrs.version}-${finalAttrs.kodiReleaseName}";
+    hash  = "sha256-xrFWqgwTkurEwt3/+/e4SCM6Uk9nxuW62SrCFWWqZO0=";
+  };
+
+  sourceRoot = "source/tools/depends/native/JsonSchemaBuilder/src";
+
+  nativeBuildInputs = [
+    cmake makeWrapper which pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DKODI_SOURCE_DIR=/build/source"
+    "-DCMAKE_MODULE_PATH=/build/source/cmake/modules/"
+  ];
+})

--- a/pkgs/applications/video/kodi/texturepacker.nix
+++ b/pkgs/applications/video/kodi/texturepacker.nix
@@ -1,0 +1,39 @@
+{
+  stdenv, lib, fetchFromGitHub,
+  cmake, makeWrapper, which, pkg-config,
+  giflib, zlib, libpng, libjpeg, lzo,
+  buildPackages
+}:
+
+stdenv.mkDerivation(finalAttrs: {
+  pname = "kodi-texturePacker";
+  version = "21.0";
+  kodiReleaseName = "Omega";
+
+  src = fetchFromGitHub {
+    owner = "xbmc";
+    repo  = "xbmc";
+    rev   = "${finalAttrs.version}-${finalAttrs.kodiReleaseName}";
+    hash  = "sha256-xrFWqgwTkurEwt3/+/e4SCM6Uk9nxuW62SrCFWWqZO0=";
+  };
+
+  sourceRoot = "source/tools/depends/native/TexturePacker/src";
+
+  nativeBuildInputs = [
+    cmake makeWrapper which pkg-config
+  ];
+
+  buildInputs = [
+    giflib zlib libpng libjpeg lzo
+  ];
+
+  # Hack to set a preprocessor directive
+  preConfigure = ''
+      sed -i "s/find_package(JPEG REQUIRED)/find_package(JPEG REQUIRED)\nadd_definitions(-DTARGET_POSIX)/" CMakeLists.txt
+    '';
+
+  cmakeFlags = [
+    "-DKODI_SOURCE_DIR=/build/source"
+    "-DCMAKE_MODULE_PATH=/build/source/cmake/modules/"
+  ];
+})


### PR DESCRIPTION
In 24.05, 24.11 and unstable, Kodi does not cross-compile from x86_64 to armvl7, or most likely it does not cross-compile at all. This PR fixes this.

Kodi has some vendored build-time dependencies. Most of these are unvendored in nixpkgs, of course, but two of them, JsonSchemaBuilder and TexturePacker are Kodi-specific build tools. For native builds, it seems Kodi can build these itself automatically or something to that effect, but for cross builds this does not work. Previously a hack was in place to build these tools in cross-compilation, but this did not work for me.

With the help of [some wonderful people on the nixOS discourse](https://discourse.nixos.org/t/crosscompiling-kodi-to-armv7-fails/56968/24), I made crosscompilation work for Kodi by building these two tools in separate derivations.

Testing whether the binary works on my rpi 2b is underway, I'll update when done, wanted to get this PR out.

- Split out vendored build-time dependencies into separate packages and derivations which are called using callPackage (jsonSchemaBuilder and texturePacker), rather than trying to build them in preConfigure.
- This also means that the unified Kodi build/configure system for their vendored dependencies is bypassed, for better or worse.
- Use jre_headless from buildPackages such that we get the correct architecture for it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux -> armv7l-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
