### PR TITLE
python312Packages.deid: 0.3.22 -> 0.3.25

### DIFF
--- a/pkgs/development/python-modules/deid/default.nix
+++ b/pkgs/development/python-modules/deid/default.nix
@@ -14,11 +14,13 @@ let
   deid-data = buildPythonPackage rec {
     pname = "deid-data";
     version = "unstable-2022-12-06";
-    format = "pyproject";
+    pyproject = true;
+
     disabled = pythonOlder "3.7";
 
-    nativeBuildInputs = [ setuptools ];
-    propagatedBuildInputs = [ pydicom ];
+    build-system = [ setuptools ];
+
+    dependencies = [ pydicom ];
 
     src = fetchFromGitHub {
       owner = "pydicom";
@@ -37,9 +39,9 @@ let
 in
 buildPythonPackage rec {
   pname = "deid";
-  version = "0.3.22";
+  version = "0.3.25";
+  pyproject = true;
 
-  format = "pyproject";
   disabled = pythonOlder "3.7";
 
   # Pypi version has no tests
@@ -47,11 +49,13 @@ buildPythonPackage rec {
     owner = "pydicom";
     repo = pname;
     # the github repo does not contain Pypi version tags:
-    rev = "40dc96125daeb65856d643e12c3d6dfec756be0d";
-    hash = "sha256-OtxQPF29eqt8I1Q12ga8a1IjBVO+VBk6y0DQmRtCNoU=";
+    rev = "830966d52846c6b721fabb4cc1c75f39eabd55cc";
+    hash = "sha256-+slwnQSeRHpoCsvZ24Gq7rOBpQL37a6Iqrj4Mqj6PCo=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     matplotlib
     pydicom
     python-dateutil
@@ -64,11 +68,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "deid" ];
 
-  meta = with lib; {
+  meta = {
     description = "Best-effort anonymization for medical images";
     mainProgram = "deid";
+    changelog = "https://github.com/pydicom/deid/blob/${version}/CHANGELOG.md";
     homepage = "https://pydicom.github.io/deid";
-    license = licenses.mit;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
Routine update. [changelog](https://github.com/pydicom/deid/blob/830966d52846c6b721fabb4cc1c75f39eabd55cc/CHANGELOG.md)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
