### PR TITLE
python312Packages.equinox: 0.11.9 -> 0.11.10

### DIFF
--- a/pkgs/development/python-modules/equinox/default.nix
+++ b/pkgs/development/python-modules/equinox/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "equinox";
-  version = "0.11.9";
+  version = "0.11.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "equinox";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-7RVhSdvD96oRUk6cGRS1rET4ztqjBnGfzJObjE+MioU=";
+    tag = "v${version}";
+    hash = "sha256-QoqwLdtWCDrXyqiI6Xw7jq2sxiRCmLaxk3/ZGHrvqL4=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/lineax/default.nix
+++ b/pkgs/development/python-modules/lineax/default.nix
@@ -16,6 +16,8 @@
   beartype,
   pytest,
   python,
+
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
@@ -26,9 +28,19 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "lineax";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-HcFI55Ww/y7ZaUkawj7xWSb7VDTBec3u0ulWL8kTm2c=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Reported upstream: https://github.com/patrick-kidger/lineax/issues/118
+      # Fixed by https://github.com/patrick-kidger/lineax/pull/119
+      name = "fix-vmap-tests";
+      url = "https://github.com/patrick-kidger/lineax/pull/119/commits/d21552ac4c504d7b139ad8e4f15d5f102b54d705.patch";
+      hash = "sha256-pBejiqIVNjXi7dXuDBQdAy892wro1WxzwbI7v07N86c=";
+    })
+  ];
 
   build-system = [ hatchling ];
 
@@ -59,7 +71,7 @@ buildPythonPackage rec {
   meta = {
     description = "Linear solvers in JAX and Equinox";
     homepage = "https://github.com/patrick-kidger/lineax";
-    changelog = "https://github.com/patrick-kidger/lineax/releases/tag/v${version}";
+    changelog = "https://github.com/patrick-kidger/lineax/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };


### PR DESCRIPTION
## Things done

Changelog: https://github.com/patrick-kidger/equinox/releases/tag/v0.11.10

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
