### PR TITLE
touche: init at 2.0.14

### DIFF
--- a/pkgs/by-name/to/touche/package.nix
+++ b/pkgs/by-name/to/touche/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+
+  meson,
+  ninja,
+  pkg-config,
+  nodejs,
+  npmHooks,
+  desktop-file-utils,
+  appstream-glib,
+  gjs,
+  gobject-introspection,
+  glib,
+  gtk3,
+  python3,
+  wrapGAppsHook4,
+
+  libadwaita,
+  xorg,
+
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "touche";
+  version = "2.0.14";
+
+  src = fetchFromGitHub {
+    owner = "JoseExposito";
+    repo = "touche";
+    tag = finalAttrs.version;
+    hash = "sha256-yRZeVN6KW/FA4Z6Aa3EnvqE9TKEC2tEhFQFkmqMUm3E=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    nodejs
+    npmHooks.npmConfigHook
+    desktop-file-utils # `desktop-file-validate`, `update-desktop-database`
+    appstream-glib # `appstream-util`
+    gjs
+    gobject-introspection
+    glib # `glib-compile-schemas`
+    gtk3 # `gtk-update-icon-cache`
+    python3
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    xorg.libX11
+  ];
+
+  npmDeps = fetchNpmDeps {
+    pname = "touche-npm-deps";
+    inherit (finalAttrs) version src;
+    hash = "sha256-zm6nP7789rDcXqcDKS9z8XIoAlhCzKdscPSueL79dTM=";
+  };
+
+  preConfigure = ''
+    patchShebangs bundle/scripts
+  '';
+
+  # GJS uses the invocation name to add gresource files
+  # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L159
+  # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L37
+  # To work around this, we manually set the name
+  preFixup =
+    let
+      fullName = "com.github.joseexposito.touche";
+    in
+    ''
+      sed -i "1 a imports.package._findEffectiveEntryPointName = () => '${fullName}';" $out/bin/${fullName}
+
+      # Also provide a symlink for easier CLI use
+      ln -s $out/bin/${fullName} $out/bin/touche
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Desktop application to configure Touchégg";
+    homepage = "https://github.com/JoseExposito/touche";
+    license = with lib.licenses; [ gpl3Plus ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "touche";
+  };
+})


### PR DESCRIPTION
Closes #212065.

Note: the Touchégg module probably needs to be changed to write a default system `touchegg.conf` file and add it to `XDG_CONFIG_DIRS`, otherwise Touché won't work
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
