### PR TITLE
bottles: 51.15 -> 51.17

### DIFF
--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -43,6 +43,7 @@ python3Packages.buildPythonApplication rec {
   patches =
     [
       ./vulkan_icd.patch
+      ./redirect-bugtracker.patch
       ./remove-flatpak-check.patch
       ./remove-core-tab.patch
     ]

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -89,7 +89,9 @@ python3Packages.buildPythonApplication rec {
       pathvalidate
       fvs
       orjson
+      pycairo
       pygobject3
+      charset-normalizer
       idna
       urllib3
       certifi

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -44,6 +44,7 @@ python3Packages.buildPythonApplication rec {
     [
       ./vulkan_icd.patch
       ./remove-flatpak-check.patch
+      ./remove-core-tab.patch
     ]
     ++ (
       if removeWarningPopup then

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -24,21 +24,35 @@
   mangohud,
   vkbasalt-cli,
   vmtouch,
+  libportal,
   nix-update-script,
+  removeWarningPopup ? false, # Final reminder to report any issues on nixpkgs' bugtracker
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles-unwrapped";
-  version = "51.15";
+  version = "51.17";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = "bottles";
-    rev = "refs/tags/${version}";
-    hash = "sha256-HjGAeIh9s7xWBy35Oj66tCtgKCd/DpHg1sMPsdjWKDs=";
+    tag = version;
+    hash = "sha256-m4ATWpAZxIBp1X0cNeyNGmt6aIBo/cHH+DpOMkLia0E=";
   };
 
-  patches = [ ./vulkan_icd.patch ];
+  patches =
+    [
+      ./vulkan_icd.patch
+      ./remove-flatpak-check.patch
+    ]
+    ++ (
+      if removeWarningPopup then
+        [ ./remove-unsupported-warning.patch ]
+      else
+        [
+          ./warn-unsupported.patch
+        ]
+    );
 
   # https://github.com/bottlesdevs/Bottles/wiki/Packaging
   nativeBuildInputs = [
@@ -57,6 +71,7 @@ python3Packages.buildPythonApplication rec {
     gtk4
     gtksourceview5
     libadwaita
+    libportal
   ];
 
   propagatedBuildInputs =

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -79,21 +79,21 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs =
     with python3Packages;
     [
-      pathvalidate
-      pycurl
       pyyaml
-      requests
-      pygobject3
-      patool
-      markdown
-      fvs
-      pefile
-      urllib3
+      pycurl
       chardet
-      certifi
-      idna
-      orjson
+      requests
+      markdown
       icoextract
+      patool
+      pathvalidate
+      fvs
+      orjson
+      pygobject3
+      idna
+      urllib3
+      certifi
+      pefile
     ]
     ++ [
       cabextract

--- a/pkgs/by-name/bo/bottles-unwrapped/redirect-bugtracker.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/redirect-bugtracker.patch
@@ -1,0 +1,13 @@
+diff --git a/data/com.usebottles.bottles.metainfo.xml.in.in b/data/com.usebottles.bottles.metainfo.xml.in.in
+index bdda5c6e..9292df50 100644
+--- a/data/com.usebottles.bottles.metainfo.xml.in.in
++++ b/data/com.usebottles.bottles.metainfo.xml.in.in
+@@ -52,7 +52,7 @@
+   <translation type="gettext">@APP_ID@</translation>
+   <content_rating type="oars-1.1"/>
+   <url type="homepage">https://usebottles.com</url>
+-  <url type="bugtracker">https://github.com/bottlesdevs/Bottles/issues</url>
++  <url type="bugtracker">https://github.com/NixOS/nixpkgs/issues</url>
+   <url type="help">https://docs.usebottles.com</url>
+   <url type="donation">https://usebottles.com/funding</url>
+   <url type="translate">https://hosted.weblate.org/engage/bottles</url>

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-core-tab.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-core-tab.patch
@@ -1,0 +1,76 @@
+diff --git a/bottles/frontend/ui/preferences.blp b/bottles/frontend/ui/preferences.blp
+index 9dd12a16..c1fcf649 100644
+--- a/bottles/frontend/ui/preferences.blp
++++ b/bottles/frontend/ui/preferences.blp
+@@ -284,20 +284,6 @@ template $PreferencesWindow: Adw.PreferencesWindow {
+     }
+   }
+ 
+-  Adw.PreferencesPage pref_core {
+-    icon-name: "application-x-addon-symbolic";
+-    title: _("Core");
+-    visible: false;
+-
+-    Adw.PreferencesGroup list_runtimes {
+-      title: _("Runtime");
+-    }
+-
+-    Adw.PreferencesGroup list_winebridge {
+-      title: _("WineBridge");
+-    }
+-  }
+-
+   Adw.PreferencesPage {
+     icon-name: "applications-science-symbolic";
+     title: _("Experiments");
+diff --git a/bottles/frontend/views/preferences.py b/bottles/frontend/views/preferences.py
+index ce7ec958..f46c6e5b 100644
+--- a/bottles/frontend/views/preferences.py
++++ b/bottles/frontend/views/preferences.py
+@@ -53,8 +53,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
+     switch_steam_programs = Gtk.Template.Child()
+     switch_epic_games = Gtk.Template.Child()
+     switch_ubisoft_connect = Gtk.Template.Child()
+-    list_winebridge = Gtk.Template.Child()
+-    list_runtimes = Gtk.Template.Child()
+     list_runners = Gtk.Template.Child()
+     list_dxvk = Gtk.Template.Child()
+     list_vkd3d = Gtk.Template.Child()
+@@ -66,7 +64,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
+     btn_bottles_path_reset = Gtk.Template.Child()
+     label_bottles_path = Gtk.Template.Child()
+     btn_steam_proton_doc = Gtk.Template.Child()
+-    pref_core = Gtk.Template.Child()
+ 
+     # endregion
+ 
+@@ -170,10 +167,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
+             self.installers_stack.set_visible_child_name("installers_offline")
+             self.dlls_stack.set_visible_child_name("dlls_offline")
+ 
+-        # populate components lists
+-        self.populate_runtimes_list()
+-        self.populate_winebridge_list()
+-
+         RunAsync(self.ui_update)
+ 
+         # connect signals
+@@ -319,18 +312,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
+             list_component.add(_entry)
+             self.__registry.append(_entry)
+ 
+-    def populate_runtimes_list(self):
+-        for runtime in self.manager.supported_runtimes.items():
+-            self.list_runtimes.add(
+-                ComponentEntry(self.window, runtime, "runtime", is_upgradable=True)
+-            )
+-
+-    def populate_winebridge_list(self):
+-        for bridge in self.manager.supported_winebridge.items():
+-            self.list_winebridge.add(
+-                ComponentEntry(self.window, bridge, "winebridge", is_upgradable=True)
+-            )
+-
+     def populate_dxvk_list(self):
+         self.__populate_component_list(
+             "dxvk", self.manager.supported_dxvk, self.list_dxvk

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
@@ -1,0 +1,17 @@
+diff --git a/bottles/frontend/meson.build b/bottles/frontend/meson.build
+index 6ff7c011..c26ea0b9 100644
+--- a/bottles/frontend/meson.build
++++ b/bottles/frontend/meson.build
+@@ -23,12 +23,6 @@ params_file = configure_file(
+     configuration: conf
+ )
+ 
+-fs = import('fs')
+-
+-if not fs.is_file('/' + '.flatpak-info')
+-  error('file does not exist')
+-endif
+-
+ bottles_sources = [
+   '__init__.py',
+   'main.py',

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-unsupported-warning.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-unsupported-warning.patch
@@ -1,0 +1,40 @@
+diff --git a/bottles/frontend/windows/main_window.py b/bottles/frontend/windows/main_window.py
+index 79bf0d72..e37ca43e 100644
+--- a/bottles/frontend/windows/main_window.py
+index 79bf0d72..e37ca43e 100644
+--- a/bottles/frontend/windows/main_window.py
++++ b/bottles/frontend/windows/main_window.py
+@@ -104,29 +104,15 @@ class MainWindow(Adw.ApplicationWindow):
+ 
+             def response(dialog, response, *args):
+                 if response == "close":
+-                    quit(1)
++                    return
+ 
+-            body = _(
+-                "Bottles is only supported within a sandboxed environment. Official sources of Bottles are available at"
+-            )
+-            download_url = "usebottles.com/download"
+-
+-            error_dialog = Adw.AlertDialog.new(
+-                _("Unsupported Environment"),
+-                f"{body} <a href='https://{download_url}' title='https://{download_url}'>{download_url}.</a>",
+-            )
+-
+-            error_dialog.add_response("close", _("Close"))
+-            error_dialog.set_body_use_markup(True)
+-            error_dialog.connect("response", response)
+-            error_dialog.present(self)
+-            logging.error(
++            logging.warn(
+                 _(
+                     "Bottles is only supported within a sandboxed format. Official sources of Bottles are available at:"
+                 )
+             )
+-            logging.error("https://usebottles.com/download/")
+-            return
++            logging.warn("https://usebottles.com/download/")
++            logging.warn("Please report any issues at: https://github.com/NixOS/nixpkgs/issues")
+ 
+         # Loading view
+         self.page_loading = LoadingView()

--- a/pkgs/by-name/bo/bottles-unwrapped/warn-unsupported.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/warn-unsupported.patch
@@ -1,0 +1,42 @@
+diff --git a/bottles/frontend/windows/main_window.py b/bottles/frontend/windows/main_window.py
+index 79bf0d72..e3a15cb5 100644
+--- a/bottles/frontend/windows/main_window.py
++++ b/bottles/frontend/windows/main_window.py
+@@ -104,29 +104,29 @@ class MainWindow(Adw.ApplicationWindow):
+ 
+             def response(dialog, response, *args):
+                 if response == "close":
+-                    quit(1)
++                    return
+ 
+             body = _(
+-                "Bottles is only supported within a sandboxed environment. Official sources of Bottles are available at"
++                "Bottles is only supported within a sandboxed environment. Please report any issues at:"
+             )
+-            download_url = "usebottles.com/download"
++            bugtracker_url = "github.com/NixOS/nixpkgs/issues"
+ 
+             error_dialog = Adw.AlertDialog.new(
+                 _("Unsupported Environment"),
+-                f"{body} <a href='https://{download_url}' title='https://{download_url}'>{download_url}.</a>",
++                f"{body} <a href='https://{bugtracker_url}' title='https://{bugtracker_url}'>{bugtracker_url}.</a>",
+             )
+ 
+-            error_dialog.add_response("close", _("Close"))
++            error_dialog.add_response("close", _("Understood"))
+             error_dialog.set_body_use_markup(True)
+             error_dialog.connect("response", response)
+             error_dialog.present(self)
+-            logging.error(
++            logging.warn(
+                 _(
+                     "Bottles is only supported within a sandboxed format. Official sources of Bottles are available at:"
+                 )
+             )
+-            logging.error("https://usebottles.com/download/")
+-            return
++            logging.warn("https://usebottles.com/download/")
++            logging.warn("Please report any issues at: https://github.com/NixOS/nixpkgs/issues")
+ 
+         # Loading view
+         self.page_loading = LoadingView()

--- a/pkgs/by-name/bo/bottles/package.nix
+++ b/pkgs/by-name/bo/bottles/package.nix
@@ -4,6 +4,7 @@
   bottles-unwrapped,
   extraPkgs ? pkgs: [ ],
   extraLibraries ? pkgs: [ ],
+  removeWarningPopup ? false,
 }:
 
 let
@@ -16,7 +17,7 @@ let
       pkgs:
       with pkgs;
       [
-        bottles-unwrapped
+        (bottles-unwrapped.override { inherit removeWarningPopup; })
         # This only allows to enable the toggle, vkBasalt won't work if not installed with environment.systemPackages (or nix-env)
         # See https://github.com/bottlesdevs/Bottles/issues/2401
         vkbasalt


### PR DESCRIPTION
51.16: https://github.com/bottlesdevs/Bottles/releases/tag/51.16
51.17: https://github.com/bottlesdevs/Bottles/releases/tag/51.17
Full diff: https://github.com/bottlesdevs/Bottles/compare/51.15...51.17

A check has been added in `51.16` that will make `bottles` exit if it is not running as a sandboxed flatpak, I added a patch to remove this check.

I added another patch to remove the "Core" tab that was in the preferences.
This tab is not used for quite some time in the official Flatpak and is not functioning anyway.
I opted to patch it out since it will only cause confusion and may lead to unwanted bug report to upstream.

I re-ordered the python3 packages in `propagatedBuildInputs` so they are in the same order as the official flatpak (to make it easier to review if we are missing dependencies) and added `pycairo` and `charset-normalizer` since they are included in the official package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
