### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
-  "sha256": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
+  "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
+  "sha256": "1am61kcakn9j47435k4cgsarvypb8klv4avszxza0jn362hp3ck8"
 }


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/361165, but now including the nixfmt update from https://github.com/NixOS/nixpkgs/pull/361875. Needed for https://github.com/NixOS/nixpkgs/pull/322537 to use the latest nixfmt version.

Ran `ci/update-pinned-nixpkgs.sh`, which updated it to the version from this nixpkgs-unstable Hydra eval: https://hydra.nixos.org/eval/1810299#tabs-inputs

Ping @NixOS/nix-formatting 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
