### PR TITLE
nixos/ddclient: update defaults for usev4/6

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -167,14 +167,14 @@ in
         '';
       };
       usev4 = lib.mkOption {
-        default = "webv4, webv4=checkip.dyndns.com/, webv4-skip='Current IP Address: '";
+        default = "webv4, webv4=ipify-ipv4";
         type = str;
         description = ''
           Method to determine the IPv4 address to send to the dynamic DNS provider. Only used if `use` is not set.
         '';
       };
       usev6 = lib.mkOption {
-        default = "webv6, webv6=checkipv6.dyndns.com/, webv6-skip='Current IP Address: '";
+        default = "webv6, webv6=ipify-ipv6";
         type = str;
         description = ''
           Method to determine the IPv6 address to send to the dynamic DNS provider. Only used if `use` is not set.


### PR DESCRIPTION
Set to future upstream [default](https://github.com/ddclient/ddclient/commit/5b104ad116c023c3760129cab6e141f04f72b406) as current defaults are broken because the endpoints of dyndns.com only serve http. See [ddclient issue 597](https://github.com/ddclient/ddclient/issues/597)

One could set this to `http://...` to work again and still using http despite the default option set to `ssl = true;` when [ddclient pull #608](https://github.com/ddclient/ddclient/pull/608) lands in nixpkgs with `ddclient v4.0.0`. I think the better option is to switch to a endpoint supporting `https` as the default option in the module is already set to `ssl = ture;` so a user would expect a TLS connection.

I opted for the same endpoint upstream uses as [future default](https://github.com/ddclient/ddclient/commit/5b104ad116c023c3760129cab6e141f04f72b406) with [ipify.org](https://www.ipify.org/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested on my local setup with:

```nix
services.ddclient = {
    ...
    usev4 = "webv4, webv4=ipify-ipv4";
    usev6 = "webv6, webv6=ipify-ipv6";
    ...
};
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
