### PR TITLE
python3Packages.dirsearch: enable tests & misc fixes

### DIFF
--- a/pkgs/development/python-modules/dirsearch/default.nix
+++ b/pkgs/development/python-modules/dirsearch/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   python,
+  pytestCheckHook,
   # deps
   /*
     ntlm-auth is in the requirements.txt, however nixpkgs tells me
@@ -50,6 +51,9 @@ buildPythonPackage rec {
       --replace-fail 'shutil.copytree(os.path.abspath(os.getcwd()), os.path.join(env_dir, "dirsearch"))' ""
   '';
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   dependencies = [
     # maybe needed, see above
     #pyspnego
@@ -84,9 +88,34 @@ buildPythonPackage rec {
     cp -r $src/db $dirsearchpath/dirsearch
   '';
 
+  # tests
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  disabledTestPaths = [
+    # needs network?
+    "tests/reports/test_reports.py"
+  ];
+  disabledTests = [
+    # failing for unknown reason
+    "test_detect_scheme"
+  ];
+  pythonRemoveDeps = [
+    # not available, see above
+    "ntlm-auth"
+  ];
+  pythonRelaxDeps = [
+    # version checker doesn't recognize 0.8.0.rc2 as >=0.7.0
+    "defusedxml"
+    # probably not but we don't have old charset-normalizer versions in nixpkgs
+    # and requests also depends on it so we can't just override it with an
+    # older version due to package duplication
+    "charset-normalizer"
+  ];
+
   meta = {
     changelog = "https://github.com/maurosoria/dirsearch/releases/tag/${version}";
-    description = "command-line tool for brute-forcing directories and files in webservers, AKA a web path scanner";
+    description = "Command-line tool for brute-forcing directories and files in webservers, AKA a web path scanner";
     homepage = "https://github.com/maurosoria/dirsearch";
     license = lib.licenses.gpl2Only;
     mainProgram = "dirsearch";


### PR DESCRIPTION
In #350550 i added dirsearch, and some people suggested changes right after it was merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
