### PR TITLE
nixos/neo4j: add advertisedAddress options

### DIFF
--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -61,17 +61,17 @@ let
     # HTTP Connector
     server.http.enabled=${lib.boolToString cfg.http.enable}
     server.http.listen_address=${cfg.http.listenAddress}
-    server.http.advertised_address=${cfg.http.listenAddress}
+    server.http.advertised_address=${cfg.http.advertisedAddress}
 
     # HTTPS Connector
     server.https.enabled=${lib.boolToString cfg.https.enable}
     server.https.listen_address=${cfg.https.listenAddress}
-    server.https.advertised_address=${cfg.https.listenAddress}
+    server.https.advertised_address=${cfg.https.advertisedAddress}
 
     # BOLT Connector
     server.bolt.enabled=${lib.boolToString cfg.bolt.enable}
     server.bolt.listen_address=${cfg.bolt.listenAddress}
-    server.bolt.advertised_address=${cfg.bolt.listenAddress}
+    server.bolt.advertised_address=${cfg.bolt.advertisedAddress}
     server.bolt.tls_level=${cfg.bolt.tlsLevel}
 
     # SSL Policies
@@ -99,10 +99,8 @@ let
     # Extra Configuration
     ${cfg.extraServerConfig}
   '';
-
 in
 {
-
   imports = [
     (lib.mkRenamedOptionModule
       [ "services" "neo4j" "host" ]
@@ -160,7 +158,6 @@ in
   ###### interface
 
   options.services.neo4j = {
-
     enable = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -244,6 +241,16 @@ in
         default = ":7687";
         description = ''
           Neo4j listen address for BOLT traffic. The listen address is
+          expressed in the format `<ip-address>:<port-number>`.
+        '';
+      };
+
+      advertisedAddress = lib.mkOption {
+        type = lib.types.str;
+        default = cfg.bolt.listenAddress;
+        defaultText = lib.literalExpression "config.${opt.bolt.listenAddress}";
+        description = ''
+          Neo4j advertised address for BOLT traffic. The advertised address is
           expressed in the format `<ip-address>:<port-number>`.
         '';
       };
@@ -379,6 +386,16 @@ in
           expressed in the format `<ip-address>:<port-number>`.
         '';
       };
+
+      advertisedAddress = lib.mkOption {
+        type = lib.types.str;
+        default = cfg.http.listenAddress;
+        defaultText = lib.literalExpression "config.${opt.http.listenAddress}";
+        description = ''
+          Neo4j advertised address for HTTP traffic. The advertised address is
+          expressed in the format `<ip-address>:<port-number>`.
+        '';
+      };
     };
 
     https = {
@@ -397,6 +414,16 @@ in
         default = ":7473";
         description = ''
           Neo4j listen address for HTTPS traffic. The listen address is
+          expressed in the format `<ip-address>:<port-number>`.
+        '';
+      };
+
+      advertisedAddress = lib.mkOption {
+        type = lib.types.str;
+        default = cfg.https.listenAddress;
+        defaultText = lib.literalExpression "config.${opt.https.listenAddress}";
+        description = ''
+          Neo4j advertised address for HTTPS traffic. The advertised address is
           expressed in the format `<ip-address>:<port-number>`.
         '';
       };
@@ -440,7 +467,6 @@ in
             }:
             {
               options = {
-
                 allowKeyGeneration = lib.mkOption {
                   type = lib.types.bool;
                   default = false;
@@ -590,13 +616,11 @@ in
                     default value.
                   '';
                 };
-
               };
 
               config.directoriesToCreate = lib.optionals (
                 certDirOpt.highestPrio >= 1500 && options.baseDirectory.highestPrio >= 1500
               ) (map (opt: opt.value) (lib.filter isDefaultPathOption (lib.attrValues options)));
-
             }
           )
         );
@@ -610,7 +634,6 @@ in
         for further details.
       '';
     };
-
   };
 
   ###### implementation
@@ -630,7 +653,6 @@ in
         lib.attrValues cfg.ssl.policies
       );
     in
-
     lib.mkIf cfg.enable {
       assertions = [
         {


### PR DESCRIPTION
Closes #362321

Added new `services.neo4j.{bolt,http,https}.advertisedAddress` options. For now they default to their `listenAddress` counterparts to avoid breaking changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
