### PR TITLE
Add default.nix for nemodex-usb-flasher

### DIFF
--- a/pkgs/applications/misc/nemodex-usb-flasher/default.nix
+++ b/pkgs/applications/misc/nemodex-usb-flasher/default.nix
@@ -1,0 +1,55 @@
+{ pkgs ? import (builtins.fetchTarball {
+  url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
+  sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
+}) {} }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "nemodex-usb-flasher";
+  version = "1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkgs.python3
+    pkgs.makeWrapper
+  ];
+
+  buildInputs = [
+    pkgs.python3Packages.tkinter
+    pkgs.python3Packages.psutil
+    pkgs.libglvnd
+    pkgs.qt5.qtbase
+    pkgs.qt5.qtx11extras
+    pkgs.xorg.libxcb
+    pkgs.xorg.libX11
+    pkgs.xorg.libXrender
+    pkgs.xorg.libXi
+    pkgs.xorg.libXtst
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/flasher.py $out/bin/
+    cp $src/nemodex-usb-flasher.sh $out/bin/
+    chmod +x $out/bin/flasher.py
+    chmod +x $out/bin/nemodex-usb-flasher.sh
+    ln -s $out/bin/nemodex-usb-flasher.sh $out/bin/nemodex-usb-flasher
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/nemodex-usb-flasher \
+      --prefix PYTHONPATH : ${pkgs.python3Packages.tkinter}/lib/python3.11/site-packages \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${pkgs.qt5.qtbase}/lib/qt-5.15/plugins \
+      --set QT_PLUGIN_PATH ${pkgs.qt5.qtbase}/lib/qt-5.15/plugins \
+      --set QT_QPA_PLATFORM xcb \
+      --set LD_LIBRARY_PATH ${pkgs.qt5.qtbase}/lib:${pkgs.xorg.libxcb}/lib:${pkgs.libglvnd}/lib:$LD_LIBRARY_PATH
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Nemodex USB Flasher";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maintainers.nemodex ];
+  };
+}

--- a/pkgs/applications/misc/nemodex-usb-flasher/default.nix
+++ b/pkgs/applications/misc/nemodex-usb-flasher/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import (builtins.fetchTarball {
   url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
   sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
-}) {} }:
+}) { } }:
 
 pkgs.stdenv.mkDerivation {
   pname = "nemodex-usb-flasher";
@@ -9,10 +9,7 @@ pkgs.stdenv.mkDerivation {
 
   src = ./.;
 
-  nativeBuildInputs = [
-    pkgs.python3
-    pkgs.makeWrapper
-  ];
+  nativeBuildInputs = [ pkgs.python3 pkgs.makeWrapper ];
 
   buildInputs = [
     pkgs.python3Packages.tkinter

--- a/pkgs/applications/misc/nemodex-usb-flasher/default.nix
+++ b/pkgs/applications/misc/nemodex-usb-flasher/default.nix
@@ -1,7 +1,9 @@
-{ pkgs ? import (builtins.fetchTarball {
-  url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
-  sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
-}) { } }:
+{
+  pkgs ? import (builtins.fetchTarball {
+    url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
+    sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
+  }) { },
+}:
 
 pkgs.stdenv.mkDerivation {
   pname = "nemodex-usb-flasher";
@@ -9,7 +11,10 @@ pkgs.stdenv.mkDerivation {
 
   src = ./.;
 
-  nativeBuildInputs = [ pkgs.python3 pkgs.makeWrapper ];
+  nativeBuildInputs = [
+    pkgs.python3
+    pkgs.makeWrapper
+  ];
 
   buildInputs = [
     pkgs.python3Packages.tkinter

--- a/pkgs/nemodex-usb-flasher/default.nix
+++ b/pkgs/nemodex-usb-flasher/default.nix
@@ -1,7 +1,9 @@
-{ pkgs ? import (builtins.fetchTarball {
-  url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
-  sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
-}) {} }:
+{
+  pkgs ? import (builtins.fetchTarball {
+    url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
+    sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
+  }) { },
+}:
 
 pkgs.stdenv.mkDerivation {
   pname = "nemodex-usb-flasher";

--- a/pkgs/nemodex-usb-flasher/default.nix
+++ b/pkgs/nemodex-usb-flasher/default.nix
@@ -1,0 +1,60 @@
+{ pkgs ? import (builtins.fetchTarball {
+  url = "https://nixos.org/channels/nixos-24.05/nixexprs.tar.xz";
+  sha256 = "06g8b0ga935dnziyzhxznwcx1vb2clc84hcxwrcqb26lgjgwsgbf";
+}) {} }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "nemodex-usb-flasher";
+  version = "1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkgs.python3
+    pkgs.makeWrapper
+  ];
+
+  buildInputs = [
+    pkgs.python3Packages.tkinter
+    pkgs.python3Packages.psutil
+    pkgs.libglvnd
+    pkgs.qt5.qtbase
+    pkgs.qt5.qtx11extras
+    pkgs.xorg.libxcb
+    pkgs.xorg.libX11
+    pkgs.xorg.libXrender
+    pkgs.xorg.libXi
+    pkgs.xorg.libXtst
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/flasher.py $out/bin/
+    cp $src/nemodex-usb-flasher.sh $out/bin/
+    chmod +x $out/bin/flasher.py
+    chmod +x $out/bin/nemodex-usb-flasher.sh
+    ln -s $out/bin/nemodex-usb-flasher.sh $out/bin/nemodex-usb-flasher
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/nemodex-usb-flasher \
+      --prefix PYTHONPATH : ${pkgs.python3Packages.tkinter}/lib/python3.11/site-packages \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${pkgs.qt5.qtbase}/lib/qt-5.15/plugins \
+      --set QT_PLUGIN_PATH ${pkgs.qt5.qtbase}/lib/qt-5.15/plugins \
+      --set QT_QPA_PLATFORM xcb \
+      --set LD_LIBRARY_PATH ${pkgs.qt5.qtbase}/lib:${pkgs.xorg.libxcb}/lib:${pkgs.libglvnd}/lib:$LD_LIBRARY_PATH
+  '';
+
+  shellHook = ''
+    # Run the flasher script when entering the shell
+    $out/bin/nemodex-usb-flasher
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Nemodex USB Flasher";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maintainers.nemodex ];
+  };
+}

--- a/pkgs/nemodex-usb-flasher/flasher.py
+++ b/pkgs/nemodex-usb-flasher/flasher.py
@@ -1,0 +1,111 @@
+#!/nix/store/zv1kaq7f1q20x62kbjv6pfjygw5jmwl6-python3-3.12.7/bin/python3
+
+import tkinter as tk
+from tkinter import simpledialog, filedialog, messagebox
+import subprocess
+import os
+import json
+
+class FlasherApp:
+    def __init__(self, root):
+        print("Initializing FlasherApp...")  # Debug
+        self.root = root
+        self.root.title("NemoDex USB Flasher")
+        self.root.configure(bg='black')
+
+        self.create_widgets()
+        print("FlasherApp initialized.")  # Debug
+
+    def create_widgets(self):
+        print("Creating widgets...")  # Debug
+        # ISO Label
+        self.iso_label = tk.Label(self.root, text="No ISO file selected", bg='black', fg='#CFA34D')
+        self.iso_label.pack(pady=10)
+
+        # Browse ISO Button
+        self.browse_button = tk.Button(self.root, text="Browse ISO", command=self.open_file_dialog, bg='#CFA34D', fg='black')
+        self.browse_button.pack(pady=10)
+
+        # USB Drive Label
+        self.usb_label = tk.Label(self.root, text="Select USB Drive:", bg='black', fg='#CFA34D')
+        self.usb_label.pack(pady=10)
+
+        # USB Drive Dropdown
+        self.usb_combobox = tk.Listbox(self.root, bg='#CFA34D', fg='black')
+        self.update_usb_drives()
+        self.usb_combobox.pack(pady=10)
+
+        # Flash Button
+        self.flash_button = tk.Button(self.root, text="Flash ISO to USB", command=self.flash_iso, bg='#CFA34D', fg='black')
+        self.flash_button.pack(pady=10)
+
+        # Status Label
+        self.status_label = tk.Label(self.root, text="", bg='black', fg='#CFA34D')
+        self.status_label.pack(pady=10)
+        print("Widgets created.")  # Debug
+
+    def open_file_dialog(self):
+        iso_path = filedialog.askopenfilename(filetypes=[("ISO files", "*.iso")])
+        if iso_path:
+            self.iso_label.config(text=iso_path)
+
+    def update_usb_drives(self):
+        print("Updating USB drives...")  # Debug
+        self.usb_combobox.delete(0, tk.END)  # Clear the listbox
+
+        # Use lsblk to detect removable USB drives
+        try:
+            result = subprocess.run(['lsblk', '-o', 'NAME,TRAN,MOUNTPOINT', '-J'], capture_output=True, text=True, check=True)
+            devices = json.loads(result.stdout)
+            for device in devices['blockdevices']:
+                if device['tran'] == 'usb':
+                    # Check if any of the partitions are mounted
+                    mounted_partitions = [child for child in device.get('children', []) if child['mountpoint']]
+                    if mounted_partitions:
+                        usb_partition = f"/dev/{mounted_partitions[0]['name']}"
+                        print(f"Detected mounted USB partition: {usb_partition} with mountpoint {mounted_partitions[0]['mountpoint']}")  # Debug
+                        self.usb_combobox.insert(tk.END, usb_partition)
+        except subprocess.CalledProcessError as e:
+            print(f"Error detecting USB drives: {e}")  # Debug
+
+        print("USB drives updated.")  # Debug
+
+    def flash_iso(self):
+        print("Starting flash process...")  # Debug
+        iso_path = self.iso_label.cget("text")
+        usb_drive = self.usb_combobox.get(tk.ACTIVE)
+        if not iso_path or iso_path == "No ISO file selected":
+            messagebox.showwarning("Warning", "Please select an ISO file.")
+            return
+        if not usb_drive:
+            messagebox.showwarning("Warning", "Please select a USB drive.")
+            return
+
+        # Prompt for the sudo password
+        password = simpledialog.askstring("Password", "Enter your sudo password:", show='*')
+        if not password:
+            messagebox.showwarning("Warning", "Please enter your password to proceed.")
+            return
+
+        self.status_label.config(text="Flashing...")
+        self.root.update_idletasks()
+
+        # Execute the flashing process
+        try:
+            print(f"Unmounting {usb_drive}...")  # Debug
+            subprocess.run(['sudo', '-S', 'umount', usb_drive], input=f"{password}\n", text=True, check=True)
+            print(f"Writing ISO to {usb_drive}...")  # Debug
+            subprocess.run(['sudo', '-S', 'dd', f'if={iso_path}', f'of={usb_drive}', 'bs=4M', 'status=progress', 'conv=fsync'], input=f"{password}\n", text=True, check=True)
+            print("Flashing complete.")  # Debug
+            self.status_label.config(text="Flashing complete!")
+        except subprocess.CalledProcessError as e:
+            print(f"Flashing failed: {e}")  # Debug
+            self.status_label.config(text="Flashing failed!")
+            messagebox.showerror("Error", f"Flashing failed: {e}")
+
+if __name__ == "__main__":
+    print("Starting application...")  # Debug
+    root = tk.Tk()
+    app = FlasherApp(root)
+    root.mainloop()
+    print("Application started.")  # Debug

--- a/pkgs/nemodex-usb-flasher/nemodex-usb-flasher.sh
+++ b/pkgs/nemodex-usb-flasher/nemodex-usb-flasher.sh
@@ -1,0 +1,28 @@
+#!/run/current-system/sw/bin/bash
+
+# Source the profile to ensure environment variables are correctly set
+source /etc/profile
+
+# Debugging information
+echo "Running in $(pwd)"
+echo "Current shell: $SHELL"
+echo "User: $USER"
+echo "Home directory: $HOME"
+echo "Hostname: $(hostname)"
+echo "Date: $(date)"
+echo "Script directory: $(dirname "$(realpath "$0")")"
+echo "Files in script directory: $(ls -l $(dirname "$(realpath "$0")"))"
+echo "Environment variables:"
+env
+
+# Get the directory of the current script
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Check if the Python script exists
+if [ ! -f "$SCRIPT_DIR/flasher.py" ]; then
+  echo "Error: Python script not found at $SCRIPT_DIR/flasher.py"
+  exit 1
+fi
+
+# Ensure `tkinter` and `lsblk` are available in the Nix environment and run the script
+nix-shell --pure -p bash python3 python3Packages.tkinter util-linux --run "bash -c 'which lsblk; python3 $SCRIPT_DIR/flasher.py'"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10359,6 +10359,8 @@ with pkgs;
     };
 
   ndi = callPackage ../development/libraries/ndi { };
+  
+  nemodex-usb-flasher = callPackage ../pkgs/nemodex-usb-flasher {};
 
   nettle = import ../development/libraries/nettle { inherit callPackage fetchurl; };
 


### PR DESCRIPTION
<!-- Added nemodex-usb-flasher as new package for Linux-based systems.
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
--> NemoDex USB Flasher (nemodex-usb-flasher) is a USB flashing tool similar to Rufus or Balena Etcher. A user may choose a .iso file, a mounted USB device, and enter their 'sudo' password to flash the image onto the USB. Running 'nemodex-usb-flasher' in the CLI launches this tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
