### PR TITLE
pkgsStatic: Allow commutation with pkgsLLVM

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -309,7 +309,11 @@ let
       overlays = [ (self': super': {
         pkgsStatic = super';
       })] ++ overlays;
-      crossSystem = {
+      crossSystem = (
+        builtins.intersectAttrs {
+          useLLVM = true; linker = true; # Allow pkgsStatic to commute with pkgsLLVM.
+        } stdenv.hostPlatform
+      ) // {
         isStatic = true;
         config = lib.systems.parse.tripleFromSystem (
           if stdenv.hostPlatform.isLinux


### PR DESCRIPTION
Prior to this commit, pkgsStatic.pkgsLLVM.hello would give a static
binary built with LLVM, but pkgsLLVM.pkgsStatic would not.

The reason is that pkgsStatic would not supply the LLVM attributes into
the crossSystem, but pkgsLLVM on top of pkgsStatic does.

This can be confusing to users, since if they pick the wrong ordering,
they may conclude that these two don't compose, when they do.

Before commit:

```
$ nix eval --system x86_64-linux -f . pkgsStatic.pkgsLLVM.hello.outPath
"/nix/store/4b2fmnp5ishi4jzm2hhfs5a7gpj2ig6p-hello-static-x86_64-unknown-linux-musl-2.12.1"
$ nix eval --system x86_64-linux -f . pkgsLLVM.pkgsStatic.hello.outPath
"/nix/store/al3jmj73mczwlc9adbcy3ljxxvn99jam-hello-static-x86_64-unknown-linux-musl-2.12.1"
```

(The other is not built with LLVM).

After commit, they're the same:

```
$ nix eval --system x86_64-linux -f . pkgsStatic.pkgsLLVM.hello.outPath
"/nix/store/4b2fmnp5ishi4jzm2hhfs5a7gpj2ig6p-hello-static-x86_64-unknown-linux-musl-2.12.1"
$ nix eval --system x86_64-linux -f . pkgsLLVM.pkgsStatic.hello.outPath
"/nix/store/4b2fmnp5ishi4jzm2hhfs5a7gpj2ig6p-hello-static-x86_64-unknown-linux-musl-2.12.1"
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
