### PR TITLE
[release-24.05] lib/tests: Fix after treewide reformat

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -497,21 +497,21 @@ checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix
 
 # Declaration positions
 # Line should be present for direct options
-checkConfigOutput '^10$' options.imported.line10.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '^14$' options.imported.line10.declarationPositions.0.line ./declaration-positions.nix
 checkConfigOutput '/declaration-positions.nix"$' options.imported.line10.declarationPositions.0.file ./declaration-positions.nix
 # Generated options may not have line numbers but they will at least get the
 # right file
 checkConfigOutput '/declaration-positions.nix"$' options.generated.line18.declarationPositions.0.file ./declaration-positions.nix
 checkConfigOutput '^null$' options.generated.line18.declarationPositions.0.line ./declaration-positions.nix
 # Submodules don't break it
-checkConfigOutput '^39$' config.submoduleLine34.submodDeclLine39.0.line ./declaration-positions.nix
+checkConfigOutput '^45$' config.submoduleLine34.submodDeclLine39.0.line ./declaration-positions.nix
 checkConfigOutput '/declaration-positions.nix"$' config.submoduleLine34.submodDeclLine39.0.file ./declaration-positions.nix
 # New options under freeform submodules get collected into the parent submodule
 # (consistent with .declarations behaviour, but weird; notably appears in system.build)
-checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.0.line ./declaration-positions.nix
-checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.1.line ./declaration-positions.nix
+checkConfigOutput '^38|27$' options.submoduleLine34.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '^38|27$' options.submoduleLine34.declarationPositions.1.line ./declaration-positions.nix
 # nested options work
-checkConfigOutput '^30$' options.nested.nestedLine30.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '^34$' options.nested.nestedLine30.declarationPositions.0.line ./declaration-positions.nix
 
 cat <<EOF
 ====== module tests ======


### PR DESCRIPTION
The test checks against line numbers, which changed with https://github.com/NixOS/nixpkgs/pull/327796.

This is effectively a partial backport of https://github.com/NixOS/nixpkgs/pull/326430.

Ping @vcunat 

## Things done
- [x] Ran `nix-build -A lib/tests/release.nix` successfully on `x86_64-linux`

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
