### PR TITLE
syspower: init at 0-unstable-2024-12-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11265,6 +11265,12 @@
     githubId = 31776703;
     name = "Ariel Ebersberger";
   };
+  justdeeevin = {
+    email = "devin.droddy@gmail.com";
+    github = "justdeeevin";
+    githubId = 90054389;
+    name = "Devin Droddy";
+  };
   justinas = {
     email = "justinas@justinas.org";
     github = "justinas";

--- a/pkgs/by-name/sy/syspower/package.nix
+++ b/pkgs/by-name/sy/syspower/package.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  pkg-config,
+  gtkmm4,
+  gtk4-layer-shell,
+}:
+stdenv.mkDerivation {
+  pname = "syspower";
+  version = "0-unstable-2024-12-10";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "syspower";
+    rev = "b205c3443daaee6c3454f23b93b78f42c10221a1";
+    hash = "sha256-kLaWIaMTRurY7a8Nn7C9ft/Zdvx35AiU7Db8n/NFy90=";
+  };
+
+  buildInputs = [
+    gtkmm4
+    gtk4-layer-shell
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postFixup = ''
+    wrapProgram $out/bin/syspower --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  meta = {
+    description = "Simple power menu/shutdown screen for Hyprland";
+    homepage = "https://gihub.com/System64fumo/syspower";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ justdeeevin ];
+    mainProgram = "syspower";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/sy/syspower/package.nix
+++ b/pkgs/by-name/sy/syspower/package.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "System64fumo";
     repo = "syspower";
-    rev = "b205c3443daaee6c3454f23b93b78f42c10221a1";
-    hash = "sha256-kLaWIaMTRurY7a8Nn7C9ft/Zdvx35AiU7Db8n/NFy90=";
+    rev = "323332b4d97a30360455682194ed35868fcbaf71";
+    hash = "sha256-obL9XUf8kONBWZoyrPvN1PWmEyQx8vMsl6KIneSjkGM=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds Syspower, a simple power menu/shutdown screen for Hyprland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
