### PR TITLE
cns11643-kai: init at 0-unstable-2025-01-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19574,6 +19574,13 @@
     githubId = 7309170;
     name = "Ryota Kameoka";
   };
+  rypervenche = {
+    email = "git@ryper.org";
+    github = "rypervenche";
+    githubId = 1411504;
+    name = "rypervenche";
+    keys = [ { fingerprint = "1198 7A9F 03AE 47F0 4919  E334 6A41 2C4A ECE1 66EF"; } ];
+  };
   rytone = {
     email = "max@ryt.one";
     github = "rastertail";

--- a/pkgs/by-name/cn/cns11643-kai/package.nix
+++ b/pkgs/by-name/cn/cns11643-kai/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "cns11643-kai";
+  version = "0-unstable-2025-01-13";
+
+  src = fetchFromGitHub {
+    owner = "rypervenche";
+    repo = "cns11643-fonts";
+    rev = "refs/tags/${version}";
+    hash = "sha256-A/4iwNvyzOYEpBzxKeq1xM/6aU6EOCATAr0lQlyckKQ=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 TW-Kai*.ttf -t $out/share/fonts/truetype/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Chinese TrueType Kai font by Ministry of Education of Taiwan government";
+    homepage = "https://www.cns11643.gov.tw/";
+    license = lib.licenses.ofl;
+    maintainers = [ lib.maintainers.rypervenche ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This is a new package for a Chinese font created by the Taiwan Ministry of Education. It contains 108,906 characters, including both simplified and traditional variants. It is the Standard script (a.k.a. "Kai"), which is the most common script used in modern printed materials.

A link to the government website that contains the link to the font can be found at the bottom of:
https://www.cns11643.gov.tw/pageView.jsp?ID=59

which leads to the government website:
https://data.gov.tw/dataset/5961 (It's the second ZIP button)

Note: as the download link is hosted on a government site in Taiwan, it's quite slow, but it does eventually download.

This is my first package submission, so if anything needs to be changed, please let me know. I'm happy to be a maintainer for this package and all future packages that I plan to submit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
