### PR TITLE
writers: add writeGuile[Bin]

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -1,6 +1,8 @@
 {
   haskellPackages,
   lib,
+  guile-lib,
+  akkuPackages,
   nodePackages,
   perlPackages,
   python3Packages,
@@ -26,6 +28,8 @@ let
     writeFish
     writeFishBin
     writeFSharp
+    writeGuile
+    writeGuileBin
     writeHaskell
     writeHaskellBin
     writeJS
@@ -106,6 +110,12 @@ recurseIntoAttrs {
     babashka = expectSuccessBin (
       writeBabashkaBin "test-writers-babashka-bin" { } ''
         (println "success")
+      ''
+    );
+
+    guile = expectSuccessBin (
+      writeGuileBin "test-writers-guile-bin" { } ''
+        (display "success\n")
       ''
     );
 
@@ -247,6 +257,51 @@ recurseIntoAttrs {
       writeBabashka "test-writers-babashka" { } ''
         (println "success")
       ''
+    );
+
+    guile = expectSuccess (
+      writeGuile "test-writers-guile"
+        {
+          libraries = [ guile-lib ];
+          srfi = [ 1 ];
+        }
+        ''
+          (use-modules (unit-test))
+          (assert-true (= (second '(1 2 3))
+                       2))
+          (display "success\n")
+        ''
+    );
+
+    guileR6RS = expectSuccess (
+      writeGuile "test-writers-guile-r6rs"
+        {
+          r6rs = true;
+          libraries = with akkuPackages; [ r6rs-slice ];
+        }
+        ''
+          (import (rnrs base (6))
+                  (rnrs io simple (6))
+                  (slice))
+          (assert (equal? (slice '(1 2 3) 0 2)
+                          '(1 2)))
+          (display "success\n")
+        ''
+    );
+
+    guileR7RS = expectSuccess (
+      writeGuile "test-writers-guile-r7rs"
+        {
+          r7rs = true;
+        }
+        ''
+          (import (scheme write)
+                  (srfi 1))
+          (unless (= (second '(1 2 3))
+                     2)
+                  (error "The value should be 2."))
+          (display "success\n")
+        ''
     );
 
     haskell = expectSuccess (


### PR DESCRIPTION
Add `writeGuile` and `writeGuileBin` to `pkgs.writers`, which write an executable Guile script just like other writers there.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
