### PR TITLE
services.mysqlBackup: add option to change compression algorithm

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -251,6 +251,9 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/modules/services/databases/postgresql.nix @NixOS/postgres
 /nixos/tests/postgresql @NixOS/postgres
 
+# MySQL/MariaDB and related stuff
+/nixos/modules/services/backup/mysql-backup.nix @6543
+
 # Hardened profile & related modules
 /nixos/modules/profiles/hardened.nix                       @joachifm
 /nixos/modules/security/lock-kernel-modules.nix            @joachifm

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -5,9 +5,6 @@
   ...
 }:
 let
-
-  inherit (pkgs) mariadb gzip;
-
   cfg = config.services.mysqlBackup;
   defaultUser = "mysqlbackup";
 
@@ -22,7 +19,7 @@ let
   '';
   backupDatabaseScript = db: ''
     dest="${cfg.location}/${db}.gz"
-    if ${mariadb}/bin/mysqldump ${lib.optionalString cfg.singleTransaction "--single-transaction"} ${db} | ${gzip}/bin/gzip -c ${cfg.gzipOptions} > $dest.tmp; then
+    if ${pkgs.mariadb}/bin/mysqldump ${lib.optionalString cfg.singleTransaction "--single-transaction"} ${db} | ${pkgs.gzip}/bin/gzip -c ${cfg.gzipOptions} > $dest.tmp; then
       mv $dest.tmp $dest
       echo "Backed up to $dest"
     else
@@ -33,12 +30,9 @@ let
   '';
 
 in
-
 {
   options = {
-
     services.mysqlBackup = {
-
       enable = lib.mkEnableOption "MySQL backups";
 
       calendar = lib.mkOption {
@@ -106,7 +100,6 @@ in
       {
         name = cfg.user;
         ensurePermissions =
-          with lib;
           let
             privs = "SELECT, SHOW VIEW, TRIGGER, LOCK TABLES";
             grant = db: lib.nameValuePair "${db}.*" privs;

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -93,7 +93,7 @@ in
               name: algo: "- For ${name}: ${toString algo.minLevel}-${toString algo.maxLevel}"
             ) compressionAlgs
           )}
-          
+
           :::{.note}
           If compression level is also specified in gzipOptions, the gzipOptions value will be overwritten
           :::
@@ -148,7 +148,9 @@ in
     # assert config to be correct
     assertions = [
       {
-        assertion = cfg.compressionLevel == null || selectedAlg.minLevel <= cfg.compressionLevel && cfg.compressionLevel <= selectedAlg.maxLevel;
+        assertion =
+          cfg.compressionLevel == null
+          || selectedAlg.minLevel <= cfg.compressionLevel && cfg.compressionLevel <= selectedAlg.maxLevel;
         message = "${cfg.compressionAlg} compression level must be between ${toString selectedAlg.minLevel} and ${toString selectedAlg.maxLevel}";
       }
     ];

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -214,4 +214,6 @@ in
       ];
     };
   };
+
+  meta.maintainers = [ lib.maintainers._6543 ];
 }

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -90,10 +90,13 @@ in
           Compression level to use for ${lib.concatStringsSep ", " (lib.init (lib.attrNames compressionAlgs))} or ${lib.last (lib.attrNames compressionAlgs)}.
           ${lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
-              name: algo: "  For ${name}: ${toString algo.minLevel}-${toString algo.maxLevel}"
+              name: algo: "- For ${name}: ${toString algo.minLevel}-${toString algo.maxLevel}"
             ) compressionAlgs
           )}
-          (note: if compression level is also specified in gzipOptions, the gzipOptions value will be overwritten)
+          
+          :::{.note}
+          If compression level is also specified in gzipOptions, the gzipOptions value will be overwritten
+          :::
         '';
       };
 


### PR DESCRIPTION
Currently the backup enforces gzip.

But depending on the environment landscape different tools are prevered.
Also with other tools you can save more storage or utilize multiple CPU-Cores better (image is just an example, in this pull here we just add support for zstd and xz)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
