### PR TITLE
uiua{,-unstable}: use lib.fix to reference self, rename unstable flag to uiua_versionType

### DIFF
--- a/pkgs/by-name/ui/uiua/package.nix
+++ b/pkgs/by-name/ui/uiua/package.nix
@@ -10,9 +10,7 @@
   alsa-lib,
   webcamSupport ? false,
 
-  # passthru.tests.run
   runCommand,
-  uiua,
 
   unstable ? false,
 }:
@@ -20,51 +18,56 @@
 let
   versionInfo = import (if unstable then ./unstable.nix else ./stable.nix);
 in
-rustPlatform.buildRustPackage rec {
-  pname = "uiua";
-  inherit (versionInfo) version cargoHash;
 
-  src = fetchFromGitHub {
-    owner = "uiua-lang";
-    repo = "uiua";
-    inherit (versionInfo) rev hash;
-  };
+# buildRustPackage doesn't support finalAttrs, so we can't use finalPackage for the tests
+lib.fix (
+  uiua:
+  rustPlatform.buildRustPackage rec {
+    pname = "uiua";
+    inherit (versionInfo) version cargoHash;
 
-  nativeBuildInputs =
-    lib.optionals (webcamSupport || stdenv.hostPlatform.isDarwin) [ rustPlatform.bindgenHook ]
-    ++ lib.optionals audioSupport [ pkg-config ];
+    src = fetchFromGitHub {
+      owner = "uiua-lang";
+      repo = "uiua";
+      inherit (versionInfo) rev hash;
+    };
 
-  buildInputs =
-    [ libffi ] # we force dynamic linking our own libffi below
-    ++ lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
+    nativeBuildInputs =
+      lib.optionals (webcamSupport || stdenv.hostPlatform.isDarwin) [ rustPlatform.bindgenHook ]
+      ++ lib.optionals audioSupport [ pkg-config ];
 
-  buildFeatures =
-    [ "libffi/system" ] # force libffi to be linked dynamically instead of rebuilding it
-    ++ lib.optional audioSupport "audio"
-    ++ lib.optional webcamSupport "webcam";
+    buildInputs =
+      [ libffi ] # we force dynamic linking our own libffi below
+      ++ lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
 
-  passthru.updateScript = versionInfo.updateScript;
-  passthru.tests.run = runCommand "uiua-test-run" { nativeBuildInputs = [ uiua ]; } ''
-    uiua init
-    diff -U3 --color=auto <(uiua run main.ua) <(echo '"Hello, World!"')
-    touch $out
-  '';
+    buildFeatures =
+      [ "libffi/system" ] # force libffi to be linked dynamically instead of rebuilding it
+      ++ lib.optional audioSupport "audio"
+      ++ lib.optional webcamSupport "webcam";
 
-  meta = {
-    changelog = "https://github.com/uiua-lang/uiua/blob/${src.rev}/changelog.md";
-    description = "Stack-oriented array programming language with a focus on simplicity, beauty, and tacit code";
-    longDescription = ''
-      Uiua combines the stack-oriented and array-oriented paradigms in a single
-      language. Combining these already terse paradigms results in code with a very
-      high information density and little syntactic noise.
+    passthru.updateScript = versionInfo.updateScript;
+    passthru.tests.run = runCommand "uiua-test-run" { nativeBuildInputs = [ uiua ]; } ''
+      uiua init
+      diff -U3 --color=auto <(uiua run main.ua) <(echo '"Hello, World!"')
+      touch $out
     '';
-    homepage = "https://www.uiua.org/";
-    license = lib.licenses.mit;
-    mainProgram = "uiua";
-    maintainers = with lib.maintainers; [
-      cafkafk
-      tomasajt
-      defelo
-    ];
-  };
-}
+
+    meta = {
+      changelog = "https://github.com/uiua-lang/uiua/blob/${src.rev}/changelog.md";
+      description = "Stack-oriented array programming language with a focus on simplicity, beauty, and tacit code";
+      longDescription = ''
+        Uiua combines the stack-oriented and array-oriented paradigms in a single
+        language. Combining these already terse paradigms results in code with a very
+        high information density and little syntactic noise.
+      '';
+      homepage = "https://www.uiua.org/";
+      license = lib.licenses.mit;
+      mainProgram = "uiua";
+      maintainers = with lib.maintainers; [
+        cafkafk
+        tomasajt
+        defelo
+      ];
+    };
+  }
+)

--- a/pkgs/by-name/ui/uiua/package.nix
+++ b/pkgs/by-name/ui/uiua/package.nix
@@ -1,4 +1,6 @@
 {
+  uiua_versionType ? "stable",
+
   lib,
   stdenv,
   rustPlatform,
@@ -11,12 +13,15 @@
   webcamSupport ? false,
 
   runCommand,
-
-  unstable ? false,
 }:
 
 let
-  versionInfo = import (if unstable then ./unstable.nix else ./stable.nix);
+  versionInfo =
+    {
+      "stable" = import ./stable.nix;
+      "unstable" = import ./unstable.nix;
+    }
+    .${uiua_versionType};
 in
 
 # buildRustPackage doesn't support finalAttrs, so we can't use finalPackage for the tests

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7090,7 +7090,7 @@ with pkgs;
   babashka-unwrapped = callPackage ../development/interpreters/babashka { };
   babashka = callPackage ../development/interpreters/babashka/wrapped.nix { };
 
-  uiua-unstable = callPackage ../by-name/ui/uiua/package.nix { unstable = true; };
+  uiua-unstable = callPackage ../by-name/ui/uiua/package.nix { uiua_versionType = "unstable"; };
 
   # BQN interpreters and compilers
 


### PR DESCRIPTION
I made uiua use `lib.fix` to reference itself for running the tests.
I could have used `let uiua = ...; in uiua`, but `lib.fix` is a bit closer to the `finalAttrs` pattern.

Also, I renamed the `unstable` flag, to not accidentally interfere with people's overlays.

This is rebased on my previous PR, so ideally, that should be merged first.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
