### PR TITLE
opam: fix opam sandboxing on nixos

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -4,12 +4,12 @@
 
 assert lib.versionAtLeast ocaml.version "4.08.0";
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opam";
   version = "2.3.0";
 
   src = fetchurl {
-    url = "https://github.com/ocaml/opam/releases/download/2.3.0/opam-full-2.3.0.tar.gz";
+    url = "https://github.com/ocaml/opam/releases/download/${finalAttrs.version}/opam-full-${finalAttrs.version}.tar.gz";
     hash = "sha256-UGunaGXcMVtn35qonnq9XBqJen8KkteyaUl0/cUys0Y=";
   };
 
@@ -23,36 +23,30 @@ stdenv.mkDerivation {
   patches = [ ./opam-shebangs.patch ];
 
   preConfigure = ''
-    patchShebangs src/state/shellscripts
+    # Fix opam sandboxing on nixos. Remove after opam >= 2.4.0 is released
+    substituteInPlace src/state/shellscripts/bwrap.sh \
+      --replace-fail 'for dir in /*; do' 'for dir in /{*,run/current-system/sw}; do'
   '';
 
   configureFlags = [ "--with-vendored-deps" "--with-mccs" ];
 
-  # Dirty, but apparently ocp-build requires a TERM
-  makeFlags = ["TERM=screen"];
-
   outputs = [ "out" "installer" ];
   setOutputFlags = false;
 
-  # change argv0 to "opam" as a workaround for
-  # https://github.com/ocaml/opam/issues/2142
   postInstall = ''
-    mv $out/bin/opam $out/bin/.opam-wrapped
-    makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
-      --argv0 "opam" \
-      --suffix PATH : ${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.hostPlatform.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
-      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
+    wrapProgram $out/bin/opam \
+      --suffix PATH : ${lib.makeBinPath ([ curl getconf unzip ] ++ lib.optionals stdenv.hostPlatform.isLinux [ bubblewrap ])}
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Package manager for OCaml";
     homepage = "https://opam.ocaml.org/";
-    changelog = "https://github.com/ocaml/opam/raw/${version}/CHANGES";
+    changelog = "https://github.com/ocaml/opam/raw/${finalAttrs.version}/CHANGES";
     maintainers = [ ];
-    license = licenses.lgpl21Only;
-    platforms = platforms.all;
+    license = lib.licenses.lgpl21Only;
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Before this commit, executing `opam init` would display that sandboxing fails with "bwrap: execvp sh: No such file or directory". `makeWrapper` with `--set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/` had been used here to fix that, however, OPAM_USER_PATH_RO has been removed since 2021: https://github.com/ocaml/opam/commit/9b6370d6fef68750f41435261ee2965c49e8806a (released as opam 2.2.0 in 2024)

This also fixes a funny bug which caused the changelog link to be broken because of `with lib`:
```nix
meta = with lib; {                                                   
  description = "Package manager for OCaml";                         
  homepage = "https://opam.ocaml.org/";                              
  changelog = "https://github.com/ocaml/opam/raw/${version}/CHANGES";
  maintainers = [ ];                                                 
  license = licenses.lgpl21Only;                                     
  platforms = platforms.all;                                         
};                                                                   
```
It uses `meta = with lib;`; at the same time, the derivation's attrset is not `rec`, and `${version}` ends to be `lib.version`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @kit-ty-kate 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
