### PR TITLE
phpExtensions.redis: 6.0.2 -> 6.1.0

### DIFF
--- a/pkgs/development/php-packages/redis/default.nix
+++ b/pkgs/development/php-packages/redis/default.nix
@@ -3,11 +3,10 @@
   lib,
   php,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 let
-  version = "6.0.2";
+  version = "6.1.0";
 in
 buildPecl {
   inherit version;
@@ -17,28 +16,8 @@ buildPecl {
     repo = "phpredis";
     owner = "phpredis";
     rev = version;
-    hash = "sha256-Ie31zak6Rqxm2+jGXWg6KN4czHe9e+190jZRQ5VoB+M=";
+    hash = "sha256-zuvdWBJl6vBDnIAR0txfar1+c06VqGnwtobZnxok2uU=";
   };
-
-  patches = [
-    # Fix build with PHP 8.4.
-    (fetchpatch {
-      url = "https://github.com/phpredis/phpredis/commit/a51215ce2b22bcd1f506780c35b6833471e0b8cb.patch";
-      hash = "sha256-DoGPMyuI/IZdF+8jG5faoyG2aM+WDz0obH6S7HoOMX8=";
-    })
-
-    # Fix warning on Darwin.
-    (fetchpatch {
-      url = "https://github.com/phpredis/phpredis/commit/7de29d57d919f835f902f87a83312ed2549c1a13.patch";
-      hash = "sha256-INsSQTwcHQhQiqplAYQGS4zAtaIHWABG61MxnPCsrUM=";
-    })
-
-    # Fix build on Darwin.
-    (fetchpatch {
-      url = "https://github.com/phpredis/phpredis/commit/c139de3abac1dd33b97ef0de5af41b6e3a78f7ab.patch";
-      hash = "sha256-jM9N4ktGU5KAk81sZZJQmzV7y//39nVnfc52KqIvfpU=";
-    })
-  ];
 
   internalDeps = with php.extensions; [ session ];
 


### PR DESCRIPTION
Changes:
https://github.com/phpredis/phpredis/releases/tag/6.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 365053`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>php81Extensions.redis</li>
    <li>php82Extensions.redis</li>
    <li>php83Extensions.redis</li>
    <li>php84Extensions.redis</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
