### PR TITLE
vscode-extensions.ms-dotnettools: update C# and C# DevKit extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/default.nix
@@ -1,125 +1,74 @@
 {
   lib,
-  icu,
-  openssl,
-  patchelf,
   stdenv,
   vscode-utils,
+  autoPatchelfHook,
+  icu,
+  openssl,
+  libz,
+  glibc,
+  libxml2,
 }:
 let
   inherit (stdenv.hostPlatform) system;
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
+  lockfile = lib.importJSON ./lockfile.json;
   extInfo =
-    {
-      x86_64-linux = {
-        arch = "linux-x64";
-        hash = "sha256-yPenOk2sKt3DGmb69Ewbz8YT5KU371wizLdqfHCxBfg=";
-        binaries = [
-          "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/servicehub-controller-net60.linux-x64/Microsoft.ServiceHub.Controller"
-          "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-code-servicehost.linux-x64/Microsoft.VisualStudio.Code.ServiceHost"
-          "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-reliability-monitor.linux-x64/Microsoft.VisualStudio.Reliability.Monitor"
-          "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-server.linux-x64/Microsoft.VisualStudio.Code.Server"
-        ];
-      };
-      aarch64-linux = {
-        arch = "linux-arm64";
-        hash = "sha256-zjGyewO5Ss0kBr2GyWa/sBPy1K21MrNsIwzDBjGKlCc=";
-        binaries = [
-          "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/servicehub-controller-net60.linux-arm64/Microsoft.ServiceHub.Controller"
-          "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-code-servicehost.linux-arm64/Microsoft.VisualStudio.Code.ServiceHost"
-          "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-reliability-monitor.linux-arm64/Microsoft.VisualStudio.Reliability.Monitor"
-          "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-server.linux-arm64/Microsoft.VisualStudio.Code.Server"
-        ];
-      };
-      x86_64-darwin = {
-        arch = "darwin-x64";
-        hash = "sha256-nhX04v+r8IbUJ5Uoryuxvthn07MAoncDr5dxptlv9GM=";
-        binaries = [
-          "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/servicehub-controller-net60.darwin-x64/Microsoft.ServiceHub.Controller"
-          "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-x64/Microsoft.VisualStudio.Code.ServiceHost"
-          "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-reliability-monitor.darwin-x64/Microsoft.VisualStudio.Reliability.Monitor"
-          "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-server.darwin-x64/Microsoft.VisualStudio.Code.Server"
-        ];
-      };
-      aarch64-darwin = {
-        arch = "darwin-arm64";
-        hash = "sha256-IvH2wmaiw/TAMzuaFg+5gsKxjnp+Hi3PQnGLXp1KEHM=";
-        binaries = [
-          "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/servicehub-controller-net60.darwin-arm64/Microsoft.ServiceHub.Controller"
-          "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-arm64/Microsoft.VisualStudio.Code.ServiceHost"
-          "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-reliability-monitor.darwin-arm64/Microsoft.VisualStudio.Reliability.Monitor"
-          "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-server.darwin-arm64/Microsoft.VisualStudio.Code.Server"
-        ];
-      };
-    }
-    .${system} or (throw "Unsupported system: ${system}");
+    (arch: {
+      inherit arch;
+      inherit (lockfile.${arch}) hash binaries;
+    })
+      (
+        {
+          x86_64-linux = "linux-x64";
+          aarch64-linux = "linux-arm64";
+          x86_64-darwin = "darwin-x64";
+          aarch64-darwin = "darwin-arm64";
+        }
+        .${system} or (throw "Unsupported system: ${system}")
+      );
 in
 buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csdevkit";
     publisher = "ms-dotnettools";
-    version = "1.8.14";
+    inherit (lockfile) version;
     inherit (extInfo) hash arch;
   };
   sourceRoot = "extension"; # This has more than one folder.
 
-  nativeBuildInputs = [ patchelf ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib stdenv.cc.cc) # libstdc++.so.6
+    (lib.getLib glibc) # libgcc_s.so.1
+    (lib.getLib libxml2) # libxml2.so.2
+  ];
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib openssl) # libopenssl.so.3
+    (lib.getLib icu) # libicui18n.so libicuuc.so
+    (lib.getLib libz) # libz.so.1
+  ];
 
-  postPatch =
-    ''
-      declare ext_unique_id
-      ext_unique_id="$(basename "$out" | head -c 32)"
+  postPatch = ''
+    declare ext_unique_id
+    ext_unique_id="$(basename "$out" | head -c 32)"
 
-      patchelf_add_icu_as_needed() {
-        declare elf="''${1?}"
-        declare icu_major_v="${lib.head (lib.splitVersion (lib.getVersion icu.name))}"
+    substituteInPlace dist/extension.js \
+      --replace-fail 'e.extensionPath,"cache"' 'require("os").tmpdir(),"'"$ext_unique_id"'"' \
+      --replace-fail 't.setExecuteBit=async function(e){if("win32"!==process.platform){const t=o.join(e[a.SERVICEHUB_CONTROLLER_COMPONENT_NAME],"Microsoft.ServiceHub.Controller"),r=o.join(e[a.SERVICEHUB_HOST_COMPONENT_NAME],(0,a.getServiceHubHostEntrypointName)()),n=[(0,a.getServerPath)(e),t,r,(0,c.getReliabilityMonitorPath)(e)];await Promise.all(n.map((e=>(0,i.chmod)(e,"0755"))))}}' 't.setExecuteBit=async function(e){}'
 
-        for icu_lib in icui18n icuuc icudata; do
-          patchelf --add-needed "lib''${icu_lib}.so.$icu_major_v" "$elf"
-        done
-      }
+    chmod +x ${lib.escapeShellArgs extInfo.binaries}
+  '';
 
-      patchelf_common() {
-        declare elf="''${1?}"
-
-        patchelf_add_icu_as_needed "$elf"
-        patchelf --add-needed "libssl.so" "$elf"
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${
-            lib.makeLibraryPath [
-              stdenv.cc.cc
-              openssl
-              icu.out
-            ]
-          }:\$ORIGIN" \
-          "$elf"
-      }
-
-      substituteInPlace dist/extension.js \
-        --replace 'e.extensionPath,"cache"' 'require("os").tmpdir(),"'"$ext_unique_id"'"' \
-        --replace 't.setExecuteBit=async function(e){if("win32"!==process.platform){const t=i.join(e[a.SERVICEHUB_CONTROLLER_COMPONENT_NAME],"Microsoft.ServiceHub.Controller"),n=i.join(e[a.SERVICEHUB_HOST_COMPONENT_NAME],(0,a.getServiceHubHostEntrypointName)()),r=[(0,a.getServerPath)(e),t,n,(0,c.getReliabilityMonitorPath)(e)];await Promise.all(r.map((e=>(0,o.chmod)(e,"0755"))))}}' 't.setExecuteBit=async function(e){}'
-
-    ''
-    + (lib.concatStringsSep "\n" (
-      map (bin: ''
-        chmod +x "${bin}"
-      '') extInfo.binaries
-    ))
-    + lib.optionalString stdenv.hostPlatform.isLinux (
-      lib.concatStringsSep "\n" (
-        map (bin: ''
-          patchelf_common "${bin}"
-        '') extInfo.binaries
-      )
-    );
+  passthru.updateScript = ./update.sh;
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/ms-dotnettools.csdevkit/changelog";
     description = "Official Visual Studio Code extension for C# from Microsoft";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit";
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.ggg ];
+    maintainers = with lib.maintainers; [ ggg ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/lockfile.json
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/lockfile.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.14.14",
+  "linux-x64": {
+    "hash": "sha256-kblLJbiDSYC9uVhzKLgcdck1TJZa4vI6Rwvc9ZNSDEg=",
+    "binaries": [
+      "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/servicehub-controller-net60.linux-x64/Microsoft.ServiceHub.Controller",
+      "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-code-servicehost.linux-x64/Microsoft.VisualStudio.Code.ServiceHost",
+      "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-reliability-monitor.linux-x64/Microsoft.VisualStudio.Reliability.Monitor",
+      "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-server.linux-x64/Microsoft.VisualStudio.Code.Server"
+    ]
+  },
+  "linux-arm64": {
+    "hash": "sha256-yvmcAtb1t1jq3zLsvIrSZLBIGAy/OkOy8LabFgbl04o=",
+    "binaries": [
+      "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/servicehub-controller-net60.linux-arm64/Microsoft.ServiceHub.Controller",
+      "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-code-servicehost.linux-arm64/Microsoft.VisualStudio.Code.ServiceHost",
+      "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-reliability-monitor.linux-arm64/Microsoft.VisualStudio.Reliability.Monitor",
+      "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-server.linux-arm64/Microsoft.VisualStudio.Code.Server"
+    ]
+  },
+  "darwin-x64": {
+    "hash": "sha256-CABphtcOMxCFYUfzRBcBx3tgL5aKTtEiZj4dikIni50=",
+    "binaries": [
+      "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/servicehub-controller-net60.darwin-x64/Microsoft.ServiceHub.Controller",
+      "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-x64/Microsoft.VisualStudio.Code.ServiceHost",
+      "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-reliability-monitor.darwin-x64/Microsoft.VisualStudio.Reliability.Monitor",
+      "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-server.darwin-x64/Microsoft.VisualStudio.Code.Server"
+    ]
+  },
+  "darwin-arm64": {
+    "hash": "sha256-dGoLB9bmEUsbF18Mp7DZfMp18BHBKmyVAGFjjKm9J58=",
+    "binaries": [
+      "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/servicehub-controller-net60.darwin-arm64/Microsoft.ServiceHub.Controller",
+      "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-arm64/Microsoft.VisualStudio.Code.ServiceHost",
+      "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-reliability-monitor.darwin-arm64/Microsoft.VisualStudio.Reliability.Monitor",
+      "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-server.darwin-arm64/Microsoft.VisualStudio.Code.Server"
+    ]
+  }
+}

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/update.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl coreutils jq nix unzip
+# shellcheck shell=bash
+set -euo pipefail
+shopt -s globstar
+
+export LC_ALL=C
+
+PUBLISHER=ms-dotnettools
+EXTENSION=csdevkit
+LOCKFILE=pkgs/applications/editors/vscode/extensions/$PUBLISHER.$EXTENSION/lockfile.json
+
+response=$(curl -s 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery' \
+    -H 'accept: application/json;api-version=3.0-preview.1' \
+    -H 'content-type: application/json' \
+    --data-raw '{"filters":[{"criteria":[{"filterType":7,"value":"'"$PUBLISHER.$EXTENSION"'"}]}],"flags":16}')
+
+# Find the latest version compatible with stable vscode version
+latest_version=$(jq --raw-output '
+.results[0].extensions[0].versions
+| map(select(has("properties")))
+| map(select(.properties | map(select(.key == "Microsoft.VisualStudio.Code.Engine")) | .[0].value | test("\\^[0-9.]+$")))
+| map(select(.properties | map(select(.key == "Microsoft.VisualStudio.Code.PreRelease")) | .[0].value != "true"))
+| .[0].version' <<<"$response")
+
+current_version=$(jq '.version' --raw-output <"$LOCKFILE")
+
+if [[ "$latest_version" == "$current_version" ]]; then
+    echo "Package is up to date." >&2
+    exit 1
+fi
+
+# Return success if the specified file is an ELF object.
+isELF() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}<"$fn"
+    read -r -n 4 -u "$fd" magic
+    exec {fd}<&-
+    if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
+}
+
+# Return success if the specified file is a Mach-O object.
+isMachO() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}<"$fn"
+    read -r -n 4 -u "$fd" magic
+    exec {fd}<&-
+
+    # nix uses 'declare -F' in get-env.sh to retrieve the loaded functions.
+    # If we use the $'string' syntax instead of 'echo -ne' then 'declare' will print the raw characters and break nix.
+    # See https://github.com/NixOS/nixpkgs/pull/138334 and https://github.com/NixOS/nix/issues/5262.
+
+    # https://opensource.apple.com/source/lldb/lldb-310.2.36/examples/python/mach_o.py.auto.html
+    if [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xcf") || "$magic" = $(echo -ne "\xcf\xfa\xed\xfe") ]]; then
+        # MH_MAGIC_64 || MH_CIGAM_64
+        return 0
+    elif [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xce") || "$magic" = $(echo -ne "\xce\xfa\xed\xfe") ]]; then
+        # MH_MAGIC || MH_CIGAM
+        return 0
+    elif [[ "$magic" = $(echo -ne "\xca\xfe\xba\xbe") || "$magic" = $(echo -ne "\xbe\xba\xfe\xca") ]]; then
+        # FAT_MAGIC || FAT_CIGAM
+        return 0
+    else
+        return 1
+    fi
+}
+
+getDownloadUrl() {
+    nix-instantiate \
+        --eval \
+        --strict \
+        --json \
+        pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix \
+        --attr url \
+        --argstr publisher $PUBLISHER \
+        --argstr name $EXTENSION \
+        --argstr version "$latest_version" \
+        --argstr arch "$1" | jq . --raw-output
+}
+
+TEMP=$(mktemp --directory --tmpdir)
+OUTPUT="$TEMP/lockfile.json"
+trap 'rm -r "$TEMP"' EXIT
+
+HASH=
+BINARIES=()
+fetchMarketplace() {
+    arch="$1"
+
+    echo "  Downloading VSIX..."
+    if ! curl -sLo "$TEMP/$arch".zip "$(getDownloadUrl "$arch")"; then
+        echo "    Failed to download extension for arch $arch" >&2
+        exit 1
+    fi
+
+    HASH=$(nix hash file --type sha256 --sri "$TEMP/$arch".zip)
+    BINARIES=()
+
+    echo "  Extracting VSIX..."
+    mkdir "$TEMP/$arch"
+    if ! unzip "$TEMP/$arch".zip -d "$TEMP/$arch" >/dev/null; then
+        echo "    Failed to unzip extension for arch $arch" >&2
+        file "$TEMP/$arch".zip >&2
+        exit 1
+    fi
+
+    echo "  Listing binaries..."
+    for file in "$TEMP/$arch"/**/*; do
+        if [[ ! -f "$file" || "$file" == *.so || "$file" == *.dylib ]] ||
+            (! isELF "$file" && ! isMachO "$file"); then
+            continue
+        fi
+
+        echo "    FOUND: ${file#"$TEMP/$arch/extension/"}"
+        BINARIES+=("${file#"$TEMP/$arch/extension/"}")
+    done
+    rm -r "${TEMP:?}/$arch"
+}
+
+cat >"$OUTPUT" <<EOF
+{
+  "version": "$latest_version",
+EOF
+firstArch=true
+for arch in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+    if [ "$firstArch" = false ]; then
+        echo -e ',' >>"$OUTPUT"
+    fi
+    firstArch=false
+
+    echo "Getting data for $arch..."
+    fetchMarketplace "$arch"
+
+    cat >>"$OUTPUT" <<EOF
+  "$arch": {
+    "hash": "$HASH",
+    "binaries": [
+EOF
+
+    firstBin=true
+    for binary in "${BINARIES[@]}"; do
+        if [ "$firstBin" = false ]; then
+            echo -e ',' >>"$OUTPUT"
+        fi
+        firstBin=false
+
+        echo -n "      \"$binary\"" >>"$OUTPUT"
+    done
+    echo -ne '\n    ]\n  }' >>"$OUTPUT"
+done
+echo -e '\n}' >>"$OUTPUT"
+
+mv "$OUTPUT" "$LOCKFILE"

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -1,111 +1,62 @@
 {
   lib,
-  vscode-utils,
-  patchelf,
-  icu,
   stdenv,
+  vscode-utils,
+  autoPatchelfHook,
+  icu,
   openssl,
+  libz,
+  glibc,
   coreutils,
 }:
 let
   inherit (stdenv.hostPlatform) system;
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
+  lockfile = lib.importJSON ./lockfile.json;
   extInfo =
-    let
-      baseBins = [
-        ".roslyn/Microsoft.CodeAnalysis.LanguageServer"
-        ".razor/rzls"
-      ];
-      linuxBins = baseBins ++ [
-        ".debugger/vsdbg-ui"
-        ".debugger/vsdbg"
-      ];
-      darwinBins = baseBins ++ [
-        ".debugger/x86_64/vsdbg-ui"
-        ".debugger/x86_64/vsdbg"
-      ];
-    in
-    {
-      x86_64-linux = {
-        arch = "linux-x64";
-        hash = "sha256-uCayu7WU+qqiCDxxfO4j1aOypP+O49uNZMnfwq+hO4k=";
-        binaries = linuxBins;
-      };
-      aarch64-linux = {
-        arch = "linux-arm64";
-        hash = "sha256-b4Q3JWNdZtLlgxMUBpu+5ppJDILxjPHBZeMxsQHiDa0=";
-        binaries = linuxBins;
-      };
-      x86_64-darwin = {
-        arch = "darwin-x64";
-        hash = "sha256-uVI2PmHfhmuQMTCbwrGuLamC1DyjeLCZf41pjT891GE=";
-        binaries = darwinBins;
-      };
-      aarch64-darwin = {
-        arch = "darwin-arm64";
-        hash = "sha256-zNSvznX7nYTBexlkD49t3Ne66/u3paecZJZwMuPmSf4=";
-        binaries = darwinBins ++ [
-          ".debugger/arm64/vsdbg-ui"
-          ".debugger/arm64/vsdbg"
-        ];
-      };
-    }
-    .${system} or (throw "Unsupported system: ${system}");
+    (arch: {
+      inherit arch;
+      inherit (lockfile.${arch}) hash binaries;
+    })
+      (
+        {
+          x86_64-linux = "linux-x64";
+          aarch64-linux = "linux-arm64";
+          x86_64-darwin = "darwin-x64";
+          aarch64-darwin = "darwin-arm64";
+        }
+        .${system} or (throw "Unsupported system: ${system}")
+      );
 in
 buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csharp";
     publisher = "ms-dotnettools";
-    version = "2.39.29";
+    inherit (lockfile) version;
     inherit (extInfo) hash arch;
   };
 
-  nativeBuildInputs = [ patchelf ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib stdenv.cc.cc) # libstdc++.so.6
+    (lib.getLib glibc) # libgcc_s.so.1
+    (lib.getLib libz) # libz.so.1
+  ];
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib openssl) # libopenssl.so.3
+    (lib.getLib icu) # libicui18n.so libicuuc.so
+    (lib.getLib libz) # libz.so.1
+  ];
 
-  postPatch =
-    ''
-      patchelf_add_icu_as_needed() {
-        declare elf="''${1?}"
-        declare icu_major_v="${lib.head (lib.splitVersion (lib.getVersion icu.name))}"
+  postPatch = ''
+    substituteInPlace dist/extension.js \
+      --replace-fail 'uname -m' '${lib.getExe' coreutils "uname"} -m'
 
-        for icu_lib in icui18n icuuc icudata; do
-          patchelf --add-needed "lib''${icu_lib}.so.$icu_major_v" "$elf"
-        done
-      }
+    chmod +x ${lib.escapeShellArgs extInfo.binaries}
+  '';
 
-      patchelf_common() {
-        declare elf="''${1?}"
-
-        patchelf_add_icu_as_needed "$elf"
-        patchelf --add-needed "libssl.so" "$elf"
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${
-            lib.makeLibraryPath [
-              stdenv.cc.cc
-              openssl
-              icu.out
-            ]
-          }:\$ORIGIN" \
-          "$elf"
-      }
-
-      substituteInPlace dist/extension.js \
-        --replace 'uname -m' '${lib.getExe' coreutils "uname"} -m'
-
-    ''
-    + (lib.concatStringsSep "\n" (
-      map (bin: ''
-        chmod +x "${bin}"
-      '') extInfo.binaries
-    ))
-    + lib.optionalString stdenv.hostPlatform.isLinux (
-      lib.concatStringsSep "\n" (
-        map (bin: ''
-          patchelf_common "${bin}"
-        '') extInfo.binaries
-      )
-    );
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Official C# support for Visual Studio Code";

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/lockfile.json
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/lockfile.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.55.29",
+  "linux-x64": {
+    "hash": "sha256-3RQk5VNrI2sSUBCBfRTEsxjLqZkpoTELt/v+CIp94QU=",
+    "binaries": [
+      ".debugger/createdump",
+      ".debugger/vsdbg",
+      ".debugger/vsdbg-ui",
+      ".razor/rzls",
+      ".roslyn/Microsoft.CodeAnalysis.LanguageServer"
+    ]
+  },
+  "linux-arm64": {
+    "hash": "sha256-p8VbpeLtGDO3TKpjY9EuqDVyCDvZaQe9+KeAMTMulDc=",
+    "binaries": [
+      ".debugger/createdump",
+      ".debugger/vsdbg",
+      ".debugger/vsdbg-ui",
+      ".razor/rzls",
+      ".roslyn/Microsoft.CodeAnalysis.LanguageServer"
+    ]
+  },
+  "darwin-x64": {
+    "hash": "sha256-r85BNsxIXuQD20kjgqBvCLzTof4ExYDfbKG0zHaR86o=",
+    "binaries": [
+      ".debugger/x86_64/createdump",
+      ".debugger/x86_64/vsdbg",
+      ".debugger/x86_64/vsdbg-ui",
+      ".razor/rzls",
+      ".roslyn/Microsoft.CodeAnalysis.LanguageServer"
+    ]
+  },
+  "darwin-arm64": {
+    "hash": "sha256-p56EkUDxsukTx0FCCE2OrUBk3t2zj/kU6cdUVqdpfb8=",
+    "binaries": [
+      ".debugger/arm64/createdump",
+      ".debugger/arm64/vsdbg",
+      ".debugger/arm64/vsdbg-ui",
+      ".debugger/x86_64/createdump",
+      ".debugger/x86_64/vsdbg",
+      ".debugger/x86_64/vsdbg-ui",
+      ".razor/rzls",
+      ".roslyn/Microsoft.CodeAnalysis.LanguageServer"
+    ]
+  }
+}

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/update.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl coreutils jq nix unzip
+# shellcheck shell=bash
+set -euo pipefail
+shopt -s globstar
+shopt -s dotglob
+
+export LC_ALL=C
+
+PUBLISHER=ms-dotnettools
+EXTENSION=csharp
+LOCKFILE=pkgs/applications/editors/vscode/extensions/$PUBLISHER.$EXTENSION/lockfile.json
+
+response=$(curl -s 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery' \
+    -H 'accept: application/json;api-version=3.0-preview.1' \
+    -H 'content-type: application/json' \
+    --data-raw '{"filters":[{"criteria":[{"filterType":7,"value":"'"$PUBLISHER.$EXTENSION"'"}]}],"flags":16}')
+
+# Find the latest version compatible with stable vscode version
+latest_version=$(jq --raw-output '
+.results[0].extensions[0].versions
+| map(select(has("properties")))
+| map(select(.properties | map(select(.key == "Microsoft.VisualStudio.Code.Engine")) | .[0].value | test("\\^[0-9.]+$")))
+| map(select(.properties | map(select(.key == "Microsoft.VisualStudio.Code.PreRelease")) | .[0].value != "true"))
+| .[0].version' <<<"$response")
+
+current_version=$(jq '.version' --raw-output <"$LOCKFILE")
+
+if [[ "$latest_version" == "$current_version" ]]; then
+    echo "Package is up to date." >&2
+    exit 1
+fi
+
+# Return success if the specified file is an ELF object.
+isELF() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}<"$fn"
+    read -r -n 4 -u "$fd" magic
+    exec {fd}<&-
+    if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
+}
+
+# Return success if the specified file is a Mach-O object.
+isMachO() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}<"$fn"
+    read -r -n 4 -u "$fd" magic
+    exec {fd}<&-
+
+    # nix uses 'declare -F' in get-env.sh to retrieve the loaded functions.
+    # If we use the $'string' syntax instead of 'echo -ne' then 'declare' will print the raw characters and break nix.
+    # See https://github.com/NixOS/nixpkgs/pull/138334 and https://github.com/NixOS/nix/issues/5262.
+
+    # https://opensource.apple.com/source/lldb/lldb-310.2.36/examples/python/mach_o.py.auto.html
+    if [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xcf") || "$magic" = $(echo -ne "\xcf\xfa\xed\xfe") ]]; then
+        # MH_MAGIC_64 || MH_CIGAM_64
+        return 0
+    elif [[ "$magic" = $(echo -ne "\xfe\xed\xfa\xce") || "$magic" = $(echo -ne "\xce\xfa\xed\xfe") ]]; then
+        # MH_MAGIC || MH_CIGAM
+        return 0
+    elif [[ "$magic" = $(echo -ne "\xca\xfe\xba\xbe") || "$magic" = $(echo -ne "\xbe\xba\xfe\xca") ]]; then
+        # FAT_MAGIC || FAT_CIGAM
+        return 0
+    else
+        return 1
+    fi
+}
+
+getDownloadUrl() {
+    nix-instantiate \
+        --eval \
+        --strict \
+        --json \
+        pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix \
+        --attr url \
+        --argstr publisher $PUBLISHER \
+        --argstr name $EXTENSION \
+        --argstr version "$latest_version" \
+        --argstr arch "$1" | jq . --raw-output
+}
+
+TEMP=$(mktemp --directory --tmpdir)
+OUTPUT="$TEMP/lockfile.json"
+trap 'rm -r "$TEMP"' EXIT
+
+HASH=
+BINARIES=()
+fetchMarketplace() {
+    arch="$1"
+
+    echo "  Downloading VSIX..."
+    if ! curl -sLo "$TEMP/$arch".zip "$(getDownloadUrl "$arch")"; then
+        echo "    Failed to download extension for arch $arch" >&2
+        exit 1
+    fi
+
+    HASH=$(nix hash file --type sha256 --sri "$TEMP/$arch".zip)
+    BINARIES=()
+
+    echo "  Extracting VSIX..."
+    mkdir "$TEMP/$arch"
+    if ! unzip "$TEMP/$arch".zip -d "$TEMP/$arch" >/dev/null; then
+        echo "    Failed to unzip extension for arch $arch" >&2
+        file "$TEMP/$arch".zip >&2
+        exit 1
+    fi
+
+    echo "  Listing binaries..."
+    for file in "$TEMP/$arch"/**/*; do
+        if [[ ! -f "$file" || "$file" == *.so || "$file" == *.dylib ]] ||
+            (! isELF "$file" && ! isMachO "$file"); then
+            continue
+        fi
+
+        echo "    FOUND: ${file#"$TEMP/$arch/extension/"}"
+        BINARIES+=("${file#"$TEMP/$arch/extension/"}")
+    done
+    rm -r "${TEMP:?}/$arch"
+}
+
+cat >"$OUTPUT" <<EOF
+{
+  "version": "$latest_version",
+EOF
+firstArch=true
+for arch in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+    if [ "$firstArch" = false ]; then
+        echo -e ',' >>"$OUTPUT"
+    fi
+    firstArch=false
+
+    echo "Getting data for $arch..."
+    fetchMarketplace "$arch"
+
+    cat >>"$OUTPUT" <<EOF
+  "$arch": {
+    "hash": "$HASH",
+    "binaries": [
+EOF
+
+    firstBin=true
+    for binary in "${BINARIES[@]}"; do
+        if [ "$firstBin" = false ]; then
+            echo -e ',' >>"$OUTPUT"
+        fi
+        firstBin=false
+
+        echo -n "      \"$binary\"" >>"$OUTPUT"
+    done
+    echo -ne '\n    ]\n  }' >>"$OUTPUT"
+done
+echo -e '\n}' >>"$OUTPUT"
+
+mv "$OUTPUT" "$LOCKFILE"


### PR DESCRIPTION
Updates the VSCode C# extension with the following changes:
- v2.45.20: https://github.com/dotnet/vscode-csharp/releases/tag/v2.45.20
- v2.45.25: https://github.com/dotnet/vscode-csharp/releases/tag/v2.45.25
- v2.50.25: https://github.com/dotnet/vscode-csharp/releases/tag/v2.50.25
- v2.55.28: https://github.com/dotnet/vscode-csharp/releases/tag/v2.55.28
- v2.55.29: https://github.com/dotnet/vscode-csharp/releases/tag/v2.55.29

And the VSCode C# DevKit extension with the following changes: https://marketplace.visualstudio.com/items/ms-dotnettools.csdevkit/changelog

An update script was added for ease of update for both extensions.
It fetches the extension VSIX for each supported platform double, calculates their hash and lists the binaries that need to be marked as executable and saves all that information in a JSON file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
