### PR TITLE
arion: 0.2.1.0 -> 0.2.2.0

### DIFF
--- a/pkgs/development/haskell-modules/replacements-by-name/arion-compose.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/arion-compose.nix
@@ -1,0 +1,80 @@
+{
+  mkDerivation,
+  aeson,
+  aeson-pretty,
+  async,
+  base,
+  bytestring,
+  directory,
+  hspec,
+  lens,
+  lens-aeson,
+  lib,
+  optparse-applicative,
+  process,
+  protolude,
+  QuickCheck,
+  temporary,
+  text,
+  unix,
+}:
+mkDerivation {
+  pname = "arion-compose";
+  version = "0.2.2.0";
+  sha256 = "55c7484b90b278fe502bda5feff67dec37a9bd64454a68e6e855277d96d73d67";
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson
+    aeson-pretty
+    async
+    base
+    bytestring
+    directory
+    lens
+    lens-aeson
+    process
+    protolude
+    temporary
+    text
+    unix
+  ];
+  executableHaskellDepends = [
+    aeson
+    aeson-pretty
+    async
+    base
+    bytestring
+    directory
+    lens
+    lens-aeson
+    optparse-applicative
+    process
+    protolude
+    temporary
+    text
+    unix
+  ];
+  testHaskellDepends = [
+    aeson
+    aeson-pretty
+    async
+    base
+    bytestring
+    directory
+    hspec
+    lens
+    lens-aeson
+    process
+    protolude
+    QuickCheck
+    temporary
+    text
+    unix
+  ];
+  homepage = "https://github.com/hercules-ci/arion#readme";
+  description = "Run docker-compose with help from Nix/NixOS";
+  license = lib.licenses.asl20;
+  mainProgram = "arion";
+}


### PR DESCRIPTION
This updates `arion`, including an important fix for `arion repl`, required for Nix 2.24, which got more strict about `nix repl` arguments.

[Release notes](https://github.com/hercules-ci/arion/releases/tag/v0.2.2.0)

This update is implemented with [replacements-by-name/README.md](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/development/haskell-modules/replacements-by-name/README.md).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
