### PR TITLE
xen: mark 4.16 as EOL

### DIFF
--- a/pkgs/build-support/xen/default.nix
+++ b/pkgs/build-support/xen/default.nix
@@ -94,7 +94,7 @@ let
     ;
 
   # Mark versions older than minSupportedVersion as EOL.
-  minSupportedVersion = "4.16";
+  minSupportedVersion = "4.17";
 
   #TODO: fix paths instead.
   scriptEnvPath = makeSearchPathOutput "out" "bin" [


### PR DESCRIPTION
Xen 4.16 has reached its [end of life](https://xenbits.xen.org/docs/unstable/support-matrix.html). We don't build it, but considering the generic nature of the Xen builder, it's good to let downstreams using our builder know that their custom build of Xen 4.16 is now unsupported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Zero rebuilds.
- [x] No release notes, as we don't have Xen 4.16; NixOS' release cycle is much faster than Xen's.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
