### PR TITLE
guile: workaround for libunistring / darwin libiconv

### DIFF
--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -11,15 +11,22 @@
   libffi,
   libtool,
   libunistring,
+  libiconvReal,
   makeWrapper,
   pkg-config,
   pkgsBuildBuild,
   readline,
-}:
+}@args:
 
 let
   # Do either a coverage analysis build or a standard build.
   builder = if coverageAnalysis != null then coverageAnalysis else stdenv.mkDerivation;
+  # workaround for libiconv bug in macOS 14/15
+  libunistring =
+    if stdenv.hostPlatform.isDarwin then
+      args.libunistring.override { libiconv = libiconvReal; }
+    else
+      args.libunistring;
 in
 builder rec {
   pname = "guile";

--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -11,15 +11,22 @@
   libffi,
   libtool,
   libunistring,
+  libiconvReal,
   makeWrapper,
   pkg-config,
   pkgsBuildBuild,
   readline,
-}:
+}@args:
 
 let
   # Do either a coverage analysis build or a standard build.
   builder = if coverageAnalysis != null then coverageAnalysis else stdenv.mkDerivation;
+  # workaround for libiconv bug in macOS 14/15
+  libunistring =
+    if stdenv.hostPlatform.isDarwin then
+      args.libunistring.override { libiconv = libiconvReal; }
+    else
+      args.libunistring;
 in
 builder rec {
   pname = "guile";

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -11,17 +11,24 @@
   libffi,
   libtool,
   libunistring,
+  libiconvReal,
   libxcrypt,
   makeWrapper,
   pkg-config,
   pkgsBuildBuild,
   readline,
   writeScript,
-}:
+}@args:
 
 let
   # Do either a coverage analysis build or a standard build.
   builder = if coverageAnalysis != null then coverageAnalysis else stdenv.mkDerivation;
+  # workaround for libiconv bug in macOS 14/15
+  libunistring =
+    if stdenv.hostPlatform.isDarwin then
+      args.libunistring.override { libiconv = libiconvReal; }
+    else
+      args.libunistring;
 in
 builder rec {
   pname = "guile";


### PR DESCRIPTION
guile will fail in the configure phase on darwin due to libunistring not
building with libiconv as libunistring 1.3 rejects darwin's libiconv
implementation. Work around this by using the gnu libiconv.

https://lists.gnu.org/archive/html/bug-gnulib/2024-05/msg00375.html

alternative to: https://github.com/NixOS/nixpkgs/pull/364495
closes: https://github.com/NixOS/nixpkgs/pull/364495

results in under 8k rebuilds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
