### PR TITLE
tsm-client: 8.1.24.0 -> 8.1.25.0 (and update URLs)

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -75,7 +75,7 @@ let
     {
       freeformType = attrsOf (either scalarType (listOf scalarType));
       # Client system-options file directives are explained here:
-      # https://www.ibm.com/docs/en/storage-protect/8.1.24?topic=commands-processing-options
+      # https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=commands-processing-options
       options.servername = mkOption {
         type = servernameType;
         default = name;

--- a/nixos/modules/services/backup/tsm.nix
+++ b/nixos/modules/services/backup/tsm.nix
@@ -89,7 +89,7 @@ in
       environment.HOME = "/var/lib/tsm-backup";
       serviceConfig = {
         # for exit status description see
-        # https://www.ibm.com/docs/en/storage-protect/8.1.24?topic=clients-client-return-codes
+        # https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=clients-client-return-codes
         SuccessExitStatus = "4 8";
         # The `-se` option must come after the command.
         # The `-optfile` option suppresses a `dsm.opt`-not-found warning.

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -23,7 +23,7 @@
 
 # For an explanation of optional packages
 # (features provided by them, version limits), see
-# https://www.ibm.com/support/pages/node/660813#Version%208.1
+# https://web.archive.org/web/20240118051918/https://www.ibm.com/support/pages/node/660813#Version%208.1
 
 # IBM Tivoli Storage Manager Client uses a system-wide
 # client system-options file `dsm.sys` and expects it
@@ -46,24 +46,11 @@
 # depending on local configuration or usage; see:
 # https://www.ibm.com/docs/en/storage-protect/8.1.24?topic=solaris-set-api-environment-variables
 
-# The newest version of TSM client should be discoverable by
-# going to the `downloadPage` (see `meta` below).
-# Find the "Backup-archive client" table on that page.
-# Look for "Download Documents" of the latest release.
-# Follow the "Download Information" link.
-# Look for the "Linux x86_64 ..." rows in the table at
-# the bottom of the page and follow their "HTTPS" links (one
-# link per row -- each link might point to the latest release).
-# In the directory listings to show up,
-# check the big `.tar` file.
-#
-# (as of 2023-07-01)
-
 let
 
   meta = {
     homepage = "https://www.ibm.com/products/storage-protect";
-    downloadPage = "https://www.ibm.com/support/pages/ibm-storage-protect-downloads-latest-fix-packs-and-interim-fixes";
+    downloadPage = "https://www.ibm.com/support/fixcentral/swg/selectFixes?product=ibm/StorageSoftware/IBM+Spectrum+Protect";
     platforms = [ "x86_64-linux" ];
     mainProgram = "dsmc";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -44,7 +44,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/storage-protect/8.1.24?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=solaris-set-api-environment-variables
 
 let
 
@@ -91,10 +91,10 @@ let
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     name = "tsm-client-${finalAttrs.version}-unwrapped";
-    version = "8.1.24.0";
+    version = "8.1.25.0";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
-      hash = "sha512-TqTDE2oJK/Wu/MNYUCqxmOE6asAqDLz4GtdcFZuKqvfT8pJUCYKz9yjRPIrM3u2XfLH0wDq+Q8ER4ui680mswA==";
+      hash = "sha512-OPNjSMnWJ/8Ogy9O0wG0H4cEbYiOwyCVzkWhpG00v/Vm0LDxLzPteMnMOyH8L1egIDhy7lmQYSzI/EC4WWUDDA==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
*   Update some URLs (mainly comments) in the `tsm-client` package to adapt to new IBM website structure.
*   Update `tsm-client` to newest version, released today.

Note: The observation from https://github.com/NixOS/nixpkgs/pull/345039#issuecomment-2384475650 persists, but also still does not cause any problems as far as I can observe (see also https://github.com/NixOS/nixpkgs/pull/345039#issuecomment-2386770373).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] Both test derivations (cli and gui) build/pass.
- [x] Successfully tested with a real tsm-server: uploaded some files for backup without errors/problems.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
