### PR TITLE
nixos/k3s: make assertions about missing configuration options warnings

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -462,27 +462,25 @@ in
       ++ (lib.optional (cfg.role != "server" && cfg.charts != { })
         "k3s: Helm charts are only made available to the cluster on server nodes (role == server), they will be ignored by this node."
       )
-      ++ (lib.optional (cfg.disableAgent && cfg.images != [ ])
-        "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node"
+      ++ (lib.optional (
+        cfg.disableAgent && cfg.images != [ ]
+      ) "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node")
+      ++ (lib.optional (
+        cfg.role == "agent" && cfg.configPath == null && cfg.serverAddr == ""
+      ) "k3s: ServerAddr or configPath (with 'server' key) should be set if role is 'agent'")
+      ++ (lib.optional
+        (cfg.role == "agent" && cfg.configPath == null && cfg.tokenFile == null && cfg.token == "")
+        "k3s: Token or tokenFile or configPath (with 'token' or 'token-file' keys) should be set if role is 'agent'"
       );
 
     assertions = [
       {
-        assertion = cfg.role == "agent" -> (cfg.configPath != null || cfg.serverAddr != "");
-        message = "serverAddr or configPath (with 'server' key) should be set if role is 'agent'";
-      }
-      {
-        assertion =
-          cfg.role == "agent" -> cfg.configPath != null || cfg.tokenFile != null || cfg.token != "";
-        message = "token or tokenFile or configPath (with 'token' or 'token-file' keys) should be set if role is 'agent'";
-      }
-      {
         assertion = cfg.role == "agent" -> !cfg.disableAgent;
-        message = "disableAgent must be false if role is 'agent'";
+        message = "k3s: disableAgent must be false if role is 'agent'";
       }
       {
         assertion = cfg.role == "agent" -> !cfg.clusterInit;
-        message = "clusterInit must be false if role is 'agent'";
+        message = "k3s: clusterInit must be false if role is 'agent'";
       }
     ];
 


### PR DESCRIPTION
It is possible to configure k3s in various ways (cli flags, env variables, single config file, multiple config files) and everything is merged together in a final config. The nixos module cannot know if a configuration option that is missing from the module point of view is supplied in another way, so it shouldn't assert missing configuration options.

See also https://docs.k3s.io/installation/configuration?_highlight=configuration#putting-it-all-together

I have currently the case where I want to configure agent nodes via the NixOS module and provide the server address later via a separate config file. This is currently not possible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@NixOS/k3s 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
