### PR TITLE
gamescope: 3.15.15 -> 3.16.1

### DIFF
--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -176,18 +176,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "SteamOS session compositing window manager";
     homepage = "https://github.com/ValveSoftware/gamescope";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
       nrdxp
       pedrohlc
       Scrumplex
       zhaofengli
       k900
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "gamescope";
   };
 })

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -186,6 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
       Scrumplex
       zhaofengli
       k900
+      Gliczy
     ];
     platforms = lib.platforms.linux;
     mainProgram = "gamescope";

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -39,8 +39,8 @@
   enableWsi ? true,
 }:
 let
-  joshShaders = fetchFromGitHub {
-    owner = "Joshua-Ashton";
+  frogShaders = fetchFromGitHub {
+    owner = "misyltoad";
     repo = "GamescopeShaders";
     rev = "v0.1";
     hash = "sha256-gR1AeAHV/Kn4ntiEDUSPxASLMFusV6hgSGrTbMCBUZA=";
@@ -171,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Install ReShade shaders
     mkdir -p $out/share/gamescope/reshade
-    cp -r ${joshShaders}/* $out/share/gamescope/reshade/
+    cp -r ${frogShaders}/* $out/share/gamescope/reshade/
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   # We can't substitute the patch itself because substituteAll is itself a derivation,
   # so `placeholder "out"` ends up pointing to the wrong place
   postPatch = ''
-    substituteInPlace src/reshade_effect_manager.cpp --replace "@out@" "$out"
+    substituteInPlace src/reshade_effect_manager.cpp --replace-fail "@out@" "$out"
     # Patching shebangs in the main `libdisplay-info` build
     patchShebangs subprojects/libdisplay-info/tool/gen-search-table.py
     # Replace gamescopereeaper with absolute path

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -32,6 +32,7 @@
   libdecor,
   lcms,
   lib,
+  luajit,
   makeBinaryWrapper,
   nix-update-script,
   enableExecutable ? true,
@@ -47,14 +48,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.15.15";
+  version = "3.16.1";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-FiPSGzfA3YH9TED8E5hpfpd+IQGthvwsxAFXZuqVZ4Q=";
+    hash = "sha256-+0QGt4UADJmZok2LzvL+GBad0t4vVL4HXq27399zH3Y=";
   };
 
   patches = [
@@ -72,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs subprojects/libdisplay-info/tool/gen-search-table.py
     # Replace gamescopereeaper with absolute path
     substituteInPlace src/Utils/Process.cpp --subst-var-by "gamescopereaper" "$out/bin/gamescopereaper"
+    patchShebangs default_scripts_install.sh
   '';
 
   mesonFlags = [
@@ -118,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       wayland-protocols
       vulkan-loader
       glm
+      luajit
     ]
     ++ lib.optionals enableWsi [
       vulkan-headers


### PR DESCRIPTION
https://github.com/ValveSoftware/gamescope/compare/3.15.15...3.16.1

Added `luajit` to `buildInputs` as it is now required.

I updated the source for the shaders to the owner's new account. While it works without changing it, I feel like it wouldn't hurt to use correct owner. As for the variable name, misyltoad seem to like frog, so I figure this would fit.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
