### PR TITLE
forgejo: add pyrox0 as maintainer, nixos/forgejo: fix builtin ssh conditional, replace `GITEA_` prefix in env with `FORGEJO_`

### DIFF
--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -789,7 +789,9 @@ in
       } // lib.listToAttrs (map (e: lib.nameValuePair e.env "%d/${e.env}") secrets);
     };
 
-    services.openssh.settings.AcceptEnv = mkIf (!cfg.settings.START_SSH_SERVER or false) "GIT_PROTOCOL";
+    services.openssh.settings.AcceptEnv = mkIf (
+      !cfg.settings.server.START_SSH_SERVER or false
+    ) "GIT_PROTOCOL";
 
     users.users = mkIf (cfg.user == "forgejo") {
       forgejo = {

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -840,5 +840,6 @@ in
   meta.maintainers = with lib.maintainers; [
     bendlas
     emilylange
+    pyrox0
   ];
 }

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -784,10 +784,8 @@ in
       environment = {
         USER = cfg.user;
         HOME = cfg.stateDir;
-        # `GITEA_` prefix until https://codeberg.org/forgejo/forgejo/issues/497
-        # is resolved.
-        GITEA_WORK_DIR = cfg.stateDir;
-        GITEA_CUSTOM = cfg.customDir;
+        FORGEJO_WORK_DIR = cfg.stateDir;
+        FORGEJO_CUSTOM = cfg.customDir;
       } // lib.listToAttrs (map (e: lib.nameValuePair e.env "%d/${e.env}") secrets);
     };
 
@@ -814,10 +812,8 @@ in
       environment = {
         USER = cfg.user;
         HOME = cfg.stateDir;
-        # `GITEA_` prefix until https://codeberg.org/forgejo/forgejo/issues/497
-        # is resolved.
-        GITEA_WORK_DIR = cfg.stateDir;
-        GITEA_CUSTOM = cfg.customDir;
+        FORGEJO_WORK_DIR = cfg.stateDir;
+        FORGEJO_CUSTOM = cfg.customDir;
       };
 
       serviceConfig = {

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -195,6 +195,7 @@ buildGoModule rec {
       bendlas
       adamcstephens
       marie
+      pyrox0
     ];
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "gitea";


### PR DESCRIPTION
New attempt of #306457 (in coordination with @pyrox0):

- environment variable cleanup (`GITEA_` -> `FORGEJO_`)
- fixes/closes #306205 (ssh conditional)
- @pyrox0 as maintainer

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
