### PR TITLE
holepunch tools: init

### DIFF
--- a/pkgs/by-name/hy/hyper-cmd-utils/package.nix
+++ b/pkgs/by-name/hy/hyper-cmd-utils/package.nix
@@ -1,0 +1,41 @@
+{
+  buildNpmPackage,
+  lib,
+  fetchurl,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage {
+  pname = "hyper-cmd-utils";
+  version = "1.0.0";
+
+  npmDepsHash = "sha256-FgUIHdmmeRhVoXisc2WdWUNA76vzFCfkM58RpqLoK5s=";
+
+  dontNpmBuild = true;
+
+  makeCacheWritable = true;
+
+  src = fetchFromGitHub {
+    owner = "holepunchto";
+    repo = "hyper-cmd-utils";
+    rev = "b8f1da1a1f4bc28ff9dbdbb6f4d777c2378d6137";
+    hash = "sha256-fQkXCor6Fnl0E5XAgIm7SP4Nq6oTHdQtKFEbvXoXx9A=";
+  };
+
+  patches = [
+    # TODO: remove after this is merged: https://github.com/holepunchto/hyper-cmd-utils/pull/6
+    (fetchurl {
+      url = "https://github.com/holepunchto/hyper-cmd-utils/commit/9bec5ca0a58fc9ba263afe750134f82e7e1c30c4.patch";
+      hash = "sha256-p32r5y8PnROePbpsBLYza1+lGR2n0amSdo8qDWhyYxo=";
+    })
+  ];
+
+  meta = {
+    description = "HyperCmd Utils";
+    homepage = "https://github.com/holepunchto/hyper-cmd-utils";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ davhau ];
+    mainProgram = "hyper-cmd-utils";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/hy/hyperbeam/package.nix
+++ b/pkgs/by-name/hy/hyperbeam/package.nix
@@ -1,0 +1,39 @@
+{
+  buildNpmPackage,
+  lib,
+  fetchurl,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "hyperbeam";
+  version = "3.0.2";
+
+  npmDepsHash = "sha256-ZZX3BOtSSiLvAEcWuKiUMHrYOt8N6SYYQ+QGzbprL3E=";
+
+  dontNpmBuild = true;
+
+  src = fetchFromGitHub {
+    owner = "holepunchto";
+    repo = "hyperbeam";
+    rev = "v${version}";
+    hash = "sha256-g3eGuol3g1yfGHDSzI1wQXMxJudGCt4PHHdmtiRQS/Q=";
+  };
+
+  patches = [
+    # TODO: remove after this is merged: https://github.com/holepunchto/hyperbeam/pull/22
+    (fetchurl {
+      url = "https://github.com/holepunchto/hyperbeam/commit/e84e4be979bf89d8e8042878d2beb5c1a5dbf946.patch";
+      hash = "sha256-AdXmfti9/08kRYuL1l4gXmvSV7bV0kE72Pf/bNqiFQw=";
+    })
+  ];
+
+  meta = {
+    description = "A 1-1 end-to-end encrypted internet pipe powered by Hyperswarm ";
+    homepage = "https://github.com/holepunchto/hyperbeam";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ davhau ];
+    mainProgram = "hyperbeam";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/hy/hypershell/package.nix
+++ b/pkgs/by-name/hy/hypershell/package.nix
@@ -1,0 +1,45 @@
+{
+  buildNpmPackage,
+  lib,
+  fetchurl,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "hypershell";
+  version = "0.0.15";
+
+  npmDepsHash = "sha256-WBGuJBxuOTBPOLGvO9VfTeVrA4+SMVf8LA+fBDCif1c=";
+
+  dontNpmBuild = true;
+
+  src = fetchFromGitHub {
+    owner = "holepunchto";
+    repo = "hypershell";
+    rev = "v${version}";
+    hash = "sha256-UWXlcY65elw+xKLte5KE5eyFLDZmEVQBSwsSpv9G7ng=";
+  };
+
+  patches = [
+    # TODO: remove after this is merged: https://github.com/holepunchto/hypershell/pull/41
+    (fetchurl {
+      url = "https://github.com/holepunchto/hypershell/commit/a1775ee32d93bfe06b839da41d1727a575bccb3a.patch";
+      hash = "sha256-xqQNXKaBN3sVWIEuzB67Ww43mQRkVQl7Div2SCMn0o0=";
+    })
+  ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/hypershell --help
+  '';
+
+  meta = {
+    description = "Spawn shells anywhere. Fully peer-to-peer, authenticated, and end to end encrypted";
+    homepage = "https://github.com/holepunchto/hypershell";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ davhau ];
+    mainProgram = "hypershell";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/hy/hyperssh/package.nix
+++ b/pkgs/by-name/hy/hyperssh/package.nix
@@ -1,0 +1,41 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+}:
+
+buildNpmPackage {
+  pname = "hyperssh";
+  version = "5.0.3";
+
+  npmDepsHash = "sha256-nT++cvYbY+zsebIaMZ0hUhK9pAX17GTbQyuixdCjojM=";
+
+  makeCacheWritable = true;
+
+  dontNpmBuild = true;
+
+  src = fetchFromGitHub {
+    owner = "mafintosh";
+    repo = "hyperssh";
+    rev = "v5.0.3";
+    hash = "sha256-vjPSNcQRsqu0ee0hownEE9y8dFf9dqaL7alGRc9WjcI=2";
+  };
+
+  patches = [
+    # TODO: remove after this is merged: https://github.com/mafintosh/hyperssh/pull/16
+    (fetchurl {
+      url = "https://github.com/mafintosh/hyperssh/commit/ad1d0e06a133e71c9df9f59dd5f805c49f46ec70.patch";
+      hash = "sha256-fUjgHHbZHgqokNg2fVVZCjoDA3LqSJiFzBwgA8Tt1m4=";
+    })
+  ];
+
+  meta = {
+    description = "Run SSH over hyperswarm";
+    homepage = "https://github.com/mafintosh/hyperssh";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ davhau ];
+    mainProgram = "hyperssh";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds the following cli tools released by holepunch, see https://docs.pears.com/ for more information.
`hyperbeam` for example is an alternative for `magic-wormhole` and `hyperssh` a similar tool for establishing ssh connections between machines behind NAT's.

Those are some of the components that have previously been shipped with the deprecated and since removed hyperspace-cli package, see https://github.com/NixOS/nixpkgs/pull/188834

- **hyperssh: init at 5.0.3**
- **hypershell: init at 0.0.15**
- **hyper-cmd-utils: init at 1.0.0**
- **hyperbeam: init at 3.0.2**

See https://docs.pears.com/tools

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
