### PR TITLE
matomo_5: 5.1.1 -> 5.1.2

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -19,17 +19,12 @@ let
     };
   };
   common = pname: { version, hash, beta ? null }:
-    let
-      fullVersion = version + lib.optionalString (beta != null) "-${toString beta}";
-      name = "${pname}-${fullVersion}";
-    in
-
-      stdenv.mkDerivation rec {
-        inherit name;
-        version = fullVersion;
+      stdenv.mkDerivation (finalAttrs: {
+        name = "${pname}-${finalAttrs.version}";
+        version = version + lib.optionalString (beta != null) "-${toString beta}";
 
         src = fetchurl {
-          url = "https://builds.matomo.org/matomo-${version}.tar.gz";
+          url = "https://builds.matomo.org/matomo-${finalAttrs.version}.tar.gz";
           inherit hash;
         };
 
@@ -45,7 +40,7 @@ let
           ./make-localhost-default-database-host.patch
           # This changes the default config for path.geoip2 so that it doesn't point
           # to the nix store.
-          (if lib.versionOlder version "5.0"
+          (if lib.versionOlder finalAttrs.version "5.0"
            then ./change-path-geoip2-4.x.patch
            else ./change-path-geoip2-5.x.patch)
         ];
@@ -120,6 +115,6 @@ let
           platforms = platforms.all;
           maintainers = with maintainers; [ florianjacob sebbel twey boozedog ] ++ teams.flyingcircus.members;
         };
-      };
+      });
 in
 lib.mapAttrs common versions

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -14,8 +14,8 @@ let
       hash = "sha256-cGnsxfpvt7FyhxFcA2/gWWe7CyanVGZVKtCDES3XLdI=";
     };
     matomo_5 = {
-      version = "5.1.1";
-      hash = "sha256-xi6R9O/pOxBgga6+wwqziwDKK7Q1Ispldvxg+0mpdeQ=";
+      version = "5.1.2";
+      hash = "sha256-6kR6OOyqwQfV+pRqHO+VMLM1eZQb0om65EilAnIlW9U=";
     };
     matomo-beta = {
       version = "5.0.0";

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -18,11 +18,11 @@ let
       hash = "sha256-6kR6OOyqwQfV+pRqHO+VMLM1eZQb0om65EilAnIlW9U=";
     };
     matomo-beta = {
-      version = "5.0.0";
+      version = "5.2.0";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
-      beta = "rc9";
-      hash = "sha256-OXxJCEXcrl6UXYh+jbNqLQGYphrSjxaOAZg3AZVPAqs=";
+      beta = "rc1";
+      hash = "sha256-heAd01p8QHkrxQY2MEf//YXNplgL19Opw/WhA2cwZ+c=";
     };
   };
   common =

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchurl, makeWrapper, php, nixosTests }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  php,
+  nixosTests,
+}:
 
 let
   versions = {
@@ -18,103 +25,120 @@ let
       hash = "sha256-OXxJCEXcrl6UXYh+jbNqLQGYphrSjxaOAZg3AZVPAqs=";
     };
   };
-  common = pname: { version, hash, beta ? null }:
-      stdenv.mkDerivation (finalAttrs: {
-        name = "${pname}-${finalAttrs.version}";
-        version = version + lib.optionalString (beta != null) "-${toString beta}";
+  common =
+    pname:
+    {
+      version,
+      hash,
+      beta ? null,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      name = "${pname}-${finalAttrs.version}";
+      version = version + lib.optionalString (beta != null) "-${toString beta}";
 
-        src = fetchurl {
-          url = "https://builds.matomo.org/matomo-${finalAttrs.version}.tar.gz";
-          inherit hash;
-        };
+      src = fetchurl {
+        url = "https://builds.matomo.org/matomo-${finalAttrs.version}.tar.gz";
+        inherit hash;
+      };
 
-        nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [ makeWrapper ];
 
-        patches = [
-          # This changes the default value of the database server field
-          # from 127.0.0.1 to localhost.
-          # unix socket authentication only works with localhost,
-          # but password-based SQL authentication works with both.
-          # TODO: is upstream interested in this?
-          # -> discussion at https://github.com/matomo-org/matomo/issues/12646
-          ./make-localhost-default-database-host.patch
-          # This changes the default config for path.geoip2 so that it doesn't point
-          # to the nix store.
-          (if lib.versionOlder finalAttrs.version "5.0"
-           then ./change-path-geoip2-4.x.patch
-           else ./change-path-geoip2-5.x.patch)
-        ];
+      patches = [
+        # This changes the default value of the database server field
+        # from 127.0.0.1 to localhost.
+        # unix socket authentication only works with localhost,
+        # but password-based SQL authentication works with both.
+        # TODO: is upstream interested in this?
+        # -> discussion at https://github.com/matomo-org/matomo/issues/12646
+        ./make-localhost-default-database-host.patch
+        # This changes the default config for path.geoip2 so that it doesn't point
+        # to the nix store.
+        (
+          if lib.versionOlder finalAttrs.version "5.0" then
+            ./change-path-geoip2-4.x.patch
+          else
+            ./change-path-geoip2-5.x.patch
+        )
+      ];
 
-        # this bootstrap.php adds support for getting PIWIK_USER_PATH
-        # from an environment variable. Point it to a mutable location
-        # to be able to use matomo read-only from the nix store
-        postPatch = ''
-          cp ${./bootstrap.php} bootstrap.php
-        '';
+      # this bootstrap.php adds support for getting PIWIK_USER_PATH
+      # from an environment variable. Point it to a mutable location
+      # to be able to use matomo read-only from the nix store
+      postPatch = ''
+        cp ${./bootstrap.php} bootstrap.php
+      '';
 
-        # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
-        # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
-        #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
-        #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
-        installPhase = ''
-          runHook preInstall
+      # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
+      # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
+      #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
+      #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
+      installPhase = ''
+        runHook preInstall
 
-          # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
-          mkdir -p $out/share
-          cp -ra * $out/share/
-          # tmp/ is created by matomo in PIWIK_USER_PATH
-          rmdir $out/share/tmp
-          # config/ needs to be accessed by PIWIK_USER_PATH anyway
-          ln -s $out/share/config $out/
+        # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
+        mkdir -p $out/share
+        cp -ra * $out/share/
+        # tmp/ is created by matomo in PIWIK_USER_PATH
+        rmdir $out/share/tmp
+        # config/ needs to be accessed by PIWIK_USER_PATH anyway
+        ln -s $out/share/config $out/
 
-          makeWrapper ${php}/bin/php $out/bin/matomo-console \
-            --add-flags "$out/share/console"
+        makeWrapper ${php}/bin/php $out/bin/matomo-console \
+          --add-flags "$out/share/console"
 
-          runHook postInstall
-        '';
+        runHook postInstall
+      '';
 
-        filesToFix = [
-          "misc/composer/build-xhprof.sh"
-          "misc/composer/clean-xhprof.sh"
-          "misc/cron/archive.sh"
-          "plugins/GeoIp2/config/config.php"
-          "plugins/Installation/FormDatabaseSetup.php"
-          "vendor/pear/archive_tar/sync-php4"
-          "vendor/szymach/c-pchart/coverage.sh"
-          "vendor/matomo/matomo-php-tracker/run_tests.sh"
-          "vendor/twig/twig/drupal_test.sh"
-        ];
+      filesToFix = [
+        "misc/composer/build-xhprof.sh"
+        "misc/composer/clean-xhprof.sh"
+        "misc/cron/archive.sh"
+        "plugins/GeoIp2/config/config.php"
+        "plugins/Installation/FormDatabaseSetup.php"
+        "vendor/pear/archive_tar/sync-php4"
+        "vendor/szymach/c-pchart/coverage.sh"
+        "vendor/matomo/matomo-php-tracker/run_tests.sh"
+        "vendor/twig/twig/drupal_test.sh"
+      ];
 
-        # This fixes the consistency check in the admin interface
-        #
-        # The filesToFix list may contain files that are exclusive to only one of the versions we build
-        # make sure to test for existence to avoid erroring on an incompatible version and failing
-        postFixup = ''
-          pushd $out/share > /dev/null
-          for f in $filesToFix; do
-            if [ -f "$f" ]; then
-              length="$(wc -c "$f" | cut -d' ' -f1)"
-              hash="$(md5sum "$f" | cut -d' ' -f1)"
-              sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
-            else
-              echo "INFO(files-to-fix): $f does not exist in this version"
-            fi
-          done
-          popd > /dev/null
-        '';
+      # This fixes the consistency check in the admin interface
+      #
+      # The filesToFix list may contain files that are exclusive to only one of the versions we build
+      # make sure to test for existence to avoid erroring on an incompatible version and failing
+      postFixup = ''
+        pushd $out/share > /dev/null
+        for f in $filesToFix; do
+          if [ -f "$f" ]; then
+            length="$(wc -c "$f" | cut -d' ' -f1)"
+            hash="$(md5sum "$f" | cut -d' ' -f1)"
+            sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+          else
+            echo "INFO(files-to-fix): $f does not exist in this version"
+          fi
+        done
+        popd > /dev/null
+      '';
 
-        passthru = {
-          tests = nixosTests.matomo."${pname}";
-        };
+      passthru = {
+        tests = nixosTests.matomo."${pname}";
+      };
 
-        meta = with lib; {
-          description = "Real-time web analytics application";
-          mainProgram = "matomo-console";
-          license = licenses.gpl3Plus;
-          homepage = "https://matomo.org/";
-          platforms = platforms.all;
-          maintainers = with maintainers; [ florianjacob sebbel twey boozedog ] ++ teams.flyingcircus.members;
-        };
-      });
+      meta = with lib; {
+        description = "Real-time web analytics application";
+        mainProgram = "matomo-console";
+        license = licenses.gpl3Plus;
+        homepage = "https://matomo.org/";
+        platforms = platforms.all;
+        maintainers =
+          with maintainers;
+          [
+            florianjacob
+            sebbel
+            twey
+            boozedog
+          ]
+          ++ teams.flyingcircus.members;
+      };
+    });
 in
 lib.mapAttrs common versions


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://matomo.org/changelog/matomo-5-1-2/

## Security release

> This release contains some security fixes.
> 
> A **high impact security fix** is included in this release, an improper request parameter validation could lead to unnecessary resource consumption
> 
> A moderate impact security improvement is also included that limits the length of annotations to 255 characters.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
