### PR TITLE
python313Packages.xnatpy: 0.5.1 -> 0.7.2

### DIFF
--- a/pkgs/development/python-modules/xnatpy/default.nix
+++ b/pkgs/development/python-modules/xnatpy/default.nix
@@ -3,35 +3,51 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  setuptools,
+  hatchling,
+  versioningit,
   click,
+  click-option-group,
+  importlib-metadata,
   isodate,
   progressbar2,
   pydicom,
+  python-dateutil,
+  pyyaml,
   requests,
 }:
 
 buildPythonPackage rec {
   pname = "xnatpy";
-  version = "0.5.1";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.7";
+  version = "0.7.2";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "xnat";
     inherit version;
-    hash = "sha256-iOw9cVWP5Am4S9JQ0NTmtew38KZiKmau+19K2KG2aKQ=";
+    hash = "sha256-YbZJl6lvhuhpmeC+0LikZghIEsR2OYe0Om6IRxZcBwg=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [
+    hatchling
+    versioningit
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
+    click-option-group
+    importlib-metadata
     isodate
     progressbar2
     pydicom
+    python-dateutil
+    pyyaml
     requests
+  ];
+
+  pythonRelaxDeps = [
+    "importlib-metadata"
+    "python-dateutil"
+    "pydicom"
   ];
 
   # tests missing in PyPI dist and require network access and Docker container
@@ -39,12 +55,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "xnat" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://xnat.readthedocs.io";
     description = "New XNAT client (distinct from pyxnat) that exposes XNAT objects/functions as Python objects/functions";
     changelog = "https://gitlab.com/radiology/infrastructure/xnatpy/-/blob/${version}/CHANGELOG?ref_type=tags";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
     mainProgram = "xnat";
   };
 }


### PR DESCRIPTION
Routine update ([changelog](https://gitlab.com/radiology/infrastructure/xnatpy/-/blob/0.7.0/CHANGELOG?ref_type=tags))

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
