### PR TITLE
sla2pdf: init at 0.0.1

### DIFF
--- a/pkgs/by-name/sl/sla2pdf/package.nix
+++ b/pkgs/by-name/sl/sla2pdf/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  scribus,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "sla2pdf";
+  version = "0.0.1-unstable-2023-05-17";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sla2pdf-team";
+    repo = "sla2pdf";
+    rev = "1524e6ca490da71eb201ff13bf32ef7206b0e4ef";
+    hash = "sha256-mvZ6Es8TLJmNwdacRJ3Gw5z0nI6xW1igz50yjIFBUds=";
+  };
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ scribus ]}"
+  ];
+
+  meta = {
+    description = "Convert Scribus SLA files to PDF from the command line";
+    homepage = "https://github.com/sla2pdf-team/sla2pdf";
+    license = with lib.licenses; [
+      cc-by-40
+      mpl20
+    ];
+    maintainers = with lib.maintainers; [ ob7 ];
+    mainProgram = "sla2pdf";
+  };
+}


### PR DESCRIPTION
This PR adds ```sla2pdf``` to nixpkgs

Converts Scribus .SLA files to PDF from command line

https://github.com/sla2pdf-team/sla2pdf
https://scribus.net

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
