### PR TITLE
buildbot: Remove broken on Darwin.

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildbot/master.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/master.nix
@@ -176,6 +176,5 @@ buildPythonApplication rec {
     changelog = "https://github.com/buildbot/buildbot/releases/tag/v${version}";
     maintainers = teams.buildbot.members;
     license = licenses.gpl2Only;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/tools/continuous-integration/buildbot/worker.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/worker.nix
@@ -56,6 +56,5 @@ buildPythonPackage ({
     description = "Buildbot Worker Daemon";
     maintainers = teams.buildbot.members;
     license = licenses.gpl2;
-    broken = stdenv.hostPlatform.isDarwin; # https://hydra.nixos.org/build/243534318/nixlog/6
   };
 })


### PR DESCRIPTION
It seems to me that buildbot is not broken on Darwin anymore.

A build failure was referenced from a comment: https://hydra.nixos.org/build/243534318/nixlog/6.

I was able to successfully build, run and get a basic buildbot master, worker and web ui going on my aarch64-darwin machine:

```
❯ nix run .#nix-info -- -m
 - system: `"aarch64-darwin"`
 - host os: `Darwin 24.0.0, macOS 15.0.1`
 - multi-user?: `no`
 - sandbox: `yes`
 - version: `nix-env (Lix, like Nix) 2.91.1
System type: aarch64-darwin
Additional system types:
Features: gc, signed-caches
System configuration file: /etc/nix/nix.conf
User configuration files: /Users/andreas/.config/nix/nix.conf:/etc/xdg/nix/nix.conf
Store directory: /nix/store
State directory: /nix/var/nix
Data directory: /nix/store/1phn7b1smb3g9jqz7v39q13wlyji2msz-lix-2.91.1/share`
 - nixpkgs: `not found`

❯ nix build .#buildbot-full
❯ result/bin/buildbot create-master /tmp/my_master
mkdir /tmp/my_master
creating /tmp/my_master/master.cfg.sample
creating database (sqlite:///state.sqlite)
buildmaster configured in /tmp/my_master
❯ mv /tmp/my_master/master.cfg.sample /tmp/my_master/master.cfg
❯ result/bin/buildbot start /tmp/my_master
Following twistd.log until startup finished..
The buildmaster appears to have (re)started correctly.

❯ nix build .#buildbot-worker
❯ result/bin/buildbot-worker create-worker /tmp/my_worker localhost example-worker pass
mkdir /tmp/my_worker
mkdir /tmp/my_worker/info
Creating info/admin, you need to edit it appropriately.
Creating info/host, you need to edit it appropriately.
Not creating info/access_uri - add it if you wish
Please edit the files in /tmp/my_worker/info appropriately.
worker configured in /tmp/my_worker
❯ result/bin/buildbot-worker start /tmp/my_worker
Following twistd.log until startup finished..
The buildbot-worker appears to have (re)started correctly.
```

Yay buildbot!
<img width="945" alt="image" src="https://github.com/user-attachments/assets/b1e7399e-0554-4a79-82a6-1a42fd17e321" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
