### PR TITLE
tenere: init at 0.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16336,7 +16336,7 @@
     email = "dev@ob7.us";
     github = "ob7";
     githubId = 6877929;
-    keys = [{ fingerprint = "5C1C 0251 FA85 8C62 0E96  7AC5 2766 5625 0571 34E4"; }];
+    keys = [ { fingerprint = "5C1C 0251 FA85 8C62 0E96  7AC5 2766 5625 0571 34E4"; } ];
   };
   obadz = {
     email = "obadz-nixos@obadz.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16331,6 +16331,13 @@
     github = "oaksoaj";
     githubId = 103952141;
   };
+  ob7 = {
+    name = "ob7";
+    email = "dev@ob7.us";
+    github = "ob7";
+    githubId = 6877929;
+    keys = [{ fingerprint = "5C1C 0251 FA85 8C62 0E96  7AC5 2766 5625 0571 34E4"; }];
+  };
   obadz = {
     email = "obadz-nixos@obadz.com";
     github = "obadz";

--- a/pkgs/by-name/te/tenere/package.nix
+++ b/pkgs/by-name/te/tenere/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tenere";
+  version = "0.11.2-unstable-2024-12-05";
+  src = fetchFromGitHub {
+    owner = "pythops";
+    repo = "tenere";
+    rev = "0f3181ab23066aa69aa4fec387a7e16578078179";
+    hash = "sha256-HKPCX0bmXkB3LwvgE1li3dlWTgpW5CXuWZNq3mFY6FY=";
+  };
+  cargoHash = "sha256-u6QCs3RaLeRoVfhRzUG7wwx7kd0O3KyiC5vhZ3mE7UM=";
+
+  requiredSystemFeatures = [ "big-parallel" ]; # for fat LTO from upstream
+
+  meta = {
+    description = "Terminal interface for large language models (LLMs)";
+    homepage = "https://github.com/pythops/tenere";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ob7 ];
+    mainProgram = "tenere";
+  };
+}


### PR DESCRIPTION
### tenere

Terminal interface for large language models (LLMs) written in Rust, provides a TUI for interacting with LLM services like Ollama.  

This PR is for adding the tenere application to nixpkgs

Project home page: https://github.com/pythops/tenere

---
Cargo package, uses wrapProgram to create config/data dirs and set permissions on them

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).