### PR TITLE
noita-entangled-worlds: init at 0.32.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16818,6 +16818,12 @@
     githubId = 75299;
     name = "Malcolm Matalka";
   };
+  orbsa = {
+    email = "mail@ericbell.dev";
+    github = "orbsa";
+    githubId = 9121811;
+    name = "Eric Bell";
+  };
   orhun = {
     email = "orhunparmaksiz@gmail.com";
     github = "orhun";

--- a/pkgs/by-name/no/noita-entangled-worlds/package.nix
+++ b/pkgs/by-name/no/noita-entangled-worlds/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  steam-run,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "noita_entangled_worlds";
+  version = "0.32.5";
+
+  src = fetchzip {
+    url = "https://github.com/IntQuant/noita_entangled_worlds/releases/download/v${finalAttrs.version}/noita-proxy-linux.zip";
+    hash = "sha256-qvcSf82RqPoRVwVVWqMcQNEa03b/asLgBwD5hsbyBoE=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    steam-run
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mkdir -p $out/libexec
+    cp noita_proxy.x86_64 $out/libexec/noita-proxy-bin
+    cp libsteam_api.so $out/libexec/
+
+    # Create a wrapper script that calls the binary from libexec
+    makeWrapper ${steam-run}/bin/steam-run $out/bin/noita-proxy \
+      --add-flags "$out/libexec/noita-proxy-bin"
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${finalAttrs.version}";
+    description = "True coop multiplayer mod for Noita";
+    homepage = "https://github.com/IntQuant/noita_entangled_worlds";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ orbsa ];
+    platforms = lib.platforms.linux;
+    mainProgram = "noita-proxy";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Tested and working great on NixOS.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
