### PR TITLE
switchaudio-osx: init at 1.2.2

### DIFF
--- a/pkgs/by-name/sw/switchaudio-osx/001-macos-legacy-support.patch
+++ b/pkgs/by-name/sw/switchaudio-osx/001-macos-legacy-support.patch
@@ -1,0 +1,25 @@
+From 02803f510bae37eac88b0168ff887bdf7d71a7f0 Mon Sep 17 00:00:00 2001
+From: James Woglom <j@wogloms.net>
+Date: Wed, 1 May 2024 00:36:14 -0400
+Subject: [PATCH] Fix build when run on pre-macOS Monterey
+
+---
+ audio_switch.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/audio_switch.c b/audio_switch.c
+index 814edce..a064c3e 100644
+--- a/audio_switch.c
++++ b/audio_switch.c
+@@ -715,7 +715,11 @@ OSStatus setMute(ASDeviceType typeRequested, ASMuteType muteRequested) {
+     AudioObjectPropertyAddress propertyAddress = {
+         .mSelector  = kAudioDevicePropertyMute,
+         .mScope     = scope,
++        #ifndef MAC_OS_VERSION_12_0
++        .mElement   = kAudioObjectPropertyElementMaster,
++        #else
+         .mElement   = kAudioObjectPropertyElementMain,
++        #endif
+     };
+ 
+     UInt32 muted = (UInt32)muteRequested;

--- a/pkgs/by-name/sw/switchaudio-osx/package.nix
+++ b/pkgs/by-name/sw/switchaudio-osx/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  xcodebuild,
+  xcbuildHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "switchaudio-osx";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "deweller";
+    repo = "switchaudio-osx";
+    tag = version;
+    hash = "sha256-AZJn5kHK/al94ONfIHcG+W0jyMfgdJkIngN+PVj+I44=";
+  };
+
+  buildInputs = [ xcodebuild ];
+
+  nativeBuildInputs = [ xcbuildHook ];
+
+  patches = [
+    # Patch to fix running on earlier version of macOS
+    # https://github.com/deweller/switchaudio-osx/pull/65
+    ./001-macos-legacy-support.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # for some reason binary is located in Products/ rather than in build/
+    install -Dm755 Products/Release/SwitchAudioSource $out/bin/SwitchAudioSource
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line utility to manage audio input/output devices on macOS";
+    homepage = "https://github.com/deweller/switchaudio-osx";
+    mainProgram = "SwitchAudioSource";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ taranarmo ];
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
Command-line utility to manage audio input/output devices on macOS. Useful to be able to toggle mute audio source (microphone) with a key.
https://github.com/deweller/switchaudio-osx
https://github.com/deweller/switchaudio-osx/releases/tag/1.2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
