### PR TITLE
cardimpose: init at 0.2.1

### DIFF
--- a/pkgs/by-name/ca/cardimpose/package.nix
+++ b/pkgs/by-name/ca/cardimpose/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: python3Packages.toPythonApplication python3Packages.cardimpose

--- a/pkgs/development/python-modules/cardimpose/default.nix
+++ b/pkgs/development/python-modules/cardimpose/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
 
   dependencies = [ pymupdf ];
 
+  pythonImportsCheck = [ "cardimpose" ];
+
   meta = {
     mainProgram = "cardimpose";
     description = "Library for imposing PDF files";

--- a/pkgs/development/python-modules/cardimpose/default.nix
+++ b/pkgs/development/python-modules/cardimpose/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pymupdf,
+}:
+buildPythonPackage rec {
+  pname = "cardimpose";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-7GyLTUzWd9cZ8/k+0FfzKW3H2rKZ3NHqkZkNmiQ+Tec=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pymupdf ];
+
+  meta = {
+    mainProgram = "cardimpose";
+    description = "Library for imposing PDF files";
+    longDescription = ''
+      Cardimpose is a Python library that makes it easy to arrange multiple
+      copies of a PDF on a larger document, perfect for scenarios like printing
+      business cards. The library lets you customize your layout while adding
+      crop marks and comes with a handy command line tool.
+    '';
+    homepage = "https://github.com/frsche/cardimpose";
+    license = lib.licenses.agpl3Only;
+    platforms = pymupdf.meta.platforms;
+    badPlatforms = pymupdf.meta.badPlatforms or [ ];
+    maintainers = [ lib.maintainers.me-and ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2056,6 +2056,8 @@ self: super: with self; {
 
   carbon = callPackage ../development/python-modules/carbon { };
 
+  cardimpose = callPackage ../development/python-modules/cardimpose { };
+
   cart = callPackage ../development/python-modules/cart { };
 
   cartopy = callPackage ../development/python-modules/cartopy { };


### PR DESCRIPTION
New Python library and (more likely to be useful to folk) general-purpose package for laying out PDFs on a page, for example to print a sheet of business cards.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
