### PR TITLE
lomiri.telephony-service: Fix NotificationInterface build issue

### DIFF
--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   gitUpdater,
   nixosTests,
+  runCommand,
   ayatana-indicator-messages,
   bash,
   cmake,
@@ -73,6 +74,23 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/3a387670ed13041db069068292b1f41229e79583.patch";
       hash = "sha256-b7gxzr6Mmtogclq3hR7a/zl+816H2wmJqv3oHjUJggw=";
     })
+
+    # Remove when version > 0.5.3
+    # Patched to be compatible with pre-rename code
+    (runCommand "0004-lomiri-telephony-service-Fix-NotificationInterface-regeneration-backported.patch"
+      {
+        src = fetchpatch {
+          name = "0004-lomiri-telephony-service-Fix-NotificationInterface-regeneration.patch";
+          url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/9533ce1a9495e5c11e9b78fc0166e903e19519b4.patch";
+          hash = "sha256-3rsZ08bz2CxKpcwYWCCd6f7gJ22v9jl7Lg7JPnWz50A=";
+        };
+      }
+      ''
+        cp $src $out
+        substituteInPlace $out \
+          --replace-fail 'lomiritelephony' 'telephony'
+      ''
+    )
   ];
 
   postPatch =


### PR DESCRIPTION
For all the details, see:

- https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/merge_requests/92
- https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/merge_requests/104
- https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/merge_requests/105

The TL;DR is that this fixes a consistent FTBFS when using 1 build core, and build flakiness with >1 core.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
