### PR TITLE
nixos-rebuild-ng: add --add-root in nix.remote_build

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -275,7 +275,7 @@ def reexec(
             build_attr = BuildAttr.from_arg(args.attr, args.file)
             drv = nix.build(attr, build_attr, **build_flags, no_out_link=True)
     except CalledProcessError:
-        logger.warning("could not find a newer version of nixos-rebuild")
+        logger.warning("could not build a newer version of nixos-rebuild")
 
     if drv:
         new = drv / f"bin/{EXECUTABLE}"

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import assert_never
 
-from . import nix
+from . import nix, tmpdir
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, NRError, Profile
 from .process import Remote, cleanup_ssh
@@ -280,7 +280,10 @@ def reexec(
                 argv[0],
                 new,
             )
+            # Manually call clean-up functions since os.execve() will replace
+            # the process immediately
             cleanup_ssh()
+            tmpdir.TMPDIR.cleanup()
             os.execve(new, argv, os.environ | {"_NIXOS_REBUILD_REEXEC": "1"})
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -485,6 +485,15 @@ def main() -> None:
 
     try:
         execute(sys.argv)
+    except CalledProcessError as ex:
+        if logger.level == logging.DEBUG:
+            import traceback
+
+            traceback.print_exc()
+        else:
+            print(str(ex), file=sys.stderr)
+        # Exit with the error code of the process that failed
+        sys.exit(ex.returncode)
     except (Exception, KeyboardInterrupt) as ex:
         if logger.level == logging.DEBUG:
             raise

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -1,5 +1,4 @@
 import argparse
-import atexit
 import json
 import logging
 import os
@@ -292,8 +291,6 @@ def execute(argv: list[str]) -> None:
 
     if not WITH_NIX_2_18:
         logger.warning("you're using Nix <2.18, some features will not work correctly")
-
-    atexit.register(cleanup_ssh)
 
     common_flags = vars(args_groups["common_flags"])
     common_build_flags = common_flags | vars(args_groups["common_build_flags"])

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -268,8 +268,9 @@ def reexec(
     drv = None
     attr = "config.system.build.nixos-rebuild"
     try:
-        # Need to set target_host=None, to avoid connecting to remote
-        if flake := Flake.from_arg(args.flake, None):
+        # Parsing the args here but ignore ask_sudo_password since it is not
+        # needed and we would end up asking sudo password twice
+        if flake := Flake.from_arg(args.flake, Remote.from_arg(args.target_host, None)):
             drv = nix.build_flake(attr, flake, **flake_build_flags, no_link=True)
         else:
             build_attr = BuildAttr.from_arg(args.attr, args.file)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -19,7 +19,14 @@ logger.setLevel(logging.INFO)
 
 def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]:
     common_flags = argparse.ArgumentParser(add_help=False)
-    common_flags.add_argument("--verbose", "-v", action="count", dest="v", default=0)
+    common_flags.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        dest="v",
+        default=0,
+        help="Enable verbose logging (includes nix)",
+    )
     common_flags.add_argument("--max-jobs", "-j")
     common_flags.add_argument("--cores")
     common_flags.add_argument("--log-format")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -4,19 +4,17 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 from getpass import getpass
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Self, Sequence, TypedDict, Unpack
+
+from . import tmpdir
 
 logger = logging.getLogger(__name__)
 
-TMPDIR = TemporaryDirectory(prefix="nixos-rebuild.")
-TMPDIR_PATH = Path(TMPDIR.name)
 SSH_DEFAULT_OPTS = [
     "-o",
     "ControlMaster=auto",
     "-o",
-    f"ControlPath={TMPDIR_PATH / "ssh-%n"}",
+    f"ControlPath={tmpdir.TMPDIR_PATH / "ssh-%n"}",
     "-o",
     "ControlPersist=60",
 ]
@@ -70,13 +68,12 @@ class RunKwargs(TypedDict, total=False):
 
 def cleanup_ssh() -> None:
     "Close SSH ControlMaster connection."
-    for ctrl in TMPDIR_PATH.glob("ssh-*"):
+    for ctrl in tmpdir.TMPDIR_PATH.glob("ssh-*"):
         run_wrapper(
             ["ssh", "-o", f"ControlPath={ctrl}", "-O", "exit", "dummyhost"],
             check=False,
             capture_output=True,
         )
-    TMPDIR.cleanup()
 
 
 def run_wrapper(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -5,13 +5,13 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 from getpass import getpass
-from typing import Self, Sequence, TypedDict, Unpack
+from typing import Final, Self, Sequence, TypedDict, Unpack
 
 from . import tmpdir
 
 logger = logging.getLogger(__name__)
 
-SSH_DEFAULT_OPTS = [
+SSH_DEFAULT_OPTS: Final = [
     "-o",
     "ControlMaster=auto",
     "-o",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import shlex
@@ -74,6 +75,9 @@ def cleanup_ssh() -> None:
             check=False,
             capture_output=True,
         )
+
+
+atexit.register(cleanup_ssh)
 
 
 def run_wrapper(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Final
 
-TMPDIR = TemporaryDirectory(prefix="nixos-rebuild.")
-TMPDIR_PATH = Path(TMPDIR.name)
+TMPDIR: Final = TemporaryDirectory(prefix="nixos-rebuild.")
+TMPDIR_PATH: Final = Path(TMPDIR.name)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+TMPDIR = TemporaryDirectory(prefix="nixos-rebuild.")
+TMPDIR_PATH = Path(TMPDIR.name)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -83,9 +83,7 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-instantiate":
             return CompletedProcess([], 0, str(nixpkgs_path))
         elif args[0] == "git" and "rev-parse" in args:
@@ -95,7 +93,7 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--fast"])
 
@@ -158,15 +156,13 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix":
             return CompletedProcess([], 0, str(config_path))
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(
         [
@@ -231,15 +227,13 @@ def test_execute_nix_switch_flake_target_host(
     config_path = tmp_path / "test"
     config_path.touch()
 
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix":
             return CompletedProcess([], 0, str(config_path))
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(
         [
@@ -322,9 +316,7 @@ def test_execute_nix_switch_flake_build_host(
     config_path = tmp_path / "test"
     config_path.touch()
 
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix" and "eval" in args:
             return CompletedProcess([], 0, str(config_path))
         if args[0] == "ssh" and "nix" in args:
@@ -332,7 +324,7 @@ def test_execute_nix_switch_flake_build_host(
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(
         [
@@ -483,15 +475,13 @@ def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix":
             return CompletedProcess([], 0, str(config_path))
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(
         ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--fast"]
@@ -530,9 +520,7 @@ def test_execute_test_rollback(
     mock_path_exists: Any,
     mock_run: Any,
 ) -> None:
-    def run_wrapper_side_effect(
-        args: list[str], **kwargs: Any
-    ) -> CompletedProcess[str]:
+    def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-env":
             return CompletedProcess(
                 [],
@@ -546,7 +534,7 @@ def test_execute_test_rollback(
         else:
             return CompletedProcess([], 0)
 
-    mock_run.side_effect = run_wrapper_side_effect
+    mock_run.side_effect = run_side_effect
 
     nr.execute(
         ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--fast"]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -82,18 +82,20 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path.mkdir()
     config_path = tmp_path / "test"
     config_path.touch()
-    mock_run.side_effect = [
-        # update_nixpkgs_rev
-        CompletedProcess([], 0, str(nixpkgs_path)),
-        CompletedProcess([], 0, "nixpkgs-rev"),
-        CompletedProcess([], 0),
-        # nixos_build
-        CompletedProcess([], 0, str(config_path)),
-        # set_profile
-        CompletedProcess([], 0),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix-instantiate":
+            return CompletedProcess([], 0, str(nixpkgs_path))
+        elif args[0] == "git" and "rev-parse" in args:
+            return CompletedProcess([], 0, "nixpkgs-rev")
+        elif args[0] == "nix-build":
+            return CompletedProcess([], 0, str(config_path))
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--fast"])
 
@@ -155,14 +157,16 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
 def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
-    mock_run.side_effect = [
-        # nixos_build_flake
-        CompletedProcess([], 0, str(config_path)),
-        # set_profile
-        CompletedProcess([], 0),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix":
+            return CompletedProcess([], 0, str(config_path))
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(
         [
@@ -226,16 +230,16 @@ def test_execute_nix_switch_flake_target_host(
 ) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
-    mock_run.side_effect = [
-        # nixos_build_flake
-        CompletedProcess([], 0, str(config_path)),
-        # set_profile
-        CompletedProcess([], 0),
-        # copy_closure
-        CompletedProcess([], 0),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix":
+            return CompletedProcess([], 0, str(config_path))
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(
         [
@@ -317,18 +321,18 @@ def test_execute_nix_switch_flake_build_host(
 ) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
-    mock_run.side_effect = [
-        # nixos_build_flake
-        CompletedProcess([], 0, str(config_path)),
-        CompletedProcess([], 0),
-        CompletedProcess([], 0, str(config_path)),
-        # set_profile
-        CompletedProcess([], 0),
-        # copy_closure
-        CompletedProcess([], 0),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix" and "eval" in args:
+            return CompletedProcess([], 0, str(config_path))
+        if args[0] == "ssh" and "nix" in args:
+            return CompletedProcess([], 0, str(config_path))
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(
         [
@@ -478,12 +482,16 @@ def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
 def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
-    mock_run.side_effect = [
-        # nixos_build_flake
-        CompletedProcess([], 0, str(config_path)),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix":
+            return CompletedProcess([], 0, str(config_path))
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(
         ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--fast"]
@@ -522,20 +530,23 @@ def test_execute_test_rollback(
     mock_path_exists: Any,
     mock_run: Any,
 ) -> None:
-    mock_run.side_effect = [
-        # rollback_temporary_profile
-        CompletedProcess(
-            [],
-            0,
-            stdout=textwrap.dedent("""\
-            2082   2024-11-07 22:58:56
-            2083   2024-11-07 22:59:41
-            2084   2024-11-07 23:54:17   (current)
-            """),
-        ),
-        # switch_to_configuration
-        CompletedProcess([], 0),
-    ]
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
+        if args[0] == "nix-env":
+            return CompletedProcess(
+                [],
+                0,
+                stdout=textwrap.dedent("""\
+                2082   2024-11-07 22:58:56
+                2083   2024-11-07 22:59:41
+                2084   2024-11-07 23:54:17   (current)
+                """),
+            )
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
 
     nr.execute(
         ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--fast"]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -1,11 +1,11 @@
 import textwrap
+import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
 from unittest.mock import ANY, call, patch
 
 import pytest
-import uuid
 
 import nixos_rebuild.models as m
 import nixos_rebuild.nix as n
@@ -80,13 +80,17 @@ def test_remote_build(mock_uuid4: Any, mock_run: Any, monkeypatch: Any) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
-    def run_wrapper_side_effect(args, **kwargs):  # type: ignore
+    def run_wrapper_side_effect(
+        args: list[str], **kwargs: Any
+    ) -> CompletedProcess[str]:
         if args[0] == "nix-instantiate":
             return CompletedProcess([], 0, stdout=" \n/path/to/file\n ")
         elif args[0] == "mktemp":
             return CompletedProcess([], 0, stdout=" \n/tmp/tmpdir\n ")
         elif args[0] == "nix-store":
-            return CompletedProcess([], 0, stdout=" \n/tmp/tmpdir/00000000000000000000000000000000\n ")
+            return CompletedProcess(
+                [], 0, stdout=" \n/tmp/tmpdir/00000000000000000000000000000000\n "
+            )
         elif args[0] == "readlink":
             return CompletedProcess([], 0, stdout=" \n/path/to/config\n ")
         else:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import ANY, call, patch
 
 import pytest
+import uuid
 
 import nixos_rebuild.models as m
 import nixos_rebuild.nix as n
@@ -73,14 +74,27 @@ def test_build_flake(mock_run: Any) -> None:
     )
 
 
-@patch(
-    get_qualified_name(n.run_wrapper, n),
-    autospec=True,
-    return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
-)
-def test_remote_build(mock_run: Any, monkeypatch: Any) -> None:
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
+@patch(get_qualified_name(n.uuid4, n), autospec=True)
+def test_remote_build(mock_uuid4: Any, mock_run: Any, monkeypatch: Any) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
+
+    def run_wrapper_side_effect(args, **kwargs):  # type: ignore
+        if args[0] == "nix-instantiate":
+            return CompletedProcess([], 0, stdout=" \n/path/to/file\n ")
+        elif args[0] == "mktemp":
+            return CompletedProcess([], 0, stdout=" \n/tmp/tmpdir\n ")
+        elif args[0] == "nix-store":
+            return CompletedProcess([], 0, stdout=" \n/tmp/tmpdir/00000000000000000000000000000000\n ")
+        elif args[0] == "readlink":
+            return CompletedProcess([], 0, stdout=" \n/path/to/config\n ")
+        else:
+            return CompletedProcess([], 0)
+
+    mock_run.side_effect = run_wrapper_side_effect
+    mock_uuid4.return_value = uuid.UUID(int=0)
+
     assert n.remote_build(
         "config.system.build.toplevel",
         m.BuildAttr("<nixpkgs/nixos>", "preAttr"),
@@ -88,7 +102,8 @@ def test_remote_build(mock_run: Any, monkeypatch: Any) -> None:
         build_flags={"build": True},
         instantiate_flags={"inst": True},
         copy_flags={"copy": True},
-    ) == Path("/path/to/file")
+    ) == Path("/path/to/config")
+
     mock_run.assert_has_calls(
         [
             call(
@@ -97,6 +112,8 @@ def test_remote_build(mock_run: Any, monkeypatch: Any) -> None:
                     "<nixpkgs/nixos>",
                     "--attr",
                     "preAttr.config.system.build.toplevel",
+                    "--add-root",
+                    n.tmpdir.TMPDIR_PATH / "00000000000000000000000000000000",
                     "--inst",
                 ],
                 stdout=PIPE,
@@ -114,10 +131,28 @@ def test_remote_build(mock_run: Any, monkeypatch: Any) -> None:
                 },
             ),
             call(
-                ["nix-store", "--realise", Path("/path/to/file"), "--build"],
+                ["mktemp", "-d", "-t", "nixos-rebuild.XXXXX"],
                 remote=build_host,
                 stdout=PIPE,
             ),
+            call(
+                [
+                    "nix-store",
+                    "--realise",
+                    Path("/path/to/file"),
+                    "--add-root",
+                    Path("/tmp/tmpdir/00000000000000000000000000000000"),
+                    "--build",
+                ],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+            call(
+                ["readlink", "-f", "/tmp/tmpdir/00000000000000000000000000000000"],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+            call(["rm", "-rf", Path("/tmp/tmpdir")], remote=build_host, check=False),
         ]
     )
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix: #365225.

Untested since I have no non-Flakes systems.

The idea of this PR is not really to remove the race conditions, only to hide the warnings. The race condition situation is really unlikely to happen, and doesn't seem to be an issue in `nixos-rebuild` right now, so I think we can ignore at least until someone starts having actual issues with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
