### PR TITLE
`runPhase` subshell and exit status

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1712,8 +1712,14 @@ runPhase() {
     startTime=$(date +"%s")
 
     # Evaluate the variable named $curPhase if it exists, otherwise the
-    # function named $curPhase.
-    eval "${!curPhase:-$curPhase}"
+    # function named $curPhase. Create a subshell with the errexit option so
+    # that invoking this function in the devshell behaves similarly to building
+    # the derivation (which uses the -e option).
+    (
+        set -e
+        eval "${!curPhase:-$curPhase}"
+    )
+    local status=$?
 
     endTime=$(date +"%s")
 
@@ -1725,6 +1731,7 @@ runPhase() {
 
         cd -- "${sourceRoot:-.}"
     fi
+    return $status
 }
 
 


### PR DESCRIPTION
This PR follows up on #330751, modifying the `runPhase` function to be more useful for command chaining and scripting in devshells. I will restate the context below so this PR is self-sufficient, but newcomers are encouraged to review that PR and comment thread for additional context.

The [relatively new `runPhase`](https://github.com/NixOS/nixpkgs/pull/230874/files) function in stdenv seems to be the best practice for building packages within a devshell, rather than manually executing sub-commands (e.g., `cmake .. && make`). This creates better consistency between dev workflow and the eventual realized derivation created by `nix build`.

However, the `runPhase` command obscures any failures which take place within the individual build phases. To fix that problem, this PR sets the errexit / `set -e` shell option so that errors within simple commands, lists, or compound commands in the individual build phases will cause the phase to exit immediately, and cause `runPhase` to return non-zero. This is consistent with the behavior of the stdenv builder [which uses the `set -e` option](https://github.com/NixOS/nixpkgs/blob/c2a7c0ae1060ebb45466f046fcaffeb000b92141/pkgs/stdenv/generic/default.nix#L102).


A subshell is used to prevent setting the errexit option in the devshell, causing the devshell to exit on failure, which is generally not preferred.

This allows workflows like chaining commands in lists (e.g., `runPhase configurePhase && runPhase buildPhase`) or scripting phases in the devshell (trivial example: `runPhase buildPhase && echo "Succeeded" || echo "Failure"`).

**Caveat**: using a subshell means that phases cannot modify variables in the devshell, which could be breaking or could (?) be beneficial. I'll convert this PR to "Ready for Review" once this is better understood.

Edit: I have now encountered an example where a preConfigureHook was intended to mutate `cmakeFlags`, which does not work as intended with this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
