### PR TITLE
jetbrains: fix mismatched versions for source-built packages

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -91,8 +91,9 @@ let
             url = products."${pname}".url;
             sha256 = products."${pname}".sha256;
           };
-      inherit (products."${pname}") version;
-      buildNumber = products."${pname}".build_number;
+      version = if fromSource then communitySources."${pname}".version else products."${pname}".version;
+      buildNumber =
+        if fromSource then communitySources."${pname}".buildNumber else products."${pname}".build_number;
       inherit (ideInfo."${pname}") wmClass product;
       productShort = ideInfo."${pname}".productShort or ideInfo."${pname}".product;
       meta = mkMeta ideInfo."${pname}".meta fromSource;

--- a/pkgs/applications/editors/jetbrains/readme.md
+++ b/pkgs/applications/editors/jetbrains/readme.md
@@ -20,7 +20,7 @@ To test the build process of every IDE (as well as the process for adding plugin
  - Source builds need a bit more effort, as they **aren't automated at the moment**:
    - Find the build of the stable release you want to target (usually different for pycharm and idea, should have three components)
    - I find this at https://jetbrains.com/updates/updates.xml (search for `product name="`, then `fullNumber`)
-   - Update the `buildVer` field in source/default.nix
+   - Update the `version` & `buildVer` fields in source/default.nix
    - Empty the `ideaHash`, `androidHash`, `jpsHash` and `restarterHash` (only `ideaHash` and `restarterHash` changes on a regular basis) fields and try to build to get the new hashes
    - Run `nix build .#jetbrains.(idea/pycharm)-community-src.src.src`, then `./source/build_maven.py source/idea_maven_artefacts.json result/`
    - Update `source/brokenPlugins.json` (from https://plugins.jetbrains.com/files/brokenPlugins.json)

--- a/pkgs/applications/editors/jetbrains/readme.md
+++ b/pkgs/applications/editors/jetbrains/readme.md
@@ -20,7 +20,7 @@ To test the build process of every IDE (as well as the process for adding plugin
  - Source builds need a bit more effort, as they **aren't automated at the moment**:
    - Find the build of the stable release you want to target (usually different for pycharm and idea, should have three components)
    - I find this at https://jetbrains.com/updates/updates.xml (search for `product name="`, then `fullNumber`)
-   - Update the `version` & `buildVer` fields in source/default.nix
+   - Update the `version` & `buildNumber` fields in source/default.nix
    - Empty the `ideaHash`, `androidHash`, `jpsHash` and `restarterHash` (only `ideaHash` and `restarterHash` changes on a regular basis) fields and try to build to get the new hashes
    - Run `nix build .#jetbrains.(idea/pycharm)-community-src.src.src`, then `./source/build_maven.py source/idea_maven_artefacts.json result/`
    - Update `source/brokenPlugins.json` (from https://plugins.jetbrains.com/files/brokenPlugins.json)

--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -20,7 +20,7 @@
 , xorg
 
 , version
-, buildVer
+, buildNumber
 , buildType
 , ideaHash
 , androidHash
@@ -36,14 +36,14 @@ let
   ideaSrc = fetchFromGitHub {
     owner = "jetbrains";
     repo = "intellij-community";
-    rev = "${buildType}/${buildVer}";
+    rev = "${buildType}/${buildNumber}";
     hash = ideaHash;
   };
 
   androidSrc = fetchFromGitHub {
     owner = "jetbrains";
     repo = "android";
-    rev = "${buildType}/${buildVer}";
+    rev = "${buildType}/${buildNumber}";
     hash = androidHash;
   };
 
@@ -76,7 +76,7 @@ let
 
   libdbm = stdenv.mkDerivation {
     pname = "libdbm";
-    version = buildVer;
+    version = buildNumber;
     nativeBuildInputs = [ cmake pkg-config ];
     buildInputs = [ glib xorg.libX11 libdbusmenu ];
     inherit src;
@@ -96,12 +96,12 @@ let
 
   fsnotifier = stdenv.mkDerivation {
     pname = "fsnotifier";
-    version = buildVer;
+    version = buildNumber;
     inherit src;
     sourceRoot = "${src.name}/native/fsNotifier/linux";
     buildPhase = ''
       runHook preBuild
-      $CC -O2 -Wall -Wextra -Wpedantic -D "VERSION=\"${buildVer}\"" -std=c11 main.c inotify.c util.c -o fsnotifier
+      $CC -O2 -Wall -Wextra -Wpedantic -D "VERSION=\"${buildNumber}\"" -std=c11 main.c inotify.c util.c -o fsnotifier
       runHook postBuild
     '';
     installPhase = ''
@@ -114,7 +114,7 @@ let
 
   restarter = rustPlatform.buildRustPackage {
     pname = "restarter";
-    version = buildVer;
+    version = buildNumber;
     inherit src;
     sourceRoot = "${src.name}/native/restarter";
     cargoHash = restarterHash;
@@ -137,7 +137,7 @@ let
 
   jps-bootstrap = stdenvNoCC.mkDerivation {
     pname = "jps-bootstrap";
-    version = buildVer;
+    version = buildNumber;
     inherit src;
     sourceRoot = "${src.name}/platform/jps-bootstrap";
     nativeBuildInputs = [ ant makeWrapper jbr ];
@@ -201,8 +201,7 @@ let
 in
 stdenvNoCC.mkDerivation rec {
   pname = "${buildType}-community";
-  inherit version;
-  buildNumber = buildVer;
+  inherit version buildNumber;
   name = "${pname}-${version}.tar.gz";
   inherit src;
   nativeBuildInputs = [ p7zip jbr jps-bootstrap ];
@@ -232,7 +231,7 @@ stdenvNoCC.mkDerivation rec {
       -e 's|MAVEN_REPO_HERE|${mvnRepo}/.m2/repository/|' \
       -e 's|MAVEN_PATH_HERE|${maven}/maven|' \
       -i build/deps/src/org/jetbrains/intellij/build/impl/BundledMavenDownloader.kt
-    echo '${buildVer}.SNAPSHOT' > build.txt
+    echo '${buildNumber}.SNAPSHOT' > build.txt
   '';
 
   configurePhase = ''
@@ -241,7 +240,7 @@ stdenvNoCC.mkDerivation rec {
     ln -s "$repo"/.m2 /build/.m2
     export JPS_BOOTSTRAP_COMMUNITY_HOME=/build/source
     jps-bootstrap \
-      -Dbuild.number=${buildVer} \
+      -Dbuild.number=${buildNumber} \
       -Djps.kotlin.home=${kotlin} \
       -Dintellij.build.target.os=linux \
       -Dintellij.build.target.arch=x64 \

--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -19,6 +19,7 @@
 , pkg-config
 , xorg
 
+, version
 , buildVer
 , buildType
 , ideaHash
@@ -200,7 +201,8 @@ let
 in
 stdenvNoCC.mkDerivation rec {
   pname = "${buildType}-community";
-  version = buildVer;
+  inherit version;
+  buildNumber = buildVer;
   name = "${pname}-${version}.tar.gz";
   inherit src;
   nativeBuildInputs = [ p7zip jbr jps-bootstrap ];

--- a/pkgs/applications/editors/jetbrains/source/default.nix
+++ b/pkgs/applications/editors/jetbrains/source/default.nix
@@ -3,6 +3,7 @@
 
 {
   idea-community = callPackage ./build.nix {
+    version = "2024.1.3";
     buildVer = "241.17890.1";
     buildType = "idea";
     ideaHash = "sha256-jWFnewxRkriSmV6CgGX1r//uaErMINfx3Z+JpkE34jk=";
@@ -12,6 +13,7 @@
     mvnDeps = ./idea_maven_artefacts.json;
   };
   pycharm-community = callPackage ./build.nix {
+    version = "2024.1.3";
     buildVer = "241.17890.14";
     buildType = "pycharm";
     ideaHash = "sha256-tTB91/RHEWP/ZILPNFAbolVBLvgjLXTdD/uF/pdJ22Y=";

--- a/pkgs/applications/editors/jetbrains/source/default.nix
+++ b/pkgs/applications/editors/jetbrains/source/default.nix
@@ -4,7 +4,7 @@
 {
   idea-community = callPackage ./build.nix {
     version = "2024.1.3";
-    buildVer = "241.17890.1";
+    buildNumber = "241.17890.1";
     buildType = "idea";
     ideaHash = "sha256-jWFnewxRkriSmV6CgGX1r//uaErMINfx3Z+JpkE34jk=";
     androidHash = "sha256-hX2YdRYNRg0guskNiYfxdl9osgZojRen82IhgA6G0Eo=";
@@ -14,7 +14,7 @@
   };
   pycharm-community = callPackage ./build.nix {
     version = "2024.1.3";
-    buildVer = "241.17890.14";
+    buildNumber = "241.17890.14";
     buildType = "pycharm";
     ideaHash = "sha256-tTB91/RHEWP/ZILPNFAbolVBLvgjLXTdD/uF/pdJ22Y=";
     androidHash = "sha256-hX2YdRYNRg0guskNiYfxdl9osgZojRen82IhgA6G0Eo=";


### PR DESCRIPTION
Fixes #304755.

When `mkJetBrainsProduct` is building a source-built package, it should get the version info from the underlying `communitySources` rather than `versions.json`, as that JSON file relates to version info for binary packages.

As part of this change, the "version" is now supplied to `source/build.nix` alongside the build number.

The `buildVer` argument was renamed `buildNumber` for consistency with upstream jetbrains terminology and also naming elsewhere in the jetbrains packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
