### PR TITLE
pkcs11-provider: 0.5 -> 0.6

### DIFF
--- a/pkgs/by-name/pk/pkcs11-provider/package.nix
+++ b/pkgs/by-name/pk/pkcs11-provider/package.nix
@@ -1,8 +1,20 @@
-{ lib, stdenv, fetchFromGitHub
-, openssl, nss, p11-kit
-, opensc, gnutls, expect, which
-, meson, ninja, pkg-config, valgrind, python3
-, nix-update-script
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+  nss,
+  p11-kit,
+  opensc,
+  gnutls,
+  expect,
+  which,
+  meson,
+  ninja,
+  pkg-config,
+  valgrind,
+  python3,
+  nix-update-script,
 }:
 
 let
@@ -20,11 +32,29 @@ stdenv.mkDerivation rec {
     hash = "sha256-wYqmxxAzraaVR2+mbsRfgyvD/tapn8UOO0UzBX2ZJH4=";
   };
 
-  buildInputs = [ openssl nss p11-kit ];
-  nativeBuildInputs = [ meson ninja pkg-config which ];
+  buildInputs = [
+    openssl
+    nss
+    p11-kit
+  ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    which
+  ];
 
   # don't add SoftHSM to here: https://github.com/openssl/openssl/issues/22508
-  nativeCheckInputs = [ p11-kit.bin opensc nss.tools gnutls openssl.bin expect valgrind pkcs11ProviderPython3 ];
+  nativeCheckInputs = [
+    p11-kit.bin
+    opensc
+    nss.tools
+    gnutls
+    openssl.bin
+    expect
+    valgrind
+    pkcs11ProviderPython3
+  ];
 
   postPatch = ''
     patchShebangs --build .
@@ -48,7 +78,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex" "v(\d\.\d)"];
+    extraArgs = [
+      "--version-regex"
+      "v(\d\.\d)"
+    ];
   };
 
   meta = with lib; {

--- a/pkgs/by-name/pk/pkcs11-provider/package.nix
+++ b/pkgs/by-name/pk/pkcs11-provider/package.nix
@@ -1,26 +1,30 @@
 { lib, stdenv, fetchFromGitHub
 , openssl, nss, p11-kit
-, opensc, gnutls, expect
-, meson, ninja, pkg-config
+, opensc, gnutls, expect, which
+, meson, ninja, pkg-config, valgrind, python3
 , nix-update-script
 }:
 
+let
+  pkcs11ProviderPython3 = python3.withPackages (pythonPkgs: with pythonPkgs; [ six ]);
+in
 stdenv.mkDerivation rec {
   pname = "pkcs11-provider";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "latchset";
     repo = "pkcs11-provider";
     rev = "v${version}";
-    hash = "sha256-ii2xQPBgqIjrAP27qTQR9IXbEGZcc79M/cYzFwcAajQ=";
+    fetchSubmodules = true;
+    hash = "sha256-wYqmxxAzraaVR2+mbsRfgyvD/tapn8UOO0UzBX2ZJH4=";
   };
 
   buildInputs = [ openssl nss p11-kit ];
-  nativeBuildInputs = [ meson ninja pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config which ];
 
   # don't add SoftHSM to here: https://github.com/openssl/openssl/issues/22508
-  nativeCheckInputs = [ p11-kit.bin opensc nss.tools gnutls openssl.bin expect ];
+  nativeCheckInputs = [ p11-kit.bin opensc nss.tools gnutls openssl.bin expect valgrind pkcs11ProviderPython3 ];
 
   postPatch = ''
     patchShebangs --build .


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes many bugs when using a token to establish a TLS connection:

> Several issues with handling keys related to run a full end-to-end TLS connection on the token have been fixed

https://github.com/latchset/pkcs11-provider/releases/tag/v0.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
