### PR TITLE
flycast : 2.3.2 -> 2.4

### DIFF
--- a/pkgs/by-name/fl/flycast/package.nix
+++ b/pkgs/by-name/fl/flycast/package.nix
@@ -18,23 +18,15 @@
 
 stdenv.mkDerivation rec {
   pname = "flycast";
-  version = "2.3.2";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner = "flyinghead";
     repo = "flycast";
     rev = "v${version}";
-    hash = "sha256-YFLSUaEikwLPglHh3t8sHiKHRn5cchKzzkJlZDdgVsU=";
+    hash = "sha256-1Rso7/S95+8KPoKa+3oFPJBWE+YGw4Qqo3Hn+crxNio=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # miniupnp: add support for api version 18
-    (fetchpatch2 {
-      url = "https://github.com/flyinghead/flycast/commit/71982eda7a038e24942921e558845103b6c12326.patch?full_index=1";
-      hash = "sha256-5fFCgX7MfCqW7zxXJuHt9js+VTZZKEQHRYuWh7MTKzI=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Changelog: https://github.com/flyinghead/flycast/releases/tag/v2.4

## What's Changed
* RetroAchievements support
* UI improvements with save state thumbnails
* Force Feedback support for some arcade games (F355, 18 Wheeler, Maximum Speed, Faster Than Speed, Initial D, Club Kart, King of Route 66, Tokyo Bus Guide, Sega Driving Simulator)
* Discord Rich Presence (Windows, macOS, linux)
* Android: gamepad rumble, custom Adreno drivers and many bug fixes and improvements
* Vulkan optimizations
* Various fixes
* Many upgrades

## Fixed Games
* Beach Spikers
* Capcom vs SNK 2000 Pro
* Irides: Master of blocks
* Mars TV
* Metropolis Street Racer
* Mortal Kombat
* Quake III
* Red Dog Superior Firepower
* Shin Nihon Pro Wrestling
* Soul Surfer
* Virtua Cop 2

**Full Changelog**: https://github.com/flyinghead/flycast/compare/v2.3.2...v2.4