### PR TITLE
cryptpad: add missing `x2t.js`

### DIFF
--- a/pkgs/by-name/cr/cryptpad/package.nix
+++ b/pkgs/by-name/cr/cryptpad/package.nix
@@ -1,11 +1,13 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
+  fetchurl,
   lib,
   makeBinaryWrapper,
   nixosTests,
   nodejs,
   rdfind,
+  unzip,
 }:
 
 let
@@ -59,6 +61,17 @@ let
     }
   ];
 
+  x2t_version = "v7.3+1";
+  x2t = fetchurl {
+    url = "https://github.com/cryptpad/onlyoffice-x2t-wasm/releases/download/${x2t_version}/x2t.zip";
+    hash = "sha256-hrbxrI8RC1pBatGZ76TAiVfUbZid7+eRuXk6lmz7OgQ=";
+  };
+  x2t_install = ''
+    local X2T_DIR=$out_cryptpad/www/common/onlyoffice/dist/x2t
+    unzip ${x2t} -d "$X2T_DIR"
+    echo "${x2t_version}" > "$X2T_DIR"/.version
+  '';
+
 in
 buildNpmPackage {
   inherit version;
@@ -76,6 +89,7 @@ buildNpmPackage {
   nativeBuildInputs = [
     makeBinaryWrapper
     rdfind
+    unzip
   ];
 
   patches = [
@@ -106,6 +120,7 @@ buildNpmPackage {
     # install OnlyOffice (install-onlyoffice.sh without network)
     mkdir -p "$out_cryptpad/www/common/onlyoffice/dist"
     ${lib.concatMapStringsSep "\n" onlyoffice_install onlyoffice_versions}
+    ${x2t_install}
     rdfind -makehardlinks true -makeresultsfile false "$out_cryptpad/www/common/onlyoffice/dist"
 
     # cryptpad assumes it runs in the source directory and also outputs


### PR DESCRIPTION
This dependency is necessary for cryptpad to convert between various document formats. I ran into this when trying to import a `.xlsx` file into cryptpad.

This code was inspired by the [`install_x2t` function in upstream's `install-onlyoffice.sh` script](https://github.com/cryptpad/cryptpad/blob/2024.9.1/install-onlyoffice.sh#L37).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
