### PR TITLE
wireshark: 4.2.8 -> 4.2.9

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -58,7 +58,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.2.8";
+  version = "4.2.9";
 
   outputs = [
     "out"
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-QnBETFkYoeBTQFV8g2c/dZjgCXaMtFi1MQUgmkOool8=";
+    hash = "sha256-4GnDHGfd2FUOhel8/ZCzAH1iuUz1nTPdAAUCTcY0R5E=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of Changes

Fixes CVE-2024-11596 and CVE-2024-11595
https://www.wireshark.org/security/wnpa-sec-2024-15.html, https://www.wireshark.org/security/wnpa-sec-2024-14.html

Changes:
https://www.wireshark.org/docs/relnotes/wireshark-4.2.9.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of nixpkgs-review for 'x86_64-linux':
<details>
  <summary>28 packages built:</summary>

- compactor 
- credslayer 
- credslayer.dist 
- dbmonster 
- haka
- hfinger 
- hfinger.dist 
- ostinato 
- python311Packages.dissect-cobaltstrike 
- python311Packages.dissect-cobaltstrike.dist 
- python311Packages.manuf 
- python311Packages.manuf.dist python311Packages.pyshark 
- python311Packages.pyshark.dist 
- python312Packages.dissect-cobaltstrike 
- python312Packages.dissect-cobaltstrike.dist 
- python312Packages.manuf 
- python312Packages.manuf.dist 
- python312Packages.pyshark 
- python312Packages.pyshark.dist 
- qtwirediff 
- termshark 
- tshark 
- tshark.dev 
- wifite2 
- wifite2.dist 
- wireshark 
- wireshark.dev

</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
