### PR TITLE
scx.full: 1.0.6 -> 1.0.7; nixos/scx: add new schedulers

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -40,15 +40,18 @@ in
       type = lib.types.enum [
         "scx_bpfland"
         "scx_central"
+        "scx_flash"
         "scx_flatcg"
         "scx_lavd"
         "scx_layered"
+        "scx_mitosis"
         "scx_nest"
         "scx_pair"
         "scx_qmap"
         "scx_rlfifo"
         "scx_rustland"
         "scx_rusty"
+        "scx_sdt"
         "scx_simple"
         "scx_userland"
       ];

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -2,6 +2,7 @@
   lib,
   llvmPackages,
   fetchFromGitHub,
+  fetchpatch,
   writeShellScript,
   bash,
   meson,
@@ -27,6 +28,22 @@ in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "scx_cscheds";
   inherit (scx-common) version src;
+
+  patches = [
+    # TODO: remove at the next point release
+    (fetchpatch {
+      url = "https://github.com/sched-ext/scx/commit/22d45e6ddbea81efc17a91ca6d713a7e396cea52.patch?full_index=1";
+      hash = "sha256-SLSQNqRpKNT1HuuuT1h+fR1o3nbbVpfRCB30cFieIeg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/sched-ext/scx/commit/a72c24e7e5670b4533c4508d6d6c980d8487cb50.patch?full_index=1";
+      hash = "sha256-RUo7tl3V8iPN/fEm0oyj8UBwiWdna/ttZh+/OtcvflE=";
+    })
+    (fetchpatch {
+      url = "https://github.com/sched-ext/scx/commit/21cf3ccd1d263cf7aac3afe337911f18ba329dca.patch?full_index=1";
+      hash = "sha256-vOHM+1QvVxI89azqoIrOhjfSyYHTMGuIWAAupcGQ7Oc=";
+    })
+  ];
 
   # scx needs specific commits of bpftool and libbpf
   # can be found in meson.build of scx src

--- a/pkgs/os-specific/linux/scx/version.json
+++ b/pkgs/os-specific/linux/scx/version.json
@@ -1,15 +1,15 @@
 {
   "scx": {
-    "version": "1.0.6",
-    "hash": "sha256-hE0O15/9fplKrkmdiiHRJK6DzD9XaGhBwtGPqq/sX58=",
-    "cargoHash": "sha256-K/pLWEUQyzdGDBhP5MXVOiAXCA4h0dh0S2q0SzlsSDY="
+    "version": "1.0.7",
+    "hash": "sha256-qiXgRsbYP7aPGDM8R+Z6M5klKGwFXWBONvKVLoEkW3s=",
+    "cargoHash": "sha256-0Wdr+hCkGianyuFBq9hh+cPCvqedNQq52zWtH4tEhrM="
   },
   "bpftool": {
-    "rev": "77a72987353fcae8ce330fd87d4c7afb7677a169",
-    "hash": "sha256-pItTVewlXgB97AC/WH9rW9J/eYSe2ZdBkJaAgGnDeUU="
+    "rev": "183e7010387d1fc9f08051426e9a9fbd5f8d409e",
+    "hash": "sha256-ZZly6csVWOmtLmld1fhSDUqyRgZx2gSMGXTaSASGv7c="
   },
   "libbpf": {
-    "rev": "686f600bca59e107af4040d0838ca2b02c14ff50",
-    "hash": "sha256-uIu57gFkPhBCq3RqKb6J4r5OB4X5/V9q8HqIafUc+Do="
+    "rev": "c5f22aca0f3aa855daa159b2777472b35e721804",
+    "hash": "sha256-ggGVqAkdZt28KAx+LztVIYGxj0j79hKcPKmUy8TrJy8="
   }
 }


### PR DESCRIPTION
Cherry-picked upstream patches:

https://github.com/sched-ext/scx/commit/22d45e6ddbea81efc17a91ca6d713a7e396cea52 https://github.com/sched-ext/scx/commit/a72c24e7e5670b4533c4508d6d6c980d8487cb50 https://github.com/sched-ext/scx/commit/21cf3ccd1d263cf7aac3afe337911f18ba329dca

Needed to fix: https://github.com/sched-ext/scx/issues/1068

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
