### PR TITLE
libuv: disable flaky darwin test and enable some tests on x64 darwin

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -127,12 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
           # can enable on upgrade from 1.49.2
           "udp_mmsg"
         ]
-        ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-          # fail on macos < 10.15 (starting in libuv 1.47.0)
-          "fs_write_alotof_bufs_with_offset"
-          "fs_write_multiple_bufs"
-          "fs_read_bufs"
-        ]
         ++ lib.optionals stdenv.hostPlatform.isAarch32 [
           # I observe this test failing with some regularity on ARMv7:
           # https://github.com/libuv/libuv/issues/1871

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tcp_ref3"
           "tcp_ref4"
           "tcp_bind6_error_inval"
-          "tcp_bind6_error_addrinuse"
           "tcp_read_stop"
           "tcp_unexpected_read"
           "tcp_write_to_half_open_connection"
@@ -98,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tcp_open"
           "tcp_write_queue_order"
           "tcp_try_write"
-          "tcp_writealot"
           "multiple_listen"
           "delayed_accept"
           "udp_recv_in_a_row"
@@ -109,7 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tty_pty"
           "condvar_5"
           "hrtime"
-          "udp_multicast_join"
           # Tests that fail when sandboxing is enabled.
           "fs_event_close_in_callback"
           "fs_event_watch_dir"

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -122,6 +122,11 @@ stdenv.mkDerivation (finalAttrs: {
           "udp_create_early_bad_bind"
           "fs_event_watch_delete_dir"
         ]
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionOlder finalAttrs.version "1.49.3") [
+          # https://github.com/libuv/libuv/issues/4650
+          # can enable on upgrade from 1.49.2
+          "udp_mmsg"
+        ]
         ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
           # fail on macos < 10.15 (starting in libuv 1.47.0)
           "fs_write_alotof_bufs_with_offset"


### PR DESCRIPTION
test fails on darwin sometimes but will pass eventually

https://hydra.nixos.org/build/281912463/nixlog/234

enable x64 darwin tests that were disabled due to using an sdk < 10.15 now that it uses sdk 11

remove conditionally disabled tests which are already disabled by default


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
