### PR TITLE
[24.11]: openstack dependencies: support Python 3.12

### DIFF
--- a/pkgs/development/python-modules/openstackdocstheme/default.nix
+++ b/pkgs/development/python-modules/openstackdocstheme/default.nix
@@ -14,8 +14,7 @@ buildPythonPackage rec {
   version = "3.4.0";
   pyproject = true;
 
-  # breaks on import due to distutils import through pbr.packaging
-  disabled = pythonAtLeast "3.12";
+  disabled = pythonAtLeast "3.13";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pbr/default.nix
+++ b/pkgs/development/python-modules/pbr/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   callPackage,
+  distutils,
   fetchPypi,
   setuptools,
   six,
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    distutils # for distutils.command in pbr/packaging.py
     setuptools # for pkg_resources
     six
   ];

--- a/pkgs/development/python-modules/reno/default.nix
+++ b/pkgs/development/python-modules/reno/default.nix
@@ -1,42 +1,48 @@
 {
+  buildPythonApplication,
+  dulwich,
+  docutils,
   lib,
-  fetchPypi,
+  fetchFromGitHub,
   git,
-  gnupg1,
-  python3Packages,
+  gnupg,
+  pbr,
+  pyyaml,
+  setuptools,
+  sphinx,
+  stestr,
+  testtools,
+  testscenarios,
 }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "reno";
   version = "4.1.0";
   pyproject = true;
 
-  # Must be built from python sdist because of versioning quirks
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-+ZLx/b0WIV7J3kevCBMdU6KDDJ54Q561Y86Nan9iU3A=";
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "reno";
+    rev = "refs/tags/${version}";
+    hash = "sha256-le9JtE0XODlYhTFsrjxFXG/Weshr+FyN4M4S3BMBLUE=";
   };
 
-  # remove b/c doesn't list all dependencies, and requires a few packages not in nixpkgs
-  postPatch = ''
-    rm test-requirements.txt
-  '';
+  env.PBR_VERSION = version;
 
-  build-system = with python3Packages; [
+  build-system = [
     setuptools
   ];
 
-  dependencies = with python3Packages; [
+  dependencies = [
     dulwich
     pbr
     pyyaml
-    setuptools # required for finding pkg_resources at runtime
+    setuptools
   ];
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = [
     # Python packages
     docutils
-    fixtures
     sphinx
     stestr
     testtools
@@ -44,12 +50,12 @@ python3Packages.buildPythonApplication rec {
 
     # Required programs to run all tests
     git
-    gnupg1
+    gnupg
   ];
 
   checkPhase = ''
     runHook preCheck
-    export HOME=$TMPDIR
+    export HOME=$(mktemp -d)
     stestr run -e <(echo "
       # Expects to be run from a git repository
       reno.tests.test_cache.TestCache.test_build_cache_db
@@ -79,11 +85,6 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "reno";
     homepage = "https://docs.openstack.org/reno/latest";
     license = licenses.asl20;
-    maintainers =
-      teams.openstack.members
-      ++ (with maintainers; [
-        drewrisinger
-        guillaumekoenig
-      ]);
+    maintainers = teams.openstack.members;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8571,9 +8571,7 @@ with pkgs;
 
   inherit (regclient) regbot regctl regsync;
 
-  reno = callPackage ../development/tools/reno {
-    python3Packages = python311Packages;
-  };
+  reno = with python311Packages; toPythonApplication reno;
 
   replace-secret = callPackage ../build-support/replace-secret/replace-secret.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13738,6 +13738,8 @@ self: super: with self; {
 
   rencode = callPackage ../development/python-modules/rencode { };
 
+  reno = callPackage ../development/python-modules/reno { };
+
   renson-endura-delta = callPackage ../development/python-modules/renson-endura-delta { };
 
   reorder-python-imports = callPackage ../development/python-modules/reorder-python-imports { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Rebased version of the automatic backport PR
https://github.com/NixOS/nixpkgs/pull/363679, which got a conflict due to the
treewide reformatting.

This is a step towards fixing jenkins-job-builder on NixOS 24.11.

- **reno: move to python3Packages, fetch from source, misc cleanup**
- **python312Packages.pbr: fix python 3.12 compatibility for packaging module**
- **python312Packages.openstackdocstheme: allow for python 3.12**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
