### PR TITLE
ocamlPackages.tls-eio: init at 1.0.4, and remove incorrect optimization from mdx

### DIFF
--- a/pkgs/development/ocaml-modules/tls/eio.nix
+++ b/pkgs/development/ocaml-modules/tls/eio.nix
@@ -1,0 +1,36 @@
+{
+  buildDunePackage,
+  crowbar,
+  eio,
+  eio_main,
+  logs,
+  mdx,
+  mirage-crypto-rng-eio,
+  ptime,
+  tls,
+}:
+
+buildDunePackage rec {
+  pname = "tls-eio";
+
+  inherit (tls) src meta version;
+
+  minimalOCamlVersion = "5.0";
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    crowbar
+    eio_main
+    (mdx.override { inherit logs; })
+  ];
+
+  propagatedBuildInputs = [
+    ptime
+    eio
+    mirage-crypto-rng-eio
+    tls
+  ];
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1844,6 +1844,8 @@ let
 
     tls-async = callPackage ../development/ocaml-modules/tls/async.nix { };
 
+    tls-eio = callPackage ../development/ocaml-modules/tls/eio.nix { };
+
     tls-lwt = callPackage ../development/ocaml-modules/tls/lwt.nix { };
 
     tls-mirage = callPackage ../development/ocaml-modules/tls/mirage.nix { };


### PR DESCRIPTION
Add the missing variant `ocamlPackages.tls-eio` of the `ocamlPackages.tls-*` packages.

This requires the removal of an incorrect optimization from the `mdx` package, which is explained in the commit message:

> The original purpose of this optimization was described by its author as follows:
>
> > Strip optional dependencies from logs to make the closure smaller as this
> > package contains a binary
>
> However, that optimization is _incorrect_ because it affects not only the command line tool (output "mdx.bin") but also the mdx library (output "mdx").
>
> Pull request #290291 recognized this issue, but merely moved this optimization from `development/ocaml-modules/mdx/default.nix` to `top-level/ocaml-packages.nix`, so everyone affected can help themselves via attribute overriding.  As such, it didn't fix the original problem, i.e. that this optimization is simply incorrect.  Moreover, that doesn't help if we ever want an affected library, such as "tls-eio", to be officially included in nixpkgs.
>
> This commit fixes the root of the problem by removing the incorrect optimization.
>
> Please note that this commit is not intended to discourage the re-introduction of such an optimization.  However, a new variant of this optimization should only be included if it is correct, i.e. reduces just "mdx.bin" without making "mdx" incompatible with every package that directly or indirectly depends on the "logs" library.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
