### PR TITLE
[Backport release-24.11] just: 1.36.0 -> 1.38.0

### DIFF
--- a/pkgs/by-name/ju/just/package.nix
+++ b/pkgs/by-name/ju/just/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "1.37.0";
+  version = "1.38.0";
   outputs = [
     "out"
     "man"
@@ -24,10 +24,10 @@ rustPlatform.buildRustPackage rec {
     owner = "casey";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-WF1kyIZyqnIYfFL/HZWBER97aXH3FSCbTRonOKSwgNg=";
+    hash = "sha256-jIc8+SFAcH2TsY12+txwlMoJmpDdDpC0H+UrjYH61Lk=";
   };
 
-  cargoHash = "sha256-/uWxYxczTOlUs2wOCCn5wwbGETHwIqdDI2mb/h4xVxQ=";
+  cargoHash = "sha256-JHLkjMy5b1spJrAqFCCzqgnlYTAKA1Z9Tx4w1WWuiAI=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/ju/just/package.nix
+++ b/pkgs/by-name/ju/just/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "1.36.0";
+  version = "1.37.0";
   outputs = [
     "out"
     "man"
@@ -24,10 +24,10 @@ rustPlatform.buildRustPackage rec {
     owner = "casey";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-4p4otR0W/v0DoWwwcNq/UEDa1V8vlZMpdk33B/9A4Bo=";
+    hash = "sha256-WF1kyIZyqnIYfFL/HZWBER97aXH3FSCbTRonOKSwgNg=";
   };
 
-  cargoHash = "sha256-y6wBFjBOeymbXUIeflQ35FxQRMPlDvB0Zeo2bQeZjJ0=";
+  cargoHash = "sha256-/uWxYxczTOlUs2wOCCn5wwbGETHwIqdDI2mb/h4xVxQ=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Slight complication with the formatting commit in a different spot relative to master requiring this backport to be manual.
I changed the 1.36.0 -> 1.37.0 commit to match the formatting in it's prior commit on release
1.37.0 -> 1.38.0 is unchanged

* [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.