### PR TITLE
 python3Packages.basedmypy: init at 2.8.1 

### DIFF
--- a/pkgs/development/python-modules/basedmypy/default.nix
+++ b/pkgs/development/python-modules/basedmypy/default.nix
@@ -1,0 +1,133 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonAtLeast,
+  pythonOlder,
+  stdenv,
+
+  # build-system
+  setuptools,
+  types-psutil,
+  types-setuptools,
+
+  # propagates
+  basedtyping,
+  mypy-extensions,
+  tomli,
+  typing-extensions,
+
+  # optionals
+  lxml,
+  psutil,
+
+  # tests
+  attrs,
+  filelock,
+  pytest-xdist,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "basedmypy";
+  version = "2.8.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "KotlinIsland";
+    repo = "basedmypy";
+    tag = "v${version}";
+    hash = "sha256-scPIcUoay8cChiKNhaXcKjN5S5G7teGCakkaFMmAJlo=";
+  };
+
+  postPatch = ''
+    substituteInPlace \
+      pyproject.toml \
+      --replace-warn 'types-setuptools==' 'types-setuptools>='
+  '';
+
+  build-system = [
+    basedtyping
+    mypy-extensions
+    types-psutil
+    types-setuptools
+    typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+
+  dependencies = [
+    basedtyping
+    mypy-extensions
+    typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+
+  optional-dependencies = {
+    dmypy = [ psutil ];
+    reports = [ lxml ];
+  };
+
+  # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled
+  # version is also the default in the wheels on Pypi that include binaries.
+  # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
+  env.MYPY_USE_MYPYC = stdenv.buildPlatform.is64bit;
+
+  # when testing reduce optimisation level to reduce build time by 20%
+  env.MYPYC_OPT_LEVEL = 1;
+
+  pythonImportsCheck =
+    [
+      "mypy"
+      "mypy.api"
+      "mypy.fastparse"
+      "mypy.types"
+      "mypyc"
+      "mypyc.analysis"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isi686) [
+      # ImportError: cannot import name 'map_instance_to_supertype' from partially initialized module 'mypy.maptype' (most likely due to a circular import)
+      "mypy.report"
+    ];
+
+  nativeCheckInputs = [
+    attrs
+    filelock
+    pytest-xdist
+    pytestCheckHook
+    setuptools
+    tomli
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
+
+  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+    # cannot find distutils, and distutils cannot find types
+    # https://github.com/NixOS/nixpkgs/pull/364818#discussion_r1895715378
+    "test_c_unit_test"
+  ];
+
+  disabledTestPaths =
+    [
+      # fails to find typing_extensions
+      "mypy/test/testcmdline.py"
+      "mypy/test/testdaemon.py"
+      # fails to find setuptools
+      "mypyc/test/test_commandline.py"
+      # fails to find hatchling
+      "mypy/test/testpep561.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isi686 [
+      # https://github.com/python/mypy/issues/15221
+      "mypyc/test/test_run.py"
+    ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Based Python static type checker with baseline, sane default settings and based typing features";
+    homepage = "https://kotlinisland.github.io/basedmypy/";
+    changelog = "https://github.com/KotlinIsland/basedmypy/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "mypy";
+    maintainers = with lib.maintainers; [ perchun ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8595,6 +8595,8 @@ with pkgs;
 
   mypy-protobuf = with python3Packages; toPythonApplication mypy-protobuf;
 
+  basedmypy = with python3Packages; toPythonApplication basedmypy;
+
   ### DEVELOPMENT / LIBRARIES
 
   abseil-cpp_202103 = callPackage ../development/libraries/abseil-cpp/202103.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1506,6 +1506,8 @@ self: super: with self; {
 
   basedtyping = callPackage ../development/python-modules/basedtyping { };
 
+  basedmypy = callPackage ../development/python-modules/basedmypy { };
+
   baseline = callPackage ../development/python-modules/baseline { };
 
   baselines = callPackage ../development/python-modules/baselines { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/KotlinIsland/basedmypy: Based Python static type checker with baseline, sane default settings and based typing features 

~~Depends on #364817~~ merged

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
