### PR TITLE
home-assistant-custom-lovelace-modules.plotly-graph-card: init at 2.34.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/plotly-chart-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/plotly-chart-card/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildNpmPackage,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+let
+  # The node build requires its pinned esbuild version
+  esbuild = buildGoModule rec {
+    pname = "esbuild";
+    version = "0.16.10";
+
+    src = fetchFromGitHub {
+      owner = "evanw";
+      repo = "esbuild";
+      tag = "v${version}";
+      hash = "sha256-plcI3p/m1tPODZNcBoP/kc3avO11oXww7NIA9wdX+Pc=";
+    };
+
+    vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+
+    meta.mainProgram = "esbuild";
+  };
+in
+
+buildNpmPackage rec {
+  pname = "plotly-graph-card";
+  version = "3.3.5";
+
+  src = fetchFromGitHub {
+    owner = "dbuezas";
+    repo = "lovelace-plotly-graph-card";
+    tag = "v${version}";
+    hash = "sha256-I0lP0Z0tUiuJ4cC2Ud4uePS8zEZIBNP5X3EEa9ZVQ24=";
+  };
+
+  npmDepsHash = "sha256-CwIx5/kAAY+PAjEkJi7/7NpApzFSoIfuIl7zmsaqicE=";
+
+  # for ml-regression-logarithmic
+  forceGitDeps = true;
+  makeCacheWritable = true;
+
+  # custom pinned esbuild version
+  env.ESBUILD_BINARY_PATH = lib.getExe esbuild;
+
+  installPhase = ''
+    install -d $out
+    install -m0644 dist/plotly-graph-card.js $out/
+  '';
+
+  meta = {
+    description = "Highly customisable Lovelace card to plot interactive graphs. Brings scrolling, zooming, and much more";
+    homepage = "https://github.com/dbuezas/lovelace-plotly-graph-card";
+    changelog = "https://github.com/dbuezas/lovelace-plotly-graph-card/releases/tag/${src.tag}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ hexa ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Highly customisable Lovelace card to plot interactive graphs. Brings scrolling, zooming, and much more!

https://github.com/dbuezas/lovelace-plotly-graph-card/tree/master
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
