### PR TITLE
nixos/wireguard-networkd: disable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -121,7 +121,7 @@
 
 - Cinnamon has been updated to 6.4.
 
-- `networking.wireguard` now has an optional networkd backend. It is enabled by default when `networking.useNetworkd` is enabled, and it can be enabled alongside scripted networking with `networking.wireguard.useNetworkd`. Some `networking.wireguard` options have slightly different behavior with the networkd and script-based backends, documented in each option. Before upgrading, make sure the `privateKeyFile` and `presharedKeyFile` paths are readable by the `systemd-network` user if using the networkd backend.
+- `networking.wireguard` now has an optional networkd backend, enabled with `networking.wireguard.useNetworkd`. Some `networking.wireguard` options have slightly different behavior with the networkd and script-based backends, documented in each option. Before upgrading, make sure the `privateKeyFile` and `presharedKeyFile` paths are readable by the `systemd-network` user if using the networkd backend.
 
 - `services.avahi.ipv6` now defaults to true.
 

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -96,8 +96,7 @@ in
 
   options.networking.wireguard = {
     useNetworkd = mkOption {
-      default = config.networking.useNetworkd;
-      defaultText = literalExpression "config.networking.useNetworkd";
+      default = false;
       type = types.bool;
       description = ''
         Whether to use networkd as the network configuration backend for

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -128,7 +128,7 @@ in
     #
     # socketNamespace and interfaceNamespace can be implemented once networkd
     # supports setting a netdev's namespace. See:
-    # https://github.com/systemd/systemd/issues/11629
+    # https://github.com/systemd/systemd/issues/11103
     # https://github.com/systemd/systemd/pull/14915
 
     assertions = concatLists (


### PR DESCRIPTION
Enabling networking.wireguard.useNetworkd currently requires users to modify the permissions of their private key files. Since that is a bad upgrade experience, the module should be disabled by default for now. Once systemd credential support is added to the module, it should be safe to once again enable it by default for networkd users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
