### PR TITLE
k9s: Fix check on darwin with CGO_ENABLED=0

### DIFF
--- a/pkgs/by-name/k9/k9s/package.nix
+++ b/pkgs/by-name/k9/k9s/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, nix-update-script, k9s }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, nix-update-script, k9s }:
 
 buildGoModule rec {
   pname = "k9s";
@@ -19,14 +19,12 @@ buildGoModule rec {
     "-X github.com/derailed/k9s/cmd.date=1970-01-01T00:00:00Z"
   ];
 
-  tags = [ "netcgo" ];
-
   proxyVendor = true;
 
   vendorHash = "sha256-ENn2BpGFEpiTNZbnNVt4hv4R6NTT3GivFd3rTy3xEH8=";
 
-  # TODO investigate why some config tests are failing
-  doCheck = !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64);
+  CGO_ENABLED = 0;
+
   # Required to workaround test check error:
   preCheck = "export HOME=$(mktemp -d)";
   # For arch != x86


### PR DESCRIPTION
I don't use k9s on macOS. Just checked the darwin build on github hosted runners. So, I hope macOS and k9s users will check the behaviors🙏 

---

This flag is disabled in compiler by default since go 1.20 https://github.com/golang/website/blob/ed80a58848789c5fd82f52a279dbc22e110989a9/_content/doc/go1.20.md?plain=1#L180-L218

And k9s official is testing and releasing under CGO_ENABLED=0 https://github.com/derailed/k9s/blob/v0.32.7/.github/workflows/test.yml#L28 https://github.com/derailed/k9s/blob/v0.32.7/.goreleaser.yml#L13-L14

But nixpkgs use different value for the default
https://github.com/NixOS/nixpkgs/blob/3dff76a8eed239feaca184bc91a63ac083e54cb7/doc/languages-frameworks/go.section.md?plain=1#L179-L202

Also reverting netcgo with this change
https://go.dev/cl/446178
https://go.dev/cl/448020
https://github.com/derailed/k9s/issues/780
https://github.com/NixOS/nixpkgs/pull/329114#discussion_r1705157449
https://github.com/derailed/k9s/blob/v0.32.7/Makefile#L3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
