### PR TITLE
[Backport release-24.11] nixos/ebusd: fix device access

### DIFF
--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -156,7 +156,11 @@ in
 
   config =
     let
-      usesDev = hasPrefix "/" cfg.device;
+      usesDev = lib.any (prefix: lib.hasPrefix prefix cfg.device) [
+        "/"
+        "ens:/"
+        "enh:/"
+      ];
     in
     mkIf cfg.enable {
       systemd.services.ebusd = {
@@ -201,12 +205,14 @@ in
 
           # Hardening
           CapabilityBoundingSet = "";
-          DeviceAllow = optionals usesDev [ cfg.device ];
+          DeviceAllow = lib.optionals usesDev [
+            (lib.removePrefix "ens:" (lib.removePrefix "enh:" cfg.device))
+          ];
           DevicePolicy = "closed";
           LockPersonality = true;
           MemoryDenyWriteExecute = false;
           NoNewPrivileges = true;
-          PrivateDevices = usesDev;
+          PrivateDevices = !usesDev;
           PrivateUsers = true;
           PrivateTmp = true;
           ProtectClock = true;


### PR DESCRIPTION
Manual backport of #352743

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).