### PR TITLE
zsh-you-should-use: adopt, modernize, hardcode tput dependency

### DIFF
--- a/pkgs/by-name/zs/zsh-you-should-use/package.nix
+++ b/pkgs/by-name/zs/zsh-you-should-use/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub, gitUpdater }:
+{ lib, stdenvNoCC, ncurses, fetchFromGitHub, gitUpdater }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-you-should-use";
@@ -13,6 +13,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   strictDeps = true;
   dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace you-should-use.plugin.zsh \
+      --replace-fail "tput" "${lib.getExe' ncurses "tput"}"
+  '';
 
   installPhase = ''
     install -D you-should-use.plugin.zsh $out/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh

--- a/pkgs/by-name/zs/zsh-you-should-use/package.nix
+++ b/pkgs/by-name/zs/zsh-you-should-use/package.nix
@@ -22,6 +22,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/MichaelAquilina/zsh-you-should-use";
     license = lib.licenses.gpl3;
     description = "ZSH plugin that reminds you to use existing aliases for commands you just typed";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomodachi94 ];
   };
 })

--- a/pkgs/by-name/zs/zsh-you-should-use/package.nix
+++ b/pkgs/by-name/zs/zsh-you-should-use/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub, gitUpdater }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-you-should-use";
@@ -17,6 +17,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     install -D you-should-use.plugin.zsh $out/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://github.com/MichaelAquilina/zsh-you-should-use";

--- a/pkgs/by-name/zs/zsh-you-should-use/package.nix
+++ b/pkgs/by-name/zs/zsh-you-should-use/package.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-you-should-use";
   version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "MichaelAquilina";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-+3iAmWXSsc4OhFZqAMTwOL7AAHBp5ZtGGtvqCnEOYc0=";
+    repo = "zsh-you-should-use";
+    tag = finalAttrs.version;
+    hash = "sha256-+3iAmWXSsc4OhFZqAMTwOL7AAHBp5ZtGGtvqCnEOYc0=";
   };
 
   strictDeps = true;
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
     install -D you-should-use.plugin.zsh $out/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/MichaelAquilina/zsh-you-should-use";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     description = "ZSH plugin that reminds you to use existing aliases for commands you just typed";
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm not satisfied with the way that we now hardcode the `tput` dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
