### PR TITLE
tailwindcss-language-server: 0.0.21 -> 0.0.27

### DIFF
--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -1,41 +1,76 @@
-{ lib
-, stdenv
-, buildNpmPackage
-, fetchFromGitHub
-, python3
-, darwin
-, libsecret
-, pkg-config
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs_22,
+  pnpm,
 }:
 
 let
-  version = "0.0.21";
+  version = "0.0.27";
 in
-buildNpmPackage {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tailwindcss-language-server";
   inherit version;
 
   src = fetchFromGitHub {
     owner = "tailwindlabs";
     repo = "tailwindcss-intellisense";
-    rev = "@tailwindcss/language-server@v${version}";
-    hash = "sha256-LMQ+HA74Y0n65JMO9LqCHbDVRiu4dIUvQofFTA03pWU=";
+    rev = "@tailwindcss/language-server@v${finalAttrs.version}";
+    hash = "sha256-FphKiGMTMQj/tBmrwkPVlb+dEGjf+N4EgZtOVg7iL2M=";
   };
 
-  makeCacheWritable = true;
-  npmDepsHash = "sha256-T7YNHunncSv+z86Td1QuBt4dMGF1ipo85ZhW7U9I0Zw=";
-  npmWorkspace = "packages/tailwindcss-language-server";
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      prePnpmInstall
+      ;
+    hash = "sha256-kLB84P2Zb3gXpNlXCnQFIxz8xibACB39URIhy6Na9p8=";
+  };
 
-  buildInputs = [ libsecret ] ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ Security AppKit ]);
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm.configHook
+  ];
 
-  nativeBuildInputs = [ python3 pkg-config ];
+  buildInputs = [ nodejs_22 ];
+
+  pnpmWorkspaces = [ "@tailwindcss/language-server..." ];
+  prePnpmInstall = ''
+    # Warning section for "pnpm@v8"
+    # https://pnpm.io/cli/install#--filter-package_selector
+    pnpm config set dedupe-peer-dependents false
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Must build the "@tailwindcss/language-service" package. Dependency is linked via workspace by "pnpm"
+    # (https://github.com/tailwindlabs/tailwindcss-intellisense/blob/%40tailwindcss/language-server%40v0.0.27/pnpm-lock.yaml#L47)
+    pnpm --filter "@tailwindcss/language-server..." build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/tailwindcss-language-server}
+    cp -r {packages,node_modules} $out/lib/tailwindcss-language-server
+    ln -s $out/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server $out/bin/tailwindcss-language-server
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
-    description = "Intelligent Tailwind CSS tooling for Visual Studio Code";
+    description = "Tailwind CSS Language Server";
     homepage = "https://github.com/tailwindlabs/tailwindcss-intellisense";
     license = licenses.mit;
-    maintainers = with maintainers; [ happysalada];
+    maintainers = with maintainers; [ happysalada ];
     mainProgram = "tailwindcss-language-server";
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates `tailwindcss-language-server` from `0.0.21` to `0.0.27`.

The [`tailwindlabs/tailwindcss-intellisense`](https://github.com/tailwindlabs/tailwindcss-intellisense) repository switched from `npm` to `pnpm` workspaces, which required me to make changes to the derivation. I took the [`astro-language-server`](https://github.com/NixOS/nixpkgs/blob/a73246e2eef4c6ed172979932bc80e1404ba2d56/pkgs/by-name/as/astro-language-server/package.nix) package derivation as a guide.

I also updated `meta.description` to the description of the language-server and not the tailwind-intellisense repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
   - `./result/bin/tailwindcss-language-server` binary seems to work
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
