### PR TITLE
osu-lazer: add native Wayland option

### DIFF
--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -5,6 +5,7 @@
   fetchzip,
   appimageTools,
   makeWrapper,
+  nativeWayland ? false,
 }:
 
 let
@@ -91,8 +92,11 @@ else
       ''
         . ${makeWrapper}/nix-support/setup-hook
         mv -v $out/bin/${pname} $out/bin/osu!
+
         wrapProgram $out/bin/osu! \
+          ${lib.optionalString nativeWayland "--set SDL_VIDEODRIVER wayland"} \
           --set OSU_EXTERNAL_UPDATE_PROVIDER 1
+
         install -m 444 -D ${contents}/osu!.desktop -t $out/share/applications
         for i in 16 32 48 64 96 128 256 512 1024; do
           install -D ${contents}/osu!.png $out/share/icons/hicolor/''${i}x$i/apps/osu!.png

--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -16,6 +16,7 @@
   xorg,
   udev,
   vulkan-loader,
+  nativeWayland ? false,
 }:
 
 buildDotnetModule rec {
@@ -69,6 +70,7 @@ buildDotnetModule rec {
     runHook preFixup
 
     wrapProgram $out/bin/osu! \
+      ${lib.optionalString nativeWayland "--set SDL_VIDEODRIVER wayland"} \
       --set OSU_EXTERNAL_UPDATE_PROVIDER 1
 
     for i in 16 32 48 64 96 128 256 512 1024; do


### PR DESCRIPTION
Since upstream does not default to native Wayland support, end-users are supposed to opt into using `SDL_VIDEODRIVER=wayland`. [1]

While the package still builds successfully with the previous `nativeWayland = false;` behaviour, it fails as follows with the new `nativeWayland = true;` option:

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/k31v9rc86iqhbrgzkmnq6amihhxmf7ic-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: configureNuget
@nix { "action": "setPhase", "phase": "configureNuget" }
The template "NuGet Config" was created successfully.

Processing post-creation actions...


Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Executing dotnetConfigureHook
Tool 'jetbrains.resharper.globaltools' (version '2023.3.3') was restored. Available commands: jb
Tool 'nvika' (version '3.0.0') was restored. Available commands: nvika
Tool 'codefilesanity' (version '0.0.37') was restored. Available commands: CodeFileSanity
Tool 'ppy.localisationanalyser.tools' (version '2024.802.0') was restored. Available commands: localisation

Restore was successful.
  Determining projects to restore...
  Restored /build/source/osu.Game/osu.Game.csproj (in 1.42 sec).
  Restored /build/source/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj (in 1.42 sec).
  Restored /build/source/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj (in 1.42 sec).
  Restored /build/source/osu.Desktop/osu.Desktop.csproj (in 1.42 sec).
  Restored /build/source/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj (in 1.42 sec).
  Restored /build/source/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj (in 1.42 sec).
  Restored /build/source/osu.Game.Tournament/osu.Game.Tournament.csproj (in 1.42 sec).
Finished dotnetConfigureHook
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing dotnetBuildHook
  osu.Game -> /build/source/osu.Game/bin/Release/net8.0/osu.Game.dll
  osu.Game.Rulesets.Taiko -> /build/source/osu.Game.Rulesets.Taiko/bin/Release/net8.0/osu.Game.Rulesets.Taiko.dll
  osu.Game.Rulesets.Catch -> /build/source/osu.Game.Rulesets.Catch/bin/Release/net8.0/osu.Game.Rulesets.Catch.dll
  osu.Game.Rulesets.Mania -> /build/source/osu.Game.Rulesets.Mania/bin/Release/net8.0/osu.Game.Rulesets.Mania.dll
  osu.Game.Tournament -> /build/source/osu.Game.Tournament/bin/Release/net8.0/osu.Game.Tournament.dll
  osu.Game.Rulesets.Osu -> /build/source/osu.Game.Rulesets.Osu/bin/Release/net8.0/osu.Game.Rulesets.Osu.dll
  osu.Desktop -> /build/source/osu.Desktop/bin/Release/net8.0/linux-x64/osu!.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:28.11
Finished dotnetBuildHook
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing dotnetInstallHook
  osu.Desktop -> /nix/store/yxyd5d2zpcmi10xsgryf13lc5my1pb3v-osu-lazer-2024.1115.3/lib/osu-lazer/
Copying '/nix/store/wzv97nsl9215dns8kp5mz519lrpk9agp-osu.desktop/share/applications/osu.desktop' into '/nix/store/yxyd5d2zpcmi10xsgryf13lc5my1pb3v-osu-lazer-2024.1115.3/share/applications'
Finished dotnetInstallHook
Running phase: dotnetFixupHook
@nix { "action": "setPhase", "phase": "dotnetFixupHook" }
installed wrapper to /nix/store/yxyd5d2zpcmi10xsgryf13lc5my1pb3v-osu-lazer-2024.1115.3/bin/osu!
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }

Builder called die: makeWrapper doesn't understand the arg OSU_EXTERNAL_UPDATE_PROVIDER
Backtrace:
185 makeShellWrapper /nix/store/bs5spxg8s8mawd0zpqlyzv41m7xm43h4-make-shell-wrapper-hook/nix-support/setup-hook
224 wrapProgramShell /nix/store/bs5spxg8s8mawd0zpqlyzv41m7xm43h4-make-shell-wrapper-hook/nix-support/setup-hook
212 wrapProgram /nix/store/bs5spxg8s8mawd0zpqlyzv41m7xm43h4-make-shell-wrapper-hook/nix-support/setup-hook
1716 runPhase /nix/store/spb2bpcnw0gbbr4x94cq8xs9n72hipwj-stdenv-linux/setup
1755 genericBuild /nix/store/spb2bpcnw0gbbr4x94cq8xs9n72hipwj-stdenv-linux/setup
4 main /nix/store/v6x3cs394jgqfbi0a42pam708flxaphh-default-builder.sh
```

As I am not using this package, I hope someone else can resolve this double `--set` misuse in [`wrapProgram`](https://github.com/NixOS/nixpkgs/blob/0acd6eb6eec33ed798551cdb41dbd929f720c080/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh).

[1]: https://github.com/ppy/osu/discussions/22651

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
