### PR TITLE
weektodo: init at 2.2.0

### DIFF
--- a/pkgs/by-name/we/weektodo/package.nix
+++ b/pkgs/by-name/we/weektodo/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchYarnDeps,
+
+  yarnConfigHook,
+  yarnBuildHook,
+  yarnInstallHook,
+  nodejs,
+  jq,
+  moreutils,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  nix-update-script,
+}:
+let
+  description = "Free and open-source minimalist weekly planner and to-do list app";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "weektodo";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "manuelernestog";
+    repo = "weektodo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oOS7ylpB/x5fOPTEKO9gSOUH8REV8qLvF3zX3eX64zs=";
+  };
+
+  # Darwin requires writable Electron dist
+  postUnpack =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      ''
+        cp -r ${electron.dist} electron-dist
+        chmod -R u+w electron-dist
+      ''
+    else
+      ''
+        ln -s ${electron.dist} electron-dist
+      '';
+
+  postPatch = ''
+    # Unpin electron-builder version
+    jq 'del(.resolutions)' package.json | sponge package.json
+  '';
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-ii/DkEu0XUOe1MPBkxkPiyhRS1Suswk+sqp0KKy2RfI=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    nodejs
+    jq
+    moreutils
+    copyDesktopItems
+  ];
+
+  yarnBuildScript = "electron:build";
+  yarnBuildFlags = [
+    "--dir"
+    "-c.electronDist=electron-dist"
+    "-c.electronVersion=${electron.version}"
+    # Bug in electron-builder makes it rebuild native dependencies for Darwin on Linux for whatever reason
+    # See https://github.com/electron-userland/electron-builder/issues/5015
+    "-c.npmRebuild=false"
+    # Fix entrypoint path
+    "-c.extraMetadata.main=dist_electron/bundled/background.js"
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+    ELECTRON_OVERRIDE_DIST_PATH = "electron-dist";
+    # See https://github.com/webpack/webpack/issues/14532
+    NODE_OPTIONS = "--openssl-legacy-provider";
+  };
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p $out/bin
+    ''
+    + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+      mkdir -p $out/share/weektodo
+      cp -r dist/*-unpacked/{locales,resources{,.pak}} -t $out/share/weektodo
+
+      makeWrapper ${lib.getExe electron} $out/bin/weektodo \
+        --add-flags "$out/share/weektodo/resources/app.asar" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+
+      install -D build/icon/icon.png $out/share/icons/hicolor/512x512/apps/weektodo.png
+    ''
+    + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r dist/mac*/WeekToDo.app $out/Applications
+      ln -s "$out/Applications/WeekToDo.app/Contents/MacOS/WeekToDo" $out/bin/weektodo
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  desktopItems = lib.optional stdenvNoCC.hostPlatform.isLinux (makeDesktopItem {
+    name = "weektodo";
+    desktopName = "WeekToDo";
+    comment = description;
+    icon = "weektodo";
+    exec = "weektodo %U";
+    terminal = false;
+    categories = [ "Utility" ];
+  });
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    inherit description;
+    homepage = "https://weektodo.me/";
+    changelog = "https://github.com/manuelernestog/weektodo/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Only ];
+    inherit (electron.meta) platforms;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "weektodo";
+  };
+})


### PR DESCRIPTION
Minimalist Weekly Planner

Quick, simple and very, very useful appt & planner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
