### PR TITLE
bartender: add `passthru.updateScript`, format with `nixfmt-rfc-style`, use `lib.platforms.darwin`, 5.2.3 -> 5.2.7

### DIFF
--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -12,14 +12,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "bartender";
-  version = "5.2.3";
+  version = "5.2.7";
 
   src = fetchurl {
     name = "Bartender ${lib.versions.major finalAttrs.version}.dmg";
     url = "https://www.macbartender.com/B2/updates/${
       builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }/Bartender%20${lib.versions.major finalAttrs.version}.dmg";
-    hash = "sha256-G1XL6o5Rk/U5SsT/Q5vWaVSg0qerfzVizjFmudWAI3E=";
+    hash = "sha256-TY6ioG80W8q6LC0FCMRQMJh4DiEKiM6htVf+irvmpnI=";
   };
 
   dontPatch = true;

--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -63,7 +63,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       Bartender improves your workflow with quick reveal, search, custom hotkeys and triggers, and lots more.
     '';
     homepage = "https://www.macbartender.com";
-    changelog = "https://www.macbartender.com/Bartender${lib.versions.major finalAttrs.version}/release_notes/";
+    changelog = "https://macbartender.com/B2/updates/${
+      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+    }/rnotes.html";
     license = [ lib.licenses.unfree ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, stdenvNoCC
-, fetchurl
-, _7zz
-, curl
-, cacert
-, xmlstarlet
-, writeShellApplication
-, common-updater-scripts
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  curl,
+  cacert,
+  xmlstarlet,
+  writeShellApplication,
+  common-updater-scripts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -15,7 +16,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     name = "Bartender ${lib.versions.major finalAttrs.version}.dmg";
-    url = "https://www.macbartender.com/B2/updates/${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}/Bartender%20${lib.versions.major finalAttrs.version}.dmg";
+    url = "https://www.macbartender.com/B2/updates/${
+      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+    }/Bartender%20${lib.versions.major finalAttrs.version}.dmg";
     hash = "sha256-G1XL6o5Rk/U5SsT/Q5vWaVSg0qerfzVizjFmudWAI3E=";
   };
 
@@ -63,7 +66,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     changelog = "https://www.macbartender.com/Bartender${lib.versions.major finalAttrs.version}/release_notes/";
     license = [ lib.licenses.unfree ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-    maintainers = with lib.maintainers; [ stepbrobd DimitarNestorov ];
-    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+    maintainers = with lib.maintainers; [
+      stepbrobd
+      DimitarNestorov
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
   };
 })

--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -70,9 +70,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       stepbrobd
       DimitarNestorov
     ];
-    platforms = [
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
+    platforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -2,6 +2,11 @@
 , stdenvNoCC
 , fetchurl
 , _7zz
+, curl
+, cacert
+, xmlstarlet
+, writeShellApplication
+, common-updater-scripts
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -31,6 +36,22 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "bartender-update-script";
+    runtimeInputs = [
+      curl
+      cacert
+      xmlstarlet
+      common-updater-scripts
+    ];
+    text = ''
+      version_major="${lib.versions.major finalAttrs.version}"
+      url="https://www.macbartender.com/B2/updates/AppcastB$version_major.xml"
+      version=$(curl -s "$url" | xmlstarlet sel -t -v '(//item)[last()]/sparkle:shortVersionString' -n)
+      update-source-version bartender "$version"
+    '';
+  });
 
   meta = {
     description = "Take control of your menu bar";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc