### PR TITLE
m1-terraform-provider-helper: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4022,6 +4022,12 @@
     githubId = 7467038;
     name = "Chris Hammill";
   };
+  cfl4g = {
+    email = "martinlynge@gmail.com";
+    github = "mlh-csis";
+    githubId = 1171892;
+    name = "Martin Lynge Hansen";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/by-name/m1/m1-terraform-provider-helper/package.nix
+++ b/pkgs/by-name/m1/m1-terraform-provider-helper/package.nix
@@ -1,0 +1,58 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  pkgs,
+}:
+
+buildGoModule {
+  pname = "m1-terraform-provider-helper";
+  version = "0.9.0";
+
+  nativeBuildInputs = [
+    pkgs.curl
+    pkgs.cacert
+    pkgs.git
+  ];
+  src = fetchFromGitHub {
+    owner = "kreuzwerker";
+    repo = "m1-terraform-provider-helper";
+    rev = "0.9.0";
+    sha256 = "0plng7kz768v1km8mxw7jzsrvpxfzg991lrwwndpkgnyk2m28cnv";
+  };
+
+  # Only build from the root package
+  subPackages = [ "." ];
+
+  vendorHash = "sha256-+UzPs1kiapYy5WMwx6EkQBlBs3DpWhzaQcYqdlzH94U=";
+
+  passthru.updateScript = nix-update-script { };
+
+  # Use custom build command from Makefile
+  buildPhase = ''
+    make build-release VERSION=$version
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp dist/release/m1-terraform-provider-helper $out/bin/
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    make test-functional TEST_TIMEOUT=2m
+  '';
+  meta = {
+    description = "A CLI to manage the installation and compilation of Terraform providers for an ARM-based Mac.";
+    longDescription = ''
+      Helper tool for local building of older terraform providers that are not available for Apple silicon.
+      Requires `go` for building and `git` for checking out providers.
+    '';
+    homepage = "https://github.com/kreuzwerker/m1-terraform-provider-helper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cfl4g ];
+    platforms = lib.platforms.darwin;
+    changelog = "https://github.com/kreuzwerker/m0-terraform-provider-helper/releases/tag/$version";
+  };
+}


### PR DESCRIPTION
Introducing m1-terraform-provider-helper package, which helps build older terraform providers for Apple Silicon. This tool is particularly useful for developers using M1/M2 Macs who are stuck with terraform providers that don't have native ARM builds.

This program needs `git` and `go` installed since it checks out and compiles providers with them, but they are not detected as runtime dependencies as they are not linked directly.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin

- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [x] `sandbox = false` 
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`

- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Verified that the tool successfully builds terraform providers
  - Tested the built providers with terraform
  - The package now runs the functional testsuite too.

- [25.05 Release Notes]
  - [x] (Package updates) N/A - This is a new package
  - [ ] (Module updates) N/A
  - [ ] (Module addition) N/A

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)