### PR TITLE
qqsp: init at 1.9, qsp: init at 0-unstable-2024-11-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12895,6 +12895,12 @@
     githubId = 2576152;
     name = "John M. Harris, Jr.";
   };
+  JohnMolotov = {
+    name = "John Molotov";
+    email = "johnmolotov@cryptolab.net";
+    github = "JohnMolotov";
+    githubId = 171455312;
+  };
   johnpyp = {
     name = "John Paul Penaloza";
     email = "johnpyp.dev@gmail.com";

--- a/pkgs/by-name/qq/qqsp/package.nix
+++ b/pkgs/by-name/qq/qqsp/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  adwaita-qt,
+  libadwaita,
+  adw-gtk3,
+  gst_all_1,
+  gnome-themes-extra,
+  librsvg,
+  qt5,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qqsp";
+  version = "1.9";
+  src = fetchFromGitHub {
+    owner = "Sonnix1";
+    repo = "Qqsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eDgoa+/dcJ8Ti+YLHgKUKus0+zRrFEuJ19wUpbFpcBU=";
+  };
+  buildInputs = [
+    adwaita-qt
+    libadwaita
+    adw-gtk3
+    gnome-themes-extra
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    qt5.qtmultimedia
+    qt5.qtwebengine
+    qt5.qtbase
+  ];
+  nativeBuildInputs = [
+    qt5.qmake
+    qt5.qtbase
+    qt5.qtmultimedia
+    qt5.qtwebengine
+    qt5.wrapQtAppsHook
+    librsvg
+  ];
+  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types";
+  installPhase = ''
+    install -D Qqsp $out/bin/Qqsp
+    install -D $src/icons/qsp-logo-vector.svg $out/icons/scalable/apps/qsp.svg
+    install -D $src/Qqsp.desktop $out/share/applications/Qqsp.desktop
+    install -D $src/qsp.mime $out/share/mime/packages/qsp.xml
+    for i in 16 24 32 48 64 96 128 256 512; do
+      mkdir -p $out/share/icons/''${i}x$i/apps
+      rsvg-convert -w $i -h $i -f png $src/icons/qsp-logo-vector.svg -o $out/share/icons/''${i}x$i/apps/qsp.png
+    done
+  '';
+  meta = {
+    description = "Qt Quest Soft Player";
+    license = lib.licenses.mit;
+    homepage = "https://gitlab.com/Sonnix1/Qqsp";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+    mainProgram = "Qqsp";
+    maintainers = [ lib.maintainers.JohnMolotov ];
+  };
+})

--- a/pkgs/by-name/qs/qsp/package.nix
+++ b/pkgs/by-name/qs/qsp/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  oniguruma,
+}:
+stdenv.mkDerivation {
+  name = "qsp";
+  version = "0-unstable-2024-11-27";
+  src = fetchFromGitHub {
+    owner = "QSPFoundation";
+    repo = "qsp";
+    rev = "f6ede7f8756e49604de056fcbdfe99fa4abd4812";
+    hash = "sha256-MoNam2IFnLpk02tKp+lkl4l+mBiaWNPhFc3/n4zUHcw=";
+  };
+  buildInputs = [ oniguruma ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  cmakeFlags = [ (lib.cmakeBool "USE_INSTALLED_ONIGURUMA" true) ];
+  meta = {
+    description = "QuestSoft game engine";
+    homepage = "https://qsp.org/";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.JohnMolotov ];
+  };
+}


### PR DESCRIPTION
Adds the [QSP](https://qsp.org/) [Library](https://github.com/QSPFoundation/qsp) and a [QuestSoft Player for QT](https://gitlab.com/Sonnix1/Qqsp). Used to play videogames made in the QuestSoft engine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
