### PR TITLE
[release-24.05] Update pinned nixpkgs version

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
-  "sha256": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
+  "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
+  "sha256": "1am61kcakn9j47435k4cgsarvypb8klv4avszxza0jn362hp3ck8"
 }

--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "521d48afa9ae596930a95325529df27fa7135ff5",
-  "sha256": "0a1pa5azw990narsfipdli1wng4nc3vhvrp00hb8v1qfchcq7dc9"
+  "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
+  "sha256": "0l3b9jr5ydzqgvd10j12imc9jqb6jv5v2bdi1gyy5cwkwplfay67"
 }

--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
-  "sha256": "0l3b9jr5ydzqgvd10j12imc9jqb6jv5v2bdi1gyy5cwkwplfay67"
+  "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
+  "sha256": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
 }

--- a/pkgs/applications/editors/vscode/extensions/vscodeExts2nix.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscodeExts2nix.nix
@@ -19,13 +19,11 @@ writeShellScriptBin "vscodeExts2nix" ''
   echo '['
 
   for line in $(${vscode}/bin/code --list-extensions --show-versions \
-    ${
-      lib.optionalString (extensionsToIgnore != [ ]) ''
-        | grep -v -i '^\(${
-          lib.concatMapStringsSep "\\|" (e: "${e.publisher}.${e.name}") extensionsToIgnore
-        }\)'
-      ''
-    }
+    ${lib.optionalString (extensionsToIgnore != [ ]) ''
+      | grep -v -i '^\(${
+        lib.concatMapStringsSep "\\|" (e: "${e.publisher}.${e.name}") extensionsToIgnore
+      }\)'
+    ''}
   ) ; do
     [[ $line =~ ([^.]*)\.([^@]*)@(.*) ]]
     name=''${BASH_REMATCH[2]}

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -67,9 +67,9 @@ lib.makeOverridable (
             cp -a "${scriptPath}" "${scriptsDir}/${scriptName}"
           else
             install -m644 -Dt "${scriptsDir}" ${escaped scriptPath}
-            ${
-              lib.optionalString (extraScripts != [ ]) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''
-            }
+            ${lib.optionalString (
+              extraScripts != [ ]
+            ) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''}
           fi
 
           runHook postInstall

--- a/pkgs/development/cuda-modules/cudatoolkit/default.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/default.nix
@@ -267,36 +267,34 @@ backendStdenv.mkDerivation rec {
         mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
         rm $out/host-linux-x64/libstdc++.so*
       ''}
-        ${
-          lib.optionalString (lib.versionAtLeast version "11.8" && lib.versionOlder version "12")
-            # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/.......-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
-            # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
-            # TODO: don't copy, come up with a symlink-based "merge"
-            ''
-              rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
-            ''
+        ${lib.optionalString (lib.versionAtLeast version "11.8" && lib.versionOlder version "12")
+          # error: auto-patchelf could not satisfy dependency libtiff.so.5 wanted by /nix/store/.......-cudatoolkit-12.0.1/host-linux-x64/Plugins/imageformats/libqtiff.so
+          # we only ship libtiff.so.6, so let's use qt plugins built by Nix.
+          # TODO: don't copy, come up with a symlink-based "merge"
+          ''
+            rsync ${lib.getLib qt6Packages.qtimageformats}/lib/qt-6/plugins/ $out/host-linux-x64/Plugins/ -aP
+          ''
         }
-        ${
-          lib.optionalString (lib.versionAtLeast version "12")
-            # Use Qt plugins built by Nix.
-            ''
-              for qtlib in $out/host-linux-x64/Plugins/*/libq*.so; do
-                qtdir=$(basename $(dirname $qtlib))
-                filename=$(basename $qtlib)
-                for qtpkgdir in ${
-                  lib.concatMapStringsSep " " (x: qt6Packages.${x}) [
-                    "qtbase"
-                    "qtimageformats"
-                    "qtsvg"
-                    "qtwayland"
-                  ]
-                }; do
-                  if [ -e $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename ]; then
-                    ln -snf $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename $qtlib
-                  fi
-                done
+        ${lib.optionalString (lib.versionAtLeast version "12")
+          # Use Qt plugins built by Nix.
+          ''
+            for qtlib in $out/host-linux-x64/Plugins/*/libq*.so; do
+              qtdir=$(basename $(dirname $qtlib))
+              filename=$(basename $qtlib)
+              for qtpkgdir in ${
+                lib.concatMapStringsSep " " (x: qt6Packages.${x}) [
+                  "qtbase"
+                  "qtimageformats"
+                  "qtsvg"
+                  "qtwayland"
+                ]
+              }; do
+                if [ -e $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename ]; then
+                  ln -snf $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename $qtlib
+                fi
               done
-            ''
+            done
+          ''
         }
 
       rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?


### PR DESCRIPTION
This is necessary for https://github.com/NixOS/nixpkgs/pull/327796, the backport of https://github.com/NixOS/nixpkgs/pull/322537, to work, because:
- The 24.05 branch enforces (some) Nix files to be formatted with the nixfmt-rfc-style version from the CI-pinned Nixpkgs version.
- In order for automated backports to 24.05 to succeed after the reformat, we need to use the same formatter version on all the branches, otherwise you get conflicts due to different formattings.

So this backports all the commits that updated the CI version on master and 24.11: #336555 #361165 #363585

Ping @NixOS/nix-formatting 

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
