### PR TITLE
cryptpad: verify that we've installed the correct versions of OnlyOffice

### DIFF
--- a/pkgs/by-name/cr/cryptpad/package.nix
+++ b/pkgs/by-name/cr/cryptpad/package.nix
@@ -1,6 +1,8 @@
 {
+  bash,
   buildNpmPackage,
   fetchFromGitHub,
+  fetchpatch,
   fetchurl,
   lib,
   makeBinaryWrapper,
@@ -56,8 +58,8 @@ let
     }
     {
       subdir = "v7";
-      rev = "9d8b914a";
-      hash = "sha256-M+rPJ/Xo2olhqB5ViynGRaesMLLfG/1ltUoLnepMPnM=";
+      rev = "e1267803";
+      hash = "sha256-iIds0GnCHAyeIEdSD4aCCgDtnnwARh3NE470CywseS0=";
     }
   ];
 
@@ -90,12 +92,19 @@ buildNpmPackage {
     makeBinaryWrapper
     rdfind
     unzip
+    bash
   ];
 
   patches = [
     # fix httpSafePort setting
     # https://github.com/cryptpad/cryptpad/pull/1571
     ./0001-env.js-fix-httpSafePort-handling.patch
+    # https://github.com/cryptpad/cryptpad/pull/1740
+    (fetchpatch {
+      name = "Add `--check`, `--rdfind`, `--no-rdfind` options to `install-onlyoffice.sh`";
+      url = "https://github.com/cryptpad/cryptpad/commit/f38668735e777895db2eadd3413cff386fb12c0c.patch";
+      hash = "sha256-J4AK1XIa3q+/lD74p2c9O7jt0VEtofTmfAaQNU71sp8=";
+    })
   ];
 
   # cryptpad build tries to write in cache dir
@@ -121,7 +130,11 @@ buildNpmPackage {
     mkdir -p "$out_cryptpad/www/common/onlyoffice/dist"
     ${lib.concatMapStringsSep "\n" onlyoffice_install onlyoffice_versions}
     ${x2t_install}
-    rdfind -makehardlinks true -makeresultsfile false "$out_cryptpad/www/common/onlyoffice/dist"
+    # Run upstream's `install-onlyoffice.sh` script in `--check` mode to
+    # verify that we've installed the correct versions of the various
+    # OnlyOffice components.
+    patchShebangs --build $out_cryptpad/install-onlyoffice.sh
+    $out_cryptpad/install-onlyoffice.sh --accept-license --check --rdfind
 
     # cryptpad assumes it runs in the source directory and also outputs
     # its state files there, which is not exactly great for us.


### PR DESCRIPTION
With this change, I saw the following when I built cryptpad:

```
$ nix build .#cryptpad
...
       > v1 was up to date
       > v2b was up to date
       > v4 was up to date
       > v5 was up to date
       > v6 was up to date
       > Wrong commit of /nix/store/1m2d8c4fppfav7n2s4fvali3iira2ky2-cryptpad-2024.9.1/lib/node_modules/cryptpad/www/common/onlyoffice/dist/v7 found. Expected: e1267803. Actual: 9d8b914a
```

This reproduces the issue @martinetd noticed in
<https://github.com/NixOS/nixpkgs/pull/365126#discussion_r1885015234>.

I then addressed these issue by fixing the commit we use for `v7` of OnlyOffice.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
