### PR TITLE
[staging-next] nodejs_18: fix test-os failure

### DIFF
--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -65,5 +65,15 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-6y3aEqxNC4iTQEv1oewodJrhOHxjp5xZMq1P1QL94Rg=";
     })
+    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
+    # FIXME: remove after a minor point release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
+      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
+      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
+    })
   ] ++ gypPatches;
 }


### PR DESCRIPTION
Same as #356257 and #359526. Must have missed this version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (still running)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).