### PR TITLE
Make ec2 tests a channel blocker

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -87,6 +87,7 @@ rec {
         (onFullSupported "nixos.tests.containers-ip")
         (onSystems [ "x86_64-linux" ] "nixos.tests.docker")
         (onFullSupported "nixos.tests.env")
+        (onSystems [ "x86_64-linux" "aarch64-linux" ] "nixos.tests.ec2-userdata")
 
         # Way too many manual retries required on Hydra.
         #  Apparently it's hard to track down the cause.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -490,7 +490,7 @@ in
   earlyoom = runTestOn [ "x86_64-linux" ] ./earlyoom.nix;
   easytier = runTest ./easytier.nix;
   ec2-image = runTest ./ec2-image.nix;
-  ec2-nixops = (handleTestOn [ "x86_64-linux" ] ./ec2.nix { }).ec2-nixops or { };
+  ec2-userdata = (handleTestOn [ "x86_64-linux" ] ./ec2.nix { }).ec2-userdata or { };
   echoip = runTest ./echoip.nix;
   ejabberd = runTest ./xmpp/ejabberd.nix;
   elk = handleTestOn [ "x86_64-linux" ] ./elk.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -489,9 +489,8 @@ in
   early-mount-options = runTest ./early-mount-options.nix;
   earlyoom = runTestOn [ "x86_64-linux" ] ./earlyoom.nix;
   easytier = runTest ./easytier.nix;
-  ec2-config = (handleTestOn [ "x86_64-linux" ] ./ec2.nix { }).boot-ec2-config or { };
   ec2-image = runTest ./ec2-image.nix;
-  ec2-nixops = (handleTestOn [ "x86_64-linux" ] ./ec2.nix { }).boot-ec2-nixops or { };
+  ec2-nixops = (handleTestOn [ "x86_64-linux" ] ./ec2.nix { }).ec2-nixops or { };
   echoip = runTest ./echoip.nix;
   ejabberd = runTest ./xmpp/ejabberd.nix;
   elk = handleTestOn [ "x86_64-linux" ] ./elk.nix { };

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -18,12 +18,6 @@ let
         ../modules/testing/test-instrumentation.nix
         ../modules/profiles/qemu-guest.nix
         {
-          # Hack to make the partition resizing work in QEMU.
-          boot.initrd.postDeviceCommands = mkBefore ''
-            ln -s vda /dev/xvda
-            ln -s vda1 /dev/xvda1
-          '';
-
           amazonImage.format = "qcow2";
 
           # In a NixOS test the serial console is occupied by the "backdoor"

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -44,8 +44,8 @@ let
 
 in
 {
-  ec2-nixops = makeEc2Test {
-    name = "nixops-userdata";
+  ec2-userdata = makeEc2Test {
+    name = "ec2-userdata";
     meta.timeout = 600;
     inherit image;
     sshPublicKey = snakeOilPublicKey; # That's right folks! My user's key is also the host key!

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -31,30 +31,6 @@ let
           # the configuration in virtualisation/amazon-image.nix.
           systemd.services."serial-getty@ttyS0".enable = mkForce false;
 
-          # Needed by nixos-rebuild due to the lack of network
-          # access. Determined by trial and error.
-          system.extraDependencies = with pkgs; [
-            # Needed for a nixos-rebuild.
-            busybox
-            cloud-utils
-            desktop-file-utils
-            libxslt.bin
-            mkinitcpio-nfs-utils
-            stdenv
-            stdenvNoCC
-            texinfo
-            unionfs-fuse
-            lndir
-
-            # These are used in the configure-from-userdata tests
-            # for EC2. Httpd and valgrind are requested by the
-            # configuration.
-            apacheHttpd
-            apacheHttpd.doc
-            apacheHttpd.man
-            valgrind.doc
-          ];
-
           nixpkgs.pkgs = pkgs;
         }
       ];
@@ -68,7 +44,7 @@ let
 
 in
 {
-  boot-ec2-nixops = makeEc2Test {
+  ec2-nixops = makeEc2Test {
     name = "nixops-userdata";
     meta.timeout = 600;
     inherit image;
@@ -114,51 +90,6 @@ in
       machine.shutdown()
       machine.start()
       machine.wait_for_file("/etc/ec2-metadata/user-data")
-    '';
-  };
-
-  boot-ec2-config = makeEc2Test {
-    name = "config-userdata";
-    meta.broken = true; # amazon-init wants to download from the internet while building the system
-    inherit image;
-    sshPublicKey = snakeOilPublicKey;
-
-    # ### https://channels.nixos.org/nixos-unstable nixos
-    userData = ''
-      { pkgs, ... }:
-
-      {
-        imports = [
-          <nixpkgs/nixos/modules/virtualisation/amazon-image.nix>
-          <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
-          <nixpkgs/nixos/modules/profiles/qemu-guest.nix>
-        ];
-        environment.etc.testFile = {
-          text = "whoa";
-        };
-
-        networking.hostName = "ec2-test-vm"; # required by services.httpd
-
-        services.httpd = {
-          enable = true;
-          adminAddr = "test@example.org";
-          virtualHosts.localhost.documentRoot = "''${pkgs.valgrind.doc}/share/doc/valgrind/html";
-        };
-        networking.firewall.allowedTCPPorts = [ 80 ];
-      }
-    '';
-    script = ''
-      machine.start()
-
-      # amazon-init must succeed. if it fails, make the test fail
-      # immediately instead of timing out in wait_for_file.
-      machine.wait_for_unit("amazon-init.service")
-
-      machine.wait_for_file("/etc/testFile")
-      assert "whoa" in machine.succeed("cat /etc/testFile")
-
-      machine.wait_for_unit("httpd.service")
-      assert "Valgrind" in machine.succeed("curl http://localhost")
     '';
   };
 }


### PR DESCRIPTION
This is to catch issues like https://github.com/NixOS/nixpkgs/pull/340489#issuecomment-253149474
We do not want to push NixOS updates that break SSH access on EC2 instances.

I also took the liberty to clean up the tests a little bit. And remove a test that has been broken since forever.

If someone has a good idea how to fix the `ec2-config` test I'm all ears. Perhaps `system.includeBuilDependencies = true;` ? 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
