### PR TITLE
python312Packages.bk7231tools: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/bk7231tools/default.nix
+++ b/pkgs/development/python-modules/bk7231tools/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pycryptodome,
+  py-datastruct,
+  pyserial,
+}:
+
+buildPythonPackage rec {
+  pname = "bk7231tools";
+  version = "2.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tuya-cloudcutter";
+    repo = "bk7231tools";
+    tag = "v${version}";
+    hash = "sha256-Ag63VNBSKEPDaxhS40SVB8rKIJRS1IsrZ9wSD0FglSU=";
+  };
+
+  pythonRelaxDeps = [
+    "pycryptodome"
+    "py-datastruct"
+    "pyserial"
+  ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pycryptodome
+    py-datastruct
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "bk7231tools" ];
+
+  meta = {
+    description = "Tools to interact with and analyze artifacts for BK7231 MCUs";
+    homepage = "https://github.com/tuya-cloudcutter/bk7231tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mevatron ];
+    mainProgram = "bk7231tools";
+  };
+}

--- a/pkgs/development/python-modules/py-datastruct/default.nix
+++ b/pkgs/development/python-modules/py-datastruct/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "py-datastruct";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kuba2k2";
+    repo = "datastruct";
+    tag = "v${version}";
+    hash = "sha256-KEIvibGnQnIDMpmodWN2Az/ypc37ZyGvgVPC7voFmlA=";
+  };
+
+  build-system = [ poetry-core ];
+
+  pythonImportsCheck = [ "datastruct" ];
+
+  # Add nativeCheckInputs = [ pytestCheckHook ]; once we update to v2.0.0 tag and remove below line
+  doCheck = false;
+
+  meta = {
+    description = "Combination of struct and dataclasses for easy parsing of binary formats";
+    homepage = "https://github.com/kuba2k2/datastruct";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mevatron ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1695,6 +1695,8 @@ self: super: with self; {
 
   bjoern = callPackage ../development/python-modules/bjoern { };
 
+  bk7231tools = callPackage ../development/python-modules/bk7231tools { };
+
   bkcharts = callPackage ../development/python-modules/bkcharts { };
 
   black = callPackage ../development/python-modules/black { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9380,6 +9380,8 @@ self: super: with self; {
 
   py-ccm15 = callPackage ../development/python-modules/py-ccm15 { };
 
+  py-datastruct = callPackage ../development/python-modules/py-datastruct { };
+
   py-deprecate = callPackage ../development/python-modules/py-deprecate { };
 
   py-ecc = callPackage ../development/python-modules/py-ecc { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`bk7231tools` is a collection of tools for interacting with and analyzing artifacts related to BK7231 microcontrollers. It includes functionality for parsing, analyzing, and working with BK7231 firmware and related data.

https://github.com/tuya-cloudcutter/bk7231tools

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
