### PR TITLE
joplin-desktop: exclude apple code signatures when unpacking DMG with 7zz

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -68,7 +68,7 @@ let
 
     unpackPhase = ''
       runHook preUnpack
-      7zz x -x'!Joplin ${version}/Applications' $src
+      7zz x -x'!Joplin ${version}/Applications' -xr'!*:com.apple.cs.Code*' $src
       runHook postUnpack
     '';
 


### PR DESCRIPTION
…ive with 7zz on x86_64-darwin


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `_7zz` tool unpacks the `x86_64-darwin` version of the `joplin-desktop` DMG file differently than the `undmg` tool (which was used up to NixOS 24.05).
When using `undmg`, the resulting `Joplin.app` can be opened successfully on my `x86_64-darwin` system, while the `Joplin.app` unpacked using `7zz` cannot - it opens a blank window and an error pop-up box.
Comparing the two `Joplin.app` outputs reveals that the `7zz` version includes additional files:

```bash
~/tmp/jop ❯ diff -r 7zz/Joplin\ 3.0.15/Joplin.app undmg/Joplin.app/
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Frameworks/Electron Framework.framework/Resources: MainMenu.nib:com.apple.cs.CodeDirectory
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Frameworks/Electron Framework.framework/Resources: MainMenu.nib:com.apple.cs.CodeEntitlements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Frameworks/Electron Framework.framework/Resources: MainMenu.nib:com.apple.cs.CodeRequirements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Frameworks/Electron Framework.framework/Resources: MainMenu.nib:com.apple.cs.CodeRequirements-1
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Frameworks/Electron Framework.framework/Resources: MainMenu.nib:com.apple.cs.CodeSignature

... snip several lines ...

Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources/build/tesseract.js-core: tesseract-core.wasm:com.apple.cs.CodeEntitlements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources/build/tesseract.js-core: tesseract-core.wasm:com.apple.cs.CodeRequirements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources/build/tesseract.js-core: tesseract-core.wasm:com.apple.cs.CodeRequirements-1
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources/build/tesseract.js-core: tesseract-core.wasm:com.apple.cs.CodeSignature
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources: icon.icns:com.apple.cs.CodeDirectory
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources: icon.icns:com.apple.cs.CodeEntitlements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources: icon.icns:com.apple.cs.CodeRequirements
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources: icon.icns:com.apple.cs.CodeRequirements-1
Only in 7zz/Joplin 3.0.15/Joplin.app/Contents/Resources: icon.icns:com.apple.cs.CodeSignature

~/tmp/jop ❯
```

## Things done

These `*com.apple.cs.Code*` files can be excluded from being extracted by adding a `-x` switch as I have done in the proposed PR.
I have tested this on my `x86_64-darwin` system and it now allows me to open Joplin.
What I can't do is test whether the modified joplin-desktop pacakge builds/opens correctly on an ARM-based Mac because I don't have access to one.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
