### PR TITLE
ks: add completions for bash and zsh

### DIFF
--- a/pkgs/by-name/ks/ks/ks-completion.bash
+++ b/pkgs/by-name/ks/ks/ks-completion.bash
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+_ks_completions() {
+  local cur prev commands secrets
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  commands="add show cp rm ls rand init help version"
+
+  case "$prev" in
+    ks)
+      # Provide top-level command suggestions
+      COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+      return 0
+      ;;
+    show|cp|rm)
+      # Provide dynamic completion for secrets
+      if secrets=$(ks ls 2>/dev/null); then
+        COMPREPLY=($(compgen -W "$secrets" -- "$cur"))
+      fi
+      return 0
+      ;;
+    add)
+      # For `ks add`, suggest options for adding secrets
+      COMPREPLY=($(compgen -W "-n" -- "$cur"))
+      return 0
+      ;;
+    rand)
+      # No specific completions for `ks rand`
+      return 0
+      ;;
+  esac
+
+  case "${COMP_WORDS[1]}" in
+    ls|init|help|version)
+      # No additional completions for these commands
+      return 0
+      ;;
+  esac
+}
+
+# Register the completion function for the `ks` command
+complete -F _ks_completions ks

--- a/pkgs/by-name/ks/ks/ks-completion.zsh
+++ b/pkgs/by-name/ks/ks/ks-completion.zsh
@@ -1,0 +1,55 @@
+#compdef ks
+
+_ks() {
+  local -a commands
+  commands=(
+    "add:Add a secret (-n for secure note)"
+    "show:Decrypt and reveal a secret"
+    "cp:Copy a secret to the clipboard"
+    "rm:Remove a secret from the keychain"
+    "ls:List all secrets in the keychain"
+    "rand:Generate a random secret (optionally specify size)"
+    "init:Initialize the selected keychain"
+    "help:Show help information"
+    "version:Print the version number"
+  )
+
+  local context curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments \
+    '(-k)-k[Specify keychain]:keychain name:_files' \
+    '1:command:->command' \
+    '*::arguments:->args'
+
+  case $state in
+    command)
+      _describe -t commands 'ks commands' commands
+      ;;
+    args)
+      case $line[1] in
+        add)
+          _arguments \
+            '(-n)-n[Add a secure note instead of a password]' \
+            '1:key[The name of the secret to add]' \
+            '2:value[The value of the secret to add]' \
+            '*::values:filename'
+          ;;
+        show|cp|rm)
+          local -a secrets
+          secrets=("${(@f)$(ks ls 2>/dev/null)}")
+          _describe -t secrets 'secrets' secrets
+          ;;
+        ls)
+          # No additional arguments for `ks ls`
+          ;;
+        rand)
+          _arguments '1:size[The size of the random secret to generate]'
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+  esac
+}
+

--- a/pkgs/by-name/ks/ks/package.nix
+++ b/pkgs/by-name/ks/ks/package.nix
@@ -1,7 +1,8 @@
 {
-  stdenv,
   lib,
+  stdenv,
   fetchFromGitHub,
+  installShellFiles,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,9 +16,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-v05wqlG7Utq1b7ctvDY9MCdjHVVZZNNzuHaIBwuRjEE=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp ${finalAttrs.pname} $out/bin/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion \
+      --bash ${./ks-completion.bash} \
+      --zsh --name _ks ${./ks-completion.zsh}
   '';
 
   meta = {


### PR DESCRIPTION
Added completions
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
New files: ks-completion.{zsh,bash}
Added: in postInstall run installShellCompletions

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
