### PR TITLE
workflows/eval: Improve debuggabilitiy

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -179,7 +179,7 @@ jobs:
           done
 
           if [[ "$conclusion" != "success" ]]; then
-            echo "Workflow was not successful, cannot make comparison"
+            echo "Workflow was not successful (conclusion: $conclusion), cannot make comparison"
             exit 0
           fi
 


### PR DESCRIPTION
Sometimes successful workflows trigger that condition, see https://github.com/NixOS/nixpkgs/actions/runs/12278493443/job/34260660227:

    Comparing against "https://github.com/NixOS/nixpkgs/actions/runs/12278495895"
    Workflow not done, waiting 10 seconds before checking again
    Workflow was not successful, cannot make comparison

Even though

    $ gh api /repos/NixOS/nixpkgs/actions/runs/12278495895 --jq .conclusion
    success

Let's print the conclusion when it's not "success" to debug this.

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
