### PR TITLE
github-runner: use finalAttrs to make it possible to override the version

### DIFF
--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -23,14 +23,14 @@
 # Node.js runtimes supported by upstream
 assert builtins.all (x: builtins.elem x [ "node20" ]) nodeRuntimes;
 
-buildDotnetModule rec {
+buildDotnetModule (finalAttrs: {
   pname = "github-runner";
   version = "2.321.0";
 
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-KZ072v5kYlD78RGQl13Aj05DGzj2+r2akzyZ1aJn93A=";
     leaveDotGit = true;
     postFetch = ''
@@ -52,7 +52,7 @@ buildDotnetModule rec {
       git config user.name "root"
       git add .
       git commit -m "Initial commit"
-      git checkout -b v${version}
+      git checkout -b v${finalAttrs.version}
     )
     mkdir -p $TMPDIR/bin
     cat > $TMPDIR/bin/git <<EOF
@@ -95,7 +95,7 @@ buildDotnetModule rec {
 
   DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = isNull glibcLocales;
   LOCALE_ARCHIVE = lib.optionalString (
-    !DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+    !finalAttrs.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
   ) "${glibcLocales}/lib/locale/locale-archive";
 
   postConfigure = ''
@@ -105,7 +105,7 @@ buildDotnetModule rec {
       -p:ContinuousIntegrationBuild=true \
       -p:Deterministic=true \
       -p:PackageRuntime="${dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system}" \
-      -p:RunnerVersion="${version}" \
+      -p:RunnerVersion="${finalAttrs.version}" \
       src/dir.proj
   '';
 
@@ -204,7 +204,7 @@ buildDotnetModule rec {
       "GitHub.Runner.Common.Tests.Worker.StepHostL0.DetermineNodeRuntimeVersionInAlpineContainerAsync"
       "GitHub.Runner.Common.Tests.Worker.StepHostL0.DetermineNode20RuntimeVersionInAlpineContainerAsync"
     ]
-    ++ lib.optionals DOTNET_SYSTEM_GLOBALIZATION_INVARIANT [
+    ++ lib.optionals finalAttrs.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT [
       "GitHub.Runner.Common.Tests.ProcessExtensionL0.SuccessReadProcessEnv"
       "GitHub.Runner.Common.Tests.Util.StringUtilL0.FormatUsesInvariantCulture"
       "GitHub.Runner.Common.Tests.Worker.VariablesL0.Constructor_SetsOrdinalIgnoreCaseComparer"
@@ -243,7 +243,7 @@ buildDotnetModule rec {
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace $out/lib/github-runner/config.sh \
         --replace 'command -v ldd' 'command -v ${glibc.bin}/bin/ldd' \
-        --replace 'ldd ./bin' '${glibc.bin}/bin/ldd ${dotnet-runtime}/share/dotnet/shared/Microsoft.NETCore.App/${dotnet-runtime.version}/' \
+        --replace 'ldd ./bin' '${glibc.bin}/bin/ldd ${finalAttrs.dotnet-runtime}/share/dotnet/shared/Microsoft.NETCore.App/${finalAttrs.dotnet-runtime.version}/' \
         --replace '/sbin/ldconfig' '${glibc.bin}/bin/ldconfig'
     ''
     + ''
@@ -309,7 +309,7 @@ buildDotnetModule rec {
     $out/bin/Runner.Listener --help >/dev/null
 
     version=$($out/bin/Runner.Listener --version)
-    if [[ "$version" != "${version}" ]]; then
+    if [[ "$version" != "${finalAttrs.version}" ]]; then
       printf 'Unexpected version %s' "$version"
       exit 1
     fi
@@ -347,4 +347,4 @@ buildDotnetModule rec {
     ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

With rec, it is nearly impossible to override the version since it is used in so many different places in the nix expression.
With the current change, it is possible to override version and src to build a different version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
