### PR TITLE
chromium: 131.0.6778.108 -> 131.0.6778.139

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "131.0.6778.108",
+    "version": "131.0.6778.139",
     "chromedriver": {
-      "hash_darwin": "sha256-X0kzihCQsICn5SRdU+THdthov0EPxsmMcrm6YJ6hMhs=",
-      "hash_darwin_aarch64": "sha256-3Qdj44cZD4wQTzkBx47ZCfqHE2HckkLuqYKpJxxfESk="
+      "hash_darwin": "sha256-QLYUD5SDHoPdiPHX46ps/oBhzDjwxBuQEh0hzbEY73Q=",
+      "hash_darwin_aarch64": "sha256-VZ4nS9H1J1R6OXqqOaFLHM2rD8dyUTTWur5X1CNm4sU="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "3b014839fbc4fb688b2f5af512d6ce312ad208b1",
-        "hash": "sha256-ypzu3LveMFcOFm7+JlaERjzs3SK/n9+sfm5wOKB8/zw=",
+        "rev": "c35bbcbd7c2775a12a3f320e05ac0022939b1a8a",
+        "hash": "sha256-oJ4y9W51RMiUk40Uz8b3LJH0kMD5GMDG2V//Tng4/4A=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -360,8 +360,8 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "4239b1559d11d4fa66c100543eda4161e060311e",
-        "hash": "sha256-7568UHNDOzyTCLy3TAwxZLUrKfB6A1yKA0wVZQJjKoI="
+        "rev": "ba7ed88cc5ffa428a82a0f787dd61031aa5ef4ca",
+        "hash": "sha256-WtCoxcbEkkZayB6kXdQEhZ7/ue+ka6cguhFbpeWUBJA="
       },
       "src/third_party/jsoncpp/source": {
         "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
@@ -760,8 +760,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "e38771cb283b9689683c5ac0b5831dd89f8ec690",
-        "hash": "sha256-csSDnepYxil0R3PD/LVxW7JBcasOKG4l6q6vj8zHV/I="
+        "rev": "b97fcc24b3523da5e389d2a6d76857f134be09c5",
+        "hash": "sha256-5Es9Zot/DH+UKq3+aCgeQC+Llgj7/lmPXUYvar/hX7I="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2024/12/stable-channel-update-for-desktop_10.html

This update includes 3 security fixes.

CVEs:
CVE-2024-12381 CVE-2024-12382

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
