### PR TITLE
[release-24.11] Consistently condition merge-dependent workflows

### DIFF
--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -13,15 +13,19 @@ permissions:
   contents: read
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   nixos:
     name: nixfmt-check
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.title, '[skip treewide]')"
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # pull_request_target checks out the base branch by default
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           # Fetches the merge commit and its parents
           fetch-depth: 2
       - name: Checking out base branch

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -33,10 +33,15 @@ env:
   DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   # Check that code owners is valid
   check:
     name: Check
     runs-on: ubuntu-latest
+    needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
     steps:
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
@@ -65,7 +70,7 @@ jobs:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        ref: refs/pull/${{ github.event.number }}/merge
+        ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
         path: pr
 
     - name: Validate codeowners

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -11,10 +11,14 @@ on:
       - 'release-**'
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   tests:
     name: editorconfig-check
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
     - name: Get list of changed files from PR
       env:
@@ -30,7 +34,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         # pull_request_target checks out the base branch by default
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       with:
         # nixpkgs commit is pinned so that it doesn't break

--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -15,9 +15,9 @@ jobs:
     name: nixpkgs-lib-tests
     runs-on: ubuntu-latest
     needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: needs.get-merge-commit.outputs.mergedSha
         with:
           # pull_request_target checks out the base branch by default
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -23,22 +23,21 @@ jobs:
     name: Attributes
     runs-on: ubuntu-latest
     needs: get-merge-commit
+    # Skip this and dependent steps if the PR can't be merged
+    if: needs.get-merge-commit.outputs.mergedSha
     outputs:
-      mergedSha: ${{ needs.get-merge-commit.outputs.mergedSha }}
       baseSha: ${{ steps.baseSha.outputs.baseSha }}
       systems: ${{ steps.systems.outputs.systems }}
     steps:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        # Add this to _all_ subsequent steps to skip them
-        if: needs.get-merge-commit.outputs.mergedSha
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           fetch-depth: 2
           path: nixpkgs
 
       - name: Determine base commit
-        if: github.event_name == 'pull_request_target' && needs.get-merge-commit.outputs.mergedSha
+        if: github.event_name == 'pull_request_target'
         id: baseSha
         run: |
           baseSha=$(git -C nixpkgs rev-parse HEAD^1)
@@ -46,18 +45,15 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
-        if: needs.get-merge-commit.outputs.mergedSha
 
       - name: Evaluate the list of all attributes and get the systems matrix
         id: systems
-        if: needs.get-merge-commit.outputs.mergedSha
         run: |
           nix-build nixpkgs/ci -A eval.attrpathsSuperset
           echo "systems=$(<result/systems.json)" >> "$GITHUB_OUTPUT"
 
       - name: Upload the list of all attributes
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: needs.get-merge-commit.outputs.mergedSha
         with:
           name: paths
           path: result/*
@@ -65,12 +61,12 @@ jobs:
   eval-aliases:
     name: Eval nixpkgs with aliases enabled
     runs-on: ubuntu-latest
-    needs: attrs
+    needs: [ attrs, get-merge-commit ]
     steps:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ needs.attrs.outputs.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           path: nixpkgs
 
       - name: Install Nix
@@ -83,9 +79,7 @@ jobs:
   outpaths:
     name: Outpaths
     runs-on: ubuntu-latest
-    needs: attrs
-    # Skip this and future steps if the PR can't be merged
-    if: needs.attrs.outputs.mergedSha
+    needs: [ attrs, get-merge-commit ]
     strategy:
       matrix:
         system: ${{ fromJSON(needs.attrs.outputs.systems) }}
@@ -99,7 +93,7 @@ jobs:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ needs.attrs.outputs.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           path: nixpkgs
 
       - name: Install Nix
@@ -117,7 +111,6 @@ jobs:
 
       - name: Upload the output paths and eval stats
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: needs.attrs.outputs.mergedSha
         with:
           name: intermediate-${{ matrix.system }}
           path: result/*
@@ -125,7 +118,7 @@ jobs:
   process:
     name: Process
     runs-on: ubuntu-latest
-    needs: [ outpaths, attrs ]
+    needs: [ outpaths, attrs, get-merge-commit ]
     outputs:
       baseRunId: ${{ steps.baseRunId.outputs.baseRunId }}
     steps:
@@ -138,7 +131,7 @@ jobs:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ needs.attrs.outputs.mergedSha }}
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           path: nixpkgs
 
       - name: Install Nix

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -11,10 +11,14 @@ on:
       - 'release-**'
 
 jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
   tests:
     name: nix-files-parseable-check
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
     - name: Get list of changed files from PR
       env:
@@ -30,7 +34,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         # pull_request_target checks out the base branch by default
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
       if: ${{ env.CHANGED_FILES && env.CHANGED_FILES != '' }}
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       with:

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -29,24 +29,21 @@ jobs:
     # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
     needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: needs.get-merge-commit.outputs.mergedSha
         with:
           # pull_request_target checks out the base branch by default
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
           # Fetches the merge commit and its parents
           fetch-depth: 2
       - name: Checking out base branch
-        if: needs.get-merge-commit.outputs.mergedSha
         run: |
           base=$(mktemp -d)
           git worktree add "$base" "$(git rev-parse HEAD^1)"
           echo "base=$base" >> "$GITHUB_ENV"
       - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
-        if: needs.get-merge-commit.outputs.mergedSha
       - name: Fetching the pinned tool
-        if: needs.get-merge-commit.outputs.mergedSha
         # Update the pinned version using ci/nixpkgs-vet/update-pinned-tool.sh
         run: |
           # The pinned version of the tooling to use.
@@ -59,7 +56,6 @@ jobs:
           # Adds a result symlink as a GC root.
           nix-store --realise "$toolPath" --add-root result
       - name: Running nixpkgs-vet
-        if: needs.get-merge-commit.outputs.mergedSha
         env:
           # Force terminal colors to be enabled. The library that `nixpkgs-vet` uses respects https://bixense.com/clicolors/
           CLICOLOR_FORCE: 1


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/364338

Prevents such failures on release-24.11: https://github.com/NixOS/nixpkgs/actions/runs/12359159471/job/34491259676

Ping @FliegendeWurst @wolfgangwalther

## Things done
- [x] Confirmed that it works fine on master and there's nothing substantially different on release-24.11

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
