### PR TITLE
nixos/hickory-dns: make `settings.zone` freeform; expose `configFile` option

### DIFF
--- a/nixos/modules/services/networking/hickory-dns.nix
+++ b/nixos/modules/services/networking/hickory-dns.nix
@@ -3,10 +3,6 @@ let
   cfg = config.services.hickory-dns;
   toml = pkgs.formats.toml { };
 
-  configFile = toml.generate "hickory-dns.toml" (
-    lib.filterAttrsRecursive (_: v: v != null) cfg.settings
-  );
-
   zoneType = lib.types.submodule ({ config, ... }: {
     freeformType = toml.type;
     options = with lib; {
@@ -83,6 +79,22 @@ in
           If neither `quiet` nor `debug` are enabled, logging defaults to the INFO level.
         '';
       };
+      configFile = mkOption {
+        type = types.path;
+        default = toml.generate "hickory-dns.toml" (
+          lib.filterAttrsRecursive (_: v: v != null) cfg.settings
+        );
+        defaultText = lib.literalExpression ''
+          let toml = pkgs.formats.toml { }; in toml.generate "hickory-dns.toml" cfg.settings
+        '';
+        description = ''
+          Path to an existing toml file to configure hickory-dns with.
+
+          This can usually be left unspecified, in which case it will be
+          generated from the values in `settings`.
+          If manually specified, then the options in `settings` are ignored.
+        '';
+      };
       settings = mkOption {
         description = ''
           Settings for hickory-dns. The options enumerated here are not exhaustive.
@@ -143,7 +155,7 @@ in
           flags =  (lib.optional cfg.debug "--debug") ++ (lib.optional cfg.quiet "--quiet");
           flagsStr = builtins.concatStringsSep " " flags;
         in ''
-          ${lib.getExe cfg.package} --config ${configFile} ${flagsStr}
+          ${lib.getExe cfg.package} --config ${cfg.configFile} ${flagsStr}
         '';
         Type = "simple";
         Restart = "on-failure";

--- a/nixos/modules/services/networking/hickory-dns.nix
+++ b/nixos/modules/services/networking/hickory-dns.nix
@@ -8,6 +8,7 @@ let
   );
 
   zoneType = lib.types.submodule ({ config, ... }: {
+    freeformType = toml.type;
     options = with lib; {
       zone = mkOption {
         type = types.str;


### PR DESCRIPTION
in response to <https://github.com/NixOS/nixpkgs/issues/362891>

- `settings` itself is freeform; that `settings.zone` is not was a mistake. everything in `settings` is handled by hickory-dns and the user should be free to specify options not known to nixos.
- exposing `configFile` gives users a way to configure hickory-dns outside of nixos, e.g. to deploy the example configs from hickory-dns, or as an escape hatch should the nixos module contain other bugs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
