### PR TITLE
ci/eval: Avoid noise for failing attribute evals

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -49,7 +49,7 @@ let
         export NIX_STATE_DIR=$(mktemp -d)
         mkdir $out
         export GC_INITIAL_HEAP_SIZE=4g
-        command time -v \
+        command time -f "Attribute eval done [%MKB max resident, %Es elapsed] %C" \
           nix-instantiate --eval --strict --json --show-trace \
             "$src/pkgs/top-level/release-attrpaths-superset.nix" \
             -A paths \


### PR DESCRIPTION
It's currently annoying to see the actual failure in the attrs step, because `time -v` displays like 20 lines, which get repeated, therefore requiring you to scroll up most of the time:
https://github.com/NixOS/nixpkgs/actions/runs/12290298121/job/34297218345#step:5:794

This commit fixes that by only displaying the most important stats, the same ones as the chunked system-specific evals.

## Things done
- [x] Tested: https://github.com/tweag/nixpkgs/pull/108, see the [improved error here](https://github.com/tweag/nixpkgs/actions/runs/12295902817/job/34313770481?pr=108)

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
