### PR TITLE
python312Packages.nox: apply backport for wntrblm/nox#903

### DIFF
--- a/pkgs/development/python-modules/nox/default.nix
+++ b/pkgs/development/python-modules/nox/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage rec {
     hash = "sha256-GdNz34A8IKwPG/270sY5t3SoggGCZMWfDq/Wyhk0ez8=";
   };
 
+  patches = [
+    # Backport of https://github.com/wntrblm/nox/pull/903, which can be removed on next release
+    ./fix-broken-mock-on-cpython-3.12.8.patch
+  ];
+
   build-system = [ hatchling ];
 
   dependencies =

--- a/pkgs/development/python-modules/nox/fix-broken-mock-on-cpython-3.12.8.patch
+++ b/pkgs/development/python-modules/nox/fix-broken-mock-on-cpython-3.12.8.patch
@@ -1,0 +1,35 @@
+diff --git a/nox/command.py b/nox/command.py
+index 671875c..4984168 100644
+--- a/nox/command.py
++++ b/nox/command.py
+@@ -30,6 +30,8 @@ TYPE_CHECKING = False
+ if TYPE_CHECKING:
+     from typing import IO
+ 
++_PLATFORM = sys.platform
++
+ ExternalType = Literal["error", True, False]
+ 
+ 
+@@ -63,7 +65,7 @@ def _clean_env(env: Mapping[str, str | None] | None = None) -> dict[str, str] |
+     clean_env = {k: v for k, v in env.items() if v is not None}
+ 
+     # Ensure systemroot is passed down, otherwise Windows will explode.
+-    if sys.platform == "win32":
++    if _PLATFORM.startswith("win"):
+         clean_env.setdefault("SYSTEMROOT", os.environ.get("SYSTEMROOT", ""))
+ 
+     return clean_env
+diff --git a/tests/test_command.py b/tests/test_command.py
+index ae398e9..904cf34 100644
+--- a/tests/test_command.py
++++ b/tests/test_command.py
+@@ -157,7 +157,7 @@ def test_run_env_remove(monkeypatch):
+     )
+ 
+ 
+-@mock.patch("sys.platform", "win32")
++@mock.patch("nox.command._PLATFORM", "win32")
+ def test_run_env_systemroot():
+     systemroot = os.environ.setdefault("SYSTEMROOT", "sigil")
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A backported patch for https://github.com/wntrblm/nox/pull/903 (original patch fails due to other changes) , which fixes the failing test for https://hydra.nixos.org/build/281191188/nixlog/1

ref: https://github.com/NixOS/nixpkgs/pull/361878


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
