### PR TITLE
taterclient-ddnet: fix tests, enable strictDeps, cleanup

### DIFF
--- a/pkgs/by-name/ta/taterclient-ddnet/package.nix
+++ b/pkgs/by-name/ta/taterclient-ddnet/package.nix
@@ -27,6 +27,7 @@
   glslang,
   spirv-tools,
   gtest,
+  glew,
   apple-sdk_11,
 }:
 let
@@ -55,34 +56,34 @@ stdenv.mkDerivation (finalAttrs: {
     rustc
     cargo
     rustPlatform.cargoSetupHook
+    glslang # for glslangValidator
+    python3
   ];
 
   nativeCheckInputs = [ gtest ];
+  checkInputs = [ gtest ];
 
-  buildInputs =
-    [
-      curl
-      libnotify
-      pcre
-      python3
-      sqlite
-      freetype
-      libGLU
-      libogg
-      opusfile
-      SDL2
-      wavpack
-      ffmpeg
-      x264
-      vulkan-loader
-      vulkan-headers
-      glslang
-      spirv-tools
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ libX11 ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_11
-    ];
+  buildInputs = [
+    curl
+    libnotify
+    pcre
+    sqlite
+    freetype
+    libGLU
+    libogg
+    opusfile
+    SDL2
+    wavpack
+    ffmpeg
+    x264
+    vulkan-loader
+    vulkan-headers
+    glslang
+    spirv-tools
+    glew
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libX11 ];
+
+  strictDeps = true;
 
   postPatch = ''
     substituteInPlace src/engine/shared/storage.cpp \
@@ -90,16 +91,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "-DAUTOUPDATE=OFF"
-    "-DCLIENT=ON"
-    "-DSERVER=OFF"
-    "-DTOOLS=OFF"
-    "-DCLIENT_EXECUTABLE=${clientExecutable}"
+    (lib.cmakeBool "AUTOUPDATE" false)
+    (lib.cmakeBool "CLIENT" true)
+    (lib.cmakeBool "SERVER" false)
+    (lib.cmakeBool "TOOLS" false)
+    (lib.cmakeFeature "CLIENT_EXECUTABLE" clientExecutable)
   ];
 
-  # Tests loop forever on Darwin for some reason
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = true;
   checkTarget = "run_tests";
+
+  __darwinAllowLocalNetworking = true; # for tests
 
   preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Upstream links against <prefix>/lib while it installs this library in <prefix>/lib/ddnet


### PR DESCRIPTION
Simple fixes. `glew` is added to avoid the vendored version.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).