### PR TITLE
buildEnv: builder.pl: use signature and move the `ignoreSingleFileOutputs` parameter after the collision-related ones

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -1,6 +1,7 @@
 #! @perl@ -w
 
 use strict;
+use feature 'signatures';
 use Cwd 'abs_path';
 use IO::Handle;
 use File::Path;
@@ -18,8 +19,7 @@ my $extraPrefix = $ENV{"extraPrefix"};
 
 my @pathsToLink = split ' ', $ENV{"pathsToLink"};
 
-sub isInPathsToLink {
-    my $path = shift;
+sub isInPathsToLink($path) {
     $path = "/" if $path eq "";
     foreach my $elem (@pathsToLink) {
         return 1 if
@@ -32,8 +32,7 @@ sub isInPathsToLink {
 
 # Returns whether a path in one of the linked packages may contain
 # files in one of the elements of pathsToLink.
-sub hasPathsToLink {
-    my $path = shift;
+sub hasPathsToLink($path) {
     foreach my $elem (@pathsToLink) {
         return 1 if
             $path eq "" ||
@@ -44,8 +43,7 @@ sub hasPathsToLink {
 }
 
 # Similar to `lib.isStorePath`
-sub isStorePath {
-    my $path = shift;
+sub isStorePath($path) {
     my $storePath = "@storeDir@";
 
     return substr($path, 0, 1) eq "/" && dirname($path) eq $storePath;
@@ -76,9 +74,7 @@ for my $p (@pathsToLink) {
 
 sub findFiles;
 
-sub findFilesInDir {
-    my ($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) = @_;
-
+sub findFilesInDir($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) {
     opendir DIR, "$target" or die "cannot open `$target': $!";
     my @names = readdir DIR or die;
     closedir DIR;
@@ -89,9 +85,7 @@ sub findFilesInDir {
     }
 }
 
-sub checkCollision {
-    my ($path1, $path2) = @_;
-
+sub checkCollision($path1, $path2) {
     if (! -e $path1 || ! -e $path2) {
         return 0;
     }
@@ -109,14 +103,11 @@ sub checkCollision {
     return compare($path1, $path2) == 0;
 }
 
-sub prependDangling {
-    my $path = shift;
+sub prependDangling($path) {
     return (-l $path && ! -e $path ? "dangling symlink " : "") . "`$path'";
 }
 
-sub findFiles {
-    my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) = @_;
-
+sub findFiles($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) {
     # The store path must not be a file when not ignoreSingleFileOutputs
     if (-f $target && isStorePath $target) {
         if ($ignoreSingleFileOutputs) {
@@ -203,9 +194,7 @@ sub findFiles {
 my %done;
 my %postponed;
 
-sub addPkg {
-    my ($pkgDir, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs)  = @_;
-
+sub addPkg($pkgDir, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) {
     return if (defined $done{$pkgDir});
     $done{$pkgDir} = 1;
 


### PR DESCRIPTION
This PR uses Perl's `signatures` feature to increase readability and maintainability. This makes errors related to functional argument passing more discoverable.

Perl's `signatures` feature was added in Perl 5.20 and stabilized in Perl 5.32. As the Perl version in Nixpkgs `release-24.05` (the previous stable release branch) is already `5.38.2`, it should be safe to use such a feature in current Nixpkgs.

This PR also includes a commit to move the `ignoreSingleFileOutputs` argument after the ones that deal with collisions (to be exact, after `priority`). I added right after `ignoreCollisions` in #353752 for the convenience of my development but realized later that it would look awkward when reading through the function call.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
