### PR TITLE
SDL_mixer: Fix mod support

### DIFF
--- a/pkgs/by-name/sd/SDL_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL_mixer/package.nix
@@ -4,7 +4,7 @@
   fetchpatch,
   fetchurl,
   fluidsynth,
-  libmikmod,
+  libopenmpt-modplug,
   libogg,
   libvorbis,
   pkg-config,
@@ -63,6 +63,12 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # Fix location of modplug header
+  postPatch = ''
+    substituteInPlace music_modplug.h \
+      --replace-fail '#include "modplug.h"' '#include <libmodplug/modplug.h>'
+  '';
+
   nativeBuildInputs = [
     SDL
     pkg-config
@@ -72,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL
     fluidsynth
-    libmikmod
+    libopenmpt-modplug
     libogg
     libvorbis
     smpeg
@@ -81,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     (lib.enableFeature false "music-ogg-shared")
     (lib.enableFeature false "music-mod-shared")
+    (lib.enableFeature true "music-mod-modplug")
     (lib.enableFeature enableNativeMidi "music-native-midi-gpl")
     (lib.enableFeature enableSdltest "sdltest")
     (lib.enableFeature enableSmpegtest "smpegtest")


### PR DESCRIPTION
Closes #364660

`mikmod` flags are gathered via `libmikmod-config`, which isn't in `PATH` anymore due to `strictDeps`.

`modplug`, an alternative library for mod support, is found via `pkg-config`, and `libopenmpt-modplug` is a compatibility library emulating `modplug`'s API via the actively-maintained `libopenmpt` library.

`vectoroids` now doesn't crash on startup anymore, and starting a game makes the music play fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
