### PR TITLE
hpack: 0.36.1 -> 0.37.0

### DIFF
--- a/pkgs/by-name/hp/hpack/package.nix
+++ b/pkgs/by-name/hp/hpack/package.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  haskell,
+  haskellPackages,
+}:
+let
+  hpack =
+    if
+      builtins.compareVersions haskellPackages.hpack.version haskellPackages.hpack_0_37_0.version < 0
+    then
+      haskellPackages.hpack_0_37_0
+    else
+      lib.warn "`hpack` is newer than `hpack_0_37_0`. Please remove the override in Nixpkgs: ${builtins.toPath ./package.nix}" haskellPackages.hpack;
+
+in
+haskell.lib.compose.justStaticExecutables hpack

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14142,8 +14142,6 @@ with pkgs;
 
   hovercraft = python3Packages.callPackage ../applications/misc/hovercraft { };
 
-  hpack = haskell.lib.compose.justStaticExecutables haskellPackages.hpack;
-
   hpmyroom = libsForQt5.callPackage ../applications/networking/hpmyroom { };
 
   hue-cli = callPackage ../tools/networking/hue-cli { };


### PR DESCRIPTION
The latest version of Haskell's `hpack` is 0.37.0. Increasingly `.cabal` files begin with a comment that causes Nixpkgs' `hpack` to reject them entirely:

```
-- This file has been generated from package.yaml by hpack version 0.37.0.
--
-- see: https://github.com/sol/hpack
```

```
$ hpack
shellwords.cabal was generated with a newer version of hpack, please upgrade and try again.
```

Unfortunately, `hpack`'s `--force` option does not override this error; you need to remove the `.cabal` file in question manually, which can be annoying in repositories with many `package.yaml` files.

Using the latest version of `hpack`, which is provided by Nixpkgs but not set as the default for unclear reasons. `hpack ==0.36.1` is listed as a constraint in
`pkgs/development/configuration-hackage2nix/stackage.yaml`, but `pkgs/development/haskell-modules/configuration-common.nix` makes sure to set `hpack = self.hpack_0_37_0` for Stack itself.

See: pkgs/test/haskell/upstreamStackHpackVersion/default.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
