### PR TITLE
concessio: init at 0.1.9

### DIFF
--- a/pkgs/by-name/co/concessio/package.nix
+++ b/pkgs/by-name/co/concessio/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  desktop-file-utils,
+  fetchFromGitHub,
+  gjs,
+  glib,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "concessio";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "ronniedroid";
+    repo = "concessio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XH+4oEZSKa6lAS0zXxdlCsVJcGDglKSgaD+zoRM6Pws=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gjs
+    glib # For `glib-compile-schema`
+    gobject-introspection
+    gtk4 # For `gtk-update-icon-cache`
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gjs
+    libadwaita
+  ];
+
+  # gjs uses the invocation name to add gresource files
+  # to get around this, we set the entry point name manually
+  preFixup = ''
+    sed -i "1 a imports.package._findEffectiveEntryPointName = () => 'io.github.ronniedroid.concessio';" $out/bin/io.github.ronniedroid.concessio
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Understand File Permissions";
+    homepage = "https://github.com/ronniedroid/concessio";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "io.github.ronniedroid.concessio";
+    platforms = lib.intersectLists lib.platforms.linux gjs.meta.platforms;
+  };
+})


### PR DESCRIPTION
[Concessio](https://github.com/ronniedroid/concessio) is a small GNOME app to help you understand file permissions

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
