### PR TITLE
nixos-rebuild-ng: add module changes and port tests from nixos-rebuild

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -6,6 +6,8 @@
 
 - The default PHP version has been updated to 8.3.
 
+- `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is available for testing. You can enable it by setting [system.rebuild.enableNg](options.html#opt-system.rebuild.enableNg) in your configuration (this will replace the old `nixos-rebuild`), or by adding `nixos-rebuild-ng` to your `environment.systemPackages` (in this case, it will live side-by-side with `nixos-rebuild` as `nixos-rebuild-ng`). It is expected that the next major version of NixOS (25.11) will enable `system.rebuild.enableNg` by default.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -45,6 +45,10 @@ let
 
   nixos-install = pkgs.nixos-install.override { nix = config.nix.package; };
   nixos-rebuild = pkgs.nixos-rebuild.override { nix = config.nix.package; };
+  nixos-rebuild-ng = pkgs.nixos-rebuild-ng.override {
+    nix = config.nix.package;
+    withNgSuffix = false;
+  };
 
   defaultConfigTemplate = ''
     # Edit this configuration file to define what should be installed on
@@ -214,6 +218,13 @@ in
     '';
   };
 
+  options.system.rebuild.enableNg = lib.mkEnableOption "" // {
+    description = ''
+      Whether to use ‘nixos-rebuild-ng’ in place of ‘nixos-rebuild’, the
+      Python-based re-implementation of the original in Bash.
+    '';
+  };
+
   imports = let
     mkToolModule = { name, package ? pkgs.${name} }: { config, ... }: {
       options.system.tools.${name}.enable = lib.mkEnableOption "${name} script" // {
@@ -240,7 +251,11 @@ in
 
     # These may be used in auxiliary scripts (ie not part of toplevel), so they are defined unconditionally.
     system.build = {
-      inherit nixos-generate-config nixos-install nixos-rebuild;
+      inherit nixos-generate-config nixos-install;
+      nixos-rebuild =
+        if config.system.rebuild.enableNg
+          then nixos-rebuild-ng
+          else nixos-rebuild;
       nixos-option = lib.warn "Accessing nixos-option through `config.system.build` is deprecated, use `pkgs.nixos-option` instead." pkgs.nixos-option;
       nixos-enter = lib.warn "Accessing nixos-enter through `config.system.build` is deprecated, use `pkgs.nixos-enter` instead." pkgs.nixos-enter;
     };

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -48,6 +48,7 @@ let
   nixos-rebuild-ng = pkgs.nixos-rebuild-ng.override {
     nix = config.nix.package;
     withNgSuffix = false;
+    withReexec = true;
   };
 
   defaultConfigTemplate = ''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -711,6 +711,7 @@ in {
   nixops = handleTest ./nixops/default.nix {};
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
   nixos-rebuild-install-bootloader = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix {};
+  nixos-rebuild-install-bootloader-ng = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix { withNg = true; };
   nixos-rebuild-specialisations = runTestOn ["x86_64-linux"] ./nixos-rebuild-specialisations.nix;
   nixos-rebuild-target-host = runTest ./nixos-rebuild-target-host.nix;
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -712,7 +712,14 @@ in {
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
   nixos-rebuild-install-bootloader = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix {};
   nixos-rebuild-install-bootloader-ng = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix { withNg = true; };
-  nixos-rebuild-specialisations = runTestOn ["x86_64-linux"] ./nixos-rebuild-specialisations.nix;
+  nixos-rebuild-specialisations = runTestOn ["x86_64-linux"] {
+    imports = [ ./nixos-rebuild-specialisations.nix ];
+    _module.args.withNg = false;
+  };
+  nixos-rebuild-specialisations-ng = runTestOn ["x86_64-linux"] {
+    imports = [ ./nixos-rebuild-specialisations.nix ];
+    _module.args.withNg = true;
+  };
   nixos-rebuild-target-host = runTest ./nixos-rebuild-target-host.nix;
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   nixseparatedebuginfod = handleTest ./nixseparatedebuginfod.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -720,7 +720,14 @@ in {
     imports = [ ./nixos-rebuild-specialisations.nix ];
     _module.args.withNg = true;
   };
-  nixos-rebuild-target-host = runTest ./nixos-rebuild-target-host.nix;
+  nixos-rebuild-target-host = runTest {
+    imports = [ ./nixos-rebuild-target-host.nix ];
+    _module.args.withNg = false;
+  };
+  nixos-rebuild-target-host-ng = runTest {
+    imports = [ ./nixos-rebuild-target-host.nix ];
+    _module.args.withNg = true;
+  };
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   nixseparatedebuginfod = handleTest ./nixseparatedebuginfod.nix {};
   node-red = handleTest ./node-red.nix {};

--- a/nixos/tests/nixos-rebuild-install-bootloader.nix
+++ b/nixos/tests/nixos-rebuild-install-bootloader.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, lib, withNg ? false, ... }: {
   name = "nixos-rebuild-install-bootloader";
 
   nodes = {
@@ -15,6 +15,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       };
 
       system.includeBuildDependencies = true;
+      system.rebuild.enableNg = withNg;
 
       virtualisation = {
         cores = 2;
@@ -27,7 +28,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
   testScript =
     let
-      configFile = pkgs.writeText "configuration.nix" ''
+      configFile = pkgs.writeText "configuration.nix" /* nix */ ''
         { lib, pkgs, ... }: {
           imports = [
             ./hardware-configuration.nix
@@ -40,12 +41,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             forceInstall = true;
           };
 
+          system.rebuild.enableNg = ${lib.boolToString withNg};
           documentation.enable = false;
         }
       '';
 
     in
-    ''
+    /* python */ ''
       machine.start()
       machine.succeed("udevadm settle")
       machine.wait_for_unit("multi-user.target")

--- a/nixos/tests/nixos-rebuild-specialisations.nix
+++ b/nixos/tests/nixos-rebuild-specialisations.nix
@@ -1,4 +1,4 @@
-{ hostPkgs, ... }: {
+{ hostPkgs, lib, withNg, ... }: {
   name = "nixos-rebuild-specialisations";
 
   # TODO: remove overlay from  nixos/modules/profiles/installation-device.nix
@@ -25,6 +25,7 @@
         pkgs.grub2
       ];
 
+      system.rebuild.enableNg = withNg;
       system.switch.enable = true;
 
       virtualisation = {
@@ -36,7 +37,7 @@
 
   testScript =
     let
-      configFile = hostPkgs.writeText "configuration.nix" ''
+      configFile = hostPkgs.writeText "configuration.nix" /* nix */ ''
         { lib, pkgs, ... }: {
           imports = [
             ./hardware-configuration.nix
@@ -54,6 +55,8 @@
           environment.systemPackages = [
             (pkgs.writeShellScriptBin "parent" "")
           ];
+
+          system.rebuild.enableNg = ${lib.boolToString withNg};
 
           specialisation.foo = {
             inheritParentConfig = true;
@@ -78,7 +81,7 @@
       '';
 
     in
-    ''
+    /* python */ ''
       machine.start()
       machine.succeed("udevadm settle")
       machine.wait_for_unit("multi-user.target")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -105,7 +105,7 @@ ruff format .
   old `nixos-rebuild`)
 - [x] `_NIXOS_REBUILD_REEXEC`
 - [ ] Port `nixos-rebuild.passthru.tests`
-- [ ] Change module system to allow easier opt-in, like
+- [x] Change module system to allow easier opt-in, like
   `system.switch.enableNg` for `switch-to-configuration-ng`
 - [x] Improve documentation
 - [x] `nixos-rebuild repl`

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -44,6 +44,9 @@ an attempt of the rewrite.
 
 ## How to use
 
+If you want to use `nixos-rebuild-ng` without replacing `nixos-rebuild`, add to
+your NixOS configuration:
+
 ```nix
 { pkgs, ... }:
 {
@@ -53,16 +56,29 @@ an attempt of the rewrite.
 
 And use `nixos-rebuild-ng` instead of `nixos-rebuild`.
 
+If you want to completely replace `nixos-rebuild` with `nixos-rebuild-ng`, add
+to your NixOS configuration:
+
+```nix
+{ ... }:
+{
+  system.rebuild.enableNg = true;
+}
+```
+
+This will set `config.system.build.nixos-rebuild` to `nixos-rebuild-ng`, so
+all tools that expect it in that location should work.
+
 ## Development
 
 Run:
 
 ```console
-nix-build -A nixos-rebuild-ng.tests.ci
+nix-build -A nixos-rebuild-ng -A nixos-rebuild-ng.tests.linters
 ```
 
-The command above will run the unit tests and linters, and also check if the
-code is formatted. However, sometimes is more convenient to run just a few
+The command above will build, run the unit tests and linters, and also check if
+the code is formatted. However, sometimes is more convenient to run just a few
 tests to debug, in this case you can run:
 
 ```console
@@ -85,32 +101,14 @@ ruff check --fix .
 ruff format .
 ```
 
-## Current caveats
+## Caveats
 
-- For now we will install it in `nixos-rebuild-ng` path by default, to avoid
-  conflicting with the current `nixos-rebuild`. This means you can keep both in
-  your system at the same time, but it also means that a few things like bash
-  completion are broken right now (since it looks at `nixos-rebuild` binary)
 - Bugs in the profile manipulation can cause corruption of your profile that
   may be difficult to fix, so right now I only recommend using
   `nixos-rebuild-ng` if you are testing in a VM or in a filesystem with
   snapshots like btrfs or ZFS. Those bugs are unlikely to be unfixable but the
   errors can be difficult to understand. If you want to go anyway,
   `nix-collect-garbage -d` and `nix store repair` are your friends
-
-## TODO
-
-- [x] Remote host/builders (via SSH)
-- [x] Improve nix arguments handling (e.g.: `nixFlags` vs `copyFlags` in the
-  old `nixos-rebuild`)
-- [x] `_NIXOS_REBUILD_REEXEC`
-- [ ] Port `nixos-rebuild.passthru.tests`
-- [x] Change module system to allow easier opt-in, like
-  `system.switch.enableNg` for `switch-to-configuration-ng`
-- [x] Improve documentation
-- [x] `nixos-rebuild repl`
-- [x] Generate tab completion via [`shtab`](https://docs.iterative.ai/shtab/)
-- [x] Reduce build closure
 
 ## TODON'T
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -4,6 +4,7 @@
   installShellFiles,
   mkShell,
   nix,
+  nixosTests,
   python3,
   python3Packages,
   runCommand,
@@ -94,6 +95,7 @@ python3Packages.buildPythonApplication rec {
       };
 
       tests = {
+        inherit (nixosTests) nixos-rebuild-install-bootloader-ng;
         repl = callPackage ./tests/repl.nix { };
         # NOTE: this is a passthru test rather than a build-time test because we
         # want to keep the build closures small

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  callPackage,
   installShellFiles,
   mkShell,
   nix,
@@ -92,20 +93,23 @@ python3Packages.buildPythonApplication rec {
         '';
       };
 
-      # NOTE: this is a passthru test rather than a build-time test because we
-      # want to keep the build closures small
-      tests.ci = runCommand "${pname}-ci" { nativeBuildInputs = [ python-with-pkgs ]; } ''
-        export RUFF_CACHE_DIR="$(mktemp -d)"
+      tests = {
+        repl = callPackage ./tests/repl.nix { };
+        # NOTE: this is a passthru test rather than a build-time test because we
+        # want to keep the build closures small
+        linters = runCommand "${pname}-linters" { nativeBuildInputs = [ python-with-pkgs ]; } ''
+          export RUFF_CACHE_DIR="$(mktemp -d)"
 
-        echo -e "\x1b[32m## run mypy\x1b[0m"
-        mypy ${src}
-        echo -e "\x1b[32m## run ruff\x1b[0m"
-        ruff check ${src}
-        echo -e "\x1b[32m## run ruff format\x1b[0m"
-        ruff format --check ${src}
+          echo -e "\x1b[32m## run mypy\x1b[0m"
+          mypy ${src}
+          echo -e "\x1b[32m## run ruff\x1b[0m"
+          ruff check ${src}
+          echo -e "\x1b[32m## run ruff format\x1b[0m"
+          ruff format --check ${src}
 
-        touch $out
-      '';
+          touch $out
+        '';
+      };
     };
 
   meta = {

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -95,7 +95,7 @@ python3Packages.buildPythonApplication rec {
       };
 
       tests = {
-        inherit (nixosTests) nixos-rebuild-install-bootloader-ng;
+        inherit (nixosTests) nixos-rebuild-install-bootloader-ng nixos-rebuild-specialisations-ng;
         repl = callPackage ./tests/repl.nix { };
         # NOTE: this is a passthru test rather than a build-time test because we
         # want to keep the build closures small

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -8,6 +8,7 @@
   runCommand,
   scdoc,
   withNgSuffix ? true,
+  withReexec ? false,
   withShellFiles ? true,
 }:
 let
@@ -48,6 +49,7 @@ python3Packages.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace nixos_rebuild/__init__.py \
       --subst-var-by executable ${executable} \
+      --subst-var-by withReexec ${lib.boolToString withReexec} \
       --subst-var-by withShellFiles ${lib.boolToString withShellFiles}
 
     substituteInPlace pyproject.toml \

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   callPackage,
   installShellFiles,
   mkShell,
@@ -12,6 +13,9 @@
   withNgSuffix ? true,
   withReexec ? false,
   withShellFiles ? true,
+  # Very long tmp dirs lead to "too long for Unix domain socket"
+  # SSH ControlPath errors. Especially macOS sets long TMPDIR paths.
+  withTmpdir ? if stdenv.hostPlatform.isDarwin then "/tmp" else null,
 }:
 let
   executable = if withNgSuffix then "nixos-rebuild-ng" else "nixos-rebuild";
@@ -72,6 +76,10 @@ python3Packages.buildPythonApplication rec {
   ];
 
   pytestFlagsArray = [ "-vv" ];
+
+  makeWrapperArgs = lib.optionals (withTmpdir != null) [
+    "--set TMPDIR ${withTmpdir}"
+  ];
 
   passthru =
     let

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -103,7 +103,11 @@ python3Packages.buildPythonApplication rec {
       };
 
       tests = {
-        inherit (nixosTests) nixos-rebuild-install-bootloader-ng nixos-rebuild-specialisations-ng;
+        inherit (nixosTests)
+          nixos-rebuild-install-bootloader-ng
+          nixos-rebuild-specialisations-ng
+          nixos-rebuild-target-host-ng
+          ;
         repl = callPackage ./tests/repl.nix { };
         # NOTE: this is a passthru test rather than a build-time test because we
         # want to keep the build closures small

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -181,7 +181,7 @@ def parse_args(
     }
 
     if args.help or args.action is None:
-        if "@withShellFiles@" == "true":
+        if "@withShellFiles@" == "true":  # type: ignore
             r = run(["man", "8", "@executable@"], check=False)
             parser.exit(r.returncode)
         else:
@@ -298,7 +298,7 @@ def execute(argv: list[str]) -> None:
     # Re-exec to a newer version of the script before building to ensure we get
     # the latest fixes
     if (
-        "@withReexec@" == "true"
+        "@withReexec@" == "true"  # type: ignore
         and can_run
         and not args.fast
         and not os.environ.get("_NIXOS_REBUILD_REEXEC")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -16,6 +16,12 @@ from .utils import Args, LogFormatter
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Build-time flags
+# Strings to avoid breaking standalone (e.g.: `python -m nixos_rebuild`) usage
+EXECUTABLE = "@executable@"
+WITH_REEXEC = "@withReexec@"
+WITH_SHELL_FILES = "@withShellFiles@"
+
 
 def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]:
     common_flags = argparse.ArgumentParser(add_help=False)
@@ -181,8 +187,8 @@ def parse_args(
     }
 
     if args.help or args.action is None:
-        if "@withShellFiles@" == "true":  # type: ignore
-            r = run(["man", "8", "@executable@"], check=False)
+        if WITH_SHELL_FILES == "true":
+            r = run(["man", "8", EXECUTABLE], check=False)
             parser.exit(r.returncode)
         else:
             parser.print_help()
@@ -260,10 +266,9 @@ def reexec(
         logger.warning("could not find a newer version of nixos-rebuild")
 
     if drv:
-        new = drv / "bin/@executable@"
+        new = drv / f"bin/{EXECUTABLE}"
         current = Path(argv[0])
-        # Disable re-exec during development
-        if current.name != "__main__.py" and new != current:
+        if new != current:
             logging.debug(
                 "detected newer version of script, re-exec'ing, current=%s, new=%s",
                 argv[0],
@@ -298,7 +303,7 @@ def execute(argv: list[str]) -> None:
     # Re-exec to a newer version of the script before building to ensure we get
     # the latest fixes
     if (
-        "@withReexec@" == "true"  # type: ignore
+        WITH_REEXEC == "true"
         and can_run
         and not args.fast
         and not os.environ.get("_NIXOS_REBUILD_REEXEC")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -248,22 +248,14 @@ def reexec(
     flake_build_flags: dict[str, Args],
 ) -> None:
     drv = None
+    attr = "config.system.build.nixos-rebuild"
     try:
         # Need to set target_host=None, to avoid connecting to remote
         if flake := Flake.from_arg(args.flake, None):
-            drv = nix.build_flake(
-                "pkgs.nixos-rebuild-ng",
-                flake,
-                **flake_build_flags,
-                no_link=True,
-            )
+            drv = nix.build_flake(attr, flake, **flake_build_flags, no_link=True)
         else:
-            drv = nix.build(
-                "pkgs.nixos-rebuild-ng",
-                BuildAttr.from_arg(args.attr, args.file),
-                **build_flags,
-                no_out_link=True,
-            )
+            build_attr = BuildAttr.from_arg(args.attr, args.file)
+            drv = nix.build(attr, build_attr, **build_flags, no_out_link=True)
     except CalledProcessError:
         logger.warning("could not find a newer version of nixos-rebuild")
 
@@ -306,7 +298,7 @@ def execute(argv: list[str]) -> None:
     # Re-exec to a newer version of the script before building to ensure we get
     # the latest fixes
     if (
-        False  # disabled until we introduce `config.system.build.nixos-rebuild-ng`
+        "@withReexec@" == "true"
         and can_run
         and not args.fast
         and not os.environ.get("_NIXOS_REBUILD_REEXEC")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -94,7 +94,7 @@ class Flake:
                 try:
                     return run_wrapper(
                         ["uname", "-n"],
-                        capture_output=True,
+                        stdout=subprocess.PIPE,
                         remote=target_host,
                     ).stdout.strip()
                 except (AttributeError, subprocess.CalledProcessError):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -60,7 +60,7 @@ class BuildAttr:
 
 @dataclass(frozen=True)
 class Flake:
-    path: Path
+    path: Path | str
     attr: str
     _re: ClassVar = re.compile(r"^(?P<path>[^\#]*)\#?(?P<attr>[^\#\"]*)$")
 
@@ -81,7 +81,11 @@ class Flake:
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
         nixos_attr = f"nixosConfigurations.{attr or hostname_fn() or "default"}"
-        return cls(Path(m.group("path")), nixos_attr)
+        path = m.group("path")
+        if ":" in path:
+            return cls(path, nixos_attr)
+        else:
+            return cls(Path(path), nixos_attr)
 
     @classmethod
     def from_arg(cls, flake_arg: Any, target_host: Remote | None) -> Self | None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -366,7 +366,8 @@ def repl_flake(attr: str, flake: Flake, **flake_flags: Args) -> None:
     expr = Template(
         files(__package__).joinpath(FLAKE_REPL_TEMPLATE).read_text()
     ).substitute(
-        flake_path=flake.path,
+        flake=flake,
+        flake_path=flake.path.resolve() if isinstance(flake.path, Path) else flake.path,
         flake_attr=flake.attr,
         bold="\033[1m",
         blue="\033[34;1m",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
@@ -16,7 +16,7 @@ let
         - ${blue}lib${reset}      Nixpkgs library functions
         - other module arguments
 
-        - ${blue}flake${reset}    Flake outputs, inputs and source info of ${flake_path}
+        - ${blue}flake${reset}    Flake outputs, inputs and source info of ${flake}
 
     Use tab completion to browse around ${blue}config${reset}.
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -475,6 +475,46 @@ def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
+    config_path = tmp_path / "test"
+    config_path.touch()
+    mock_run.side_effect = [
+        # nixos_build_flake
+        CompletedProcess([], 0, str(config_path)),
+        # switch_to_configuration
+        CompletedProcess([], 0),
+    ]
+
+    nr.execute(
+        ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--fast"]
+    )
+
+    assert mock_run.call_count == 2
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "--print-out-paths",
+                    "github:user/repo#nixosConfigurations.hostname.config.system.build.toplevel",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [config_path / "bin/switch-to-configuration", "test"],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
+
+
+@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
 @patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
 def test_execute_test_rollback(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -43,6 +43,12 @@ def test_flake_parse() -> None:
     assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
     assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
     assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
+    assert m.Flake.parse("path:/to/flake#attr") == m.Flake(
+        "path:/to/flake", "nixosConfigurations.attr"
+    )
+    assert m.Flake.parse("github:user/repo/branch") == m.Flake(
+        "github:user/repo/branch", "nixosConfigurations.default"
+    )
 
 
 def test_flake_to_attr() -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -399,9 +399,9 @@ def test_repl(mock_run: Any) -> None:
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_repl_flake(mock_run: Any) -> None:
     n.repl_flake("attr", m.Flake(Path("flake.nix"), "myAttr"), nix_flag=True)
-    # This method would be really annoying to test, and it is not that important
-    # So just check that we are at least calling it
-    assert mock_run.called
+    # See nixos-rebuild-ng.tests.repl for a better test,
+    # this is mostly for sanity check
+    assert mock_run.call_count == 1
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  expect,
+  nix,
+  nixos-rebuild-ng,
+  path,
+  runCommand,
+  stdenv,
+  writeText,
+}:
+let
+  # Arguably not true, but it holds up for now.
+  escapeExpect = lib.strings.escapeNixString;
+
+  expectSetup = ''
+    set timeout 180
+    proc expect_simple { pattern } {
+      puts "Expecting: $pattern"
+      expect {
+        timeout {
+          puts "\nTimeout waiting for: $pattern\n"
+          exit 1
+        }
+        $pattern
+      }
+    }
+  '';
+
+  # In case we want/need to evaluate packages or the assertions or whatever,
+  # we want to have a linux system.
+  # TODO: make the non-flake test use thise.
+  linuxSystem = lib.replaceStrings [ "darwin" ] [ "linux" ] stdenv.hostPlatform.system;
+
+in
+runCommand "test-nixos-rebuild-repl"
+  {
+    nativeBuildInputs = [
+      expect
+      nix
+      (nixos-rebuild-ng.override { withNgSuffix = false; })
+    ];
+
+    nixpkgs = if builtins.pathExists (path + "/.git") then lib.cleanSource path else path;
+  }
+  ''
+    export HOME=$(mktemp -d)
+    export TEST_ROOT=$PWD/test-tmp
+
+    # Prepare for running Nix in sandbox
+    export NIX_BUILD_HOOK=
+    export NIX_CONF_DIR=$TEST_ROOT/etc
+    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+    export NIX_STATE_DIR=$TEST_ROOT/var/nix
+    export NIX_STORE_DIR=$TEST_ROOT/store
+    export PAGER=cat
+    mkdir -p $TEST_ROOT $NIX_CONF_DIR
+
+    echo General setup
+    ##################
+
+    export NIX_PATH=nixpkgs=$nixpkgs:nixos-config=$HOME/configuration.nix
+    cat >> ~/configuration.nix <<EOF
+    {
+      boot.loader.grub.enable = false;
+      fileSystems."/".device = "x";
+      imports = [ ./hardware-configuration.nix ];
+    }
+    EOF
+
+    echo '{ }' > ~/hardware-configuration.nix
+
+
+    echo Test traditional NixOS configuration
+    #########################################
+
+    expect ${writeText "test-nixos-rebuild-repl-expect" ''
+      ${expectSetup}
+      spawn nixos-rebuild repl --fast
+
+      expect "nix-repl> "
+
+      send "config.networking.hostName\n"
+      expect "\"nixos\""
+    ''}
+
+
+    echo Test flake based NixOS configuration
+    #########################################
+
+    # Switch to flake flavored environment
+    unset NIX_PATH
+    cat > $NIX_CONF_DIR/nix.conf <<EOF
+    experimental-features = nix-command flakes
+    EOF
+
+    # Make the config pure
+    echo '{ nixpkgs.hostPlatform = "${linuxSystem}"; }' > ~/hardware-configuration.nix
+
+    cat >~/flake.nix <<EOF
+    {
+      inputs.nixpkgs.url = "path:$nixpkgs";
+      outputs = { nixpkgs, ... }: {
+        nixosConfigurations.testconf = nixpkgs.lib.nixosSystem {
+          modules = [
+            ./configuration.nix
+            # Let's change it up a bit
+            { networking.hostName = "itsme"; }
+          ];
+        };
+      };
+    }
+    EOF
+
+    # cat -n ~/flake.nix
+
+    expect ${writeText "test-nixos-rebuild-repl-absolute-path-expect" ''
+      ${expectSetup}
+      spawn sh -c "nixos-rebuild repl --fast --flake path:\$HOME#testconf"
+
+      expect_simple "nix-repl>"
+
+      send "config.networking.hostName\n"
+      expect_simple "itsme"
+
+      expect_simple "nix-repl>"
+      send "lib.version\n"
+      expect_simple ${
+        escapeExpect (
+          # The version string is a bit different in the flake lib, so we expect a prefix and ignore the rest
+          # Furthermore, including the revision (suffix) would cause unnecessary rebuilds.
+          # Note that a length of 4 only matches e.g. "24.
+          lib.strings.substring 0 4 (lib.strings.escapeNixString lib.version)
+        )
+      }
+
+      # Make sure it's the right lib - should be the flake lib, not Nixpkgs lib.
+      expect_simple "nix-repl>"
+      send "lib?nixosSystem\n"
+      expect_simple "true"
+      expect_simple "nix-repl>"
+      send "lib?nixos\n"
+      expect_simple "true"
+    ''}
+
+    pushd "$HOME"
+    expect ${writeText "test-nixos-rebuild-repl-relative-path-expect" ''
+      ${expectSetup}
+      spawn sh -c "nixos-rebuild repl --fast --flake .#testconf"
+
+      expect_simple "nix-repl>"
+
+      send "config.networking.hostName\n"
+      expect_simple "itsme"
+    ''}
+    popd
+
+    echo
+
+    #########
+    echo Done
+    touch $out
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

That's it, the "final" PR for `nixos-rebuild-ng`. Not that this is actually the final PR for `nixos-rebuild-ng`, but because this basically finishes all that I had in my initial checklist. Future PRs are expected to be smaller and more focused (e.g.: implement new features or fix bugs).

This PR implements:

- `system.rebuild.enableNg`: allow replacing `nixos-rebuild` inside `config.system.build.nixos-rebuild` with `nixos-rebuild-ng`.
- Port most of the `nixos-rebuild` tests to `nixos-rebuild-ng`. The only exception for now is the `simple-installer`, that is a huge test that tests lots of other things at the same time.
- Fix some bugs that I found while porting the tests above 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
