### PR TITLE
[wip] muse-sounds-manager: 1.1.0.587 -> 2.0.3.659

### DIFF
--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -13,28 +13,27 @@
   libXrandr,
   libICE,
   libSM,
+  libglvnd,
   openssl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "muse-sounds-manager";
-  version = "1.1.0.587";
+  version = "2.0.3.659";
 
   # Use web.archive.org since upstream does not provide a stable (versioned) URL.
   # To see if there are new versions on the Web Archive, visit
-  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb
+  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz
   # then replace the date in the URL below with date when the SHA1
-  # changes (currently A3NX3WHFZWXCHZVME2ABUL2VRENTWOD5) and replace
-  # the version above with the version in the .deb metadata (or in the
-  # settings of muse-sounds-manager).
+  # changes (currently D7XUTZISBSZLTPDZISV4E62Q2HVYFQAX) and replace
+  # the version above with the version in the settings of muse-sounds-manager.
   src = fetchurl {
-    url = "https://web.archive.org/web/20240826143936/https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb";
-    hash = "sha256-wzZAIjme1cv8+jMLiKT7kUQvCb+UhsvOnLDV4hCL3hw=";
+    url = "https://web.archive.org/web/20241208182810/https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz";
+    hash = "sha256-tZhmFYEKc86/H/IBqpnnT2e7Vvn42BSTD95zqpO9aC4=";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
-    dpkg
   ];
 
   buildInputs = [
@@ -51,17 +50,18 @@ stdenv.mkDerivation rec {
     libXrandr
     libICE
     libSM
+    libglvnd
     openssl
   ];
-
-  unpackPhase = "dpkg -x $src .";
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    mv usr/* opt $out/
-    substituteInPlace $out/bin/muse-sounds-manager --replace-fail /opt/ $out/opt/
+    mkdir -p $out/opt $out/bin $out/share/applications
+    mv bin $out/opt/muse-sounds-manager
+    ln -s $out/opt/muse-sounds-manager/muse-sounds-manager $out/bin/
+    mv res/icons $out/share/
+    mv res/muse-sounds-manager.desktop $out/share/applications/
 
     runHook postInstall
   '';


### PR DESCRIPTION
Closes #363294

Do not merge yet, it is not considered stable and has glitches.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
