### PR TITLE
extra-container: 0.12 -> 0.13

### DIFF
--- a/pkgs/by-name/ex/extra-container/package.nix
+++ b/pkgs/by-name/ex/extra-container/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
-  version = "0.12";
+  version = "0.13";
 
   src = fetchFromGitHub {
     owner = "erikarvstedt";
     repo = pname;
     rev = version;
-    hash = "sha256-/5wPv962ZHvZoZMOr4nMz7qcvbzlExRYS2nrnay/PU8=";
+    hash = "sha256-vgh3TqfkFdnPxREBedw4MQehIDc3N8YyxBOB45n+AvU=";
   };
 
   buildCommand = ''


### PR DESCRIPTION
[Release notes](https://github.com/erikarvstedt/extra-container/blob/master/CHANGELOG.md#013-2024-12-12).

- [x] Tested on x86_64-linux

cc @Lassulus