### PR TITLE
nixos/biboumi + biboumi: fixup module + make optional libraries optional

### DIFF
--- a/nixos/modules/services/networking/biboumi.nix
+++ b/nixos/modules/services/networking/biboumi.nix
@@ -64,10 +64,13 @@ in
             '';
           };
           options.db_name = lib.mkOption {
-            type = with lib.types; either path str;
+            type = with lib.types; nullOr (either path str);
             default = "${stateDir}/biboumi.sqlite";
             description = ''
               The name of the database to use.
+
+              Set it to null and use [credentialsFile](#opt-services.biboumi.credentialsFile)
+              if you do not want this connection string to go into the Nix store.
             '';
             example = "postgresql://user:secret@localhost";
           };

--- a/nixos/modules/services/networking/biboumi.nix
+++ b/nixos/modules/services/networking/biboumi.nix
@@ -26,7 +26,8 @@ in
 
       settings = lib.mkOption {
         description = ''
-          See [biboumi 8.5](https://lab.louiz.org/louiz/biboumi/blob/8.5/doc/biboumi.1.rst)
+          See [biboumi 9.0](https://doc.biboumi.louiz.org/9.0/admin.html#configuration)
+
           for documentation.
         '';
         default = { };

--- a/nixos/modules/services/networking/biboumi.nix
+++ b/nixos/modules/services/networking/biboumi.nix
@@ -22,6 +22,8 @@ in
     services.biboumi = {
       enable = lib.mkEnableOption "the Biboumi XMPP gateway to IRC";
 
+      package = lib.mkPackageOption pkgs "biboumi" { };
+
       settings = lib.mkOption {
         description = ''
           See [biboumi 8.5](https://lab.louiz.org/louiz/biboumi/blob/8.5/doc/biboumi.1.rst)
@@ -118,7 +120,7 @@ in
           };
           options.policy_directory = lib.mkOption {
             type = lib.types.path;
-            default = "${pkgs.biboumi}/etc/biboumi";
+            default = "${cfg.package}/etc/biboumi";
             defaultText = lib.literalExpression ''"''${pkgs.biboumi}/etc/biboumi"'';
             description = ''
               A directory that should contain the policy files,
@@ -208,7 +210,7 @@ in
             ''
           )
         ];
-        ExecStart = "${pkgs.biboumi}/bin/biboumi /run/biboumi/biboumi.cfg";
+        ExecStart = "${lib.getExe cfg.package} /run/biboumi/biboumi.cfg";
         ExecReload = "${pkgs.coreutils}/bin/kill -USR1 $MAINPID";
         # Firewalls needing opening for output connections can still do that
         # selectively for biboumi with:

--- a/pkgs/by-name/bi/biboumi/package.nix
+++ b/pkgs/by-name/bi/biboumi/package.nix
@@ -6,15 +6,24 @@
   cmake,
   libuuid,
   expat,
-  sqlite,
-  libidn,
   libiconv,
   botan2,
   systemd,
   pkg-config,
-  udns,
   python3Packages,
+  withIDN ? true,
+  libidn,
+  withPostgreSQL ? false,
+  postgresql,
+  withSQLite ? true,
+  sqlite,
+  withUDNS ? true,
+  udns,
 }:
+
+assert lib.assertMsg (
+  withPostgreSQL || withSQLite
+) "At least one Biboumi database provider required";
 
 let
   louiz_catch = fetchgit {
@@ -39,16 +48,18 @@ stdenv.mkDerivation rec {
     pkg-config
     python3Packages.sphinx
   ];
-  buildInputs = [
-    libuuid
-    expat
-    sqlite
-    libiconv
-    libidn
-    botan2
-    systemd
-    udns
-  ];
+  buildInputs =
+    [
+      libuuid
+      expat
+      libiconv
+      systemd
+      botan2
+    ]
+    ++ lib.optional withIDN libidn
+    ++ lib.optional withPostgreSQL postgresql
+    ++ lib.optional withSQLite sqlite
+    ++ lib.optional withUDNS udns;
 
   buildFlags = [
     "all"


### PR DESCRIPTION
Some of these libraries are entirely optional (but recommended) according to the documentation. PostgreSQL support wasn’t even added to Nixpkgs despite technically the NixOS module allowing it.

Note that Botan2, I was not able to get the GCrypt fallback to work

fixes Nixpkgs issue #365336 on proprietary, privacy-invasive Microsoft GitHub

Additionally, touched on some issues with the NixOS module

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
