### PR TITLE
python312Packages.safety: 3.2.9 -> 3.2.11

### DIFF
--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -2,9 +2,8 @@
   lib,
   buildPythonPackage,
   pythonOlder,
-  fetchPypi,
-  fetchpatch2,
-  setuptools,
+  fetchFromGitHub,
+  hatchling,
   packaging,
   tomli,
   pyyaml,
@@ -13,27 +12,21 @@
 
 buildPythonPackage rec {
   pname = "dparse";
-  version = "0.6.3";
+  version = "0.6.4";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-J7uLS8rv7DmXaXuj9uBrJEcgC6JzwLCFw9ASoEVxtSg=";
+  src = fetchFromGitHub {
+    owner = "pyupio";
+    repo = "dparse";
+    tag = version;
+    hash = "sha256-LnsmJtWLjV3xoSjacfR9sUwPlOjQTRBWirJVtIJSE8A=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "fix-configparser-deprecation-warning.patch";
-      url = "https://github.com/pyupio/dparse/pull/69.patch";
-      hash = "sha256-RolD6xDJpI8/UHgAdcsXoyxOGLok7AogLMOTl1ZPKvw=";
-    })
-  ];
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [ packaging ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+  dependencies = [ packaging ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   optional-dependencies = {
     # FIXME pipenv = [ pipenv ];

--- a/pkgs/development/python-modules/safety-schemas/default.nix
+++ b/pkgs/development/python-modules/safety-schemas/default.nix
@@ -12,18 +12,16 @@
 
 buildPythonPackage rec {
   pname = "safety-schemas";
-  version = "0.0.5";
+  version = "0.0.10";
   pyproject = true;
 
   src = fetchPypi {
     pname = "safety_schemas";
     inherit version;
-    hash = "sha256-DeX8mlPUQjZEqM6aF6LkdHFKon5X81BhRulaQXEP8QQ=";
+    hash = "sha256-Xsg7sZ4XADdI0qSxHkPh8rRHHJQ0Mp6aDYDRBplmuWw=";
   };
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [ "dparse" ];
 
   dependencies = [
     dparse

--- a/pkgs/development/python-modules/safety/default.nix
+++ b/pkgs/development/python-modules/safety/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "safety";
-  version = "3.2.9";
+  version = "3.2.11";
 
   disabled = pythonOlder "3.7";
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "pyupio";
     repo = "safety";
     rev = "refs/tags/${version}";
-    hash = "sha256-etA/S/i87w4ihsqQo5JJjt6hWC7Jt9/q8vhqyo+DTek=";
+    hash = "sha256-ekJ0o+KWS8Fih1M/scboGEjETX0/2Uh6h/zne4h+3wI=";
   };
 
   postPatch = ''
@@ -54,7 +54,6 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [
-    "dparse"
     "filelock"
   ];
 


### PR DESCRIPTION
Diff: https://github.com/pyupio/safety/compare/refs/tags/3.2.9...3.2.11

Changelog: https://github.com/pyupio/safety/blob/3.2.11/CHANGELOG.md

closes https://github.com/NixOS/nixpkgs/pull/361039
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
