### PR TITLE
simulide_1_1_0: 1.1.0-SR0 -> 1.1.0-SR1, set as default; simulide_1_2_0: init at 1.2.0-RC1

### DIFF
--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -4,7 +4,7 @@
   fetchbzr,
   fetchFromGitHub,
   libsForQt5,
-  versionNum ? "1.0.0",
+  versionNum ? "1.1.0",
 }:
 
 let

--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchbzr,
+  fetchFromGitHub,
   libsForQt5,
   versionNum ? "1.0.0",
 }:
@@ -28,11 +29,11 @@ let
       };
     };
     "1.1.0" = rec {
-      release = "SR0";
-      rev = "1917";
+      release = "SR1";
+      rev = "2005";
       src = fetchbzr {
         url = "https://code.launchpad.net/~arcachofo/simulide/1.1.0";
-        sha256 = "sha256-qNBaGWl89Le9uC1VFK+xYhrLzIvOIWjkQbutnrAmZ2M=";
+        sha256 = "sha256-YVQduUjPQF5KxMlm730FZTShHP/7JEcAMIFn+mQITrQ=";
         inherit rev;
       };
     };

--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -37,6 +37,16 @@ let
         inherit rev;
       };
     };
+    "1.2.0" = rec {
+      release = "RC1";
+      rev = "da3a925491fab9fa2a8633d18e45f8e1b576c9d2";
+      src = fetchFromGitHub {
+        owner = "eeTools";
+        repo = "SimulIDE-dev";
+        hash = "sha256-6Gh0efBizDK1rUNkyU+/ysj7QwkAs3kTA1mQZYFb/pI=";
+        inherit rev;
+      };
+    };
   };
 in
 
@@ -71,6 +81,7 @@ let
         cp simulide $out/bin/simulide
       '';
 
+  release' = lib.optionalString (lib.versionOlder versionNum "1.2.0") "-" + release;
 in
 
 stdenv.mkDerivation {
@@ -84,9 +95,9 @@ stdenv.mkDerivation {
       -e "s|^Icon=.*$|Icon=simulide|"
 
     # Note: older versions don't have REV_NO
-    sed -i SimulIDE.pro \
+    sed -i SimulIDE.pr* \
       -e "s|^VERSION = .*$|VERSION = ${versionNum}|" \
-      -e "s|^RELEASE = .*$|RELEASE = -${release}|" \
+      -e "s|^RELEASE = .*$|RELEASE = ${release'}|" \
       -e "s|^REV_NO = .*$|REV_NO = ${rev}|" \
       -e "s|^BUILD_DATE = .*$|BUILD_DATE = ??-??-??|"
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17719,7 +17719,6 @@ with pkgs;
   simulide_0_4_15 = callPackage ../by-name/si/simulide/package.nix { versionNum = "0.4.15"; };
   simulide_1_0_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.0.0"; };
   simulide_1_1_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.1.0"; };
-  simulide = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.0.0"; };
 
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17719,6 +17719,7 @@ with pkgs;
   simulide_0_4_15 = callPackage ../by-name/si/simulide/package.nix { versionNum = "0.4.15"; };
   simulide_1_0_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.0.0"; };
   simulide_1_1_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.1.0"; };
+  simulide_1_2_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.2.0"; };
 
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 


### PR DESCRIPTION
I added the first GitHub-based source to the list of sources.
This version uses `.pri` instead of `.pro` for their main file, so I just used `.pr*`.

I will remove the 1.0.0 version once 1.2.0 get a Stable Release version.

I also removed `simulide =` from `all-packages.nix`, since I don't expect people to have `versionNum` inside their overlay. This way I only have to change the default version value in the `package.nix` file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
