### PR TITLE
uiua-unstable: init at 0.14.0-dev.6

### DIFF
--- a/pkgs/by-name/ui/uiua/package.nix
+++ b/pkgs/by-name/ui/uiua/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   pkg-config,
 
-  darwin,
   audioSupport ? true,
   alsa-lib,
   webcamSupport ? false,
@@ -15,9 +14,6 @@
   uiua,
 }:
 
-let
-  inherit (darwin.apple_sdk.frameworks) AppKit AudioUnit CoreServices;
-in
 rustPlatform.buildRustPackage rec {
   pname = "uiua";
   version = "0.13.0";
@@ -35,13 +31,7 @@ rustPlatform.buildRustPackage rec {
     lib.optionals (webcamSupport || stdenv.hostPlatform.isDarwin) [ rustPlatform.bindgenHook ]
     ++ lib.optionals audioSupport [ pkg-config ];
 
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      AppKit
-      CoreServices
-    ]
-    ++ lib.optionals (audioSupport && stdenv.hostPlatform.isDarwin) [ AudioUnit ]
-    ++ lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
+  buildInputs = lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
 
   buildFeatures = lib.optional audioSupport "audio" ++ lib.optional webcamSupport "webcam";
 

--- a/pkgs/by-name/ui/uiua/stable.nix
+++ b/pkgs/by-name/ui/uiua/stable.nix
@@ -1,0 +1,7 @@
+rec {
+  version = "0.13.0";
+  rev = version;
+  hash = "sha256-5IqJ/lvozXzc7LRUzxpG04M3Nir+3h+GoL7dqTgC9J8=";
+  cargoHash = "sha256-0hbE2ZH7daw/VQLe51CxOIborABDF0x00kTyx9NCs9g=";
+  updateScript = ./update-stable.sh;
+}

--- a/pkgs/by-name/ui/uiua/unstable.nix
+++ b/pkgs/by-name/ui/uiua/unstable.nix
@@ -1,0 +1,7 @@
+rec {
+  version = "0.14.0-dev.6";
+  rev = version;
+  hash = "sha256-YRv4i014xD4d8YN5PuMsa06+7kZgISPBGkKrVLU5ZN0=";
+  cargoHash = "sha256-GYBHaYGmKcV0Gw1I4IWzfmecHwQtb2ys5bMguqfo8S0=";
+  updateScript = ./update-unstable.sh;
+}

--- a/pkgs/by-name/ui/uiua/update-stable.sh
+++ b/pkgs/by-name/ui/uiua/update-stable.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl jq nix-update common-updater-scripts
 
-nix-update uiua
+nix-update --override-filename pkgs/by-name/ui/uiua/stable.nix --version-regex '^(\d*\.\d*\.\d*)$' uiua
 
 EXT_VER=$(curl https://raw.githubusercontent.com/uiua-lang/uiua-vscode/main/package.json | jq -r .version)
 update-source-version vscode-extensions.uiua-lang.uiua-vscode $EXT_VER

--- a/pkgs/by-name/ui/uiua/update-unstable.sh
+++ b/pkgs/by-name/ui/uiua/update-unstable.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+
+nix-update --override-filename pkgs/by-name/ui/uiua/unstable.nix uiua-unstable

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7109,6 +7109,8 @@ with pkgs;
   babashka-unwrapped = callPackage ../development/interpreters/babashka { };
   babashka = callPackage ../development/interpreters/babashka/wrapped.nix { };
 
+  uiua-unstable = callPackage ../by-name/ui/uiua/package.nix { unstable = true; };
+
   # BQN interpreters and compilers
 
   mbqn = bqn;


### PR DESCRIPTION
Alternative to https://github.com/NixOS/nixpkgs/pull/362649

What's not addressed in this PR is that `passthru.tests.run` always runs the stable uiua version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
