### PR TITLE
[Backport release-24.11] cargo-deny: 0.16.1 -> 0.16.3

### DIFF
--- a/pkgs/by-name/ca/cargo-deny/package.nix
+++ b/pkgs/by-name/ca/cargo-deny/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.16.2";
+  version = "0.16.3";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-deny";
     rev = version;
-    hash = "sha256-xZ88TaodLVZ4p0PU2ocwt8isj/WTVxcmwBUrKCQG5GE=";
+    hash = "sha256-vU1MUmMzyKcCi1HR0089+MTtpy0Y+zzK5XC5/jIEhok=";
   };
 
-  cargoHash = "sha256-cU9idGvbn2KcvI7G7Az3CYFGlIxPXrs5Bq0su4FTOvg=";
+  cargoHash = "sha256-jNNmTMeNgUq7uBp2eGrSl5afcKrTUXG2Wr8peEcmG7s=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ca/cargo-deny/package.nix
+++ b/pkgs/by-name/ca/cargo-deny/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.16.1";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-deny";
     rev = version;
-    hash = "sha256-RfXKTACAVmQffOFHpQHDi/BgiMNRVuS8j4aLslMYL1Q=";
+    hash = "sha256-xZ88TaodLVZ4p0PU2ocwt8isj/WTVxcmwBUrKCQG5GE=";
   };
 
-  cargoHash = "sha256-ywDjdlPhqqs740zGcwA8Ee9/TQ/sEiulSgGSejY41oY=";
+  cargoHash = "sha256-cU9idGvbn2KcvI7G7Az3CYFGlIxPXrs5Bq0su4FTOvg=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
* `0.16.1 -> 0.16.2` - https://github.com/NixOS/nixpkgs/pull/356180/commits/2ddc74b5a3de75ceca3ee06ca27e2e95a6e67c21
* `0.16.2 -> 0.16.3` - https://github.com/NixOS/nixpkgs/pull/363484/commits/b644a1b90a3867383fe2cef8f184508a7cc64644

---

* [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
  
cc: @NickCao 