### PR TITLE
nixos/traefik: Update and revamp module

### DIFF
--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -4,148 +4,390 @@
   pkgs,
   ...
 }:
-
 let
+  inherit (lib.types)
+    nullOr
+    listOf
+    attrsOf
+    submodule
+    str
+    path
+    bool
+    package
+    ;
+  inherit (lib)
+    optional
+    optionals
+    optionalAttrs
+    mkIf
+    mkDefault
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mkRenamedOptionModule
+    mkMerge
+    mapAttrsToList
+    literalExpression
+    getExe
+    getExe'
+    ;
+  inherit (builtins) toJSON;
+  inherit (pkgs) writeText;
+
   cfg = config.services.traefik;
+  jsonValue = (pkgs.formats.json { }).type;
 
-  format = pkgs.formats.toml { };
-
-  dynamicConfigFile =
-    if cfg.dynamicConfigFile == null then
-      format.generate "config.toml" cfg.dynamicConfigOptions
+  staticFile =
+    if cfg.static.file == null then
+      writeText "static_config.json" (toJSON cfg.static.settings)
     else
-      cfg.dynamicConfigFile;
+      cfg.static.file;
 
-  staticConfigFile =
-    if cfg.staticConfigFile == null then
-      format.generate "config.toml" (
-        lib.recursiveUpdate cfg.staticConfigOptions {
-          providers.file.filename = "${dynamicConfigFile}";
-        }
-      )
-    else
-      cfg.staticConfigFile;
-
-  finalStaticConfigFile =
-    if cfg.environmentFiles == [ ] then staticConfigFile else "/run/traefik/config.toml";
+  finalStaticFile = if !cfg.useEnvSubst then staticFile else "/run/traefik/config.json";
 in
 {
+  imports = [
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "staticConfigFile"
+      ]
+      [
+        "services"
+        "traefik"
+        "static"
+        "file"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "staticConfigOptions"
+      ]
+      [
+        "services"
+        "traefik"
+        "static"
+        "settings"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "dynamicConfigFile"
+      ]
+      [
+        "services"
+        "traefik"
+        "dynamic"
+        "file"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "dynamicConfigOptions"
+      ]
+      [
+        "services"
+        "traefik"
+        "dynamic"
+        "settings"
+      ]
+    )
+  ];
   options.services.traefik = {
-    enable = lib.mkEnableOption "Traefik web server";
+    enable = mkEnableOption "Traefik web server";
+    package = mkPackageOption pkgs "traefik" { };
 
-    staticConfigFile = lib.mkOption {
-      default = null;
-      example = lib.literalExpression "/path/to/static_config.toml";
-      type = with lib.types; nullOr path;
-      description = ''
-        Path to traefik's static configuration to use.
-        (Using that option has precedence over `staticConfigOptions` and `dynamicConfigOptions`)
-      '';
-    };
+    static = {
+      file = mkOption {
+        default = null;
+        example = literalExpression "/path/to/static_config.toml";
+        type = nullOr path;
+        description = ''
+          Path to traefik's static configuration to use.
 
-    staticConfigOptions = lib.mkOption {
-      description = ''
-        Static configuration for Traefik.
-      '';
-      type = format.type;
-      default = {
-        entryPoints.http.address = ":80";
+          ::: {.note}
+          Using this option has precedence over {option}`services.traefik.static.settings`
+          :::
+        '';
       };
-      example = {
-        entryPoints.web.address = ":8080";
-        entryPoints.http.address = ":80";
+      settings = mkOption {
+        description = ''
+          Static configuration for Traefik, written in nix
 
-        api = { };
+          ::: {.note}
+          This will be serialized to JSON (which is considered valid YAML) at build, and passed to Traefik as `--configfile`
+          :::
+        '';
+        type = jsonValue;
+        default = {
+          entryPoints.http.address = ":80";
+        };
+        example = {
+          entryPoints = {
+            "web" = {
+              address = ":80";
+              http.redirections.entryPoint = {
+                permanent = true;
+                scheme = "https";
+                to = "websecure";
+              };
+            };
+            "websecure" = {
+              address = ":443";
+              asDefault = true;
+            };
+          };
+        };
       };
     };
 
-    dynamicConfigFile = lib.mkOption {
-      default = null;
-      example = lib.literalExpression "/path/to/dynamic_config.toml";
-      type = with lib.types; nullOr path;
-      description = ''
-        Path to traefik's dynamic configuration to use.
-        (Using that option has precedence over `dynamicConfigOptions`)
-      '';
+    dynamic = {
+      file = mkOption {
+        default = null;
+        example = literalExpression "/path/to/dynamic_config.toml";
+        type = nullOr path;
+        description = ''
+          Path to traefik's dynamic configuration to use.
+
+          ::: {.note}
+          Using this option has precedence over {option}`services.traefik.dynamic.settings`
+          :::
+        '';
+      };
+      dir = mkOption {
+        default = null;
+        example = literalExpression "/etc/traefik/dynamic-config";
+        type = nullOr path;
+        description = ''
+          Path to the directory traefik should watch.
+
+          ::: {.warning}
+          Files in this directory matching the glob `_nixos-*` (reserved for extraFiles) will be deleted as part of
+          systemd-tmpfiles-resetup.service, _**regardless of their origin.**_
+          :::
+        '';
+      };
+
+      settings = mkOption {
+        description = ''
+          Dynamic configuration for Traefik, written in nix.
+
+          ::: {.note}
+          This will be serialized to JSON (which is considered valid YAML) at build, and passed as part of the static file
+          :::
+        '';
+        type = jsonValue;
+        default = { };
+        example = {
+          http.routers."router1" = {
+            rule = "Host(`localhost`)";
+            service = "service1";
+          };
+          http.services."service1".loadBalancer.servers = [ { url = "http://localhost:8080"; } ];
+        };
+      };
     };
 
-    dynamicConfigOptions = lib.mkOption {
-      description = ''
-        Dynamic configuration for Traefik.
-      '';
-      type = format.type;
+    extraFiles = mkOption {
+      type = attrsOf (submodule {
+        options.settings = mkOption {
+          type = jsonValue;
+          description = "Dynamic configuration for Traefik, written in nix.";
+          example = {
+            http.routers."api" = {
+              service = "api@internal";
+              rule = "Host(`localhost`)";
+            };
+          };
+        };
+      });
       default = { };
       example = {
-        http.routers.router1 = {
-          rule = "Host(`localhost`)";
-          service = "service1";
+        "dashboard".settings = {
+          http.routers."api" = {
+            service = "api@internal";
+            rule = "Host(`192.168.122.217`)";
+          };
         };
-
-        http.services.service1.loadBalancer.servers = [ { url = "http://localhost:8080"; } ];
       };
-    };
-
-    plugins = lib.mkOption {
-      default = [ ];
-      type = with lib.types; listOf package;
-      example = lib.literalExpression "[ pkgs.fosrl-badger ]";
       description = ''
-        List of plugins to be added to the `localPlugins` attribute in the static configuration. These plugins are usually packaged in Nixpkgs, and are managed by Nix.
+        Extra dynamic configuration files to write. These are symlinked in `services.traefik.dynamic.dir` upon activation,
+        allowing configuration to be upated without restarting the primary daemon.
+
+        ::: {.note}
+        Due to [a limitation in Traefik](https://github.com/traefik/traefik/issues/10890); any syntax error in a dynamic configuration will cause the _**entire file provider**_ to be ignored.
+        This may cause interuption in service, which may include access to the traefik dashboard, if enabled and configured to use [traefik-ception](https://doc.traefik.io/traefik/operations/dashboard/#secure-mode).
+        :::
       '';
     };
 
-    dataDir = lib.mkOption {
+    plugins = mkOption {
+      default = [ ];
+      type = listOf package;
+      example = literalExpression "[ pkgs.fosrl-badger ]";
+      description = ''
+        List of plugins to be added to the `services.traefik.static.settings.localPlugins` attribute in the static configuration. These plugins are usually packaged in Nixpkgs, and are managed by Nix.
+      '';
+    };
+
+    dataDir = mkOption {
       default = "/var/lib/traefik";
-      type = lib.types.path;
+      type = path;
       description = ''
-        Location for any persistent data traefik creates, ie. acme
+        Location for any persistent data traefik creates, such as acme certificates
+
+        ::: {.note}
+        If left as the default value this directory will automatically be created
+        before the traefik server starts, otherwise you are responsible for ensuring
+        the directory exists with appropriate ownership and permissions.
+        :::
       '';
     };
 
-    group = lib.mkOption {
+    user = mkOption {
       default = "traefik";
-      type = lib.types.str;
-      example = "docker";
+      type = str;
       description = ''
-        Set the group that traefik runs under.
-        For the docker backend this needs to be set to `docker` instead.
+        User under which traefik runs.
+
+        ::: {.note}
+        If left as the default value this user will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the user exists before the traefik service starts.
+        :::
       '';
     };
 
-    package = lib.mkPackageOption pkgs "traefik" { };
+    group = mkOption {
+      default = "traefik";
+      type = str;
+      description = ''
+        Primary group under which traefik runs.
+        For the docker backend, prefer {option}`services.traefik.supplementaryGroups`
 
-    environmentFiles = lib.mkOption {
+        ::: {.note}
+        If left as the default value this group will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the group exists before the traefik service starts.
+        :::
+      '';
+    };
+
+    supplementaryGroups = mkOption {
       default = [ ];
-      type = with lib.types; listOf path;
+      type = listOf str;
+      example = [ "docker" ];
+      description = ''
+        Additional groups under which traefik runs.
+        This can be used to give additional permissions, such as required by the `docker` provider.
+
+        ::: {.note}
+        With the `docker` provider, traefik manages connection to containers via the docker socket,
+        which requires membership of the `docker` group for write access
+        :::
+      '';
+    };
+
+    environmentFiles = mkOption {
+      default = [ ];
+      type = listOf path;
       example = [ "/run/secrets/traefik.env" ];
       description = ''
-        Files to load as environment file. Environment variables from this file
-        will be substituted into the static configuration file using envsubst.
+        Files to load as an environment file just before Traefik starts.
+        This can be used to pass secrets such as [DNS challenge API tokens](https://doc.traefik.io/traefik/https/acme/#providers) or [EAB credentials](https://doc.traefik.io/traefik/reference/static-configuration/env/).
+        ```
+        DESEC_TOKEN=
+        TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EAB_HMACENCODED=
+        TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EAB_KID=
+        ```
+        ::: {.warn}
+        The traefik static configuration methods (env, CLI, and file) are mutually exclusive.
+        Rather than setting secret values with the traefik environment variable syntax,
+        it is recommended to set arbitray environment variables, then reference them with `$VARNAME` in e.g.
+        {option}`services.traefik.static.settings`.
+        :::
+      '';
+    };
+    useEnvSubst = mkOption {
+      default = cfg.environmentFiles != [ ];
+      defaultText = "config.services.traefik.environmentFiles != [ ]";
+      type = bool;
+      example = true;
+      description = ''
+        Whether to use `envSubst` in the ExecStartPre phase to augment the generated static config. See {option}`services.traefik.environmentFiles`
+
+        ::: {.note}
+        If you use environmentFiles but do not utilise environment variables in the static config, this can safely be disabled to reduce startup time
+        :::
       '';
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    services.traefik.staticConfigOptions = lib.mkIf (cfg.plugins != [ ]) {
-      experimental.localPlugins = lib.listToAttrs (
-        map (plugin: lib.nameValuePair plugin.plugin { inherit (plugin) moduleName; }) cfg.plugins
-      );
-    };
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.dynamic.file != null -> cfg.dynamic.dir == null;
+        message = "The filename and directory options are mutually exclusive. It is recommended to use directory.";
+      }
+      {
+        assertion = cfg.extraFiles != null -> cfg.dynamic.dir != null;
+        message = "extraFiles requires the dynamic file provider to be set to directory";
+      }
+      {
+        assertion = cfg.group != "docker";
+        message = "Setting the primary group to `docker` will cause files (such as those generated by extraFiles) to be owned by the group `docker`, which may be a security risk. Use `supplementaryGroups` instead.";
+      }
+      {
+        assertion = cfg.static.file != null -> cfg.plugins == [ ];
+        message = "{option}`services.traefik.static.file` and {option}`services.traefik.plugins` are set, but `plugins` is only compatible with {option}`services.traefik.static.settings`";
+      }
+    ];
 
     warnings =
-      lib.optional (!lib.all lib.id (map (plugin: plugin._isTraefikPlugin or false) cfg.plugins))
-        ''
-          Some of the Traefik plugins in 'services.traefik.plugins' may be misconfigured.
-          The following paths are built from derivations that do not have the '_isTraefikPlugin' attribute set to 'true':
-          - ${
-            lib.concatMapStringsSep "\n- " (badPlugin: badPlugin.outPath) (
-              lib.filter (plugin: plugin._isTraefikPlugin or false) cfg.plugins
-            )
-          }
-        '';
+      optional (!lib.all lib.id (map (plugin: plugin._isTraefikPlugin or false) cfg.plugins)) ''
+        Some of the Traefik plugins in 'services.traefik.plugins' may be misconfigured.
+        The following paths are built from derivations that do not have the '_isTraefikPlugin' attribute set to 'true':
+        - ${
+          lib.concatMapStringsSep "\n- " (badPlugin: badPlugin.outPath) (
+            lib.filter (plugin: plugin._isTraefikPlugin or false) cfg.plugins
+          )
+        }
+      ''
+      ++
+        optional (builtins.elem "docker" cfg.supplementaryGroups -> config.virtualisation.docker.enable)
+          ''
+            {option}`services.traefik.supplementaryGroups` contains the `docker` group, but {option}`services.docker` is not enabled.
+          '';
 
+    # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+    boot.kernel.sysctl."net.core.rmem_max" = mkDefault 2500000;
+    boot.kernel.sysctl."net.core.wmem_max" = mkDefault 2500000;
+
+    services.traefik.static.settings = mkMerge [
+      # If a dynamic file or directory has been set, add it as a provider in the static configuration
+      (mkIf (cfg.dynamic.dir != null || cfg.dynamic.file != null) {
+        providers.file = {
+          directory = mkIf (cfg.dynamic.dir != null) cfg.dynamic.dir;
+          filename = mkIf (cfg.dynamic.file != null) cfg.dynamic.file;
+          watch = mkDefault true;
+        };
+      })
+
+      (mkIf (cfg.plugins != [ ]) {
+        experimental.localPlugins = lib.listToAttrs (
+          map (plugin: lib.nameValuePair plugin.plugin { inherit (plugin) moduleName; }) cfg.plugins
+        );
+      })
+    ];
     systemd.services.traefik = {
-      description = "Traefik web server";
+      description = "Traefik reverse proxy";
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
@@ -154,15 +396,15 @@ in
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
         ExecStartPre =
-          lib.optional (cfg.environmentFiles != [ ]) (
+          optional cfg.useEnvSubst (
             pkgs.writeShellScript "traefik-pre-start-envsubst" ''
               umask 077
-              ${lib.getExe pkgs.envsubst} -i "${staticConfigFile}" > "${finalStaticConfigFile}"
+              ${getExe pkgs.envsubst} -i "${staticFile}" > "${finalStaticFile}"
             ''
           )
-          ++ lib.optional (cfg.plugins != [ ]) (
+          ++ optional (cfg.plugins != [ ]) (
             pkgs.writeShellScript "traefik-pre-start-ln-plugins" ''
-              ${lib.getExe' pkgs.coreutils "ln"} -Tsf ${
+              ${getExe' pkgs.coreutils "ln"} -Tsf ${
                 toString (
                   pkgs.symlinkJoin {
                     name = "traefik-plugins";
@@ -172,10 +414,11 @@ in
               } plugins-local
             ''
           );
-        ExecStart = "${cfg.package}/bin/traefik --configfile=${finalStaticConfigFile}";
+        ExecStart = "${getExe cfg.package} --configfile=${finalStaticFile}";
         Type = "simple";
-        User = "traefik";
+        User = cfg.user;
         Group = cfg.group;
+        SupplementaryGroups = mkIf (cfg.supplementaryGroups != [ ]) cfg.supplementaryGroups;
         Restart = "on-failure";
         AmbientCapabilities = "cap_net_bind_service";
         CapabilityBoundingSet = "cap_net_bind_service";
@@ -186,24 +429,44 @@ in
         PrivateDevices = true;
         ProtectHome = true;
         ProtectSystem = "full";
-        ReadWritePaths = [ cfg.dataDir ];
+        ReadWritePaths = [
+          cfg.dataDir
+        ];
+        ReadOnlyPaths = optional (cfg.dynamic.dir != null) cfg.dynamic.dir;
+
         RuntimeDirectory = "traefik";
         WorkingDirectory = cfg.dataDir;
       };
     };
 
-    users.users.traefik = {
-      group = "traefik";
-      home = cfg.dataDir;
-      createHome = true;
-      isSystemUser = true;
+    systemd.tmpfiles = {
+      rules =
+        optional (cfg.user == "traefik") "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.group} - -"
+        ++ optional (cfg.dynamic.dir != null) "d ${cfg.dynamic.dir} 0700 ${cfg.user} ${cfg.group} - -"
+        # Clean all old tmpfiles in the dynamic directory
+        ++ optional (cfg.dynamic.dir != null) "r ${cfg.dynamic.dir}/_nixos-* - - - - -"
+        # Only files ending in (yml|yaml|toml) are accepted by traefik, even though JSON is valid yaml
+        ++ optionals (cfg.dynamic.dir != null) (
+          mapAttrsToList (
+            key: value:
+            "L+ ${cfg.dynamic.dir}/_nixos-${key}.yml 0444 - - - ${writeText key (toJSON value.settings)}"
+          ) cfg.extraFiles
+        );
     };
-
-    users.groups.traefik = { };
+    users.users = optionalAttrs (cfg.user == "traefik") {
+      traefik = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+    users.groups = optionalAttrs (cfg.group == "traefik") {
+      traefik = { };
+    };
   };
 
   meta.maintainers = with lib.maintainers; [
     jackr
     sigmasquadron
+    therealgramdalf
   ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The nixosModule for `traefik` has not received updates (excluding treewide fixes) since January of 2020. This PR aims to update the module to be closer in line with RFC 42, make it much more ergonomic to use, and "modernize" things a little. Changes include (but are not limited to):

- Added TheRealGramdalf as package/module maintainer
- Removed usage of `with lib;`
- Added several quality of life assertions
- Only create the `traefik` user/group if left as default
- Recommend using `supplementaryGroups` instead of `group` when set to `docker`
- The `traefik` user is now a `systemUser` when created
- Rename options to be more ergonomic and in line with the spirit of RFC 42
- Added options that allow defining multiple dynamic config files that get symlinked into the dynamic file provider directory. This allows making changes to dynamic files without restarting the primary daemon, which allows for incremental changes without service interruption
- Added `mkRenamedOptionModule`s where appropriate
- Increase UDP buffer sizes, similar to `caddy`

_This module revamp is somewhat experimental - It's been in use for roughly a year in my personal configuration without issue, but has not been tested against other uses within nixpkgs/differing provider configuration. Additionally, the option descriptions may not be fully accurate and have not been tested for rendering in e.g. https://search.nixos.org. Since this is still a work in progress, release notes have not been added until at least initial review_



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
