### PR TITLE
technititum-dns-server: 13.2 -> 13.2.2

### DIFF
--- a/pkgs/by-name/te/technitium-dns-server-library/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server-library/package.nix
@@ -7,13 +7,13 @@
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server-library";
-  version = "dns-server-v13.2";
+  version = "dns-server-v13.2.2";
 
   src = fetchFromGitHub {
     owner = "TechnitiumSoftware";
     repo = "TechnitiumLibrary";
     rev = "refs/tags/${version}";
-    hash = "sha256-stfxYe0flE1daPuXw/GAgY52ZD7pkqnBIBvmSVPWWjI=";
+    hash = "sha256-KJNz4jhCKySYrYkT3BxqBh9QkeDV0XGHlRg9K0jLvBI=";
     name = "${pname}-${version}";
   };
 

--- a/pkgs/by-name/te/technitium-dns-server-library/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server-library/package.nix
@@ -7,14 +7,13 @@
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server-library";
-  version = "dns-server-v13.2.2";
+  inherit (technitium-dns-server) version;
 
   src = fetchFromGitHub {
     owner = "TechnitiumSoftware";
     repo = "TechnitiumLibrary";
-    rev = "refs/tags/${version}";
+    tag = "dns-server-v${version}";
     hash = "sha256-KJNz4jhCKySYrYkT3BxqBh9QkeDV0XGHlRg9K0jLvBI=";
-    name = "${pname}-${version}";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;

--- a/pkgs/by-name/te/technitium-dns-server-library/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server-library/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   dotnetCorePackages,
   nix-update-script,
+  technitium-dns-server,
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server-library";

--- a/pkgs/by-name/te/technitium-dns-server/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server/package.nix
@@ -9,13 +9,13 @@
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server";
-  version = "13.2";
+  version = "13.2.2";
 
   src = fetchFromGitHub {
     owner = "TechnitiumSoftware";
     repo = "DnsServer";
     rev = "refs/tags/v${version}";
-    hash = "sha256-oxLMBs+XkzvlfSst6ZD56ZIgiXwm0Px8Tn3Trdd/6H8=";
+    hash = "sha256-oEsJ4P0eUXhIsXCkY3ciJaGmElu745nNiBtlDXpSb6k=";
     name = "${pname}-${version}";
   };
 

--- a/pkgs/by-name/te/technitium-dns-server/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server/package.nix
@@ -14,9 +14,8 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "TechnitiumSoftware";
     repo = "DnsServer";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-oEsJ4P0eUXhIsXCkY3ciJaGmElu745nNiBtlDXpSb6k=";
-    name = "${pname}-${version}";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;


### PR DESCRIPTION
Update Technitium DNS Server and its library to 13.2.2. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
