### PR TITLE
openssl_quantum: init at 3.3.2

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -25,6 +25,8 @@
   conf ? null,
   removeReferencesTo,
   testers,
+  providers ? [ ],
+  autoloadProviders ? false,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -307,6 +309,26 @@ let
         ''
         + lib.optionalString (conf != null) ''
           cat ${conf} > $etc/etc/ssl/openssl.cnf
+        ''
+
+        + lib.concatStringsSep "\n" (
+          map
+            (provider: ''
+              cp --no-preserve=mode ${provider.package}/lib/ossl-modules/* "$out/lib/ossl-modules"
+
+              ${lib.optionalString (autoloadProviders) ''
+                sed -i '/^[[:space:]]*#/!s/\[provider_sect\]/[provider_sect]\n${provider.name} = ${provider.name}_sect/g' $etc/etc/ssl/openssl.cnf
+                echo -e "\n[${provider.name}_sect]" >> $etc/etc/ssl/openssl.cnf
+                echo "activate = 1" >> $etc/etc/ssl/openssl.cnf
+              ''}
+            '')
+
+            providers
+        )
+
+        + lib.optionalString (autoloadProviders) ''
+          # The default provider needs loading when there are other providers loaded by default
+          sed -i '/^[[:space:]]*#/!s/\[default_sect\]/[default_sect]\nactivate = 1/g' $etc/etc/ssl/openssl.cnf
         '';
 
       allowedImpureDLLs = [ "CRYPT32.dll" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8182,6 +8182,22 @@ with pkgs;
 
   openssl = openssl_3_6;
 
+  openssl_oqs = openssl.override {
+    providers = [
+      {
+        name = "oqsprovider";
+        package = pkgs.oqs-provider;
+      }
+    ];
+    autoloadProviders = true;
+
+    extraINIConfig = {
+      tls_system_default = {
+        Groups = "X25519MLKEM768:X25519:P-256:X448:P-521:ffdhe2048:ffdhe3072";
+      };
+    };
+  };
+
   openssl_legacy = openssl.override {
     conf = ../development/libraries/openssl/3.0/legacy.cnf;
   };


### PR DESCRIPTION
Added openssl_quantum using oqs-provider. Adapted from [my own repository](https://github.com/siddharth-narayan/openssl-quantum). This is still standard openssl but with the added abililty to make quantum safe connections.

Post quantum cryptography is becoming more important as quantum computers become more powerful, so now that liboqs and oqs-provider are in nixpkgs, I thought I would add them to openssl as well. Maybe eventually this can even become the default openssl.

This package is the same as openssl_3_3 but with a modified configuration that points to oqs-provider so that openssl knows where to look. It also loads providers by default, so they are always active.

PQ functionality can be tested with
- ```openssl list -providers```
- ```openssl list -kem-algorithms```
- ```openssl list -signature-algorithms```

## Resources
https://github.com/openssl/openssl/blob/master/README-PROVIDERS.md - About providers
https://github.com/open-quantum-safe/oqs-provider
https://www.nist.gov/cybersecurity/what-post-quantum-cryptography - Why post quantum cryptography is important _now_

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
