### PR TITLE
linger-users: Fix strict shell checks, fix for mutable users

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -379,6 +379,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
   - In all other cases, you'll need to set this option to `true` yourself.
   - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 
+- `users.users.*.linger` now defaults to `null` rather than `false`, meaning NixOS will not attempt to enable or disable lingering for that user account.  In practice, this is unlikely to make a difference for most people, as new users are created without lingering configured, but it means users who use `loginctl` commands to manage lingering imperatively will not have their changes overridden by default.  There is a new, related option, `users.manageLingering`, which can be used to prevent NixOS attempting to manage lingering entirely.
+
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
 - `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module has been removed, and users will need to switch to kernels that support the out-of-tree module.

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -927,10 +927,10 @@ in
             done
 
             if (( ''${#nonLingeringUserNames[*]} > 0 )); then
-                ${pkgs.systemd}/bin/loginctl disable-linger "''${nonLingeringUserNames[@]}"
+                ${config.systemd.package}/bin/loginctl disable-linger "''${nonLingeringUserNames[@]}"
             fi
             if (( ''${#lingeringUserNames[*]} > 0 )); then
-                ${pkgs.systemd}/bin/loginctl enable-linger "''${lingeringUserNames[@]}"
+                ${config.systemd.package}/bin/loginctl enable-linger "''${lingeringUserNames[@]}"
             fi
           '';
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -899,7 +899,6 @@ in
 
         script =
           let
-            lingerDir = "/var/lib/systemd/linger";
             userPartition = lib.lists.partition (u: u.linger) (builtins.attrValues cfg.users);
             lingeringUserNames = map (u: u.name) userPartition.right;
             nonLingeringUserNames = map (u: u.name) userPartition.wrong;
@@ -915,8 +914,6 @@ in
                 id "$1" >/dev/null
             }
 
-            mkdir -vp ${lingerDir}
-            cd ${lingerDir}
             shopt -s dotglob nullglob
             for user in *; do
                 if ! user_configured "$user"; then
@@ -934,7 +931,11 @@ in
             fi
           '';
 
-        serviceConfig.Type = "oneshot";
+        serviceConfig = {
+          Type = "oneshot";
+          StateDirectory = "systemd/linger";
+          WorkingDirectory = "/var/lib/systemd/linger";
+        };
       };
 
       # Warn about user accounts with deprecated password hashing schemes

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -661,8 +661,6 @@ let
       shells = mapAttrsToList (_: u: u.shell) cfg.users;
     in
     filter types.shellPackage.check shells;
-
-  lingeringUsers = map (u: u.name) (attrValues (flip filterAttrs cfg.users (n: u: u.linger)));
 in
 {
   imports = [
@@ -894,7 +892,7 @@ in
         else
           ""; # keep around for backwards compatibility
 
-      systemd.services.linger-users = lib.mkIf ((length lingeringUsers) > 0) {
+      systemd.services.linger-users = {
         wantedBy = [ "multi-user.target" ];
         after = [ "systemd-logind.service" ];
         requires = [ "systemd-logind.service" ];
@@ -902,21 +900,38 @@ in
         script =
           let
             lingerDir = "/var/lib/systemd/linger";
-            lingeringUsersFile = builtins.toFile "lingering-users" (
-              concatStrings (map (s: "${s}\n") (sort (a: b: a < b) lingeringUsers))
-            ); # this sorting is important for `comm` to work correctly
+            userPartition = lib.lists.partition (u: u.linger) (builtins.attrValues cfg.users);
+            lingeringUserNames = map (u: u.name) userPartition.right;
+            nonLingeringUserNames = map (u: u.name) userPartition.wrong;
           in
           ''
+            ${lib.strings.toShellVars { inherit lingeringUserNames nonLingeringUserNames; }}
+
+            user_configured () {
+                # Use `id` to check if the user exists rather than checking the
+                # NixOS configuration, as it may be that the user has been
+                # manually configured, which is permitted if users.mutableUsers
+                # is true (the default).
+                id "$1" >/dev/null
+            }
+
             mkdir -vp ${lingerDir}
             cd ${lingerDir}
-            for user in $(ls); do
-              if ! id "$user" >/dev/null; then
-                echo "Removing linger for missing user $user"
-                rm --force -- "$user"
-              fi
+            shopt -s dotglob nullglob
+            for user in *; do
+                if ! user_configured "$user"; then
+                    # systemd has this user configured to linger despite them not
+                    # existing.
+                    rm -- "$user"
+                fi
             done
-            ls | sort | comm -3 -1 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl disable-linger
-            ls | sort | comm -3 -2 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl  enable-linger
+
+            if (( ''${#nonLingeringUserNames[*]} > 0 )); then
+                ${pkgs.systemd}/bin/loginctl disable-linger "''${nonLingeringUserNames[@]}"
+            fi
+            if (( ''${#lingeringUserNames[*]} > 0 )); then
+                ${pkgs.systemd}/bin/loginctl enable-linger "''${lingeringUserNames[@]}"
+            fi
           '';
 
         serviceConfig.Type = "oneshot";

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -919,6 +919,7 @@ in
                 if ! user_configured "$user"; then
                     # systemd has this user configured to linger despite them not
                     # existing.
+                    echo "Removing linger for missing user $user" >&2
                     rm -- "$user"
                 fi
             done

--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -32,6 +32,7 @@
   boot.kexec.enable = lib.mkDefault false;
   # Relies on bash scripts
   powerManagement.enable = lib.mkDefault false;
+  users.manageLingering = lib.mkDefault false;
   # Relies on the gzip command which depends on bash
   services.logrotate.enable = lib.mkDefault false;
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1510,6 +1510,7 @@ in
   systemd-sysusers-password-option-override-ordering = runTest ./systemd-sysusers-password-option-override-ordering.nix;
   systemd-timesyncd-nscd-dnssec = runTest ./systemd-timesyncd-nscd-dnssec.nix;
   systemd-user-linger = runTest ./systemd-user-linger.nix;
+  systemd-user-linger-purge = runTest ./systemd-user-linger-purge.nix;
   systemd-user-tmpfiles-rules = runTest ./systemd-user-tmpfiles-rules.nix;
   systemd-userdbd = runTest ./systemd-userdbd.nix;
   systemtap = handleTest ./systemtap.nix { };

--- a/nixos/tests/systemd-user-linger-purge.nix
+++ b/nixos/tests/systemd-user-linger-purge.nix
@@ -25,5 +25,13 @@ rec {
           machine.succeed("touch /var/lib/systemd/linger/alice")
           machine.systemctl("restart linger-users")
           machine.succeed("test ! -e /var/lib/systemd/linger/alice")
+
+      with subtest("mutable users can linger"):
+          machine.succeed("useradd alice")
+          machine.succeed("test ! -e /var/lib/systemd/linger/alice")
+          machine.succeed("loginctl enable-linger alice")
+          machine.succeed("test -e /var/lib/systemd/linger/alice")
+          machine.systemctl("restart linger-users")
+          machine.succeed("test -e /var/lib/systemd/linger/alice")
     '';
 }

--- a/nixos/tests/systemd-user-linger.nix
+++ b/nixos/tests/systemd-user-linger.nix
@@ -27,5 +27,13 @@ rec {
 
       machine.fail("test -e /var/lib/systemd/linger/bob")
       machine.fail("systemctl status user-${uidStrings.bob}.slice")
+
+      with subtest("mutable users can linger"):
+          machine.succeed("useradd clare")
+          machine.succeed("test ! -e /var/lib/systemd/linger/clare")
+          machine.succeed("loginctl enable-linger clare")
+          machine.succeed("test -e /var/lib/systemd/linger/clare")
+          machine.systemctl("restart linger-users")
+          machine.succeed("test -e /var/lib/systemd/linger/clare")
     '';
 }

--- a/nixos/tests/systemd-user-linger.nix
+++ b/nixos/tests/systemd-user-linger.nix
@@ -1,33 +1,32 @@
-{ lib, ... }:
-{
+rec {
   name = "systemd-user-linger";
 
-  nodes.machine =
-    { ... }:
-    {
-      users.users = {
-        alice = {
-          isNormalUser = true;
-          linger = true;
-          uid = 1000;
-        };
+  nodes.machine = {
+    users.users = {
+      alice = {
+        isNormalUser = true;
+        linger = true;
+        uid = 1000;
+      };
 
-        bob = {
-          isNormalUser = true;
-          linger = false;
-          uid = 10001;
-        };
+      bob = {
+        isNormalUser = true;
+        linger = false;
+        uid = 1001;
       };
     };
+  };
 
   testScript =
-    { ... }:
+    let
+      uidStrings = builtins.mapAttrs (k: v: builtins.toString v.uid) nodes.machine.users.users;
+    in
     ''
       machine.wait_for_file("/var/lib/systemd/linger/alice")
-      machine.succeed("systemctl status user-1000.slice")
+      machine.succeed("systemctl status user-${uidStrings.alice}.slice")
 
       machine.fail("test -e /var/lib/systemd/linger/bob")
-      machine.fail("systemctl status user-1001.slice")
+      machine.fail("systemctl status user-${uidStrings.bob}.slice")
 
       with subtest("missing users have linger purged"):
           machine.succeed("touch /var/lib/systemd/linger/missing")


### PR DESCRIPTION
NixOS 24.11 introduced `systemd.enableStrictShellChecks`, which, when enabled, complains about parsing `ls` output in the systemd unit to manage lingering users. This PR rewrites the script involved to avoid those warnings.

While fixing this, I also noticed and fixed two bugs:

- One part of the tests for systemd user lingering would always pass, because it was setting up a user with UID 10001 and then checking there was no user slice for a user with UID 1001.
- If a system had systemd config that marked users as lingering, but the NixOS configuration had no users configured to linger (perhaps because some users were previously configured to linger but that configuration was removed), the systemd configuration wouldn't get cleaned up, so those users would continue to linger.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
