### PR TITLE
rustls-libssl: init at 0.2.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -909,6 +909,7 @@ in {
   rsyslogd = handleTest ./rsyslogd.nix {};
   rtkit = runTest ./rtkit.nix;
   rtorrent = handleTest ./rtorrent.nix {};
+  rustls-libssl = handleTest ./rustls-libssl.nix {};
   rxe = handleTest ./rxe.nix {};
   sabnzbd = handleTest ./sabnzbd.nix {};
   samba = handleTest ./samba.nix {};

--- a/nixos/tests/rustls-libssl.nix
+++ b/nixos/tests/rustls-libssl.nix
@@ -1,0 +1,92 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  let
+    caCert = builtins.readFile ./common/acme/server/ca.cert.pem;
+    certPath = ./common/acme/server/acme.test.cert.pem;
+    keyPath = ./common/acme/server/acme.test.key.pem;
+    hosts = ''
+      192.168.2.101 acme.test
+    '';
+  in
+  {
+    name = "rustls-libssl";
+    meta.maintainers = with pkgs.lib.maintainers; [
+      stephank
+      cpu
+    ];
+
+    nodes = {
+      server =
+        { lib, pkgs, ... }:
+        {
+          networking = {
+            interfaces.eth1 = {
+              ipv4.addresses = [
+                {
+                  address = "192.168.2.101";
+                  prefixLength = 24;
+                }
+              ];
+            };
+            extraHosts = hosts;
+            firewall.allowedTCPPorts = [ 443 ];
+          };
+
+          security.pki.certificates = [ caCert ];
+
+          services.nginx = {
+            enable = true;
+            package = pkgs.nginxMainline.override {
+              openssl = pkgs.rustls-libssl;
+              modules = [ ]; # slightly reduces the size of the build
+            };
+
+            # Hardcoded sole input accepted by rustls-libssl.
+            sslCiphers = "HIGH:!aNULL:!MD5";
+
+            virtualHosts."acme.test" = {
+              onlySSL = true;
+              sslCertificate = certPath;
+              sslCertificateKey = keyPath;
+              http2 = true;
+              reuseport = true;
+              root = lib.mkForce (
+                pkgs.runCommandLocal "testdir" { } ''
+                  mkdir "$out"
+                  cat > "$out/index.html" <<EOF
+                  <html><body>Hello World!</body></html>
+                  EOF
+                ''
+              );
+            };
+          };
+        };
+
+      client =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = [ pkgs.curlHTTP3 ];
+          networking = {
+            interfaces.eth1 = {
+              ipv4.addresses = [
+                {
+                  address = "192.168.2.201";
+                  prefixLength = 24;
+                }
+              ];
+            };
+            extraHosts = hosts;
+          };
+
+          security.pki.certificates = [ caCert ];
+        };
+    };
+
+    testScript = ''
+      start_all()
+      server.wait_for_open_port(443)
+      client.succeed("curl --verbose --http1.1 https://acme.test | grep 'Hello World!'")
+      client.succeed("curl --verbose --http2-prior-knowledge https://acme.test | grep 'Hello World!'")
+    '';
+  }
+)

--- a/pkgs/by-name/ru/rustls-libssl/package.nix
+++ b/pkgs/by-name/ru/rustls-libssl/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  llvmPackages,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  nixosTests,
+}:
+
+let
+  version = "0.2.1";
+  target = stdenv.hostPlatform.rust.rustcTargetSpec;
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+in
+rustPlatform.buildRustPackage {
+  pname = "rustls-libssl";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "rustls";
+    repo = "rustls-openssl-compat";
+    rev = "v/${version}";
+    hash = "sha256-/QSFrkFVSRBmpXHc80dJFnYwvVYceAFnoCtmAGtnmqo=";
+  };
+
+  # NOTE: No longer necessary in the next release.
+  sourceRoot = "source/rustls-libssl";
+
+  cargoHash = "sha256-Yyrs2eN4QTGGD7A+VM1YkdsIRUh3laZac3rsJThjTXM=";
+
+  nativeBuildInputs = [
+    pkg-config # for openssl-sys
+    llvmPackages.lld # build.rs specifies LLD as linker
+  ];
+  buildInputs = [
+    openssl
+  ];
+
+  preCheck = ''
+    # tests dlopen libcrypto.so.3
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath [ openssl ]}
+  '';
+
+  # rustls-libssl normally wants to be swapped in for libssl, and reuses
+  # libcrypto. Here, we accomplish something similar by symlinking most of
+  # OpenSSL, replacing only libssl.
+  outputs = [
+    "out"
+    "dev"
+  ];
+  installPhase = ''
+    mkdir -p $out/lib $dev/lib/pkgconfig
+
+    mv target/${target}/release/libssl${libExt} $out/lib/libssl${libExt}.3
+    ln -s libssl${libExt}.3 $out/lib/libssl${libExt}
+
+    ln -s ${openssl.out}/lib/libcrypto${libExt}.3 $out/lib/
+    ln -s libcrypto${libExt}.3 $out/lib/libcrypto${libExt}
+
+    if [[ -e ${openssl.out}/lib/engines-3 ]]; then
+      ln -s ${openssl.out}/lib/engines-3 $out/lib/
+    fi
+    if [[ -e ${openssl.out}/lib/ossl-modules ]]; then
+      ln -s ${openssl.out}/lib/ossl-modules $out/lib/
+    fi
+
+    ln -s ${openssl.dev}/include $dev/
+
+    cp ${openssl.dev}/lib/pkgconfig/*.pc $dev/lib/pkgconfig/
+    sed -i \
+      -e "s|${openssl.out}|$out|g" \
+      -e "s|${openssl.dev}|$dev|g" \
+      $dev/lib/pkgconfig/*.pc
+  '';
+
+  passthru.tests = nixosTests.rustls-libssl;
+
+  meta = {
+    description = "Partial reimplementation of the OpenSSL 3 libssl ABI using rustls";
+    homepage = "https://github.com/rustls/rustls-openssl-compat";
+    changelog = "https://github.com/rustls/rustls-openssl-compat/releases";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      stephank
+      cpu
+    ];
+  };
+}


### PR DESCRIPTION
Fixes #310173

I've not been able to make this work on Darwin yet. The lib builds, but the symbols are mangled incorrectly for Nginx to find them it seems. Upstream build infra doesn't really seem to support this any way.

I assume this just works on `x86_64-linux`, but haven't tested.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
