### PR TITLE
dcm2niix: 1.0.20240202 -> 1.0.20241211

### DIFF
--- a/pkgs/by-name/dc/dcm2niix/package.nix
+++ b/pkgs/by-name/dc/dcm2niix/package.nix
@@ -16,21 +16,21 @@ let
   cloudflareZlib = fetchFromGitHub {
     owner = "ningfei";
     repo = "zlib";
-    # HEAD revision of the gcc.amd64 branch on 2023-03-28. Reminder to update
+    # HEAD revision of the gcc.amd64 branch on 2025-01-05. Reminder to update
     # whenever bumping package version.
-    rev = "f49b13c3380cf9677ae9a93641ebc6f770899def";
-    sha256 = "sha256-8HNFUGx2uuEb8UrGUiqkN+uVDX83YIisT2uO1Z7GCxc=";
+    rev = "1cb075520d254005cde193982f1856b877fd39d8";
+    hash = "sha256-1+V7XwYOYqSzcFK86V+gDILGwAqKGQ+HSlXphWtqSvk=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.0.20240202";
+  version = "1.0.20241211";
   pname = "dcm2niix";
 
   src = fetchFromGitHub {
     owner = "rordenlab";
     repo = "dcm2niix";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-vJUPv/6KNCsU8UjwfktHdTlsweG7+UGgAEZeESfBkD8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NpvtMCcyVfYlnvXjyvTDsa71IxUhi8FepX82qRSG7TA=";
   };
 
   patches = lib.optionals withCloudflareZlib [


### PR DESCRIPTION
Routine update. [changelog](https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20241208)

Please also see #325863.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
