### PR TITLE
marp-cli: 3.4.0 -> 4.0.3

### DIFF
--- a/pkgs/by-name/ma/marp-cli/package.nix
+++ b/pkgs/by-name/ma/marp-cli/package.nix
@@ -1,69 +1,26 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchYarnDeps
-, makeWrapper
-, nodejs
-, fixup-yarn-lock
-, yarn
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildNpmPackage rec {
   pname = "marp-cli";
-  version = "3.4.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "marp-team";
-    repo = "marp-cli";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-azscuPkQ9/xcQtBg+5pJigXSQQVtBGvbd7ZwiLwU7Qo=";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-K638HwDOfHn5WiWqZKQ2r7conPpJi+UM7YpshmItWNU=";
   };
 
-  offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-b/JyhsfXEbmM6+ajrjL65WhX9u9MEH+m1NHE6cTyf2g=";
-  };
+  npmDepsHash = "sha256-sspS4rVRrfOZ6hqRKD4s5DGGjlI9RZcjwn+W0ZPaO8E=";
+  npmPackFlags = [ "--ignore-scripts" ];
+  makeCacheWritable = true;
 
-  nativeBuildInputs = [
-    makeWrapper
-    nodejs
-    fixup-yarn-lock
-    yarn
-  ];
-
-  configurePhase = ''
-    runHook preConfigure
-
-    export HOME=$(mktemp -d)
-    yarn config --offline set yarn-offline-mirror $offlineCache
-    fixup-yarn-lock yarn.lock
-    yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install
-    patchShebangs node_modules
-
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    yarn --offline build
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    yarn --offline --production install
-
-    mkdir -p $out/lib/node_modules/@marp-team/marp-cli
-    cp -r lib node_modules marp-cli.js $out/lib/node_modules/@marp-team/marp-cli/
-
-    makeWrapper "${nodejs}/bin/node" "$out/bin/marp" \
-      --add-flags "$out/lib/node_modules/@marp-team/marp-cli/marp-cli.js"
-
-    runHook postInstall
-  '';
+  doCheck = false;
 
   meta = with lib; {
     description = "About A CLI interface for Marp and Marpit based converters";
@@ -73,4 +30,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = nodejs.meta.platforms;
     mainProgram = "marp";
   };
-})
+}

--- a/pkgs/by-name/ma/marp-cli/package.nix
+++ b/pkgs/by-name/ma/marp-cli/package.nix
@@ -7,16 +7,16 @@
 
 buildNpmPackage rec {
   pname = "marp-cli";
-  version = "4.0.0";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "marp-team";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-K638HwDOfHn5WiWqZKQ2r7conPpJi+UM7YpshmItWNU=";
+    hash = "sha256-HiLhFRQBCrDqMDX04gI7KolphA1ogTxdj1ehpL1D9e4=";
   };
 
-  npmDepsHash = "sha256-sspS4rVRrfOZ6hqRKD4s5DGGjlI9RZcjwn+W0ZPaO8E=";
+  npmDepsHash = "sha256-8IN3MJBtq3Nu4T/WMcvg9QnckyigYhItBoGoSYOImTY=";
   npmPackFlags = [ "--ignore-scripts" ];
   makeCacheWritable = true;
 


### PR DESCRIPTION
## Things done

Upgrade marp-cli:
- continue from #352948 and add 4.0.0 -> 4.0.3 update
- closes #351203 (update request)

I unfortunately (fortunately?) didn't reproduce the npm ci hang :/ so the build just worked and I could test the generated binary, seems to work; but it's my first time using marp so I'm not sure if the theme is correct etc etc; manual test welcome!
(doesn't seem to be any nixos test)
(if there's an easy way to re-run the npm ci command multiple times to try to reproduce the hang I'll be happy to have a look; otherwise I'll just pray it's been fixed in the past month-ish and/or builder won't hit the issue...)


Cc @GuillaumeDesforges @delvinru 


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
