### PR TITLE
lirc: fix build on ubuntu

### DIFF
--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -46,6 +46,11 @@ stdenv.mkDerivation rec {
     # Add a workaround for linux-headers-5.18 until upstream adapts:
     #   https://sourceforge.net/p/lirc/git/merge-requests/45/
     ./linux-headers-5.18.patch
+
+    # remove check for `Ubuntu` in /proc/version which will override
+    # --with-systemdsystemunitdir
+    # https://sourceforge.net/p/lirc/tickets/385/
+    ./ubuntu.diff
   ];
 
   postPatch = ''

--- a/pkgs/by-name/li/lirc/ubuntu.diff
+++ b/pkgs/by-name/li/lirc/ubuntu.diff
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index d28c673..1cd0548 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -434,16 +434,7 @@ AC_CHECK_LIB([udev], [udev_device_new_from_device_id], [
+   LIBS="$LIBS $LIBUDEV_LIBS"
+ ])
+ 
+-dnl Ubuntu's systemd pkg-config seems broken beyond repair. So:
+-kernelversion=`cat /proc/version || echo "non-linux"`
+-AS_CASE([$kernelversion],
+-  [*Ubuntu*],[
+-    AC_MSG_NOTICE([Hardwiring Ubuntu systemd setup])
+-    AC_SUBST([systemdsystemunitdir], [/lib/systemd/system])
+-    AM_CONDITIONAL([WITH_SYSTEMDSYSTEMUNITDIR], [true])
+-  ],[*],[
+-    SYSTEMD_SYSTEMUNITDIR
+-])
++SYSTEMD_SYSTEMUNITDIR
+ 
+ AC_ARG_WITH(lockdir,
+   [  --with-lockdir=DIR      Old-school device lock files in DIR (/var/lock{/lockdev})],


### PR DESCRIPTION
autoconf looks in /proc/version for `Ubuntu` and on match overrides the `--with-systemdsystemunitdir` value set in `configureFlags` causing the build to fail.

> mkdir -p '/lib/systemd/system'
> mkdir: cannot create directory '/lib': Permission denied

patch `configure.ac` to prevent the override when building on ubuntu


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
