### PR TITLE
wcurl: 2024.07.10 -> 2024.12.08

### DIFF
--- a/pkgs/by-name/wc/wcurl/package.nix
+++ b/pkgs/by-name/wc/wcurl/package.nix
@@ -1,28 +1,33 @@
 {
   stdenvNoCC,
   lib,
+  coreutils,
   curl,
-  fetchFromGitLab,
+  fetchFromGitHub,
+  gnused,
   installShellFiles,
   nix-update-script,
+  makeBinaryWrapper,
   shunit2,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wcurl";
-  version = "2024.07.10";
+  version = "2024.12.08";
 
-  src = fetchFromGitLab {
-    domain = "salsa.debian.org";
-    owner = "debian";
+  src = fetchFromGitHub {
+    owner = "curl";
     repo = "wcurl";
-    rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-FYkG74uoXFNYT7tszDcdCPQCEG3ePOFBUgIUYpsAzb8=";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-X6v03oYb/n9ALJXpx5HQojths7tv1rEftGUiQElv7aY=";
   };
 
   strictDeps = true;
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
 
   nativeCheckInputs = [ shunit2 ];
 
@@ -52,10 +57,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  postFixup = ''
+    wrapProgram $out/bin/wcurl \
+      --inherit-argv0 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnused
+        ]
+      }
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://salsa.debian.org/debian/wcurl";
+    homepage = "https://curl.se/wcurl";
     description = "Simple wrapper around curl to easily download files";
     mainProgram = "wcurl";
     license = lib.licenses.curl;


### PR DESCRIPTION
Update wcurl to the latest version.

Since the last release, there's been a new homepage created and github is now the main repository, rather than a mirror.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
