### PR TITLE
gradle: add support for the new file events library

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,4 +1,4 @@
-{ jdk11, jdk17, jdk21 }:
+{ jdk17, jdk21 }:
 
 rec {
   gen =

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -104,7 +104,9 @@ rec {
 
       dontFixup = !stdenv.hostPlatform.isLinux;
 
-      fixupPhase = let arch = if stdenv.hostPlatform.is64bit then "amd64" else "i386";
+      fixupPhase = let
+        arch = if stdenv.hostPlatform.is64bit then "amd64" else "i386";
+        newFileEvents = toString (lib.versionAtLeast version "8.12");
       in ''
         . ${./patching.sh}
 
@@ -117,10 +119,17 @@ rec {
 
         # The file-events library _seems_ to follow the native-platform version, but
         # we won’t assume that.
-        fileEventsVersion="$(extractVersion file-events $out/lib/gradle/lib/file-events-*.jar)"
-        autoPatchelfInJar \
-          $out/lib/gradle/lib/file-events-linux-${arch}-''${fileEventsVersion}.jar \
-          "${lib.getLib stdenv.cc.cc}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+        if [ -n "${newFileEvents}" ]; then
+          fileEventsVersion="$(extractVersion gradle-fileevents $out/lib/gradle/lib/gradle-fileevents-*.jar)"
+          autoPatchelfInJar \
+            $out/lib/gradle/lib/gradle-fileevents-''${fileEventsVersion}.jar \
+            "${lib.getLib stdenv.cc.cc}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+        else
+          fileEventsVersion="$(extractVersion file-events $out/lib/gradle/lib/file-events-*.jar)"
+          autoPatchelfInJar \
+            $out/lib/gradle/lib/file-events-linux-${arch}-''${fileEventsVersion}.jar \
+            "${lib.getLib stdenv.cc.cc}/lib64:${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+        fi
 
         # The scanner doesn't pick up the runtime dependency in the jar.
         # Manually add a reference where it will be found.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8182,7 +8182,7 @@ with pkgs;
 
   gnumake = callPackage ../development/tools/build-managers/gnumake { };
   gradle-packages = import ../development/tools/build-managers/gradle {
-    inherit jdk11 jdk17 jdk21;
+    inherit jdk17 jdk21;
   };
   gradleGen = gradle-packages.gen;
   wrapGradle = callPackage gradle-packages.wrapGradle { };


### PR DESCRIPTION
Gradle 8.12 (currently in release candidate phase) switches from the old file-events library to a [new one](https://github.com/gradle/gradle-fileevents) that has a different name. The update is yet to land in Nixpkgs but this prepares us in advance.

I've tested that I can build Gradle 8.12 RC1 with this change by adding the following to `all-packages.nix`: 

```nix
gradle_8_12 = wrapGradle (callPackage (gradleGen { version = "8.12-rc-1"; hash = "sha256-TZ161M+IQvJ5ZJIT0vh9j36aA651rEOJUXqldLFASyo="; defaultJava = jdk23; }) {}) null;
```

I've also confirmed that Gradle 7 and 8 continue to build as before, I have `nixpkgs-review` still running just in case I've angered the gods somehow.

Looks like this PR will conflict with #356109 so I'm okay to wait it out if that is going to be merged soon.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
