### PR TITLE
shadow-launcher: init at 9.9.10132

### DIFF
--- a/pkgs/by-name/sh/shadow-launcher/package.nix
+++ b/pkgs/by-name/sh/shadow-launcher/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  pname = "shadow-launcher";
+  version = "9.9.10132";
+  channel = "prod";
+  src = fetchurl {
+    url = "https://update.shadow.tech/launcher/${channel}/linux/ubuntu_18.04/ShadowPC-${version}.AppImage";
+    hash = "sha256-evwt7S2jxyFq9Kmx4OvX4Kuabuq2fM2PWp3GI2YCe/c=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications/
+    install -Dm444 ${appimageContents}/${pname}.png -t $out/share/pixmaps/
+    substituteInPlace $out/share/applications/${pname}.desktop --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=${pname} %U'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      libinput
+      libva
+      xorg.libX11
+      xorg.libXau
+      xorg.libXdmcp
+    ];
+
+  meta = {
+    description = "Shadow PC is a cloud platform designed to provide users with access to high-performance Windows machine for gaming, creative work, and business applications.";
+    homepage = "https://shadow.tech/";
+    license = lib.licenses.unfree;
+    mainProgram = "shadow-launcher";
+    maintainers = with lib.maintainers; [ jacfal ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Shadow PC Cloud Workstation is Windows Virtual PC streamed from the cloud. Install your regular software, and work flawlessly from any device connected to the Internet.

https://shadow.tech/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
