### PR TITLE
nixos/adguardhome: Enable strict shell checks in test

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -800,7 +800,7 @@ in {
 
     environment.profiles = [
       "$HOME/.nix-profile"
-      "\${XDG_STATE_HOME}/nix/profile"
+      "\${XDG_STATE_HOME-}/nix/profile"
       "$HOME/.local/state/nix/profile"
       "/etc/profiles/per-user/$USER"
     ];

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -123,7 +123,7 @@ in
         shellAliases = builtins.mapAttrs (name: lib.mkDefault) cfge.shellAliases;
 
         shellInit = ''
-          if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]; then
+          if [ -z "''${__NIXOS_SET_ENVIRONMENT_DONE+x}" ]; then
               . ${config.system.build.setEnvironment}
           fi
 
@@ -153,7 +153,7 @@ in
         # This file is read for login shells.
 
         # Only execute this file once per shell.
-        if [ -n "$__ETC_PROFILE_SOURCED" ]; then return; fi
+        if [ -n "''${__ETC_PROFILE_SOURCED+x}" ]; then return; fi
         __ETC_PROFILE_SOURCED=1
 
         # Prevent this file from being sourced by interactive non-login child shells.
@@ -176,18 +176,18 @@ in
         # /etc/bashrc: DO NOT EDIT -- this file has been generated automatically.
 
         # Only execute this file once per shell.
-        if [ -n "$__ETC_BASHRC_SOURCED" ] || [ -n "$NOSYSBASHRC" ]; then return; fi
+        if [ -n "''${__ETC_BASHRC_SOURCED+x}" ] || [ -n "''${NOSYSBASHRC+x}" ]; then return; fi
         __ETC_BASHRC_SOURCED=1
 
         # If the profile was not loaded in a parent process, source
         # it.  But otherwise don't do it because we don't want to
         # clobber overridden values of $PATH, etc.
-        if [ -z "$__ETC_PROFILE_DONE" ]; then
+        if [ -z "''${__ETC_PROFILE_DONE+x}" ]; then
             . /etc/profile
         fi
 
         # We are not always an interactive shell.
-        if [ -n "$PS1" ]; then
+        if [ -n "''${PS1+x}" ]; then
             ${cfg.interactiveShellInit}
         fi
 

--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -177,8 +177,9 @@ in
       };
 
       preStart = lib.optionalString (settings != null) ''
+        MUTABLE_SETTINGS=${toString cfg.mutableSettings}
         if    [ -e "$STATE_DIRECTORY/AdGuardHome.yaml" ] \
-           && [ "${toString cfg.mutableSettings}" = "1" ]; then
+           && [ "$MUTABLE_SETTINGS" = "1" ]; then
           # First run a schema_version update on the existing configuration
           # This ensures that both the new config and the existing one have the same schema_version
           # Note: --check-config has the side effect of modifying the file at rest!

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -192,7 +192,7 @@ let
             script =
               ''
                 state="/run/nixos/network/addresses/${i.name}"
-                mkdir -p $(dirname "$state")
+                mkdir -p "$(dirname "$state")"
 
                 ip link set dev "${i.name}" up
 
@@ -206,14 +206,14 @@ let
                     if out=$(ip addr replace "${cidr}" dev "${i.name}" 2>&1); then
                       echo "done"
                     else
-                      echo "'ip addr replace "${cidr}" dev "${i.name}"' failed: $out"
+                      echo "ip addr replace \"${cidr}\" dev \"${i.name}\" failed: $out"
                       exit 1
                     fi
                   ''
                 )}
 
                 state="/run/nixos/network/routes/${i.name}"
-                mkdir -p $(dirname "$state")
+                mkdir -p "$(dirname "$state")"
 
                 ${flip concatMapStrings (i.ipv4.routes ++ i.ipv6.routes) (route:
                   let
@@ -228,7 +228,7 @@ let
                      if out=$(ip route add ${type} "${cidr}" ${options} ${via} dev "${i.name}" proto static 2>&1); then
                        echo "done"
                      elif ! echo "$out" | grep "File exists" >/dev/null 2>&1; then
-                       echo "'ip route add ${type} "${cidr}" ${options} ${via} dev "${i.name}"' failed: $out"
+                       echo "ip route add ${type} \"${cidr}\" ${options} ${via} dev \"${i.name}\" failed: $out"
                        exit 1
                      fi
                   ''

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -20,6 +20,7 @@ let
         export DISPLAY=:0.0
 
         if [[ -e /etc/profile ]]; then
+            # shellcheck source=/dev/null
             source /etc/profile
         fi
 
@@ -45,7 +46,7 @@ let
         # we can also run non-NixOS guests during tests. This, however, is
         # mostly futureproofing as the test instrumentation is still very
         # tightly coupled to NixOS.
-        PS1= exec ${pkgs.coreutils}/bin/env bash --norc /dev/hvc0
+        PS1="" exec ${pkgs.coreutils}/bin/env bash --norc /dev/hvc0
       '';
       serviceConfig.KillSignal = "SIGHUP";
   };

--- a/nixos/tests/adguardhome.nix
+++ b/nixos/tests/adguardhome.nix
@@ -1,6 +1,10 @@
 {
   name = "adguardhome";
 
+  defaults = {
+    systemd.enableStrictShellChecks = true;
+  };
+
   nodes = {
     nullConf = {
       services.adguardhome.enable = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
