### PR TITLE
pololu-jrk-g2-software: init at 1.4.1

### DIFF
--- a/pkgs/by-name/po/pololu-jrk-g2-software/package.nix
+++ b/pkgs/by-name/po/pololu-jrk-g2-software/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libsForQt5,
+  libusbp,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pololu-jrk-g2-software";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "pololu";
+    repo = "pololu-jrk-g2-software";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-CNXExdA0hKfZFCgLHQ7uNWwpHKggewwdb5shnFjM5L4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libusbp
+  ];
+
+  postInstall = ''
+    install -Dt $out/lib/udev/rules.d ../udev-rules/99-pololu.rules
+  '';
+
+  meta = {
+    description = "Software and drivers for the Pololu Jrk G2 USB Motor Controllers with Feedback";
+    homepage = "https://github.com/pololu/pololu-jrk-g2-software";
+    license = with lib.licenses; [
+      zlib
+      mit
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "jrk2gui";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/po/pololu-jrk-g2-software/package.nix
+++ b/pkgs/by-name/po/pololu-jrk-g2-software/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pololu";
     repo = "pololu-jrk-g2-software";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-CNXExdA0hKfZFCgLHQ7uNWwpHKggewwdb5shnFjM5L4=";
   };
 


### PR DESCRIPTION
Hi,

This add https://github.com/pololu/pololu-jrk-g2-software, to configure and control motor drivers provided by pololu.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
