### PR TITLE
steam-devices-udev-rules: init at 1.0.0.61-unstable-2024-05-22; nixos/hardware.steam-hardware: use steam-devices-udev-rules

### DIFF
--- a/nixos/modules/hardware/steam-hardware.nix
+++ b/nixos/modules/hardware/steam-hardware.nix
@@ -16,7 +16,7 @@ in
 
   config = lib.mkIf cfg.enable {
     services.udev.packages = [
-      pkgs.steam-unwrapped
+      pkgs.steam-devices-udev-rules
     ];
 
     # The uinput module needs to be loaded in order to trigger the udev rules

--- a/pkgs/by-name/st/steam-devices-udev-rules/package.nix
+++ b/pkgs/by-name/st/steam-devices-udev-rules/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  bash,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "steam-devices-udev-rules";
+  version = "1.0.0.61-unstable-2024-05-22";
+
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = "steam-devices";
+    rev = "e2971e45063f6b327ccedbf18e168bda6749155c";
+    hash = "sha256-kBqWw3TlCSWS7gJXgza2ghemypQ0AEg7NhWqAFnal04=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/udev/rules.d/
+    cp *.rules $out/lib/udev/rules.d/
+    substituteInPlace $out/lib/udev/rules.d/*.rules --replace-warn "/bin/sh" "${bash}/bin/sh"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = with lib; {
+    description = "Udev rules list for gaming devices";
+    homepage = "https://github.com/ValveSoftware/steam-devices";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ azuwis ];
+  };
+}


### PR DESCRIPTION
- steam-devices-udev-rules: init at 1.0.0.61-unstable-2024-05-22
- nixos/hardware.steam-hardware: use steam-devices-udev-rules

ValveSoftware maintains an [udev rules repo][1] to help downstream distributions.

`steam-devices-udev-rules` is created from that, and contains only udev rules.

The udev rules contents are the some as `steam-unwrapped`.

`hardware.steam-hardware.enable` option is also useful for apps like
`cemu` and `rpcs3`, after this, it can be enabled without enabling
`nixpkgs.config.allowUnfree` and installing `steam-unwrapped`.

[1]: https://github.com/ValveSoftware/steam-devices


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
