### PR TITLE
nix-prefetch-git: Fix on macOS

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, makeWrapper, buildEnv
-, bash, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, nix, subversion
+, bash, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, lix, subversion
 }:
 
 let mkPrefetchScript = tool: src: deps:
@@ -15,7 +15,7 @@ let mkPrefetchScript = tool: src: deps:
     installPhase = ''
       install -vD ${src} $out/bin/$name;
       wrapProgram $out/bin/$name \
-        --prefix PATH : ${lib.makeBinPath (deps ++ [ gnused nix ])} \
+        --prefix PATH : ${lib.makeBinPath (deps ++ [ gnused lix ])} \
         --set HOME /homeless-shelter
     '';
 


### PR DESCRIPTION
Due to [a CppNix bug which causes `nix-hash` to error on any file in a symlinked directory][1], `nix-prefetch-git` doesn't work on macOS, where `/tmp` and `/var` are both symlinks.

Due to [versions of CppNix older than 2.24 being removed from Nixpkgs despite known unfixed regressions][2], I can neither locate which version of CppNix introduced this bug or mitigate it by using an older version of CppNix.

Therefore, I have replaced CppNix with [Lix][3] in `nix-prefetch-git` (and the other `nix-prefetch-scripts`). Lix is based off of CppNix 2.18 and includes bugfixes backported from later versions of CppNix, so it does not suffer from this issue. Lix is compatible with CppNix 2.18, so this won't cause any regressions in behavior in the `nix-prefetch-scripts`.

Before:

```
$ ./result/bin/nix-prefetch-git https://github.com/iand675/hs-sqlcommenter.git
Initialized empty Git repository in /private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/git-checkout-tmp-3WITGvxC/hs-sqlcommenter/.git/
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 16 (delta 0), reused 16 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (16/16), 14.14 KiB | 1.18 MiB/s, done.
From https://github.com/iand675/hs-sqlcommenter
 * branch            HEAD       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...
error: path '/var' is a symlink
```

After:

```
$ ./result/bin/nix-prefetch-git https://github.com/iand675/hs-sqlcommenter.git
Initialized empty Git repository in /private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/git-checkout-tmp-mvc00tOe/hs-sqlcommenter/.git/
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 16 (delta 0), reused 16 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (16/16), 14.14 KiB | 1.18 MiB/s, done.
From https://github.com/iand675/hs-sqlcommenter
 * branch            HEAD       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...

git revision is 7e946654a6fb08f25ebc75b90bb6bbc60c1392bf
path is /nix/store/mkiv8ghgsyxf44ykk1n510yscvrhrgqi-hs-sqlcommenter
git human-readable version is -- none --
Commit date is 2024-07-11 19:10:11 +0200
hash is 0ijxcp0x0xismp8q457bgvj65s43s4zakk64v7h74wyknhv87hgi
{
  "url": "https://github.com/iand675/hs-sqlcommenter.git",
  "rev": "7e946654a6fb08f25ebc75b90bb6bbc60c1392bf",
  "date": "2024-07-11T19:10:11+02:00",
  "path": "/nix/store/mkiv8ghgsyxf44ykk1n510yscvrhrgqi-hs-sqlcommenter",
  "sha256": "0ijxcp0x0xismp8q457bgvj65s43s4zakk64v7h74wyknhv87hgi",
  "hash": "sha256-8cGDNrTTc3Lg2cTMqT7Rg+hi5H7rFILRrTp20MFlXUY=",
  "fetchLFS": false,
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```

[1]: https://github.com/NixOS/nix/issues/11756#issuecomment-2540202316
[2]: https://github.com/NixOS/nixpkgs/pull/359215#issuecomment-2515965863
[3]: https://lix.systems/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
