### PR TITLE
spamton-shimeji: init at 1.05-unstable-2022-10-21

### DIFF
--- a/pkgs/by-name/sp/spamton-shimeji/package.nix
+++ b/pkgs/by-name/sp/spamton-shimeji/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+
+  ant,
+  jdk8,
+  stripJavaArchivesHook,
+  makeBinaryWrapper,
+
+  jna,
+  xorg,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spamton-shimeji";
+  version = "1.05-unstable-2022-10-21";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "thatonecalculator";
+    repo = "spamton-linux-shimeji";
+    rev = "d967d78e13e12e2bf59f20c1a66c7f64d8d9310e";
+    hash = "sha256-PNQZE4/RJ6C6qhAabMrbqEsYri0+GzbcwepCC6hMf1c=";
+  };
+
+  nativeBuildInputs = [
+    ant
+    jdk8
+    stripJavaArchivesHook
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    jna
+  ];
+
+  postPatch = ''
+    # No spaces in command line arguments
+    substituteInPlace build.xml \
+      --replace-fail "lines, vars, source" "lines,vars,source"
+
+    # Long deprecated since JNA 3.2, removed since 4.x
+    substituteInPlace src_x11/com/group_finity/mascot/x11/X11TranslucentWindow.java \
+      --replace-fail "getSize()" "size()"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    ant
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D Shimeji.jar -t $out/share/java
+    cp -r conf img $out/share/java
+    install -D desktop/Spamton.desktop -t $out/share/applications
+    install -D desktop/spamton.png -t $out/share/icons/hicolor/128x128/apps
+
+    makeWrapper ${lib.getExe jdk8} $out/bin/spamton \
+      --add-flags "-cp $out/share/java/Shimeji.jar:$CLASSPATH com.group_finity.mascot.Main" \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          xorg.libX11
+          xorg.libXrender
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop mascot program";
+    homepage = "https://codeberg.org/thatonecalculator/spamton-linux-shimeji";
+    # Custom free license; see https://codeberg.org/thatonecalculator/spamton-linux-shimeji/src/branch/master/LICENSE
+    license = with lib.licenses; [ free ];
+    platforms = lib.intersectLists lib.platforms.linux jdk8.meta.platforms;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "spamton";
+  };
+})


### PR DESCRIPTION
Closes #259667
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
