### PR TITLE
jenkins-job-builder: fix build

### DIFF
--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -60,6 +60,11 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         users.users.jenkins.extraGroups = [ "users" ];
 
         systemd.services.jenkins.serviceConfig.TimeoutStartSec = "6min";
+
+        # Increase disk space to prevent this issue:
+        #
+        # WARNING h.n.DiskSpaceMonitorDescriptor#markNodeOfflineOrOnline: Making Built-In Node offline temporarily due to the lack of disk space
+        virtualisation.diskSize = 2 * 1024;
       };
 
     slave =

--- a/pkgs/development/python-modules/jenkins-job-builder/default.nix
+++ b/pkgs/development/python-modules/jenkins-job-builder/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   fasteners,
   jinja2,
+  packaging,
   pbr,
   python-jenkins,
   pyyaml,
@@ -39,6 +40,7 @@ buildPythonPackage rec {
   '';
 
   dependencies = [
+    packaging
     pbr
     python-jenkins
     pyyaml

--- a/pkgs/development/python-modules/jenkins-job-builder/default.nix
+++ b/pkgs/development/python-modules/jenkins-job-builder/default.nix
@@ -15,6 +15,7 @@
   fetchpatch,
   testtools,
   pytest-mock,
+  nixosTests,
 }:
 
 buildPythonPackage rec {
@@ -55,6 +56,8 @@ buildPythonPackage rec {
     testtools
     pytest-mock
   ];
+
+  passthru.tests = { inherit (nixosTests) jenkins; };
 
   meta = {
     description = "Jenkins Job Builder is a system for configuring Jenkins jobs using simple YAML files stored in Git";

--- a/pkgs/development/python-modules/openstackdocstheme/default.nix
+++ b/pkgs/development/python-modules/openstackdocstheme/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  distutils,
   dulwich,
   pbr,
   sphinx,
@@ -13,9 +14,6 @@ buildPythonPackage rec {
   pname = "openstackdocstheme";
   version = "3.4.0";
   pyproject = true;
-
-  # breaks on import due to distutils import through pbr.packaging
-  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;
@@ -29,6 +27,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    distutils
     dulwich
     pbr
     sphinx


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix building/running jenkins-job-builder and make nixosTests.jenkins pass.

Commits:
- **python3Packages.openstackdocstheme: add missing 'distutils' dependency**
- **nixos/tests/jenkins: increase disk size to 2 GiB**
- **python3Packages.jenkins-job-builder: add missing runtime dependency 'packaging'**
- **python3Packages.jenkins-job-builder: add passthru.tests**

Fixes https://github.com/NixOS/nixpkgs/issues/362054.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
