### PR TITLE
catppuccin-discord: init at 0-unstable-2024-12-08

### DIFF
--- a/pkgs/by-name/ca/catppuccin-discord/package.nix
+++ b/pkgs/by-name/ca/catppuccin-discord/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  yarnConfigHook,
+  npmHooks,
+  nodejs-slim,
+  fetchYarnDeps,
+  flavour ? [ "mocha" ],
+  accents ? [ "blue" ],
+}:
+let
+  validFlavours = [
+    "mocha"
+    "macchiato"
+    "frappe"
+    "latte"
+  ];
+  validAccents = [
+    "rosewater"
+    "flamingo"
+    "pink"
+    "mauve"
+    "red"
+    "maroon"
+    "peach"
+    "yellow"
+    "green"
+    "teal"
+    "sky"
+    "sapphire"
+    "blue"
+    "lavender"
+  ];
+in
+lib.checkListOfEnum "Invalid accent, valid accents are ${toString validAccents}" validAccents
+  accents
+  lib.checkListOfEnum
+  "Invalid flavour, valid flavours are ${toString validFlavours}"
+  validFlavours
+  flavour
+  stdenvNoCC.mkDerivation
+  (finalAttrs: {
+    pname = "catppuccin-discord";
+    version = "0-unstable-2024-12-08";
+
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "discord";
+      rev = "16b1e5156583ee376ded4fa602842fa540826bbc";
+      hash = "sha256-ECVHRuHbe3dvwrOsi6JAllJ37xb18HaUPxXoysyPP70=";
+    };
+
+    nativeBuildInputs = [
+      yarnConfigHook
+      npmHooks.npmInstallHook
+      nodejs-slim
+    ];
+
+    yarnOfflineCache = fetchYarnDeps {
+      yarnLock = "${finalAttrs.src}/yarn.lock";
+      hash = "sha256-2N4UI6Ap+zk7jtDCAsjGtwfDSiyOtB9YDOXUxYRCw60=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+      yarn --offline release
+
+      runHook postBuild
+    '';
+
+    # "true" disables the dist phase, as there are no binaries and installation of themes
+    # will be handled in installPhase below.
+    distPhase = "true";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+
+      for FLAVOUR in ${toString flavour}; do
+        for ACCENT in ${toString accents}; do
+          cp -va dist/dist/catppuccin-"$FLAVOUR"-"$ACCENT".theme.css $out/share
+        done;
+      done;
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Soothing pastel theme for Discord";
+      homepage = "https://github.com/catppuccin/discord";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ NotAShelf ];
+      platforms = lib.platforms.all;
+      sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    };
+  })


### PR DESCRIPTION
- **catppuccin-discord: init at 0-unstable-2024-12-08**


Adds a simple derivation, inspired by catppuccin-kvantum, for Catpuccin's
discord theme. Since upstream does not tag releases, we use an unstable
commit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
