### PR TITLE
cwtch,cwtch-ui: Update to latest versions 0.1.5 and 1.15.4

### DIFF
--- a/pkgs/by-name/cw/cwtch-ui/package.nix
+++ b/pkgs/by-name/cw/cwtch-ui/package.nix
@@ -12,18 +12,18 @@ let
 in
 flutter.buildFlutterApplication rec {
   pname = "cwtch-ui";
-  version = "1.15.1";
+  version = "1.15.4";
   # This Gitea instance has archive downloads disabled, so: fetchgit
   src = fetchgit {
     url = "https://git.openprivacy.ca/cwtch.im/cwtch-ui";
     rev = "v${version}";
-    hash = "sha256-+UtWhQMhm0UjY0kx3B5TwcBFhUfJma3rpeYls4XWy7I=";
+    hash = "sha256-Ee6LKqh4Xe+93noJktCGQyW1YLxSXgVKh6YoG0xebBc=";
   };
 
   # NOTE: The included pubspec.json does not exactly match the upstream
   # pubspec.lock. With Flutter 3.24, a newer version of material_color_utilities
   # is required than the upstream locked version. From a checkout of cwtch-ui
-  # 1.15.1, I ran `flutter pub upgrade material_color_utilities` on 2024-10-17.
+  # 1.15.4, I ran `flutter pub upgrade material_color_utilities` on 2024-12-15.
   # This upgraded material_color_utilities and its dependencies.
   pubspecLock = lib.importJSON ./pubspec.json;
   gitHashes = {

--- a/pkgs/by-name/cw/cwtch-ui/pubspec.json
+++ b/pkgs/by-name/cw/cwtch-ui/pubspec.json
@@ -238,6 +238,16 @@
       "source": "hosted",
       "version": "3.1.1"
     },
+    "coverage": {
+      "dependency": "transitive",
+      "description": {
+        "name": "coverage",
+        "sha256": "c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.9.2"
+    },
     "crypto": {
       "dependency": "direct main",
       "description": {
@@ -651,6 +661,16 @@
       "source": "hosted",
       "version": "1.0.0"
     },
+    "node_preamble": {
+      "dependency": "transitive",
+      "description": {
+        "name": "node_preamble",
+        "sha256": "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.2"
+    },
     "package_config": {
       "dependency": "transitive",
       "description": {
@@ -881,15 +901,35 @@
       "source": "hosted",
       "version": "1.4.1"
     },
+    "shelf_packages_handler": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_packages_handler",
+        "sha256": "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "shelf_static": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_static",
+        "sha256": "c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.3"
+    },
     "shelf_web_socket": {
       "dependency": "transitive",
       "description": {
         "name": "shelf_web_socket",
-        "sha256": "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611",
+        "sha256": "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "1.0.4"
     },
     "sky_engine": {
       "dependency": "transitive",
@@ -906,6 +946,26 @@
       },
       "source": "hosted",
       "version": "1.5.0"
+    },
+    "source_map_stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_map_stack_trace",
+        "sha256": "c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "source_maps": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_maps",
+        "sha256": "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.10.12"
     },
     "source_span": {
       "dependency": "transitive",
@@ -977,6 +1037,16 @@
       "source": "hosted",
       "version": "1.2.1"
     },
+    "test": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "test",
+        "sha256": "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.25.7"
+    },
     "test_api": {
       "dependency": "transitive",
       "description": {
@@ -986,6 +1056,16 @@
       },
       "source": "hosted",
       "version": "0.7.2"
+    },
+    "test_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_core",
+        "sha256": "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.4"
     },
     "timezone": {
       "dependency": "transitive",
@@ -1147,25 +1227,15 @@
       "source": "hosted",
       "version": "0.5.1"
     },
-    "web_socket": {
-      "dependency": "transitive",
-      "description": {
-        "name": "web_socket",
-        "sha256": "24301d8c293ce6fe327ffe6f59d8fd8834735f0ec36e4fd383ec7ff8a64aa078",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.1.5"
-    },
     "web_socket_channel": {
       "dependency": "transitive",
       "description": {
         "name": "web_socket_channel",
-        "sha256": "a2d56211ee4d35d9b344d9d4ce60f362e4f5d1aafb988302906bd732bc731276",
+        "sha256": "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.0"
+      "version": "2.4.5"
     },
     "webdriver": {
       "dependency": "transitive",
@@ -1176,6 +1246,16 @@
       },
       "source": "hosted",
       "version": "3.0.3"
+    },
+    "webkit_inspection_protocol": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webkit_inspection_protocol",
+        "sha256": "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
     },
     "win32": {
       "dependency": "transitive",

--- a/pkgs/by-name/cw/cwtch/package.nix
+++ b/pkgs/by-name/cw/cwtch/package.nix
@@ -5,15 +5,15 @@
 }:
 buildGoModule rec {
   pname = "libcwtch";
-  version = "0.1.3";
+  version = "0.1.5";
   # This Gitea instance has archive downloads disabled, so: fetchgit
   src = fetchgit {
     url = "https://git.openprivacy.ca/cwtch.im/autobindings.git";
     rev = "v${version}";
-    hash = "sha256-Gp6JnyjKChB7w0fUHkreu81QRXQ3YdMb2ReD/VCkVOE=";
+    hash = "sha256-SeMpL/ncDh4DgYYeikHiwRIF/RKsrOhRzPAePXglvqM=";
   };
 
-  vendorHash = "sha256-UgG/yjupUFrfjPZ4E+OM1VsWi9MuMuHxcZ4yvz+q/Y0=";
+  vendorHash = "sha256-ZgysF9ZYbuUdaxUiNAJ44JAeFKjBpOQ1DMXhO2RV7zc=";
   overrideModAttrs = (
     old: {
       preBuild = ''
@@ -30,14 +30,15 @@ buildGoModule rec {
 
   buildPhase = ''
     runHook preBuild
-    make linux
+    make libCwtch.so
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
     install -D build/linux/libCwtch.h -t $out/include
-    install -D build/linux/libCwtch.*.so $out/lib/libCwtch.so
+    # * will match either "amd64" or "arm64" depending on the platform.
+    install -D build/linux/*/libCwtch.so $out/lib/libCwtch.so
     runHook postInstall
   '';
 


### PR DESCRIPTION
This updates the cwtch bindings:

* [0.1.4](https://git.openprivacy.ca/cwtch.im/autobindings/releases/tag/v0.1.4)
* [0.1.5](https://git.openprivacy.ca/cwtch.im/autobindings/releases/tag/v0.1.5)

and the corresponding UI updates:

* [1.15.3](https://git.openprivacy.ca/cwtch.im/cwtch-ui/releases/tag/v1.15.3)
* [1.15.4](https://git.openprivacy.ca/cwtch.im/cwtch-ui/releases/tag/v1.15.4)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
