### PR TITLE
nixos/zapret: remove maintainer

### DIFF
--- a/nixos/modules/services/networking/zapret.nix
+++ b/nixos/modules/services/networking/zapret.nix
@@ -214,7 +214,6 @@ in
   );
 
   meta.maintainers = with lib.maintainers; [
-    voronind
     nishimara
   ];
 }


### PR DESCRIPTION
I wish to remove myself from the zapret module maintainers due to possible legal concerns.
Not removing myself from global maintainer list as I plan to package some stuff soon.