### PR TITLE
libthreadar: fix build on Darwin

### DIFF
--- a/pkgs/by-name/li/libthreadar/package.nix
+++ b/pkgs/by-name/li/libthreadar/package.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wJAkIUGK7Ud6n2p1275vNkSx/W7LlgKWXQaDevetPko=";
   };
 
+  postPatch = ''
+    # this field is not present on Darwin, ensure it is zero everywhere
+    substituteInPlace src/thread_signal.cpp \
+      --replace-fail 'sigac.sa_restorer = nullptr;' "" \
+      --replace-fail 'struct sigaction sigac;' 'struct sigaction sigac = {0};'
+  '';
+
   outputs = [
     "out"
     "dev"


### PR DESCRIPTION
Simple fix, see e.g. https://github.com/google/honggfuzz/issues/18 for the same issue reported elsewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).