### PR TITLE
pycdc: init at 0-unstable-2024-10-13

### DIFF
--- a/pkgs/by-name/py/pycdc/package.nix
+++ b/pkgs/by-name/py/pycdc/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pycdc";
+  version = "0-unstable-2024-10-13";
+
+  src = fetchFromGitHub {
+    owner = "zrax";
+    repo = "pycdc";
+    rev = "5e1c4037a96b966e4e6728c55b2d7ee8076a13c3";
+    hash = "sha256-c/mfM2I8Rw136aQ3IAQOkkrOEtZ5LC/xKuWXzCItW2w=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C++ python bytecode disassembler and decompiler";
+    homepage = "https://github.com/zrax/pycdc";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ msm ];
+    mainProgram = "pycdc";
+  };
+}


### PR DESCRIPTION
Pycdc is currently the state-of-the-art Python decompiler. I occasionally use it in my dayjob (I'm a reverse engineer), since it has the best support for modern python versions, and a reasonable support for malicious (obfuscated) python bytecode.

Unfortunately, even though it's mature and quite popular, it looks like it has no official release version, so I have to version it as unstable-2024-10-13.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
