### PR TITLE
radicle-node: 1.0.0 → 1.1.0

### DIFF
--- a/pkgs/by-name/ra/radicle-node/61865b5b5ad715e2b812087947281f0add9aa05e.patch
+++ b/pkgs/by-name/ra/radicle-node/61865b5b5ad715e2b812087947281f0add9aa05e.patch
@@ -1,0 +1,22 @@
+commit 61865b5b5ad715e2b812087947281f0add9aa05e
+Author: Fintan Halpenny <fintan.halpenny@gmail.com>
+Date:   2024-11-19 14:38:38 +0100
+
+    cob: fix documentation
+    
+    `no_run` will compile but not run the code. Use `ignore` instead, and also added
+    `rust` for syntax highlighting.
+
+diff --git a/radicle-cob/src/backend/git/stable.rs b/radicle-cob/src/backend/git/stable.rs
+index 0d8ea27b..ef18ae55 100644
+--- a/radicle-cob/src/backend/git/stable.rs
++++ b/radicle-cob/src/backend/git/stable.rs
+@@ -53,7 +53,7 @@ pub fn read_timestamp() -> i64 {
+ ///
+ /// # Usage
+ ///
+-/// ```no_run
++/// ```rust, ignore
+ /// let oid1 = with_advanced_timestamp(|| cob.update("New revision OID"));
+ /// let oid2 = with_advanced_timestamp(|| cob.update("Another revision OID"));
+ /// ```

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -18,15 +18,19 @@
 , xdg-utils
 }: rustPlatform.buildRustPackage rec {
   pname = "radicle-node";
-  version = "1.0.0";
+  version = "1.1.0";
   env.RADICLE_VERSION = version;
 
   src = fetchgit {
     url = "https://seed.radicle.xyz/z3gqcJUoA1n9HaHKufZs5FCSGazv5.git";
     rev = "refs/namespaces/z6MksFqXN3Yhqk8pTJdUGLwATkRfQvwZXPqR2qMEhbS9wzpT/refs/tags/v${version}";
-    hash = "sha256-sb0GroWfZWC9YCGby88eiPnhFCdDA9EUhVpoyuAA+Mk=";
+    hash = "sha256-M4oz9tWjI/eqV4Gz1b512MEmvsZ5u3R9y6P9VeeH9CA=";
   };
-  cargoHash = "sha256-+VjYX1gGf5aIGSQRMtvK6JI118X50HaxFwg5H14Vq7g=";
+  cargoHash = "sha256-QhTolHEzhdIkM5dn1o2CdbFy7JLCLHxd+IwcWl7MLQo=";
+
+  patches = [
+    ./61865b5b5ad715e2b812087947281f0add9aa05e.patch
+  ];
 
   nativeBuildInputs = [ asciidoctor installShellFiles makeWrapper ];
   nativeCheckInputs = [ git ];


### PR DESCRIPTION
Announcement: https://radicle.zulipchat.com/#narrow/channel/409174-announcements/topic/radicle.201.2E1.2E0

Background for the patch: https://radicle.zulipchat.com/#narrow/channel/383670-patches/topic/cob.3A.20fix.20documentation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
