### PR TITLE
python3Packages.ttfautohint-py: fix Darwin build

### DIFF
--- a/pkgs/development/python-modules/ttfautohint-py/default.nix
+++ b/pkgs/development/python-modules/ttfautohint-py/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -24,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/python/ttfautohint/__init__.py \
-      --replace-fail 'find_library("ttfautohint")' '"${lib.getLib ttfautohint}/lib/libttfautohint.so"'
+      --replace-fail 'find_library("ttfautohint")' '"${lib.getLib ttfautohint}/lib/libttfautohint${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 
   env.TTFAUTOHINTPY_BUNDLE_DLL = false;


### PR DESCRIPTION
Simple change to fix Darwin build.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).