### PR TITLE
redumper: init at build_657

### DIFF
--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  llvmPackages,
+}:
+
+llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
+  pname = "redumper";
+  version = "438";
+
+  src = fetchFromGitHub {
+    owner = "superg";
+    repo = "redumper";
+    tag = "build_${finalAttrs.version}";
+    hash = "sha256-Ft+fxrKt7Yue+JT6PydWIzwbKGBX/VzLjjsADD7mqy0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    llvmPackages.clang-tools
+  ];
+
+  # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
+  cmakeFlags = [
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+    "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
+    "-DREDUMPER_CLANG_LINK_OPTIONS=" # overrides the '-static' default
+  ];
+
+  # Leads to: clang++: warning: argument unused during compilation: '-stdlib=libc++' [-Wunused-command-line-argument]
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)' ""
+  '';
+
+  meta = {
+    homepage = "https://github.com/superg/redumper";
+    description = "Low level CD dumper utility";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ hughobrien ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -8,13 +8,13 @@
 
 llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   pname = "redumper";
-  version = "438";
+  version = "651";
 
   src = fetchFromGitHub {
     owner = "superg";
     repo = "redumper";
     tag = "build_${finalAttrs.version}";
-    hash = "sha256-Ft+fxrKt7Yue+JT6PydWIzwbKGBX/VzLjjsADD7mqy0=";
+    hash = "sha256-fnc4d1B7Ubu2IMHPDBXzrK0BWeCmPG/c03MEwxgKwxY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -9,13 +9,13 @@
 # redumper is using C++ modules, this requires latest C++20 compiler and build tools
 llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   pname = "redumper";
-  version = "655";
+  version = "657";
 
   src = fetchFromGitHub {
     owner = "superg";
     repo = "redumper";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-z/T/CJEBXE8mwOAtnjB5bVkIuu0tJtwfn8Y2tTnFAfw=";
+    hash = "sha256-dkdG00nbnHSC8xC6540KJmTDnEohLQfHpvYzc5dS6tk=";
   };
 
   nativeBuildInputs = [
@@ -30,12 +30,6 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
     "-DREDUMPER_CLANG_LINK_OPTIONS=" # overrides the '-static' default
   ];
-
-  # Leads to: clang++: warning: argument unused during compilation: '-stdlib=libc++' [-Wunused-command-line-argument]
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)' ""
-  '';
 
   meta = {
     homepage = "https://github.com/superg/redumper";

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -6,15 +6,16 @@
   llvmPackages,
 }:
 
+# redumper is using C++ modules, this requires latest C++20 compiler and build tools
 llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   pname = "redumper";
-  version = "651";
+  version = "655";
 
   src = fetchFromGitHub {
     owner = "superg";
     repo = "redumper";
-    tag = "build_${finalAttrs.version}";
-    hash = "sha256-fnc4d1B7Ubu2IMHPDBXzrK0BWeCmPG/c03MEwxgKwxY=";
+    tag = "b${finalAttrs.version}";
+    hash = "sha256-z/T/CJEBXE8mwOAtnjB5bVkIuu0tJtwfn8Y2tTnFAfw=";
   };
 
   nativeBuildInputs = [
@@ -42,5 +43,6 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ hughobrien ];
     platforms = lib.platforms.linux;
+    mainProgram = "redumper";
   };
 })


### PR DESCRIPTION
Introduce [Redumper](https://github.com/superg/redumper/), a low level CD dumper utility used for the preservation of optical media.

> Redumper is a low-level byte perfect CD disc dumper. It supports incremental dumps, advanced SCSI/C2 repair, intelligent audio CD offset detection and a lot of other features.

Co-authored-by: leo60228 <leo@60228.dev>

## Example usage
```shell
shell ❯ sudo redumper --drive=/dev/sr0
Please touch the device.
redumper v1980.01.01 build_438 [Jan  1 1980, 00:00:00]

arguments: --drive=/dev/sr0

drive path: /dev/sr0
drive: PLEXTOR - DVDR PX-716A (revision level: 1.11, vendor specific: 03/23/07 15:10)
drive configuration: PLEXTOR (read offset: +30, C2 shift: 295, pre-gap start: -75, read method: D8, sector order: DATA_C2_SUB)
drive read speed: <optimal>

current profile: CD-ROM

image path: .
image name: dump_241213_002239_sr0

*** DUMP

disc TOC:
  track 1 {  data }
    index 01 { LBA:      0, MSF: 00:02:00 }
  track A {  data, dcp }
    index 01 { LBA: 358329, MSF: 79:39:54 }

PLEXTOR: reading lead-in (retry: 1)
PLEXTOR: lead-in found (session: 1, sectors: 1651)
PLEXTOR: reading lead-in (retry: 2)
PLEXTOR: lead-in found (session: 1, sectors: 2786)
PLEXTOR: storing lead-in (session: 1, verified: yes)
                                                                 
media errors: 
  SCSI: 0
  C2: 577
  Q: 476

*** PROTECTION (time check: 475s)

protection: SafeDisc 00000001.TMP, C2: 577, gap range: 51-10050

*** REFINE


*** SPLIT

correcting P... done
correcting Q... done

final TOC:
  track 1 {  data }
    index 00 { LBA: [  -150 ..     -1], length:    150, MSF: 00:00:00-00:01:74 }
    index 01 { LBA: [     0 .. 358328], length: 358329, MSF: 00:02:00-79:39:53 }
  track A {  data, dcp }
    index 01 { LBA: [358329 .. 358426], length:     98, MSF: 79:39:54-79:41:01 }

analyzing... done (time: 13s)

data disc detected, offset configuration: 
  LBA:  -1726 -> 461128, MSF: A2:30:28, count:   1576, offset: -272158164
  LBA:   -150 ->   -150, MSF: 00:00:00, count: 358577, offset: -12

non-zero  TOC sample range: [   -88200 .. +210697452]
non-zero data sample range: [   -43524 .. +210755046]
warning: non-zero data range is not continuous, skipping Universal Hash calculation

disc write offset: -12

warning: lead-in contains non-zero data (session: 1, sectors: 74/74)
checking tracks
done

writing tracks
done

CUE [dump_241213_002239_sr0.cue]:
FILE "dump_241213_002239_sr0.bin" BINARY
  TRACK 01 MODE1/2352
    INDEX 01 00:00:00


*** HASH (time check: 23s)

dat:
<rom name="dump_241213_002239_sr0 (Track 0).bin" size="174048" crc="03006b01" md5="8bd9fb5920bea70c460f149dbd89236c" sha1="9f2f75cee21421f6d51348f4424bdc0430aff917" />
<rom name="dump_241213_002239_sr0.bin" size="842789808" crc="3eba0fb1" md5="5adcf306b0de169dc332d8427e79245a" sha1="485e756abf57d8bf45a1b04f04712e049c51b9b2" />

*** INFO

CD-ROM [dump_241213_002239_sr0.bin]:
  sectors count: 358329
  mode1 sectors: 358329
  ECC errors: 577
  EDC errors: 577

  REDUMP.ORG errors: 577

ISO9660 [dump_241213_002239_sr0.bin]:
  volume identifier: Max Payne
  PVD:
0320 : 20 20 20 20 20 20 20 20  20 20 20 20 20 32 30 30                200
0330 : 31 30 37 31 34 31 36 33  37 30 34 30 30 00 32 30   1071416370400.20
0340 : 30 31 30 37 31 34 31 36  33 37 30 34 30 30 00 30   01071416370400.0
0350 : 30 30 30 30 30 30 30 30  30 30 30 30 30 30 30 00   000000000000000.
0360 : 30 30 30 30 30 30 30 30  30 30 30 30 30 30 30 30   0000000000000000
0370 : 00 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................

*** END (time check: 3s)
```

Matches [Max Payne](http://redump.org/disc/9819/) disc on http://redump.org

Closes #354494

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
