### PR TITLE
mcpelauncher-{client,ui-qt}: init at 1.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15044,6 +15044,12 @@
     githubId = 92527083;
     name = "Morten Munk";
   };
+  morxemplum = {
+    email = "morxemplum@outlook.com";
+    github = "Morxemplum";
+    githubId = 44561540;
+    name = "Synth Morxemplum";
+  };
   MostAwesomeDude = {
     email = "cds@corbinsimpson.com";
     github = "MostAwesomeDude";

--- a/pkgs/by-name/mc/mcpelauncher-client/dont_download_glfw_client.patch
+++ b/pkgs/by-name/mc/mcpelauncher-client/dont_download_glfw_client.patch
@@ -1,0 +1,25 @@
+diff --git a/ext/glfw.cmake b/ext/glfw.cmake
+index 5487f32..feeb89f 100644
+--- a/ext/glfw.cmake
++++ b/ext/glfw.cmake
+@@ -1,18 +1,2 @@
+-include(FetchContent)
+-
+-set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+-set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+-set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+-
+-FetchContent_Declare(
+-        glfw3_ext
+-        URL "https://github.com/minecraft-linux/glfw/archive/fce9121962bc0a21c39e2d6f8e08bad30c566c72.zip"
+-)
+-
+-FetchContent_GetProperties(glfw3_ext)
+-if(NOT glfw3_ext_POPULATED)
+-  FetchContent_Populate(glfw3_ext)
+-  add_subdirectory(${glfw3_ext_SOURCE_DIR} ${glfw3_ext_BINARY_DIR})
+-endif()
++find_package(glfw3 REQUIRED)
+ add_library(glfw3 ALIAS glfw)
+\ No newline at end of file

--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  openssl,
+  zlib,
+  libpng,
+  libglvnd,
+  xorg,
+  libevdev,
+  curl,
+  pulseaudio,
+  qt6,
+  glfw,
+  withQtWebview ? true,
+  withQtErrorWindow ? true,
+  fetchzip,
+}:
+
+# gcc doesn't support __has_feature
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "mcpelauncher-client";
+  version = "1.1.2-qt6";
+
+  # NOTE: check mcpelauncher-ui-qt when updating
+  src = fetchFromGitHub {
+    owner = "minecraft-linux";
+    repo = "mcpelauncher-manifest";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-PmCq6Zgtp17UV0kIbNouFwj/DMiTqwE31+tTb2LUp5o=";
+  };
+
+  patches = [
+    ./dont_download_glfw_client.patch
+    # These are upcoming changes that have been merged upstream. Once these get in a release, remove these patches.
+    (fetchpatch {
+      url = "https://github.com/minecraft-linux/game-window/commit/feea8c0e0720eea7093ed95745c17f36d6c40671.diff";
+      hash = "sha256-u4uveoKwwklEooT+i+M9kZ0PshjL1IfWhlltmulsQJo=";
+      stripLen = 1;
+      extraPrefix = "game-window/";
+    })
+    (fetchpatch {
+      url = "https://github.com/minecraft-linux/mcpelauncher-client/commit/db9c31e46d7367867c85a0d0aba42c8144cdf795.diff";
+      hash = "sha256-za/9oZYwKCYyZ1BXQ/zeEjRy81B1NpTlPHEfWAOtzHk=";
+      stripLen = 1;
+      extraPrefix = "mcpelauncher-client/";
+    })
+  ];
+
+  # FORTIFY_SOURCE breaks libc_shim and the project will fail to compile
+  hardeningDisable = [ "fortify" ];
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals (withQtWebview || withQtErrorWindow) [
+      qt6.wrapQtAppsHook
+    ];
+
+  buildInputs =
+    [
+      openssl
+      zlib
+      libpng
+      libglvnd
+      xorg.libX11
+      xorg.libXi
+      xorg.libXtst
+      libevdev
+      curl
+      pulseaudio
+      glfw
+    ]
+    ++ lib.optionals (withQtWebview || withQtErrorWindow) [
+      qt6.qtbase
+      qt6.qttools
+      qt6.qtwayland
+    ]
+    ++ lib.optionals withQtWebview [
+      qt6.qtwebengine
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_NLOHMANN_JSON_EXT" (
+      toString (fetchzip {
+        url = "https://github.com/nlohmann/json/releases/download/v3.7.3/include.zip";
+        hash = "sha256-h8czZ4f5vZqvHkDVQawrQdUeQnWxewu4OONisqlrmmM=";
+        stripRoot = false;
+      })
+    ))
+    (lib.cmakeBool "USE_OWN_CURL" false)
+    (lib.cmakeBool "ENABLE_DEV_PATHS" false)
+    (lib.cmakeFeature "GAMEWINDOW_SYSTEM" "GLFW")
+    (lib.cmakeBool "USE_SDL3_AUDIO" false)
+    (lib.cmakeBool "BUILD_WEBVIEW" withQtWebview)
+    (lib.cmakeBool "XAL_WEBVIEW_USE_CLI" (!withQtWebview))
+    (lib.cmakeBool "XAL_WEBVIEW_USE_QT" withQtWebview)
+    (lib.cmakeBool "ENABLE_QT_ERROR_UI" withQtErrorWindow)
+  ];
+
+  meta = {
+    description = "Unofficial Minecraft Bedrock Edition launcher with CLI";
+    homepage = "https://minecraft-linux.github.io";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      aleksana
+      morxemplum
+    ];
+    mainProgram = "mcpelauncher-client";
+    platforms = lib.platforms.unix;
+    # Minecraft Bedrock Edition is raising minimal OpenGL version to OpenGL ES 3.1
+    # which is currently not supported on macOS.
+    # https://github.com/minecraft-linux/mcpelauncher-manifest/issues/1042
+    # https://help.minecraft.net/hc/en-us/articles/30298767427597-Upcoming-OS-Sunset-Announcements-in-Minecraft
+    # The program is also not tested on darwin. Any help from darwin users are welcomed.
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/dont_download_glfw_ui.patch
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/dont_download_glfw_ui.patch
@@ -1,0 +1,24 @@
+diff -urB mcpelauncher-ui/mcpelauncher-ui-qt/ext/glfw.cmake mcpelauncher-ui-b/mcpelauncher-ui-qt/ext/glfw.cmake
+--- mcpelauncher-ui/mcpelauncher-ui-qt/ext/glfw.cmake	2024-11-28 21:12:36.794926431 -0700
++++ mcpelauncher-ui-b/mcpelauncher-ui-qt/ext/glfw.cmake	2024-12-03 15:04:28.466197081 -0700
+@@ -1,19 +1,2 @@
+-include(FetchContent)
+-
+-set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+-set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+-set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+-set(GLFW_BUILD_WAYLAND OFF CACHE BOOL "" FORCE)
+-
+-FetchContent_Declare(
+-        glfw3_ext
+-        URL "https://github.com/glfw/glfw/archive/master.zip"
+-)
+-
+-FetchContent_GetProperties(glfw3_ext)
+-if(NOT glfw3_ext_POPULATED)
+-  FetchContent_Populate(glfw3_ext)
+-  add_subdirectory(${glfw3_ext_SOURCE_DIR} ${glfw3_ext_BINARY_DIR})
+-endif()
++find_package(glfw3 REQUIRED)
+ add_library(glfw3 ALIAS glfw)

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  mcpelauncher-client,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  zlib,
+  libzip,
+  curl,
+  protobuf,
+  qt6,
+  glfw,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcpelauncher-ui-qt";
+  inherit (mcpelauncher-client) version;
+
+  src = fetchFromGitHub {
+    owner = "minecraft-linux";
+    repo = "mcpelauncher-ui-manifest";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-R9wE1lS7x1IIPgVahXjF5Yg2ca+GsiQuF41pWf2edXY=";
+  };
+
+  patches = [
+    ./dont_download_glfw_ui.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    zlib
+    libzip
+    curl
+    protobuf
+    qt6.qtwebengine
+    qt6.qtsvg
+    qt6.qtwayland
+    glfw
+  ];
+
+  # the program refuses to start when QT_STYLE_OVERRIDE is set
+  # https://github.com/minecraft-linux/mcpelauncher-ui-qt/issues/25
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ mcpelauncher-client ]}
+      --unset QT_STYLE_OVERRIDE
+    )
+  '';
+
+  meta = mcpelauncher-client.meta // {
+    description = "Unofficial Minecraft Bedrock Edition launcher with GUI";
+    mainProgram = "mcpelauncher-ui-qt";
+  };
+})


### PR DESCRIPTION
Closes #231875.

This is a second attempt at introducing mcpelauncher to nixpkgs, after the previous attempt (#232256) wasn't merged as work stopped being done on it.

I was able to take @Aleksanaa's changes and freshen them up to the latest version, fixing the issues she ran into along the way.

### Main changes since previous pull request
- Brought the package up to the latest release (1.1.2)
- GLFW is no longer optional, and SDL is completely abandoned in this package
    - GLFW is now the main game-window frontend
    - Ensure that Nix's GLFW is used
- Added native wayland support
    - Fixed some issues with relative scaling in regards to fractional scaling
- Fixed the audio issues present by re-enabling an experimental PulseAudio backend
- Upgraded from Qt5 to Qt6

### badPlatforms = lib.platforms.darwin

Minecraft is planning on [updating their graphics minimum requirements](https://help.minecraft.net/hc/en-us/articles/30298767427597-Upcoming-OS-Sunset-Announcements-in-Minecraft) to OpenGL ES 3.1, something that the upstream package [does not support for macOS](https://github.com/minecraft-linux/mcpelauncher-manifest/issues/1042#issuecomment-2367388410) as it only does OpenGL ES 3.0 through emulation. This change takes effect starting March 2025. I don't know if the maintainer has any plans on upgrading to keep supporting macOS, but for right now I am deciding to not worry about darwin support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
