### PR TITLE
treewide: add missing manual pages

### DIFF
--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -348,8 +348,11 @@ in
     # The actual implementation for this lives in man-db.nix or mandoc.nix,
     # depending on which backend is active.
     (mkIf cfg.man.enable {
-      environment.pathsToLink = [ "/share/man" ];
-      environment.extraOutputsToInstall = [ "man" ] ++ optional cfg.dev.enable "devman";
+      environment = {
+        extraOutputsToInstall = [ "man" ] ++ optional cfg.dev.enable "devman";
+        pathsToLink = [ "/share/man" ];
+        systemPackages = [ pkgs.man-pages ];
+      };
     })
 
     (mkIf cfg.info.enable {

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -240,11 +240,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.logrotate ];
     systemd.services.logrotate = {
       description = "Logrotate Service";
       documentation = [
         "man:logrotate(8)"
-        "man:logrotate(5)"
+        "man:logrotate.conf(5)"
       ];
       startAt = "hourly";
 

--- a/nixos/modules/services/system/zram-generator.nix
+++ b/nixos/modules/services/system/zram-generator.nix
@@ -33,6 +33,7 @@ in
     systemd.packages = [ cfg.package ];
     systemd.services."systemd-zram-setup@".path = [ pkgs.util-linux ]; # for mkswap
 
+    environment.systemPackages = [ cfg.package ];
     environment.etc."systemd/zram-generator.conf".source = settingsFormat.generate "zram-generator.conf" cfg.settings;
   };
 }

--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     # error when using a kernel that's too old
     "-D=linux-4-17=true"
     "-D=system-console-users=gdm,sddm,lightdm"
+    "-D=docs=true"
   ];
 
   PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";


### PR DESCRIPTION
Recently I discovered that some manual pages are missing from my system.
```shellsession
$ systemd-analyze verify /etc/systemd/system/*.service
...
dbus-broker.service: Command 'man dbus-broker-launch(1)' failed with code 16
dbus-broker.service: Command 'man dbus-broker-launch(1)' failed with code 16
logrotate.service: Command 'man logrotate(8)' failed with code 16
logrotate.service: Command 'man logrotate(5)' failed with code 16
...
systemd-boot-random-seed.service: Command 'man random(4)' failed with code 16
...
systemd-random-seed.service: Command 'man random(4)' failed with code 16
systemd-update-utmp.service: Command 'man utmp(5)' failed with code 16
systemd-zram-setup@i.service: Command 'man zram-generator(8)' failed with code 16
systemd-zram-setup@i.service: Command 'man zram-generator.conf(5)' failed with code 16
...
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
