### PR TITLE
treewide: rev -> tag, for pkgs I maintain, remove with lib

### DIFF
--- a/pkgs/by-name/di/distrobox-tui/package.nix
+++ b/pkgs/by-name/di/distrobox-tui/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "phanirithvij";
     repo = "distrobox-tui";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-J5stvhUNaU9YMczE56vC5bw2g67zsdVWiCi8k6KV/pU=";
   };
 
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   ldflags = [ "-s" ];
 
-  meta = with lib; {
+  meta = {
     description = "A TUI for DistroBox";
     changelog = "https://github.com/phanirithvij/distrobox-tui/releases/tag/v${version}";
     homepage = "https://github.com/phanirithvij/distrobox-tui";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ phanirithvij ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "distrobox-tui";
   };
 }

--- a/pkgs/by-name/gh/gh-i/package.nix
+++ b/pkgs/by-name/gh/gh-i/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "gennaro-tedesco";
     repo = "gh-i";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-k1xfQxRh8T0SINtbFlIVNFEODYU0RhBAkjudOv1bLvw=";
   };
 
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   ldflags = [ "-s" ];
 
-  meta = with lib; {
+  meta = {
     description = "Search github issues interactively";
     changelog = "https://github.com/gennaro-tedesco/gh-i/releases/tag/v${version}";
     homepage = "https://github.com/gennaro-tedesco/gh-i";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ phanirithvij ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "gh-i";
   };
 }

--- a/pkgs/by-name/gi/gitcs/package.nix
+++ b/pkgs/by-name/gi/gitcs/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "knbr13";
     repo = "gitcs";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-IyhVVRTKftZIzqMH5pBUMLPIk8bk0rVAxPKD6bABP68=";
   };
 
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   ldflags = [ "-s" ];
 
-  meta = with lib; {
+  meta = {
     description = "Scan local git repositories and generate a visual contributions graph";
     changelog = "https://github.com/knbr13/gitcs/releases/tag/v${version}";
     homepage = "https://github.com/knbr13/gitcs";
-    license = licenses.mit;
-    maintainers = with maintainers; [ phanirithvij ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "gitcs";
   };
 }

--- a/pkgs/by-name/go/gogup/package.nix
+++ b/pkgs/by-name/go/gogup/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "nao1215";
     repo = "gup";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-I4l/sDqafc/ZO8kKc4iOSMFLS0YZrAqRFOXn0N7Myo4=";
   };
 
@@ -23,12 +23,12 @@ buildGoModule rec {
     "-X github.com/nao1215/gup/internal/cmdinfo.Version=v${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Update binaries installed by 'go install' with goroutines";
     changelog = "https://github.com/nao1215/gup/blob/v${version}/CHANGELOG.md";
     homepage = "https://github.com/nao1215/gup";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ phanirithvij ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "gup";
   };
 }

--- a/pkgs/by-name/go/gomtree/package.nix
+++ b/pkgs/by-name/go/gomtree/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "vbatts";
     repo = "go-mtree";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MDX16z4H1fyuV5atEsZHReJyvC+MRdeA54DORCFtpqI=";
   };
 
@@ -27,12 +27,12 @@ buildGoModule rec {
     "-X main.Version=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "File systems verification utility and library, in likeness of mtree(8)";
     changelog = "https://github.com/vbatts/go-mtree/releases/tag/v${version}";
     homepage = "https://github.com/vbatts/go-mtree";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ phanirithvij ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "gomtree";
   };
 }

--- a/pkgs/by-name/op/opengist/package.nix
+++ b/pkgs/by-name/op/opengist/package.nix
@@ -15,7 +15,7 @@ let
   src = fetchFromGitHub {
     owner = "thomiceli";
     repo = "opengist";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Wpn9rqOUwbwi6pbPTnVzHb+ip3ay9WykEZDyHNdXYJU=";
   };
 

--- a/pkgs/by-name/vi/viddy/package.nix
+++ b/pkgs/by-name/vi/viddy/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "sachaos";
     repo = "viddy";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-ZdDe0ymPkj0ZGiPLo1Y0qMDk2SsUcPsSStay+Tuf4p0=";
   };
 


### PR DESCRIPTION
## Things done

Same hashes before and after.

```console
$ nix build -f default.nix distrobox-tui gh-i gitcs gogup gomtree opengist viddy --print-out-paths --no-link
/nix/store/m371rkcdvc4iyzyr6c47l2sfbszj1kn6-distrobox-tui-0.1.0
/nix/store/gp1s6g12ljrk4017h48y8vcv1p7y6rmj-gh-i-0.0.10
/nix/store/mwfyjg9zpjpzq42vc48npf2dx10kdmlz-gitcs-1.2.0
/nix/store/0a2wriygwsq5byskb6nhxmx1xw5pkckz-gogup-0.27.5
/nix/store/c1aps1x1gsa4312nprkl7yz1dbradv0q-gomtree-0.5.4
/nix/store/jdl71k8c5mgw7ljlv7077fdk3yg5d6dz-opengist-1.8.3
/nix/store/z9rcg76xawrdpp0hmi2gpaci5cxn3c29-viddy-1.3.0
```

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
