### PR TITLE
oci-containers: consolidate capabilities interface

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -302,7 +302,7 @@ let
             Capabilities to configure for the container.
             When set to true, capability is added to the container.
             When set to false, capability is dropped from the container.
-            When null default runtime settings apply.
+            When null, default runtime settings apply.
           '';
           example = literalExpression ''
             {

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -295,28 +295,19 @@ let
           '';
         };
 
-        capAdd = mkOption {
+        capabilities = mkOption {
           type = with types; lazyAttrsOf (nullOr bool);
           default = { };
           description = ''
-            Capabilities to add to container
+            Capabilities to configure for the container.
+            When set to true, capability is added to the container.
+            When set to false, capability is dropped from the container.
+            When null default runtime settings apply.
           '';
           example = literalExpression ''
             {
               SYS_ADMIN = true;
-            {
-          '';
-        };
-
-        capDrop = mkOption {
-          type = with types; lazyAttrsOf (nullOr bool);
-          default = { };
-          description = ''
-            Capabilities to drop from container
-          '';
-          example = literalExpression ''
-            {
-              SYS_ADMIN = true;
+              SYS_WRITE = false;
             {
           '';
         };
@@ -441,10 +432,10 @@ let
         ++ optional (container.workdir != null) "-w ${escapeShellArg container.workdir}"
         ++ optional (container.privileged) "--privileged"
         ++ mapAttrsToList (k: _: "--cap-add=${escapeShellArg k}") (
-          filterAttrs (_: v: v == true) container.capAdd
+          filterAttrs (_: v: v == true) container.capabilities
         )
         ++ mapAttrsToList (k: _: "--cap-drop=${escapeShellArg k}") (
-          filterAttrs (_: v: v == true) container.capDrop
+          filterAttrs (_: v: v == false) container.capabilities
         )
         ++ map (d: "--device=${escapeShellArg d}") container.devices
         ++ map (n: "--network=${escapeShellArg n}") container.networks

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -1,64 +1,70 @@
-{ system ? builtins.currentSystem
-, config ? {}
-, pkgs ? import ../.. { inherit system config; }
-, lib ? pkgs.lib
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../.. { inherit system config; },
+  lib ? pkgs.lib,
 }:
 
 let
 
   inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
 
-  mkOCITest = backend: makeTest {
-    name = "oci-containers-${backend}";
+  mkOCITest =
+    backend:
+    makeTest {
+      name = "oci-containers-${backend}";
 
-    meta.maintainers = lib.teams.serokell.members
-                       ++ (with lib.maintainers; [ benley ]);
+      meta.maintainers = lib.teams.serokell.members ++ (with lib.maintainers; [ benley ]);
 
-    nodes = {
-      ${backend} = { pkgs, ... }: {
-        virtualisation.oci-containers = {
-          inherit backend;
-          containers.nginx = {
-            image = "nginx-container";
-            imageStream = pkgs.dockerTools.examples.nginxStream;
-            ports = ["8181:80"];
-            capAdd = {
-              CAP_AUDIT_READ = true;
+      nodes = {
+        ${backend} =
+          { pkgs, ... }:
+          {
+            virtualisation.oci-containers = {
+              inherit backend;
+              containers.nginx = {
+                image = "nginx-container";
+                imageStream = pkgs.dockerTools.examples.nginxStream;
+                ports = [ "8181:80" ];
+                capabilities = {
+                  CAP_AUDIT_READ = true;
+                  CAP_AUDIT_WRITE = false;
+                };
+                privileged = false;
+                devices = [
+                  "/dev/random:/dev/random"
+                ];
+              };
             };
-            capDrop = {
-              CAP_AUDIT_WRITE = true;
-            };
-            privileged = false;
-            devices = [
-              "/dev/random:/dev/random"
-            ];
+
+            # Stop systemd from killing remaining processes if ExecStop script
+            # doesn't work, so that proper stopping can be tested.
+            systemd.services."${backend}-nginx".serviceConfig.KillSignal = "SIGCONT";
           };
-        };
-
-        # Stop systemd from killing remaining processes if ExecStop script
-        # doesn't work, so that proper stopping can be tested.
-        systemd.services."${backend}-nginx".serviceConfig.KillSignal = "SIGCONT";
       };
+
+      testScript = ''
+        import json
+
+        start_all()
+        ${backend}.wait_for_unit("${backend}-nginx.service")
+        ${backend}.wait_for_open_port(8181)
+        ${backend}.wait_until_succeeds("curl -f http://localhost:8181 | grep Hello")
+        output = json.loads(${backend}.succeed("${backend} inspect nginx --format json").strip())[0]
+        ${backend}.succeed("systemctl stop ${backend}-nginx.service", timeout=10)
+        assert output['HostConfig']['CapAdd'] == ["CAP_AUDIT_READ"]
+        assert output['HostConfig']['CapDrop'] == ${
+          if backend == "docker" then "[\"CAP_AUDIT_WRITE\"]" else "[]"
+        } # Rootless podman runs with no capabilities so it cannot drop them
+        assert output['HostConfig']['Privileged'] == False
+        assert output['HostConfig']['Devices'] == [{'PathOnHost': '/dev/random', 'PathInContainer': '/dev/random', 'CgroupPermissions': '${
+          if backend == "docker" then "rwm" else ""
+        }'}]
+      '';
     };
 
-    testScript = ''
-      import json
-
-      start_all()
-      ${backend}.wait_for_unit("${backend}-nginx.service")
-      ${backend}.wait_for_open_port(8181)
-      ${backend}.wait_until_succeeds("curl -f http://localhost:8181 | grep Hello")
-      output = json.loads(${backend}.succeed("${backend} inspect nginx --format json").strip())[0]
-      ${backend}.succeed("systemctl stop ${backend}-nginx.service", timeout=10)
-      assert output['HostConfig']['CapAdd'] == ["CAP_AUDIT_READ"]
-      assert output['HostConfig']['CapDrop'] == ${if backend == "docker" then "[\"CAP_AUDIT_WRITE\"]" else "[]"} # Rootless podman runs with no capabilities so it cannot drop them
-      assert output['HostConfig']['Privileged'] == False
-      assert output['HostConfig']['Devices'] == [{'PathOnHost': '/dev/random', 'PathInContainer': '/dev/random', 'CgroupPermissions': '${if backend == "docker" then "rwm" else ""}'}]
-    '';
-  };
-
 in
-lib.foldl' (attrs: backend: attrs // { ${backend} = mkOCITest backend; }) {} [
+lib.foldl' (attrs: backend: attrs // { ${backend} = mkOCITest backend; }) { } [
   "docker"
   "podman"
 ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`capAdd` and `capDrop` were consolidated into a single `capabilities` option.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
