### PR TITLE
firefox-unwrapped: re-enable elf-hack with LTO/LLD, disable with musl

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -408,7 +408,7 @@ buildStdenv.mkDerivation {
      "--enable-lto=cross" # Cross-Language LTO
      "--enable-linker=lld"
   ]
-  ++ lib.optional (isElfhackPlatform stdenv) (if elfhackSupport then ["--enable-elf-hack"] else ["--disable-elf-hack"])
+  ++ lib.optional (isElfhackPlatform stdenv) (enableFeature elfhackSupport "elf-hack")
   ++ lib.optional (!drmSupport) "--disable-eme"
   ++ lib.optional (allowAddonSideload) "--allow-addon-sideload"
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -25,6 +25,10 @@ let
   # Rename the variables to prevent infinite recursion
   requireSigningDefault = requireSigning;
   allowAddonSideloadDefault = allowAddonSideload;
+
+  # Specifying --(dis|en)able-elf-hack on a platform for which it's not implemented will give `--disable-elf-hack is not available in this configuration`
+  # This is declared here because it's used in the default value of elfhackSupport
+  isElfhackPlatform = stdenv: stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64;
 in
 
 { lib
@@ -110,6 +114,7 @@ in
 , jemallocSupport ? !stdenv.hostPlatform.isMusl, jemalloc
 , ltoSupport ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.is64bit && !stdenv.hostPlatform.isRiscV), overrideCC, buildPackages
 , pgoSupport ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform), xvfb-run
+, elfhackSupport ? isElfhackPlatform stdenv && !(stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isAarch64)
 , pipewireSupport ? waylandSupport && webrtcSupport
 , pulseaudioSupport ? stdenv.hostPlatform.isLinux, libpulseaudio
 , sndioSupport ? stdenv.hostPlatform.isLinux, sndio
@@ -160,6 +165,7 @@ in
 
 assert stdenv.cc.libc or null != null;
 assert pipewireSupport -> !waylandSupport || !webrtcSupport -> throw "${pname}: pipewireSupport requires both wayland and webrtc support.";
+assert elfhackSupport -> isElfhackPlatform stdenv;
 
 let
   inherit (lib) enableFeature;
@@ -402,9 +408,7 @@ buildStdenv.mkDerivation {
      "--enable-lto=cross" # Cross-Language LTO
      "--enable-linker=lld"
   ]
-  # elf-hack is broken when using clang+lld:
-  # https://bugzilla.mozilla.org/show_bug.cgi?id=1482204
-  ++ lib.optional (ltoSupport && (buildStdenv.hostPlatform.isAarch32 || buildStdenv.hostPlatform.isi686 || buildStdenv.hostPlatform.isx86_64)) "--disable-elf-hack"
+  ++ lib.optional (isElfhackPlatform stdenv) (if elfhackSupport then ["--enable-elf-hack"] else ["--disable-elf-hack"])
   ++ lib.optional (!drmSupport) "--disable-eme"
   ++ lib.optional (allowAddonSideload) "--allow-addon-sideload"
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [


### PR DESCRIPTION
The elfhack was completely revamped and is now implemented with the "relrhack", which is compatible with LLD:
https://glandium.org/blog/?p=4297

Exposes a new option elfhackSupport and sets reasonable default based on testing:

|arch |libc  |lto |elfhack |works|
|---------|------|----|--------|-|
|x86_64   |glibc |0   |0       |1|
|x86_64   |glibc |0   |1       |1|
|x86_64   |glibc |1   |0       |1|
|x86_64   |glibc |1   |1       |1|
|x86_64   |musl  |0   |0       |1|
|x86_64   |musl  |0   |1       |1|
|x86_64   |musl  |1   |0       |1|
|x86_64   |musl  |1   |1       |1|
|aarch64  |glibc |0   |0       |1|
|aarch64  |glibc |0   |1       |1|
|aarch64  |glibc |1   |0       |1|
|aarch64  |glibc |1   |1       |1|
|aarch64  |musl  |0   |0       |1|
|aarch64  |musl  |0   |1       |Segmentation Fault|
|aarch64  |musl  |1   |0       |1|
|aarch64  |musl  |1   |1       |Segmentation Fault|
|riscv64  |glibc |0   |0       |?|
|riscv64  |glibc |0   |1       |Configure error: --enable-elf-hack is not available in this configuration|
|riscv64  |glibc |1   |0       |?|
|riscv64  |glibc |1   |1       |Configure error: --enable-elf-hack is not available in this configuration|


Change-Id: I687d4ee68a8e836e5c51a1fde0d28d019c0c66b9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
