### PR TITLE
[staging] unbound: bison is required when cross-compiling

### DIFF
--- a/pkgs/by-name/un/unbound/package.nix
+++ b/pkgs/by-name/un/unbound/package.nix
@@ -64,10 +64,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
 
-  nativeBuildInputs =
-    lib.optionals withMakeWrapper [ makeWrapper ]
+  nativeBuildInputs = [ bison flex pkg-config ]
+    ++ lib.optionals withMakeWrapper [ makeWrapper ]
     ++ lib.optionals withDNSTAP [ protobufc ]
-    ++ [ pkg-config flex ]
     ++ lib.optionals withPythonModule [ swig ];
 
   buildInputs = [ openssl nettle expat libevent ]
@@ -120,8 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
   in ''
     sed -E '/CONFCMDLINE/ s;${storeDir}/[a-z0-9]{32}-;${storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-;g' -i config.h
   '';
-
-  nativeCheckInputs = [ bison ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes cross-compilation to riscv64 and aarch64 (tested on staging-next)
```
% nix-build . -A pkgsCross.riscv64.unbound
<....>
./libtool --tag=CC --mode=compile riscv64-unknown-linux-gnu-gcc -I.  -I/nix/store/qkknwi8h6f65mpbxxnnz52q4lbqlyljz-openssl-riscv64-unknown-linux-gnu-3.3.2-dev/include -I/nix/store/szbfipkwyf4v51fx0hwiv3nacqvkc16b-libevent-riscv64-unknown-linux-gnu-2.1.12-dev/include -I/nix/store/4gmf7cknhipwk9x8swd8ynrq5xprf1c9-expat-riscv64-unknown-linux-gnu-2.6.4-dev/include -DSRCDIR=. -g -O2 -flto -fPIE -pthread  -o alloc.lo -c util/alloc.c
libtool: compile:  riscv64-unknown-linux-gnu-gcc -I. -I/nix/store/qkknwi8h6f65mpbxxnnz52q4lbqlyljz-openssl-riscv64-unknown-linux-gnu-3.3.2-dev/include -I/nix/store/szbfipkwyf4v51fx0hwiv3nacqvkc16b-libevent-riscv64-unknown-linux-gnu-2.1.12-dev/include -I/nix/store/4gmf7cknhipwk9x8swd8ynrq5xprf1c9-expat-riscv64-unknown-linux-gnu-2.6.4-dev/include -DSRCDIR=. -g -O2 -flto -pthread -c util/alloc.c  -fPIC -DPIC -o .libs/alloc.o
yacc -d -o util/configparser.c ./util/configparser.y
/nix/store/5mh7kaj2fyv8mk4sfq1brwxgc02884wi-bash-5.2p37/bin/bash: line 1: yacc: command not found
make: *** [Makefile:514: util/configparser.h] Error 127
```

```
% nix-build . -A pkgsCross.aarch64-multiplatform.unbound
<....>
./libtool --tag=CC --mode=compile aarch64-unknown-linux-gnu-gcc -I.  -I/nix/store/my4kn79phl99aakvcpqihrzr0kcal0s0-openssl-aarch64-unknown-linux-gnu-3.3.2-dev/include -I/nix/store/q0b3vgl5cf70j79iy7gj6a222c27nvb6-libevent-aarch64-unknown-linux-gnu-2.1.12-dev/include -I/nix/store/9dhyzcl0iglgy6n40kjpi42j2rvic461-expat-aarch64-unknown-linux-gnu-2.6.4-dev/include -DSRCDIR=. -g -O2 -flto -fPIE -pthread  -o alloc.lo -c util/alloc.c
libtool: compile:  aarch64-unknown-linux-gnu-gcc -I. -I/nix/store/my4kn79phl99aakvcpqihrzr0kcal0s0-openssl-aarch64-unknown-linux-gnu-3.3.2-dev/include -I/nix/store/q0b3vgl5cf70j79iy7gj6a222c27nvb6-libevent-aarch64-unknown-linux-gnu-2.1.12-dev/include -I/nix/store/9dhyzcl0iglgy6n40kjpi42j2rvic461-expat-aarch64-unknown-linux-gnu-2.6.4-dev/include -DSRCDIR=. -g -O2 -flto -pthread -c util/alloc.c  -fPIC -DPIC -o .libs/alloc.o
yacc -d -o util/configparser.c ./util/configparser.y
/nix/store/5mh7kaj2fyv8mk4sfq1brwxgc02884wi-bash-5.2p37/bin/bash: line 1: yacc: command not found
make: *** [Makefile:514: util/configparser.h] Error 127
```

Tested by building:
- [X] `pkgs.unbound`
- [X] `pkgsCross.riscv64.unbound`
- [X] `pkgsCross.aarch64-multiplatform.unbound`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
