### PR TITLE
nixos/wakapi: don't merge EnvironmentFile paths

### DIFF
--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -142,10 +142,10 @@ in
           (mkIf (cfg.passwordSalt != null) "WAKAPI_PASSWORD_SALT=${cfg.passwordSalt}")
           (mkIf (cfg.smtpPassword != null) "WAKAPI_MAIL_SMTP_PASS=${cfg.smtpPassword}")
         ];
-        EnvironmentFile = [
-          (optional (cfg.passwordSaltFile != null) cfg.passwordSaltFile)
-          (optional (cfg.smtpPasswordFile != null) cfg.smtpPasswordFile)
-        ];
+
+        EnvironmentFile =
+          (lib.optional (cfg.passwordSaltFile != null) cfg.passwordSaltFile)
+          ++ (lib.optional (cfg.smtpPasswordFile != null) cfg.smtpPasswordFile);
 
         User = config.users.users.wakapi.name;
         Group = config.users.users.wakapi.group;


### PR DESCRIPTION
Potentially fixes #360749.

Current approach is to merge `EnvironmentFile` paths, which isn't exactly
necessary and might run us into type errors in the future if there are any
additions to the list of `mkMerge`.

Proposed `mkIf` solution wouldn't work, because `mkIf` always returns an
attribute set (which we cannot merge, or pass to `EnvironmentFile`).
Test builds fine, but untested locally.

CC @sochotnicky and @isabelroses for testing.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  (or backporting
  [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  and
  [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
