### PR TITLE
genemichaels: apply patch to only write files if changed

### DIFF
--- a/pkgs/by-name/ge/genemichaels/genemichaels-only-write-if-changed.patch
+++ b/pkgs/by-name/ge/genemichaels/genemichaels-only-write-if-changed.patch
@@ -1,0 +1,20 @@
+diff --git a/crates/genemichaels/src/main.rs b/crates/genemichaels/src/main.rs
+index 724b38a..2fb23d0 100644
+--- a/crates/genemichaels/src/main.rs
++++ b/crates/genemichaels/src/main.rs
+@@ -348,10 +348,11 @@ impl FormatPool {
+                     log.log_with(loga::INFO, "Skipping due to skip comment", ea!());
+                     return Ok(());
+                 }
+-                fs::write(
+-                    &file,
+-                    process_file_contents(log, &config, &source).context("Error doing formatting")?.as_bytes(),
+-                ).context("Error writing formatted code back")?;
++                let processed = process_file_contents(log, &config, &source).context("Error doing formatting")?;
++                if source != processed {
++                    log.log_with(loga::INFO, "Writing newly file", ea!());
++                    fs::write(&file, processed.as_bytes()).context("Error writing formatted code back")?;
++                }
+                 return Ok(());
+             }).stack_context(log, "Error formatting file");
+             match res {

--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -15,6 +15,14 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-qPyIC9AbRQI+inBft7Dd5R5v+tXtJcZdiV4lBIBwpyM=";
   };
 
+  patches = [
+    # TODO(@djacu): remove this if this patch is merged and the version is
+    # bumped to a release that has this change
+    # See: https://github.com/andrewbaxter/genemichaels/issues/95
+    # See: https://github.com/andrewbaxter/genemichaels/pull/96
+    ./genemichaels-only-write-if-changed.patch
+  ];
+
   cargoHash = "sha256-yPxgYf8N3Dqns/uKhdM++jpzG7zTPhCVVq+7WA9G/SM=";
 
   cargoBuildFlags = [ "--package ${pname}" ];


### PR DESCRIPTION
When formatting rust files with `genemichaels`, the timestamp of the file is always modified whether or not the file was changed. This is problematic for detecting whether a file has been reformatted or not, such as when using tools such as `pre-commit`, `treefmt`, and `treefmt-nix`.

See the following:
https://github.com/andrewbaxter/genemichaels/issues/95
https://github.com/andrewbaxter/genemichaels/pull/96
https://github.com/numtide/treefmt-nix/pull/277


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
