### PR TITLE
lib.systems: introduce toolchain, cc, and bintools attributes

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -26,6 +26,7 @@ let
   platforms = import ./platforms.nix { inherit lib; };
   examples = import ./examples.nix { inherit lib; };
   architectures = import ./architectures.nix { inherit lib; };
+  toolchain = import ./toolchain.nix { inherit lib; };
 
   /**
     Elaborated systems contain functions, which means that they don't satisfy
@@ -83,6 +84,15 @@ let
       # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
       rust = args.rust or args.rustc or { };
 
+      toolchainSet = {
+        cc = toolchain.chooseComponent "cc" final;
+        bintools = toolchain.chooseComponent "bintools" final;
+        cxxlib = toolchain.chooseComponent "cxxlib" final;
+        cxxrtlib = toolchain.chooseComponent "cxxrtlib" final;
+        unwindlib = toolchain.chooseComponent "unwindlib" final;
+        rtlib = toolchain.chooseComponent "rtlib" final;
+      };
+
       final = {
         # Prefer to parse `config` as it is strictly more informative.
         parsed = parse.mkSystemFromString (args.config or allArgs.system);
@@ -116,6 +126,8 @@ let
           throw "2022-05-23: isCompatible has been removed in favor of canExecute, refer to the 22.11 changelog for details";
         # Derived meta-data
         useLLVM = final.isFreeBSD || final.isOpenBSD;
+        useArocc = false;
+        useZig = false;
 
         libc =
           if final.isDarwin then
@@ -413,6 +425,7 @@ let
       // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
       // args
+      // toolchainSet
       // {
         rust = rust // {
           # Once args.rustc.platform.target-family is deprecated and
@@ -569,6 +582,7 @@ let
     assert foldl (pass: { assertion, message }: if assertion final then pass else throw message) true (
       final.parsed.abi.assertions or [ ]
     );
+    assert toolchainSet == lib.mapAttrs (key: _: final.${key}) toolchainSet;
     final;
 
 in
@@ -585,6 +599,7 @@ in
     inspect
     parse
     platforms
+    toolchain
     systemToAttrs
     ;
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -93,6 +93,12 @@ rec {
     libc = "bionic";
     useAndroidPrebuilt = false;
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   pogoplug4 = {
@@ -370,6 +376,12 @@ rec {
     libc = "ucrt";
     rust.rustcTarget = "aarch64-pc-windows-gnullvm";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   # Target the MSVC ABI
@@ -388,11 +400,23 @@ rec {
   aarch64-freebsd = {
     config = "aarch64-unknown-freebsd";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   x86_64-freebsd = {
     config = "x86_64-unknown-freebsd";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   x86_64-netbsd = {
@@ -403,11 +427,23 @@ rec {
   x86_64-netbsd-llvm = {
     config = "x86_64-unknown-netbsd";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   x86_64-openbsd = {
     config = "x86_64-unknown-openbsd";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   #
@@ -417,12 +453,24 @@ rec {
   wasi32 = {
     config = "wasm32-unknown-wasi";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   wasm32-unknown-none = {
     config = "wasm32-unknown-none";
     rust.rustcTarget = "wasm32-unknown-unknown";
     useLLVM = true;
+    cc = "clang";
+    bintools = "llvm";
+    cxxlib = "libcxx";
+    cxxrtlib = "libcxxabi";
+    unwindlib = "libunwind";
+    rtlib = "compiler-rt";
   };
 
   # Ghcjs

--- a/lib/systems/toolchain.nix
+++ b/lib/systems/toolchain.nix
@@ -1,0 +1,87 @@
+{ lib }:
+let
+  inherit (lib)
+    isAttrs
+    ;
+
+  cc = {
+    llvm = "clang";
+    arocc = "arocc";
+    zig = "zig";
+    gnu = "gcc";
+    default = null;
+  };
+
+  bintools = {
+    llvm = "llvm";
+    gnu = "gnu";
+    default = null;
+  };
+
+  cxxlib = {
+    llvm = "libcxx";
+    gnu = "libstdcxx";
+    default = null;
+  };
+
+  cxxrtlib = {
+    llvm = "libcxxabi";
+    gnu = {
+      linux = "libsupcxx";
+      default = "libcxxrt";
+    };
+    default = null;
+  };
+
+  unwindlib = {
+    llvm = {
+      darwin = "libunwind-system";
+      default = "libunwind";
+    };
+    gnu = "libgcc";
+    default = null;
+  };
+
+  rtlib = {
+    llvm = "compiler-rt";
+    gnu = "libgcc";
+    default = null;
+  };
+
+  components = {
+    inherit
+      cc
+      bintools
+      cxxlib
+      cxxrtlib
+      unwindlib
+      rtlib
+      ;
+  };
+
+  getToolchain =
+    platform:
+    if platform.useLLVM || platform.useArocc || platform.useZig || platform.isDarwin then
+      "llvm"
+    else
+      # TODO: don't imply GNU when nothing else is specified.
+      # Return null once we allow toolchain attributes to be changed.
+      "gnu";
+
+  chooseComponent =
+    componentName: platform:
+    let
+      toolchain = getToolchain platform;
+
+      componentSet =
+        components."${componentName}"."${toolchain}" or components."${componentName}".default;
+    in
+    if isAttrs componentSet then
+      componentSet."${platform.parsed.kernel.name}" or componentSet.default
+    else
+      componentSet;
+in
+components
+// {
+  inherit chooseComponent;
+}

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -21,6 +21,9 @@ let
         abi = lib.systems.parse.abis.llvm;
       }
     );
+
+  toolchainAttrs = lib.attrNames (builtins.removeAttrs lib.systems.toolchain [ "chooseComponent" ]);
+  hostPlatform = builtins.removeAttrs stdenv.hostPlatform toolchainAttrs;
 in
 self: super: {
   pkgsLLVM = nixpkgsFun {
@@ -33,7 +36,7 @@ self: super: {
     # Bootstrap a cross stdenv using the LLVM toolchain.
     # This is currently not possible when compiling natively,
     # so we don't need to check hostPlatform != buildPlatform.
-    crossSystem = stdenv.hostPlatform // {
+    crossSystem = hostPlatform // {
       useLLVM = true;
       linker = "lld";
     };
@@ -49,7 +52,7 @@ self: super: {
     # Bootstrap a cross stdenv using the Aro C compiler.
     # This is currently not possible when compiling natively,
     # so we don't need to check hostPlatform != buildPlatform.
-    crossSystem = stdenv.hostPlatform // {
+    crossSystem = hostPlatform // {
       useArocc = true;
       linker = "lld";
     };
@@ -65,7 +68,7 @@ self: super: {
     # Bootstrap a cross stdenv using the Zig toolchain.
     # This is currently not possible when compiling natively,
     # so we don't need to check hostPlatform != buildPlatform.
-    crossSystem = stdenv.hostPlatform // {
+    crossSystem = hostPlatform // {
       useZig = true;
       linker = "lld";
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Replaces `useLLVM`, `useArocc`, and `useZig` with `toolchain`, `cc`, `linker`, and `bintools` attributes. This might not produce any rebuilds but we'll see. This has the advantage of preventing `using${compiler}` flags from colliding and not working correctly if we were to stack multiple `pkgs*` together.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
