### PR TITLE
nixos-rebuild-ng: change copy closure logic when copying from_host -> to_host

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -101,6 +101,47 @@ ruff check --fix .
 ruff format .
 ```
 
+## Breaking changes
+
+While `nixos-rebuild-ng` tries to be as much of a clone of the original as
+possible, there are still some breaking changes that were done in other to
+improve the user experience. If they break your workflow in some way that is
+not possible to fix, please open an issue and we can discuss a solution.
+
+- For `--build-host` and `--target-host`, `nixos-rebuild-ng` does not allocate
+  a pseudo-TTY via SSH (e.g.: `ssh -t`) anymore. The reason for this is because
+  pseudo-TTY breaks some expectations from SSH, like it mangles stdout and
+  stderr, and can
+  [break terminal output](https://github.com/NixOS/nixpkgs/issues/336967) in
+  some situations.
+  The issue is that `sudo` needs a TTY to ask for password, otherwise it will
+  fail. The solution for this is a new flag, `--ask-sudo-password`, that when
+  used with `--target-host` (`--build-host` doesn't need `sudo`), will ask for
+  the `sudo` password for the target host using Python's
+  [getpass](https://docs.python.org/3/library/getpass.html) and forward it to
+  every `sudo` request. Keep in mind that there is no check, so if you type
+  your password wrong, it will fail during activation (this can be improved
+  though)
+- When `--build-host` and `--target-host` is used together, we will use `nix
+  copy` (or 2 `nix-copy-closure` if you're using Nix <2.18) instead of SSH'ing
+  to build host and using `nix-copy-closure --to target-host`. The reason for
+  this is documented in PR
+  [#364698](https://github.com/NixOS/nixpkgs/pull/364698). If you do need the
+  previous behavior, you can simulate it using `ssh build-host --
+  nixos-rebuild-ng switch --target-host target-host`. If that is not the case,
+  please open an issue
+- We do some additional validation of flags, like exiting with an error when
+  `--build-host` or `--target-host` is used with `repl`, since the user could
+  assume that the `repl` would be run remotely while it always run the local
+  machine. `nixos-rebuild` silently ignored those flags, so this
+  [may cause some issues](https://github.com/NixOS/nixpkgs/pull/363922) for
+  wrappers
+- For now we are not supporting `build-vm` or `build-vm-with-bootloader` with
+  `--build-host` anymore. Support for this should be easy to add if you have
+  a use case, the only reason is that this is not supported is because in the
+  original the result would not be symlinked in the current directory, making
+  it kind useless (unless you looked at the result in `/nix/store`)
+
 ## Caveats
 
 - Bugs in the profile manipulation can cause corruption of your profile that

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -136,11 +136,6 @@ not possible to fix, please open an issue and we can discuss a solution.
   machine. `nixos-rebuild` silently ignored those flags, so this
   [may cause some issues](https://github.com/NixOS/nixpkgs/pull/363922) for
   wrappers
-- For now we are not supporting `build-vm` or `build-vm-with-bootloader` with
-  `--build-host` anymore. Support for this should be easy to add if you have
-  a use case, the only reason is that this is not supported is because in the
-  original the result would not be symlinked in the current directory, making
-  it kind useless (unless you looked at the result in `/nix/store`)
 
 ## Caveats
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -35,10 +35,6 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies = with python3Packages; [
-    tabulate
-  ];
-
   nativeBuildInputs = lib.optionals withShellFiles [
     installShellFiles
     python3Packages.shtab
@@ -94,9 +90,6 @@ python3Packages.buildPythonApplication rec {
           mypy
           pytest
           ruff
-          types-tabulate
-          # dependencies
-          tabulate
         ]
       );
     in

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -19,6 +19,11 @@
 }:
 let
   executable = if withNgSuffix then "nixos-rebuild-ng" else "nixos-rebuild";
+  # This version is kind of arbitrary, we use some features that were
+  # implemented in newer versions of Nix, but not necessary 2.18.
+  # However, Lix is a fork of Nix 2.18, so this looks like a good version
+  # to cut specific functionality.
+  withNix218 = lib.versionAtLeast nix.version "2.18";
 in
 python3Packages.buildPythonApplication rec {
   pname = "nixos-rebuild-ng";
@@ -53,8 +58,9 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postPatch = ''
-    substituteInPlace nixos_rebuild/__init__.py \
+    substituteInPlace nixos_rebuild/constants.py \
       --subst-var-by executable ${executable} \
+      --subst-var-by withNix218 ${lib.boolToString withNix218} \
       --subst-var-by withReexec ${lib.boolToString withReexec} \
       --subst-var-by withShellFiles ${lib.boolToString withShellFiles}
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -12,7 +12,7 @@ from . import nix
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, NRError, Profile
 from .process import Remote, cleanup_ssh
-from .utils import Args, LogFormatter
+from .utils import Args, LogFormatter, tabulate
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -448,8 +448,6 @@ def execute(argv: list[str]) -> None:
             if args.json:
                 print(json.dumps(generations, indent=2))
             else:
-                from tabulate import tabulate
-
                 headers = {
                     "generation": "Generation",
                     "date": "Build-date",
@@ -459,17 +457,7 @@ def execute(argv: list[str]) -> None:
                     "specialisations": "Specialisation",
                     "current": "Current",
                 }
-                # Not exactly the same format as legacy nixos-rebuild but close
-                # enough
-                table = tabulate(
-                    generations,
-                    headers=headers,
-                    tablefmt="plain",
-                    numalign="left",
-                    stralign="left",
-                    disable_numparse=True,
-                )
-                print(table)
+                print(tabulate(generations, headers=headers))
         case Action.REPL:
             if flake:
                 nix.repl_flake("toplevel", flake, **flake_build_flags)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -56,7 +56,13 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
 
     copy_flags = argparse.ArgumentParser(add_help=False)
     copy_flags.add_argument(
-        "--use-substitutes", "--substitute-on-destination", "-s", action="store_true"
+        "--use-substitutes",
+        "--substitute-on-destination",
+        "-s",
+        action="store_true",
+        # `-s` is the destination since it has the same meaning in
+        # `nix-copy-closure` and `nix copy`
+        dest="s",
     )
 
     sub_parsers = {

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -82,6 +82,9 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     )
     main_parser.add_argument("--help", "-h", action="store_true", help="Show manpage")
     main_parser.add_argument(
+        "--debug", action="store_true", help="Enable debug logging"
+    )
+    main_parser.add_argument(
         "--file", "-f", help="Enable and build the NixOS system from the specified file"
     )
     main_parser.add_argument(
@@ -198,8 +201,8 @@ def parse_args(
     def parser_warn(msg: str) -> None:
         print(f"{parser.prog}: warning: {msg}", file=sys.stderr)
 
-    # This flag affects both nix and this script
-    if args.verbose:
+    # verbose affects both nix commands and this script, debug only this script
+    if args.verbose or args.debug:
         logger.setLevel(logging.DEBUG)
 
     # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L56

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -404,10 +404,14 @@ def execute(argv: list[str]) -> None:
                         dry_run=dry_run,
                         **build_flags,
                     )
-                case m:
+                case never:
                     # should never happen, but mypy is not smart enough to
                     # handle this with assert_never
-                    raise NRError(f"invalid match for build: {m}")
+                    # https://github.com/python/mypy/issues/16650
+                    # https://github.com/python/mypy/issues/16722
+                    raise AssertionError(
+                        f"expected code to be unreachable, but got: {never}"
+                    )
 
             if not rollback:
                 nix.copy_closure(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -20,7 +20,7 @@ logger.setLevel(logging.INFO)
 
 def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]:
     common_flags = argparse.ArgumentParser(add_help=False)
-    common_flags.add_argument("--verbose", "-v", action="count", default=0)
+    common_flags.add_argument("--verbose", "-v", action="count", dest="v", default=0)
     common_flags.add_argument("--max-jobs", "-j")
     common_flags.add_argument("--cores")
     common_flags.add_argument("--log-format")
@@ -202,7 +202,7 @@ def parse_args(
         print(f"{parser.prog}: warning: {msg}", file=sys.stderr)
 
     # verbose affects both nix commands and this script, debug only this script
-    if args.verbose or args.debug:
+    if args.v or args.debug:
         logger.setLevel(logging.DEBUG)
 
     # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L56

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -1,0 +1,6 @@
+# Build-time flags
+# Strings to avoid breaking standalone (e.g.: `python -m nixos_rebuild`) usage
+EXECUTABLE = "@executable@"
+WITH_NIX_2_18 = "@withNix218@" == "true"  # type: ignore
+WITH_REEXEC = "@withReexec@" == "true"  # type: ignore
+WITH_SHELL_FILES = "@withShellFiles@" == "true"  # type: ignore

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -1,6 +1,9 @@
 # Build-time flags
-# Strings to avoid breaking standalone (e.g.: `python -m nixos_rebuild`) usage
+# Use strings to avoid breaking standalone (e.g.: `python -m nixos_rebuild`)
+# usage
 EXECUTABLE = "@executable@"
-WITH_NIX_2_18 = "@withNix218@" == "true"  # type: ignore
+# Use either `== "true"` if the default (e.g.: `python -m nixos_rebuld`) is
+# `False` or `!= "false"` if the default is `True`
+WITH_NIX_2_18 = "@withNix218@" != "false"  # type: ignore
 WITH_REEXEC = "@withReexec@" == "true"  # type: ignore
 WITH_SHELL_FILES = "@withShellFiles@" == "true"  # type: ignore

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -7,6 +7,7 @@ from string import Template
 from subprocess import PIPE, CalledProcessError
 from typing import Final
 
+from .constants import WITH_NIX_2_18
 from .models import (
     Action,
     BuildAttr,
@@ -139,30 +140,56 @@ def copy_closure(
     """Copy a nix closure to or from host to localhost.
 
     Also supports copying a closure from a remote to another remote."""
-    host = to_host or from_host
-    if not host:
-        return
 
     sshopts = os.getenv("NIX_SSHOPTS", "")
-    run_wrapper(
-        [
-            "nix-copy-closure",
-            *dict_to_flags(copy_flags),
-            "--to" if to_host else "--from",
-            host.host,
-            closure,
-        ],
-        extra_env={
-            # Using raw NIX_SSHOPTS here to avoid messing up with the passed
-            # parameters, and we do not add the SSH_DEFAULT_OPTS in the remote
-            # to remote case, otherwise it will fail because of ControlPath
-            # will not exist in remote
-            "NIX_SSHOPTS": sshopts
-            if from_host and to_host
-            else " ".join(filter(lambda x: x, [*SSH_DEFAULT_OPTS, sshopts]))
-        },
-        remote=from_host if to_host else None,
-    )
+    extra_env = {
+        "NIX_SSHOPTS": " ".join(filter(lambda x: x, [*SSH_DEFAULT_OPTS, sshopts]))
+    }
+
+    def nix_copy_closure(host: Remote, to: bool) -> None:
+        run_wrapper(
+            [
+                "nix-copy-closure",
+                *dict_to_flags(copy_flags),
+                "--to" if to else "--from",
+                host.host,
+                closure,
+            ],
+            extra_env=extra_env,
+        )
+
+    def nix_copy(to_host: Remote, from_host: Remote) -> None:
+        run_wrapper(
+            [
+                "nix",
+                "copy",
+                "--from",
+                f"ssh://{from_host.host}",
+                "--to",
+                f"ssh://{to_host.host}",
+                closure,
+            ],
+            extra_env=extra_env,
+        )
+
+    match (to_host, from_host):
+        case (None, None):
+            return
+        case (Remote(_) as host, None) | (None, Remote(_) as host):
+            nix_copy_closure(host, to=bool(to_host))
+        case (Remote(_), Remote(_)):
+            if WITH_NIX_2_18:
+                # With newer Nix, use `nix copy` instead of `nix-copy-closure`
+                # since it supports `--to` and `--from` at the same time
+                # TODO: once we drop Nix 2.3 from nixpkgs, remove support for
+                # `nix-copy-closure`
+                nix_copy(to_host, from_host)
+            else:
+                # With older Nix, we need to copy from to local and local to
+                # host. This means it is slower and need additional disk space
+                # in local
+                nix_copy_closure(from_host, to=False)
+                nix_copy_closure(to_host, to=True)
 
 
 def edit(flake: Flake | None, **flake_flags: Args) -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -246,7 +246,8 @@ def get_nixpkgs_rev(nixpkgs_path: Path | None) -> str | None:
         r = run_wrapper(
             ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
             check=False,
-            stdout=PIPE,
+            # https://github.com/NixOS/nixpkgs/issues/365222
+            capture_output=True,
         )
     except FileNotFoundError:
         # Git is not included in the closure so we need to check

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TypeAlias, assert_never, override
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias, assert_never, override
 
 Args: TypeAlias = bool | str | list[str] | int | None
 
@@ -18,7 +19,7 @@ class LogFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def dict_to_flags(d: dict[str, Args]) -> list[str]:
+def dict_to_flags(d: Mapping[str, Args]) -> list[str]:
     flags = []
     for key, value in d.items():
         flag = f"--{'-'.join(key.split('_'))}"
@@ -44,3 +45,49 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
             case _:
                 assert_never(value)
     return flags
+
+
+def remap_dicts(
+    dicts: Sequence[Mapping[str, Any]],
+    mappings: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    return [{mappings.get(k, k): v for k, v in d.items()} for d in dicts]
+
+
+def tabulate(
+    data: Sequence[Mapping[str, Any]],
+    headers: Mapping[str, str] | None = None,
+) -> str:
+    """Convert a sequence of mappings in a tabular-style format for terminal.
+
+    It expects that all mappings (dicts) have the same keys as the first one,
+    otherwise it will misbehave.
+    """
+    if not data:
+        return ""
+
+    if headers:
+        data = remap_dicts(data, headers)
+
+    data_headers = list(data[0].keys())
+
+    column_widths = [
+        max(
+            len(str(header)),
+            *(len(str(row.get(header, ""))) for row in data),
+        )
+        for header in data_headers
+    ]
+
+    def format_row(row: Mapping[str, Any]) -> str:
+        s = (2 * " ").join(
+            f"{str(row[header]).ljust(width)}"
+            for header, width in zip(data_headers, column_widths)
+        )
+        return s.strip()
+
+    result = [format_row(dict(zip(data_headers, data_headers)))]
+    for row in data:
+        result.append(format_row(row))
+
+    return "\n".join(result)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TypeAlias, override
+from typing import TypeAlias, assert_never, override
 
 Args: TypeAlias = bool | str | list[str] | int | None
 
@@ -25,6 +25,8 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
         match value:
             case None | False | 0 | []:
                 continue
+            case True if len(key) == 1:
+                flags.append(f"-{key}")
             case True:
                 flags.append(flag)
             case int():
@@ -36,4 +38,6 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
                 flags.append(flag)
                 for v in value:
                     flags.append(v)
+            case _:
+                assert_never(value)
     return flags

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -29,8 +29,11 @@ def dict_to_flags(d: dict[str, Args]) -> list[str]:
                 flags.append(f"-{key}")
             case True:
                 flags.append(flag)
+            case int() if len(key) == 1:
+                flags.append(f"-{key * value}")
             case int():
-                flags.append(f"-{key[0] * value}")
+                for i in range(value):
+                    flags.append(flag)
             case str():
                 flags.append(flag)
                 flags.append(value)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -67,12 +67,12 @@ def test_parse_args() -> None:
         ]
     )
     assert nr.logger.level == logging.DEBUG
-    assert r2.verbose == 3
+    assert r2.v == 3
     assert r2.flake is False
     assert r2.action == "dry-build"
     assert r2.file == "foo"
     assert r2.attr == "bar"
-    assert g2["common_flags"].verbose == 3
+    assert g2["common_flags"].v == 3
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -109,7 +109,7 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
             call(
                 ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
                 check=False,
-                stdout=PIPE,
+                capture_output=True,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -289,14 +289,14 @@ def test_get_nixpkgs_rev() -> None:
         mock_run.assert_called_with(
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
-            stdout=PIPE,
+            capture_output=True,
         )
 
     expected_calls = [
         call(
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
-            stdout=PIPE,
+            capture_output=True,
         ),
         call(
             ["git", "-C", path, "diff", "--quiet"],

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -9,6 +9,7 @@ def test_dict_to_flags() -> None:
             "test_flag_3": "value",
             "test_flag_4": ["v1", "v2"],
             "test_flag_5": None,
+            "t": True,
             "verbose": 5,
         }
     )
@@ -19,6 +20,7 @@ def test_dict_to_flags() -> None:
         "--test-flag-4",
         "v1",
         "v2",
+        "-t",
         "-vvvvv",
     ]
     r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -10,7 +10,8 @@ def test_dict_to_flags() -> None:
             "test_flag_4": ["v1", "v2"],
             "test_flag_5": None,
             "t": True,
-            "verbose": 5,
+            "v": 5,
+            "verbose": 2,
         }
     )
     assert r1 == [
@@ -22,6 +23,8 @@ def test_dict_to_flags() -> None:
         "v2",
         "-t",
         "-vvvvv",
+        "--verbose",
+        "--verbose",
     ]
     r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})
     assert r2 == []

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import nixos_rebuild.utils as u
 
 
@@ -28,3 +30,22 @@ def test_dict_to_flags() -> None:
     ]
     r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})
     assert r2 == []
+
+
+def test_remap_dicts() -> None:
+    assert u.remap_dicts(
+        [{"foo": 1, "bar": True}, {"qux": "keep"}],
+        {"foo": "Foo", "bar": "Bar"},
+    ) == [{"Foo": 1, "Bar": True}, {"qux": "keep"}]
+
+
+def test_tabulate() -> None:
+    assert u.tabulate([]) == ""
+    assert u.tabulate([{}]) == "\n"
+    assert u.tabulate(
+        [{"foo": 12345, "bar": ["abc", "cde"]}, {"foo": 345, "bar": 456}],
+        {"foo": "Foo", "bar": "Bar"},
+    ) == textwrap.dedent("""\
+        Foo    Bar
+        12345  ['abc', 'cde']
+        345    456""")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Change copy closure logic when copying `from_host` -> `to_host`:
- If user is using Nix 2.18+ (the default), we will switch to use `nix copy` since it supports using `--from` and `--to` at the same time
- If user is using older versions of Nix, we will call `nix-copy-closure` twice, once with `--from` and another with `--to`

The reason for this change is because the previous logic, that SSH'd to `from_host` to copy to `to_host` using `nix-copy-closure --to` means that `from_host` needs to have credentials to communicate with `to_host`, that is not always possible nor expected. It breaks even in simple cases like `--from` and `--to` is the same host because it is not common for a host to SSH'd itself. This also makes the behavior more consistent, since `--from` and `--to` is interpreted from the eval host point of view EXCEPT when they're used together.

This may of course break in the cases where this old behavior was assumed, e.g.: deploying with a bastion host. I am not sure how common this was, and I think this change in behavior should enable more cases than break, but let's see. For that particular case, running `nixos-rebuild-ng` inside SSH command (e.g.: `ssh build_host -- nixos-rebuild-ng switch --target-host target_host`) should do the trick.

More context why this change is needed: https://discourse.nixos.org/t/nixos-rebuild-ng-a-nixos-rebuild-rewrite/55606/27?u=k0kada.

#### Other improvements in this PR:
- Paralelization of `nixos-rebuild-ng list-generations`: this command can get surprinsingly slow specially with lots of generations. When I had ~10, this change reduces from ~170ms to ~100ms. For comparison, `nixos-rebuild list-generations` will take up to ~1 second(!) in the same situation, so not bad in general
- Removal of `tabulate` as dependency. It was bothering me that we were adding dependency in a library that is almost as complex as this whole program as dependency. With the help of ChatGPT, we now have 0 runtime dependencies again
- Add support to `--build-host`  for `build-vm` and `build-vm-with-bootloader`

#### Questions:
- Why not drop support for older Nix? Well, I thought about this, but it is a fact that we still supports Nix 2.3 in nixpkgs, and it is not like this add too much complication (but it is kind a pain to test). I hope we eventually drop Nix 2.3 from the tree, but until there I think we need to deal with this complexity
- Why not always use `nix copy` when Nix 2.18+? [There is this really annoying warning](https://github.com/NixOS/nix/issues/8378) that happens when you try to use `nix copy` with a path that ends with `.drv`. The use case for `--from` and `--to` is to copy the out result so it doesn't trigger this warning, but if we also changed the copy of derivation to use `nix copy` it would trigger. Also it would mean more code to maintain
- Why Nix 2.18? Because Nix 2.18 was our previous "stable" release and Lix is actually a fork of Nix 2.18 (until when I don't know, but this is true for today). And Nix 2.18 supports everything we need, but it is very likely the code is compatible with earlier versions of Nix (the `.drv` change that triggers the warning above is actually necessary for it to work once we switch everything to use `nix copy` for example, and it was introduced in Nix 2.15, so this is the minimum Nix version that the code is compatible I think)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
