### PR TITLE
glances: fix traceback on startup, fix test_105_network_plugin_method failing on aarch64-linux

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   buildPythonApplication,
   fetchFromGitHub,
+  fetchpatch,
   isPyPy,
   lib,
   defusedxml,
@@ -34,6 +35,16 @@ buildPythonApplication rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-8Jm6DE3B7OQkaNwX/KwXMNZHUyvPtln8mJYaD6yzJRM=";
   };
+
+  patches = [
+    # Fixes KeyError: 'bytes_sent_rate_per_sec' traceback on startup
+    # Remove on releases after 4.2.1
+    (fetchpatch {
+      name = "KeyError_bytes_sent_rate_per_sec.patch";
+      url = "https://github.com/nicolargo/glances/commit/07656fd7ff67e4b189aa14ca1645c90a580d72f1.patch";
+      hash = "sha256-laE4pYGiaLqJh1CmGYkVHsFD2/4C5t0PfTLrGPVzvEs=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -44,6 +44,13 @@ buildPythonApplication rec {
       url = "https://github.com/nicolargo/glances/commit/07656fd7ff67e4b189aa14ca1645c90a580d72f1.patch";
       hash = "sha256-laE4pYGiaLqJh1CmGYkVHsFD2/4C5t0PfTLrGPVzvEs=";
     })
+    # Fixes test_105_network_plugin_method failing on aarch64-linux
+    # Remove on releases after 4.2.1
+    (fetchpatch {
+      name = "aarch64_linux-test_105_network_plugin_method.patch";
+      url = "https://github.com/nicolargo/glances/commit/d9725d623f7d459232c2eb7a4887080772982447.patch";
+      hash = "sha256-xLDAO8QmgvO9BnRbIs3nSROrJ2tIL9B/S/2vpS53hwQ=";
+    })
   ];
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Cherry pick two commits from develop:

https://github.com/nicolargo/glances/commit/07656fd7ff67e4b189aa14ca1645c90a580d72f1 fixes traceback on launch
https://github.com/nicolargo/glances/commit/d9725d623f7d459232c2eb7a4887080772982447 fixes test_105_network_plugin_method failing on aarch64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
