### PR TITLE
python312Packages.albumentations: 1.4.20 -> 1.4.22

### DIFF
--- a/pkgs/development/python-modules/albucore/default.nix
+++ b/pkgs/development/python-modules/albucore/default.nix
@@ -7,12 +7,13 @@
   pytestCheckHook,
   numpy,
   opencv-python,
+  simsimd,
   stringzilla,
 }:
 
 buildPythonPackage rec {
   pname = "albucore";
-  version = "0.0.19";
+  version = "0.0.21";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -21,7 +22,7 @@ buildPythonPackage rec {
     owner = "albumentations-team";
     repo = "albucore";
     rev = "refs/tags/${version}";
-    hash = "sha256-GwT7Py7pKbpHxx4avj37/hRjSJXdH5uBU11nCITysVw=";
+    hash = "sha256-bIsJ9o1gPCGJZXrzZbRXzS3ZQURcRaWmGBQZsAdX0eg=";
   };
 
   pythonRelaxDeps = [ "opencv-python" ];
@@ -31,6 +32,7 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     opencv-python
+    simsimd
     stringzilla
   ];
 

--- a/pkgs/development/python-modules/albumentations/default.nix
+++ b/pkgs/development/python-modules/albumentations/default.nix
@@ -31,16 +31,16 @@
 
 buildPythonPackage rec {
   pname = "albumentations";
-  version = "1.4.20";
+  version = "1.4.22";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "albumentations-team";
     repo = "albumentations";
     rev = "refs/tags/${version}";
-    hash = "sha256-lyYbkO2J3kpZGk8Q3FYfRiQh+BdolCfeEcjlI3W/rIw=";
+    hash = "sha256-kRf8LhRWtzGnhPrQo5aT/4a2sNQCdwAmFFzwcE0QnxM=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/simsimd/default.nix
+++ b/pkgs/development/python-modules/simsimd/default.nix
@@ -1,0 +1,50 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  numpy,
+  pytest-repeat,
+  pytestCheckHook,
+  setuptools,
+  tabulate,
+}:
+
+buildPythonPackage rec {
+  pname = "simsimd";
+  version = "6.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ashvardanian";
+    repo = "simsimd";
+    tag = "v${version}";
+    hash = "sha256-Poe0NtDPhQ08V8/bMsZrTFDEIKTi5wTII7UBnJn0msw=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "simsimd"
+  ];
+
+  nativeCheckInputs = [
+    numpy
+    pytest-repeat
+    pytestCheckHook
+    tabulate
+  ];
+
+  pytestFlagsArray = [
+    "scripts/test.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/ashvardanian/SimSIMD/releases/tag/v${version}";
+    description = "Portable mixed-precision BLAS-like vector math library for x86 and ARM";
+    homepage = "https://github.com/ashvardanian/simsimd";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14705,6 +14705,8 @@ self: super: with self; {
 
   simpy = callPackage ../development/python-modules/simpy { };
 
+  simsimd = callPackage ../development/python-modules/simsimd { };
+
   single-source = callPackage ../development/python-modules/single-source { };
 
   single-version = callPackage ../development/python-modules/single-version { };


### PR DESCRIPTION
Diff: https://github.com/albumentations-team/albumentations/compare/refs/tags/1.4.20...1.4.22

Changelog: https://github.com/albumentations-team/albumentations/releases/tag/1.4.21
           https://github.com/albumentations-team/albumentations/releases/tag/1.4.22
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
