### PR TITLE
bashrun2: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5860,6 +5860,12 @@
     githubId = 57304299;
     keys = [ { fingerprint = "33CD 5C0A 673C C54D 661E  5E4C 0DB5 361B EEE5 30AB"; } ];
   };
+  dopplerian = {
+    name = "Dopplerian";
+    github = "Dopplerian";
+    githubId = 53937537;
+    keys = [ { fingerprint = "BBC4 C071 516B A147 8D07  F9DC D2FD E6EC 2E8C 2BF4"; } ];
+  };
   doriath = {
     email = "tomasz.zurkowski@gmail.com";
     github = "doriath";

--- a/pkgs/by-name/ba/bashrun2/package.nix
+++ b/pkgs/by-name/ba/bashrun2/package.nix
@@ -1,0 +1,90 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  makeWrapper,
+  xorg,
+  ncurses,
+  coreutils,
+  bashInteractive,
+  gnused,
+  gnugrep,
+  glibc,
+  xterm,
+  util-linux,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bashrun2";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "hbekel";
+    repo = "bashrun2";
+    tag = "v${version}";
+    hash = "sha256-U2ntplhyv8KAkaMd2D6wRsUIYkhJzxdgHo2xsbNRfqM=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    xorg.libX11
+  ];
+
+  patches = [
+    ./remote-permissions.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace \
+      man/bashrun2.1 \
+      --replace-fail '/usr/bin/brwctl' "$out/bin/brwctl"
+
+    substituteInPlace \
+      src/bindings \
+      src/registry \
+      src/utils \
+      src/bashrun2 \
+      src/frontend \
+      src/remote \
+      src/plugin \
+      src/engine \
+      src/bookmarks \
+      --replace-fail '/bin/rm' '${coreutils}/bin/rm'
+
+    substituteInPlace \
+      src/bashrun2 \
+      --replace-fail '#!/usr/bin/env bash' '#!${lib.getExe bashInteractive}'
+
+    substituteInPlace \
+      src/remote \
+      --replace-fail '/bin/cp' '${coreutils}/bin/cp'
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/bashrun2 \
+      --prefix PATH : "$out/bin:${
+        lib.makeBinPath [
+          ncurses
+          coreutils
+          gnused
+          gnugrep
+          glibc
+          bashInteractive
+          xterm
+          util-linux
+        ]
+      }" \
+      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"
+  '';
+
+  meta = {
+    maintainers = with lib.maintainers; [ dopplerian ];
+    mainProgram = "bashrun2";
+    homepage = "http://henning-liebenau.de/bashrun2/";
+    license = lib.licenses.gpl2Plus;
+    description = "Application launcher based on a modified bash session in a small terminal window";
+  };
+}

--- a/pkgs/by-name/ba/bashrun2/remote-permissions.patch
+++ b/pkgs/by-name/ba/bashrun2/remote-permissions.patch
@@ -1,0 +1,12 @@
+diff --git a/src/remote b/src/remote
+index 07674ca..07a6b25 100644
+--- a/src/remote
++++ b/src/remote
+@@ -97,6 +97,7 @@ function §remote.interface.create {
+     local bookmarks="$bashrun_cache_home/remote-bookmarks.bash"
+ 
+     /bin/cp "$bashrun_site/interface" "$interface"
++    chmod +w "$interface"
+     printf '%s\n' "$bashrun_remote_interface" >> "$interface"
+ 
+     printf '%s\n' "source $bindings" >> "$interface"


### PR DESCRIPTION
This PR adds the `bashrun2` program, which is an application launcher based on a modified bash session in a small terminal window.

[Homepage](http://henning-liebenau.de/bashrun2/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
