### PR TITLE
librist: fix darwin

### DIFF
--- a/pkgs/by-name/li/librist/no-brew-darwin.diff
+++ b/pkgs/by-name/li/librist/no-brew-darwin.diff
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+index 05d00b3..b923958 100755
+--- a/meson.build
++++ b/meson.build
+@@ -39,7 +39,8 @@ deps = []
+ platform_files = []
+ inc = []
+ inc += include_directories('.', 'src', 'include/librist', 'include', 'contrib')
+-if (host_machine.system() == 'darwin')
++if (host_machine.system() == 'darwin'
++    and find_program('brew', required : false).found())
+ 	r = run_command('brew', '--prefix', check: true)
+ 	brewoutput = r.stdout().strip()
+ 	inc += include_directories(brewoutput + '/include')

--- a/pkgs/by-name/li/librist/package.nix
+++ b/pkgs/by-name/li/librist/package.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-xWqyQl3peB/ENReMcDHzIdKXXCYOJYbhhG8tcSh36dY=";
   };
 
-  patches = [
+  # avoid rebuild on Linux for now
+  patches = lib.optionals stdenv.isDarwin [
     # https://code.videolan.org/rist/librist/-/issues/192
     ./no-brew-darwin.diff
   ];

--- a/pkgs/by-name/li/librist/package.nix
+++ b/pkgs/by-name/li/librist/package.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-xWqyQl3peB/ENReMcDHzIdKXXCYOJYbhhG8tcSh36dY=";
   };
 
+  patches = [
+    # https://code.videolan.org/rist/librist/-/issues/192
+    ./no-brew-darwin.diff
+  ];
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
https://code.videolan.org/rist/librist/-/tags/v0.2.11 uses `brew` to augment the include path which breaks with nixpkgs

https://code.videolan.org/rist/librist/-/issues/192

https://github.com/NixOS/nixpkgs/pull/357091


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
