### PR TITLE
ci/eval: allow precisely choosing which systems to evaluate for (evalSystem -> evalSystems)

### DIFF
--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -5,14 +5,16 @@ The code in this directory is used by the [eval.yml](../../.github/workflows/eva
 Furthermore it also allows local evaluation using
 ```
 nix-build ci -A eval.full \
-  --max-jobs 4
-  --cores 2
-  --arg chunkSize 10000
+  --max-jobs 4 \
+  --cores 2 \
+  --arg chunkSize 10000 \
+  --arg evalSystems '["x86_64-linux" "aarch64-darwin"]'
 ```
 
 - `--max-jobs`: The maximum number of derivations to run at the same time. Only each [supported system](../supportedSystems.nix) gets a separate derivation, so it doesn't make sense to set this higher than that number.
 - `--cores`: The number of cores to use for each job. Recommended to set this to the amount of cores on your system divided by `--max-jobs`.
 - `chunkSize`: The number of attributes that are evaluated simultaneously on a single core. Lowering this decreases memory usage at the cost of increased evaluation time. If this is too high, there won't be enough chunks to process them in parallel, and will also increase evaluation time.
+- `evalSystems`: The set of systems for which `nixpkgs` should be evaluated. Defaults to the four official platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`).
 
 A good default is to set `chunkSize` to 10000, which leads to about 3.6GB max memory usage per core, so suitable for fully utilising machines with 4 cores and 16GB memory, 8 cores and 32GB memory or 16 cores and 64GB memory.
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -259,14 +259,13 @@ let
 
   full =
     {
-      # Whether to evaluate just a single system, by default all are evaluated
-      evalSystem ? if quickTest then "x86_64-linux" else null,
+      # Whether to evaluate on a specific set of systems, by default all are evaluated
+      evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
       # The number of attributes per chunk, see ./README.md for more info.
       chunkSize,
       quickTest ? false,
     }:
     let
-      systems = if evalSystem == null then supportedSystems else [ evalSystem ];
       results = linkFarm "results" (
         map (evalSystem: {
           name = evalSystem;
@@ -274,7 +273,7 @@ let
             inherit quickTest evalSystem chunkSize;
             attrpathFile = attrpathsSuperset + "/paths.json";
           };
-        }) systems
+        }) evalSystems
       );
     in
     combine {


### PR DESCRIPTION
## Things done

This makes the `ci.eval.full` derivation more flexible.
Currently, a user can either evaluate for all platforms (the default) or a single specific one, by providing `evalSystem`.
This is uselessly too constraining.
This PR replaces `evalSystem` with `evalSystems` that directly accepts a list of platforms to evaluate on.

**Motivation:** Leveraging the new eval derivation in [nixpkgs-review](https://github.com/Mic92/nixpkgs-review).

cc @infinisil @Mic92

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
