### PR TITLE
ant: use upstream launcher script

### DIFF
--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  coreutils,
+  jre,
   makeWrapper,
   gitUpdater,
 }:
@@ -10,6 +10,8 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "ant";
   version = "1.10.15";
+
+  buildInputs = [ jre ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -19,60 +21,23 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/ant
+    mkdir -p $out/share/ant
     mv * $out/share/ant/
 
     # Get rid of the manual (35 MiB).  Maybe we should put this in a
-    # separate output.  Keep the antRun script since it's vanilla sh
-    # and needed for the <exec/> task (but since we set ANT_HOME to
-    # a weird value, we have to move antRun to a weird location).
-    # Get rid of the other Ant scripts since we provide our own.
-    mv $out/share/ant/bin/antRun $out/bin/
-    rm -rf $out/share/ant/{manual,bin,WHATSNEW}
-    mkdir $out/share/ant/bin
-    mv $out/bin/antRun $out/share/ant/bin/
+    # separate output.
+    rm -rf $out/share/ant/{manual,WHATSNEW}
 
-    cat >> $out/bin/ant <<EOF
-    #! ${stdenv.shell} -e
+    # Link Ant's special $ANT_HOME/bin to the standard /bin location
+    ln -s $out/share/ant/bin $out
 
-    ANT_HOME=$out/share/ant
-
-    # Find the JDK by looking for javac.  As a fall-back, find the
-    # JRE by looking for java.  The latter allows just the JRE to be
-    # used with (say) ECJ as the compiler.  Finally, allow the GNU
-    # JVM.
-    if [ -z "\''${JAVA_HOME-}" ]; then
-        for i in javac java gij; do
-            if p="\$(type -p \$i)"; then
-                export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
-                break
-            fi
-        done
-        if [ -z "\''${JAVA_HOME-}" ]; then
-            echo "\$0: cannot find the JDK or JRE" >&2
-            exit 1
-        fi
-    fi
-
-    if [ -z \$NIX_JVM ]; then
-        if [ -e \$JAVA_HOME/bin/java ]; then
-            NIX_JVM=\$JAVA_HOME/bin/java
-        elif [ -e \$JAVA_HOME/bin/gij ]; then
-            NIX_JVM=\$JAVA_HOME/bin/gij
-        else
-            NIX_JVM=java
-        fi
-    fi
-
-    LOCALCLASSPATH="\$ANT_HOME/lib/ant-launcher.jar\''${LOCALCLASSPATH:+:}\$LOCALCLASSPATH"
-
-    exec \$NIX_JVM \$NIX_ANT_OPTS \$ANT_OPTS -classpath "\$LOCALCLASSPATH" \
-        -Dant.home=\$ANT_HOME -Dant.library.dir="\$ANT_LIB" \
-        org.apache.tools.ant.launch.Launcher \$NIX_ANT_ARGS \$ANT_ARGS \
-        -cp "\$CLASSPATH" "\$@"
-    EOF
-
-    chmod +x $out/bin/ant
+    # Wrap the wrappers.
+    for wrapper in ant runant.py runant.pl; do
+      wrapProgram "$out/share/ant/bin/$wrapper" \
+        --set-default JAVA_HOME "${jre.home}" \
+        --set-default ANT_HOME "$out/share/ant" \
+        --prefix CLASSPATH : "$out/share/ant/lib"
+    done
   '';
 
   passthru = {


### PR DESCRIPTION
Let's use Ant's upstream launcher script. It handles far more edge-cases than ours.

Instead of writing our own, let's simply hard-code values into the launcher that are known in advance.

One small step towards #353512. Closes #4105, because a path to the JRE is one of the things we now explicitly set. Something similar first attempted by @linsui in #266313. Accidentally screwed up #359451.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
