### PR TITLE
vimPlugins: add neovimRequireCheckHook only when needed

### DIFF
--- a/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
+++ b/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
@@ -20,6 +20,7 @@
       path ? ".",
       addonInfo ? null,
       meta ? { },
+      doCheck ? true,
       ...
     }@attrs:
     let
@@ -30,6 +31,7 @@
 
           __structuredAttrs = true;
           inherit
+            doCheck
             unpackPhase
             configurePhase
             buildPhase

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1887,7 +1887,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest";
+    nvimRequireCheck = "neotest";
   };
 
   neotest-bash = super.neotest-bash.overrideAttrs {
@@ -1969,7 +1969,8 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-gtest";
+    # broken
+    # nvimRequireCheck = "neotest-gtest";
   };
 
   neotest-haskell = super.neotest-haskell.overrideAttrs {
@@ -1985,7 +1986,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-java";
+    nvimRequireCheck = "neotest-java";
   };
 
   neotest-jest = super.neotest-jest.overrideAttrs {
@@ -2010,7 +2011,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-pest";
+    nvimRequireCheck = "neotest-pest";
   };
 
   neotest-phpunit = super.neotest-phpunit.overrideAttrs {
@@ -2038,7 +2039,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-plenary";
+    nvimRequireCheck = "neotest-plenary";
   };
 
   neotest-python = super.neotest-python.overrideAttrs {
@@ -2047,7 +2048,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-python";
+    nvimRequireCheck = "neotest-python";
   };
 
   neotest-rspec = super.neotest-rspec.overrideAttrs {
@@ -2071,7 +2072,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-scala";
+    nvimRequireCheck = "neotest-scala";
   };
 
   neotest-testthat = super.neotest-testthat.overrideAttrs {
@@ -2080,7 +2081,7 @@ in
       nvim-nio
       plenary-nvim
     ];
-    nvimRequirecheck = "neotest-testthat";
+    nvimRequireCheck = "neotest-testthat";
   };
 
   neotest-vitest = super.neotest-vitest.overrideAttrs {
@@ -2106,7 +2107,7 @@ in
       plenary-nvim
       nui-nvim
     ];
-    nvimRequirecheck = "neo-tree";
+    nvimRequireCheck = "neo-tree";
   };
 
   netman-nvim = super.netman-nvim.overrideAttrs {
@@ -2136,7 +2137,7 @@ in
 
   noice-nvim = super.noice-nvim.overrideAttrs {
     dependencies = [ self.nui-nvim ];
-    nvimRequirecheck = "noice";
+    nvimRequireCheck = "noice";
   };
 
   none-ls-nvim = super.none-ls-nvim.overrideAttrs {
@@ -2555,7 +2556,7 @@ in
 
   otter-nvim = super.otter-nvim.overrideAttrs {
     dependencies = [ self.nvim-lspconfig ];
-    nvimRequirecheck = "otter";
+    nvimRequireCheck = "otter";
   };
 
   outline-nvim = super.outline-nvim.overrideAttrs {
@@ -3681,7 +3682,7 @@ in
   };
 
   vim-tabby = super.vim-tabby.overrideAttrs {
-    nvimRequirecheck = "tabby";
+    nvimRequireCheck = "tabby";
   };
 
   vim-textobj-entire = super.vim-textobj-entire.overrideAttrs {

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -488,34 +488,37 @@ rec {
 
   toVimPlugin =
     drv:
-    drv.overrideAttrs (finalAttrs: oldAttrs: {
-      name = "vimplugin-${oldAttrs.name}";
-      # dont move the "doc" folder since vim expects it
-      forceShare = [
-        "man"
-        "info"
-      ];
-
-      nativeBuildInputs =
-        oldAttrs.nativeBuildInputs or [ ]
-        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-          vimGenDocHook
+    drv.overrideAttrs (
+      finalAttrs: oldAttrs: {
+        name = "vimplugin-${oldAttrs.name}";
+        # dont move the "doc" folder since vim expects it
+        forceShare = [
+          "man"
+          "info"
         ];
 
-      doCheck = oldAttrs.doCheck or true;
+        nativeBuildInputs =
+          oldAttrs.nativeBuildInputs or [ ]
+          ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+            vimGenDocHook
+          ];
 
-      nativeCheckInputs =
-        oldAttrs.nativeCheckInputs or [ ]
-        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ([
-          vimCommandCheckHook ]
-        ++ lib.optional (finalAttrs.finalPackage ? nvimRequireCheck) neovimRequireCheckHook
-        )
-        ;
+        doCheck = oldAttrs.doCheck or true;
 
-      passthru = (oldAttrs.passthru or { }) // {
-        vimPlugin = true;
-      };
-    });
+        nativeCheckInputs =
+          oldAttrs.nativeCheckInputs or [ ]
+          ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) (
+            [
+              vimCommandCheckHook
+            ]
+            ++ lib.optional (finalAttrs.finalPackage ? nvimRequireCheck) neovimRequireCheckHook
+          );
+
+        passthru = (oldAttrs.passthru or { }) // {
+          vimPlugin = true;
+        };
+      }
+    );
 }
 // lib.optionalAttrs config.allowAliases {
   vimWithRC = throw "vimWithRC was removed, please use vim.customize instead";

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -488,7 +488,7 @@ rec {
 
   toVimPlugin =
     drv:
-    drv.overrideAttrs (oldAttrs: {
+    drv.overrideAttrs (finalAttrs: oldAttrs: {
       name = "vimplugin-${oldAttrs.name}";
       # dont move the "doc" folder since vim expects it
       forceShare = [
@@ -506,11 +506,11 @@ rec {
 
       nativeCheckInputs =
         oldAttrs.nativeCheckInputs or [ ]
-        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-          vimCommandCheckHook
-          # many neovim plugins keep using buildVimPlugin
-          neovimRequireCheckHook
-        ];
+        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ([
+          vimCommandCheckHook ]
+        ++ lib.optional (finalAttrs.finalPackage ? nvimRequireCheck) neovimRequireCheckHook
+        )
+        ;
 
       passthru = (oldAttrs.passthru or { }) // {
         vimPlugin = true;


### PR DESCRIPTION
neovim not building should not prevent the build of vim plugins that dont use neovim to run tests


## Things done
- we now include "neovimRequireCheckHook" only when doCheck is enabled and
if the derivation has an nvimRequireCheckHook.
- set doCheck to true in buildVimPlugin (might need to do something similar in buildNeovimPlugin ?)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
