### PR TITLE
jjui: init at 0-unstable-2024-12-10

### DIFF
--- a/pkgs/by-name/jj/jjui/package.nix
+++ b/pkgs/by-name/jj/jjui/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule {
+  pname = "jjui";
+  version = "0-unstable-2024-12-10";
+
+  src = fetchFromGitHub {
+    owner = "idursun";
+    repo = "jjui";
+    rev = "525c8042a51710cdaefa91176af68a22ad0045bd";
+    hash = "sha256-WSlcJFLOe5UVvWubSPP391+AxepEa5M6GpmZnjYMjww=";
+  };
+
+  vendorHash = "sha256-kg5b3tzwyAhn00GwdUDf4OdYZvCJZHgkgpzHFWy5SxI=";
+
+  postFixup = ''
+    mv $out/bin/cmd $out/bin/jjui
+  '';
+
+  meta = {
+    description = "A TUI for Jujutsu VCS";
+    homepage = "https://github.com/idursun/jjui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      adda
+    ];
+    mainProgram = "jjui";
+  };
+}


### PR DESCRIPTION
This PR initializes [`jjui`](https://github.com/idursun/jjui/) at the latest `master` (there are no release versions nor tags). `jjui` (~ Jujutsu UI) is a TUI for Jujutsu, the Git-compatible version control system.

(Edit: Should be fixed now by using `postFixup`.) I am not knowledgeable about Go toolchain. The issue with this package is that `pkgs.buildGoModule` builds the program as a binary `cmd` (since it is sometimes a convention to put the module with a `main` function of a Go program into a subfolder `cmd`). Is there a better way (more idiomatic, and with less code -- so no specifying the build and install phase manually) to name the package properly?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
