### PR TITLE
nixos/weechat: Rework module

### DIFF
--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -12,6 +12,8 @@ in
   options.services.weechat = {
     enable = lib.mkEnableOption "weechat";
 
+    package = lib.mkPackageOption pkgs "weechat" { };
+
     root = lib.mkOption {
       description = "Weechat state directory.";
       type = lib.types.path;
@@ -27,9 +29,9 @@ in
     binary = lib.mkOption {
       type = lib.types.path;
       description = "Binary to execute.";
-      default = "${pkgs.weechat}/bin/weechat";
-      defaultText = lib.literalExpression ''"''${pkgs.weechat}/bin/weechat"'';
-      example = lib.literalExpression ''"''${pkgs.weechat}/bin/weechat-headless"'';
+      default = "${cfg.package}/bin/weechat";
+      defaultText = lib.literalExpression ''"''${cfg.package}/bin/weechat"'';
+      example = lib.literalExpression ''"''${cfg.package}/bin/weechat-headless"'';
     };
   };
 

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -14,7 +14,7 @@ in
 
     root = lib.mkOption {
       description = "Weechat state directory.";
-      type = lib.types.str;
+      type = lib.types.path;
       default = "/var/lib/weechat";
     };
 

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -44,10 +44,22 @@ in
       };
     };
 
+    systemd.tmpfiles.settings."weechat" = {
+      "${cfg.root}" = lib.mkIf (cfg.root != "/var/lib/weechat") {
+        d = {
+          user = "weechat";
+          group = "weechat";
+          mode = "750";
+        };
+      };
+    };
+
     systemd.services.weechat = {
       serviceConfig = {
         User = "weechat";
         Group = "weechat";
+        StateDirectory = lib.mkIf (cfg.root == "/var/lib/weechat") "weechat";
+        StateDirectoryMode = 750;
         RemainAfterExit = "yes";
       };
       script = "exec ${config.security.wrapperDir}/screen -Dm -S ${cfg.sessionName} ${cfg.binary} --dir ${cfg.root}";

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -37,9 +37,7 @@ in
     users = {
       groups.weechat = { };
       users.weechat = {
-        createHome = true;
         group = "weechat";
-        home = cfg.root;
         isSystemUser = true;
       };
     };

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -45,13 +45,12 @@ in
     };
 
     systemd.services.weechat = {
-      environment.WEECHAT_HOME = cfg.root;
       serviceConfig = {
         User = "weechat";
         Group = "weechat";
         RemainAfterExit = "yes";
       };
-      script = "exec ${config.security.wrapperDir}/screen -Dm -S ${cfg.sessionName} ${cfg.binary}";
+      script = "exec ${config.security.wrapperDir}/screen -Dm -S ${cfg.sessionName} ${cfg.binary} --dir ${cfg.root}";
       wantedBy = [ "multi-user.target" ];
       wants = [ "network.target" ];
     };

--- a/nixos/modules/services/misc/weechat.nix
+++ b/nixos/modules/services/misc/weechat.nix
@@ -4,23 +4,26 @@
   pkgs,
   ...
 }:
+
 let
   cfg = config.services.weechat;
 in
-
 {
   options.services.weechat = {
     enable = lib.mkEnableOption "weechat";
+
     root = lib.mkOption {
       description = "Weechat state directory.";
       type = lib.types.str;
       default = "/var/lib/weechat";
     };
+
     sessionName = lib.mkOption {
       description = "Name of the `screen` session for weechat.";
       default = "weechat-screen";
       type = lib.types.str;
     };
+
     binary = lib.mkOption {
       type = lib.types.path;
       description = "Binary to execute.";


### PR DESCRIPTION
See commit messages for descriptions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
