### PR TITLE
[24.11] Backport gnome updates/fixes

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -72,7 +72,7 @@ let
     }
     ++ cfg.flashback.customSessions;
 
-  notExcluded = pkg: mkDefault (!(lib.elem pkg config.environment.gnome.excludePackages));
+  notExcluded = pkg: mkDefault (!(lib.elem (lib.getName pkg) (map lib.getName config.environment.gnome.excludePackages)));
 
 in
 

--- a/pkgs/by-name/gj/gjs/package.nix
+++ b/pkgs/by-name/gj/gjs/package.nix
@@ -164,6 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "JavaScript bindings for GNOME";
     homepage = "https://gitlab.gnome.org/GNOME/gjs/blob/master/doc/Home.md";
     license = licenses.lgpl2Plus;
+    mainProgram = "gjs";
     maintainers = teams.gnome.members;
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -74,11 +74,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "47.1.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BR/UBXFX9LIzcBP778luPRKWVOP8lg1ISdNUJSQAvnc=";
+    hash = "sha256-Q0oyLcN0OFi4nYFl2J+J3AWWi2t740AJRM7UJxJQ0+k=";
   };
 
   patches = [
@@ -151,9 +151,6 @@ stdenv.mkDerivation (finalAttrs: {
     # For animations in Mouse panel.
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
-    # vp9alphadecodebin, observed from GST_DEBUG="*:3" warnings.
-    # https://github.com/NixOS/nixpkgs/pull/333911#issuecomment-2409233470
-    gst_all_1.gst-plugins-bad
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -200,9 +200,6 @@ stdenv.mkDerivation (finalAttrs: {
       # WM keyboard shortcuts
       --prefix XDG_DATA_DIRS : "${mutter}/share"
     )
-    for i in $out/share/applications/*; do
-      substituteInPlace $i --replace "Exec=gnome-control-center" "Exec=$out/bin/gnome-control-center"
-    done
   '';
 
   separateDebugInfo = true;

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-initial-setup";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-initial-setup/${lib.versions.major finalAttrs.version}/gnome-initial-setup-${finalAttrs.version}.tar.xz";
-    hash = "sha256-KTeKVkQG7Lzn8IzzklqA3TCCWoQ/kfzwWF45mecDUw0=";
+    hash = "sha256-T00Y61YnXMVqGZOlofTRPVpkJoad5nCWuS8rKcryIjw=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -25,6 +25,7 @@
   libadwaita,
   geocode-glib_2,
   tzdata,
+  writeText,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -66,6 +67,13 @@ stdenv.mkDerivation (finalAttrs: {
     librest_1_0
     libsecret
     libsoup_3
+  ];
+
+  mesonFlags = [
+    "--cross-file=${writeText "crossfile.ini" ''
+      [binaries]
+      gjs = '${lib.getExe gjs}'
+    ''}"
   ];
 
   preCheck = ''

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -68,16 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     libsoup_3
   ];
 
-  postPatch = ''
-    # The .service file isn't wrapped with the correct environment
-    # so misses GIR files when started. By re-pointing from the gjs
-    # entry point to the wrapped binary we get back to a wrapped
-    # binary.
-    substituteInPlace "data/org.gnome.Maps.service.in" \
-      --replace-fail "Exec=@pkgdatadir@/@app-id@" \
-                     "Exec=$out/bin/gnome-maps"
-  '';
-
   preCheck = ''
     # “time.js” included by “timeTest” and “translationsTest” depends on “org.gnome.desktop.interface” schema.
     export XDG_DATA_DIRS="${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:$XDG_DATA_DIRS"

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -76,6 +76,16 @@ stdenv.mkDerivation (finalAttrs: {
     ''}"
   ];
 
+  postPatch = ''
+    # The .service file isn't wrapped with the correct environment
+    # so misses GIR files when started. By re-pointing from the gjs
+    # entry point to the wrapped binary we get back to a wrapped
+    # binary.
+    substituteInPlace "data/org.gnome.Maps.service.in" \
+      --replace-fail "Exec=@pkgdatadir@/@app-id@" \
+                     "Exec=$out/bin/gnome-maps"
+  '';
+
   preCheck = ''
     # “time.js” included by “timeTest” and “translationsTest” depends on “org.gnome.desktop.interface” schema.
     export XDG_DATA_DIRS="${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:$XDG_DATA_DIRS"

--- a/pkgs/by-name/gn/gnome-music/package.nix
+++ b/pkgs/by-name/gn/gnome-music/package.nix
@@ -31,13 +31,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "47.0";
+  version = "47.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-music/${lib.versions.major version}/gnome-music-${version}.tar.xz";
-    hash = "sha256-o1Qjz1IgX9cDfLCpprVw9uwvHjQubiDtfn2A2NyGpyY=";
+    hash = "sha256-Zm8XX1YKGtnLq2HqDzA5PKL+0pRrpG5cAOrqEX28cNA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-network-displays/package.nix
+++ b/pkgs/by-name/gn/gnome-network-displays/package.nix
@@ -29,11 +29,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-network-displays";
-  version = "0.93.0";
+  version = "0.94.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-network-displays/${lib.versions.majorMinor finalAttrs.version}/gnome-network-displays-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-xxvR8zR+Yglo0e9HRrSFPbgEriYpcRN5K0SXg/D0Oo4=";
+    sha256 = "sha256-FzNaA2Our7gb8FgEmYjRtphGVcQt3pw+wQNyLHtKI4M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts-gtk";
-  version = "3.50.4";
+  version = "3.50.5";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "gnome-online-accounts-gtk";
     rev = finalAttrs.version;
-    hash = "sha256-kgDeAH6Dj4+23dW649JR0XwvDqTiz5Tknsc4IfpQFWM=";
+    hash = "sha256-E4gZsPLOCK15xG5MiwN5sNQs/3KEkzC57I5moqcGy20=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.52.1";
+  version = "3.52.2";
 
   outputs =
     [
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-N8dSL/lFT4NxtahyW7p27XQwyVsfnvx/66YmjwUtHrc=";
+    hash = "sha256-+0E/SN7vu5/DACqRV53ulHzu7UH0nC9RMXr3SJtnb2c=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-panel/package.nix
+++ b/pkgs/by-name/gn/gnome-panel/package.nix
@@ -45,16 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./modulesdir-env-var.patch
   ];
 
-  # make .desktop Exec absolute
-  postPatch = ''
-    patch -p0 <<END_PATCH
-    +++ gnome-panel/gnome-panel.desktop.in
-    @@ -7 +7 @@
-    -Exec=gnome-panel
-    +Exec=$out/bin/gnome-panel
-    END_PATCH
-  '';
-
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gnome-menus}/share"

--- a/pkgs/by-name/gn/gnome-panel/wrapper.nix
+++ b/pkgs/by-name/gn/gnome-panel/wrapper.nix
@@ -54,9 +54,8 @@ stdenv.mkDerivation {
 
     rm $out/share/applications/gnome-panel.desktop
 
-    substitute ${gnome-panel}/share/applications/gnome-panel.desktop \
-      $out/share/applications/gnome-panel.desktop --replace \
-      "Exec=${gnome-panel}/bin/gnome-panel" "Exec=$out/bin/gnome-panel"
+    ln -s ${gnome-panel}/share/applications/gnome-panel.desktop \
+      $out/share/applications/gnome-panel.desktop
 
     runHook postInstall
   '';

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -31,11 +31,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-BG0Py4m4jQskaczTUGPbW0KkUfkHEbU/H6OrFJGsGN4=";
+    hash = "sha256-k1HdjDns5wUMlny9zr4WYrwmuP2pJPioCpsqMS0H9HE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-secrets/package.nix
+++ b/pkgs/by-name/gn/gnome-secrets/package.nix
@@ -18,7 +18,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-secrets";
-  version = "9.6";
+  version = "10.3";
   format = "other";
 
   src = fetchFromGitLab {
@@ -26,7 +26,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "secrets";
     rev = version;
-    hash = "sha256-iF2AQYAwwIr/sCZUz1pdqEa74DH4y4Nts6aJj3mS2f4=";
+    hash = "sha256-UcTLngBVp5L8Y1LmBxoxPuH5Zag2YfHA2Y+ByPBkh8A=";
   };
 
   nativeBuildInputs = [
@@ -55,7 +55,7 @@ python3Packages.buildPythonApplication rec {
     pyotp
     validators
     yubico
-    zxcvbn
+    zxcvbn-rs-py
   ];
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -42,11 +42,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-8qrL5V+jjocIWD7sCmZRBJ5TfrUFo+0s4Lqk6bZCRtE=";
+    hash = "sha256-HrdYhi6Ij1WghpGTCH8c+8x6EWNlTmMAmf9DQt0/alo=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6UOMxdOfmHXf0E6gq7UeWWLqrVwgJ0EjJDsWEgmLOoU=";
+    hash = "sha256-3XdKApFYSRer3oi7xOzPkkQXjjwmnOBhjQSVF3wSZS0=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -70,7 +70,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "47.1";
+  version = "47.2";
 
   outputs = [
     "out"
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-tGdXX4wVnSBVclhRfw3Wjf0BR9EbSNl6uOH3CbxSKmM=";
+    hash = "sha256-QYTQGhq4LLQh0couK8zgKSzrRsTHSeYbC95LdQBNLgA=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "47.0";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-0G2H/NcmqQ7QOhcMq0XUcIlJkeMSkS/FCL3g37yDz9o=";
+    hash = "sha256-2b8IuabChNHgT2/pI3pt7trRYeDlungQv/7PKF4rzd8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-share/package.nix
+++ b/pkgs/by-name/gn/gnome-user-share/package.nix
@@ -21,11 +21,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-share";
-  version = "47.0";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-share/${lib.versions.major finalAttrs.version}/gnome-user-share-${finalAttrs.version}.tar.xz";
-    hash = "sha256-yELzUv5/Dw6hj/kYa6lIK2yQ0vazZau1sR1oyQbbpJA=";
+    hash = "sha256-H6wbuIAN+kitnD4ZaQ9+EOZ6T5lNnLF8rh0b3/yRRLo=";
   };
 
   preConfigure = ''

--- a/pkgs/by-name/gn/gnome-weather/package.nix
+++ b/pkgs/by-name/gn/gnome-weather/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     # entry point to the wrapped binary we get back to a wrapped
     # binary.
     substituteInPlace "data/org.gnome.Weather.service.in" \
-        --replace-fail "Exec=@DATA_DIR@/@APP_ID@" "Exec=gnome-weather"
+        --replace-fail "Exec=@DATA_DIR@/@APP_ID@" "Exec=$out/bin/gnome-weather"
 
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py

--- a/pkgs/by-name/gn/gnome-weather/package.nix
+++ b/pkgs/by-name/gn/gnome-weather/package.nix
@@ -55,8 +55,7 @@ stdenv.mkDerivation rec {
     # entry point to the wrapped binary we get back to a wrapped
     # binary.
     substituteInPlace "data/org.gnome.Weather.service.in" \
-        --replace "Exec=@DATA_DIR@/@APP_ID@" \
-                  "Exec=$out/bin/gnome-weather"
+        --replace-fail "Exec=@DATA_DIR@/@APP_ID@" "Exec=gnome-weather"
 
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py

--- a/pkgs/by-name/gt/gtranslator/package.nix
+++ b/pkgs/by-name/gt/gtranslator/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtranslator";
-  version = "47.0";
+  version = "47.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-duEEHF77Coi6GHZOpFiLThll+lAxTgGhc/o+oBUOHNU=";
+    hash = "sha256-yRwCZLmpnjCR75EfcxqP9tCahKK8115WUZcdprvqYiI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lo/localsearch/package.nix
+++ b/pkgs/by-name/lo/localsearch/package.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "localsearch";
-  version = "3.8.0";
+  version = "3.8.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/localsearch/${lib.versions.majorMinor finalAttrs.version}/localsearch-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5Og6Ha67UmORW0W3GXMeP3BB2VnL1jfqKa++kQySu/k=";
+    hash = "sha256-p7JKTweAXfdUOk3QI2hPzeXuaZygDrWwkSOgSdOuzNg=";
   };
 
   patches = [

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "47.1";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-9gNWmpThcwHy2sNLAsEsbY48pq65vmq1uYM5P5Ve2Ho=";
+    hash = "sha256-bgRu/k965X7idI1S0dBzVsdEnSBKPTHQtCNnqAGXShU=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -1,6 +1,5 @@
 {
   fetchurl,
-  fetchpatch,
   runCommand,
   lib,
   stdenv,
@@ -69,7 +68,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "47.1";
+  version = "47.3";
 
   outputs = [
     "out"
@@ -80,22 +79,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-kFR0oyzZmzQ0LNaedLsBlxs4fi+iI2G22ZrdEJQJ3ck=";
+    hash = "sha256-dkIa9vkFCc/fGrhR1e5YJx4n6Uqo99tSHVqgba6mxWA=";
   };
-
-  patches = [
-    # Fix cursor positioning
-    # https://gitlab.gnome.org/GNOME/mutter/-/issues/3696
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/5bcaa7c80b7640e2da6135cdff83eba77c202407.patch";
-      hash = "sha256-+LDTZRagBltarGvHtTI94mA70DrkonuqA+ibLkjvZ50=";
-    })
-  ];
 
   mesonFlags = [
     "-Degl_device=true"
     "-Dinstalled_tests=false" # TODO: enable these
     "-Dtests=disabled"
+    # For NVIDIA proprietary driver up to 470.
+    # https://src.fedoraproject.org/rpms/mutter/pull-request/49
     "-Dwayland_eglstream=true"
     "-Dprofiler=true"
     "-Dxwayland_path=${lib.getExe xwayland}"

--- a/pkgs/by-name/ne/networkmanager-vpnc/package.nix
+++ b/pkgs/by-name/ne/networkmanager-vpnc/package.nix
@@ -3,7 +3,6 @@
 , fetchurl
 , substituteAll
 , vpnc
-, intltool
 , pkg-config
 , networkmanager
 , libsecret
@@ -20,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "NetworkManager-vpnc";
-  version = "1.2.8";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager-vpnc/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1l4xqlPI/cP95++EpNqpeaYFwj/THO/2R79+qqma+8w=";
+    sha256 = "47KpiIAnWht1FUvDF6eGQ8/fnqfnDfTu2WSPKeolNzA=";
   };
 
   patches = [
@@ -35,7 +34,6 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    intltool
     pkg-config
     file
   ];

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -34,7 +34,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.78.1";
+  version = "0.78.2";
 
   outputs = [
     "out"
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "vte";
     rev = finalAttrs.version;
-    hash = "sha256-dVCvf4eTIJlrSzG6xLdKU47N9uAtHDwRrGkWtSmqbEU=";
+    hash = "sha256-ZUECInBRNYkXJtGveLq8SR6YdWqJA0y9UJSxmc8mVNk=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonApplication rec {
   pname = "gnome-extensions-cli";
-  version = "0.10.3";
+  version = "0.10.4";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "gnome_extensions_cli";
     inherit version;
-    hash = "sha256-Z4MbiWB9IoRIsgH5ZGKnCh327FzGtOsW5vpjJ1ZAfTs=";
+    hash = "sha256-S+kSVvWVbg/ATaF0xacPeUnu84Xx2ot6AOLmdGQIeWo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonApplication rec {
   pname = "gnome-extensions-cli";
-  version = "0.10.2";
+  version = "0.10.3";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "gnome_extensions_cli";
     inherit version;
-    hash = "sha256-AoZINsx2DhjcMwbllF3ypjo/y/3BjOFxcjZOyUGKp7c=";
+    hash = "sha256-Z4MbiWB9IoRIsgH5ZGKnCh327FzGtOsW5vpjJ1ZAfTs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This patch set is made by manually cherry-picking these commits, if
they applied cleanly:

  git log --no-merges --oneline --grep=gnome $(git merge-base origin/master origin/release-24.11)..origin/master

Commit 785f561ddc30fdadf3fb2bccbecc348d5024602b
("gnome: replace alias with throw") was deliberately skipped, as I
think it is intended for the next NixOS release.

And then some were dropped as they had more dependencies (with conflicts), or would cause known regressions (as pointed out in code review).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
