### PR TITLE
[staging-next] openjfx{17,21,23}: fix build with GCC 14

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -181,6 +181,7 @@
         - pkgs/development/compilers/corretto/**/*
         - pkgs/development/compilers/graalvm/**/*
         - pkgs/development/compilers/openjdk/**/*
+        - pkgs/by-name/op/openjfx/**/*
         - pkgs/development/compilers/semeru-bin/**/*
         - pkgs/development/compilers/temurin-bin/**/*
         - pkgs/development/compilers/zulu/**/*

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -115,6 +115,8 @@ stdenv.mkDerivation {
 
   __darwinAllowLocalNetworking = true;
 
+  # GCC 14 makes these errors by default
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=int-conversion";
   env.config = writeText "gradle.properties" ''
     CONF = Release
     JDK_HOME = ${jdk-bootstrap.home}


### PR DESCRIPTION
As discussed on Matrix.

Very similar to other fixes.

ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).