### PR TITLE
Update jdreaver email, remove as prowlarr maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10263,7 +10263,7 @@
     name = "jdev082";
   };
   jdreaver = {
-    email = "johndreaver@gmail.com";
+    email = "me@davidreaver.com";
     github = "jdreaver";
     githubId = 1253071;
     name = "David Reaver";

--- a/nixos/tests/prowlarr.nix
+++ b/nixos/tests/prowlarr.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ lib, ... }:
 
 {
   name = "prowlarr";
-  meta.maintainers = with lib.maintainers; [ jdreaver ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://wiki.servarr.com/prowlarr";
     changelog = "https://github.com/Prowlarr/Prowlarr/releases/tag/v${version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ jdreaver ];
+    maintainers = with maintainers; [ ];
     mainProgram = "Prowlarr";
     platforms = [
       "aarch64-darwin"


### PR DESCRIPTION
Hello! This PR updates my email to my current email (me@davidreaver.com) and removes myself as the maintainer of `prowlarr`. I never actually used `prowlarr` for more than a couple days after adding the package to nixpkgs, and I don't want users to think I actually maintain it.