### PR TITLE
buildGoModule: allow settting goModulesDrv

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -11,6 +11,13 @@
   # A function to override the `goModules` derivation.
 , overrideModAttrs ? (finalAttrs: previousAttrs: { })
 
+  # A derivation that contains the vendored dependencies.
+  # Incompatible with `overrideModAttrs`.
+  # Remember to inherit relevant attrs like `vendorHash` and `proxyVendor`
+  # so the builder has the necessary information on how to handle the 
+  # modules derivation.
+, goModulesDrv ? null
+
   # Directory to the `go.mod` and `go.sum` relative to the `src`.
 , modRoot ? "./"
 
@@ -69,8 +76,9 @@ in
   args
   // {
 
-  inherit modRoot vendorHash deleteVendor proxyVendor;
-  goModules = if (finalAttrs.vendorHash == null) then "" else
+  inherit modRoot vendorHash deleteVendor proxyVendor goModulesDrv;
+  goModules = if (finalAttrs.goModulesDrv != null) then finalAttrs.goModulesDrv else
+    if (finalAttrs.vendorHash == null) then "" else
   (stdenv.mkDerivation {
     name = "${finalAttrs.name or "${finalAttrs.pname}-${finalAttrs.version}"}-go-modules";
 


### PR DESCRIPTION
This allows to share goModules derivation between different packages.

For example, let's say you have a local Go project with a single module (go.mod) but multiple binary-producing packages (e.g. cmd/server and cmd/client). server and client share the same set of dependencies, as they are in the same module, but you want only rebuild server if server code changed and vice versa. So you split you src into different filesets, each containing the relevant code for the package and go.mod, but each will pull its own set of dependencies into goModules as the goModules derivations differ (name etc.).

With this change, client can inherit server.goModules like this, and it will be independent of changes to the client src or derivation:

```nix
server  = buildGoModule {
  pname = "server";
  src = serverSrc;
  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
};
client = buildGoModule {
  pname = "client";
  src = clientSrc;
  goModulesDrv = foo.goModules;
  inherit (foo) vendorHash proxyVendor deleteVendor;
};
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
