### PR TITLE
ankama-launcher: 3.12.26 -> 3.12.27

### DIFF
--- a/pkgs/by-name/an/ankama-launcher/package.nix
+++ b/pkgs/by-name/an/ankama-launcher/package.nix
@@ -5,15 +5,15 @@
 }:
 let
   pname = "ankama-launcher";
-  version = "3.12.26";
+  version = "3.12.27";
 
   # The original URL for the launcher is:
   # https://launcher.cdn.ankama.com/installers/production/Ankama%20Launcher-Setup-x86_64.AppImage
   # As it does not encode the version, we use the wayback machine (web.archive.org) to get a fixed URL.
   # To update the client, head to web.archive.org and create a new snapshot of the download page.
   src = fetchurl {
-    url = "https://web.archive.org/web/20241206172526/https://launcher.cdn.ankama.com/installers/production/Ankama%20Launcher-Setup-x86_64.AppImage";
-    hash = "sha256-K/qe/qxMfcGWU5gyEfPdl0ptjTCWaqIXMCy4O8WEKCQ=";
+    url = "https://web.archive.org/web/20241209195235/https://launcher.cdn.ankama.com/installers/production/Ankama%20Launcher-Setup-x86_64.AppImage";
+    hash = "sha256-35seTJ8OVcMDvEkGtxRuZd7JSrqCfk2VSSDc6I8d7UI=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };
@@ -48,9 +48,6 @@ appimageTools.wrapType2 {
     description = "Ankama Launcher";
     longDescription = ''
       Ankama Launcher is a portal that allows you to access Ankama's video games, VOD animations, webtoons, and livestreams, as well as download updates, stay up to date with the latest news, and chat with your friends.
-
-      If you encounter a `wine` error while running *Dofus*, delete or rename the `cinematics/` directory:
-      - Go to the directory where you installed the game and run: `mv content/gfx/cinematics content/gfx/cinematics_DISABLE`
     '';
     homepage = "https://www.ankama.com/en/launcher";
     license = lib.licenses.unfree;


### PR DESCRIPTION
## Things done
 
cc @GaetanLepage 

* Built on platform(s)
  * [x]  x86_64-linux
   * [ ]  aarch64-linux
   * [ ]  x86_64-darwin
   * [ ]  aarch64-darwin
* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  * [ ]  `sandbox = relaxed`
  * [ ]  `sandbox = true`
* [ ]  Tested, as applicable:
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
* [x]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
* [x]  Tested basic functionality of all binary files (usually in `./result/bin/`)
   * [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
    * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
    * [ ]  (Module updates) Added a release notes entry if the change is significant
    * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
 * [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

**Note:** I have removed the text about the wine error since it was only occuring with Dofus 2 which is not available anymore.

 Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

