### PR TITLE
emacs: fix default values of withFoo flags after overrideAttrs

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -62,53 +62,41 @@
   wrapGAppsHook3,
   zlib,
 
+  # FIXME better dummy values
   # Boolean flags
-  withNativeCompilation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-  noGui ? false,
-  srcRepo ? true,
-  withAcl ? false,
-  withAlsaLib ? false,
-  withAthena ? false,
-  withCsrc ? true,
-  withDbus ? stdenv.hostPlatform.isLinux,
-  withGTK3 ? withPgtk && !noGui,
-  withGlibNetworking ? withPgtk || withGTK3 || (withX && withXwidgets),
-  withGpm ? stdenv.hostPlatform.isLinux,
-  withImageMagick ? lib.versionOlder version "27" && (withX || withNS),
+  withNativeCompilation ? throw "dummy value for backward compatibility, should never be evaled",
+  noGui ? throw "dummy value for backward compatibility, should never be evaled",
+  srcRepo ? throw "dummy value for backward compatibility, should never be evaled",
+  withAcl ? throw "dummy value for backward compatibility, should never be evaled",
+  withAlsaLib ? throw "dummy value for backward compatibility, should never be evaled",
+  withAthena ? throw "dummy value for backward compatibility, should never be evaled",
+  withCsrc ? throw "dummy value for backward compatibility, should never be evaled",
+  withDbus ? throw "dummy value for backward compatibility, should never be evaled",
+  withGTK3 ? throw "dummy value for backward compatibility, should never be evaled",
+  withGlibNetworking ? throw "dummy value for backward compatibility, should never be evaled",
+  withGpm ? throw "dummy value for backward compatibility, should never be evaled",
+  withImageMagick ? throw "dummy value for backward compatibility, should never be evaled",
   # Emacs 30+ has native JSON support
-  withJansson ? lib.versionOlder version "30",
-  withMailutils ? true,
-  withMotif ? false,
-  withNS ? stdenv.hostPlatform.isDarwin && !(variant == "macport" || noGui),
-  withPgtk ? false,
-  withSelinux ? stdenv.hostPlatform.isLinux,
-  withSQLite3 ? lib.versionAtLeast version "29",
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
-  withToolkitScrollBars ? true,
-  withTreeSitter ? lib.versionAtLeast version "29",
-  withWebP ? lib.versionAtLeast version "29",
-  withX ? !(stdenv.hostPlatform.isDarwin || noGui || withPgtk),
-  withXinput2 ? withX && lib.versionAtLeast version "29",
-  withXwidgets ?
-    !stdenv.hostPlatform.isDarwin
-    && !noGui
-    && (withGTK3 || withPgtk)
-    && (lib.versionOlder version "30"), # XXX: upstream bug 66068 precludes newer versions of webkit2gtk (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html)
-  withSmallJaDic ? false,
-  withCompressInstall ? true,
+  withJansson ? throw "dummy value for backward compatibility, should never be evaled",
+  withMailutils ? throw "dummy value for backward compatibility, should never be evaled",
+  withMotif ? throw "dummy value for backward compatibility, should never be evaled",
+  withNS ? throw "dummy value for backward compatibility, should never be evaled",
+  withPgtk ? throw "dummy value for backward compatibility, should never be evaled",
+  withSelinux ? throw "dummy value for backward compatibility, should never be evaled",
+  withSQLite3 ? throw "dummy value for backward compatibility, should never be evaled",
+  withSystemd ? throw "dummy value for backward compatibility, should never be evaled",
+  withToolkitScrollBars ? throw "dummy value for backward compatibility, should never be evaled",
+  withTreeSitter ? throw "dummy value for backward compatibility, should never be evaled",
+  withWebP ? throw "dummy value for backward compatibility, should never be evaled",
+  withX ? throw "dummy value for backward compatibility, should never be evaled",
+  withXinput2 ? throw "dummy value for backward compatibility, should never be evaled",
+  withXwidgets ? throw "dummy value for backward compatibility, should never be evaled",
+  withSmallJaDic ? throw "dummy value for backward compatibility, should never be evaled",
+  withCompressInstall ? throw "dummy value for backward compatibility, should never be evaled",
 
   # Options
-  siteStart ? ./site-start.el,
-  toolkit ? (
-    if withGTK3 then
-      "gtk3"
-    else if withMotif then
-      "motif"
-    else if withAthena then
-      "athena"
-    else
-      "lucid"
-  ),
+  siteStart ? throw "dummy value for backward compatibility, should never be evaled",
+  toolkit ? throw "dummy value for backward compatibility, should never be evaled",
 
   # macOS dependencies for NS and macPort
   Accelerate,
@@ -124,17 +112,7 @@
   QuartzCore,
   UniformTypeIdentifiers,
   WebKit,
-}:
-
-assert (withGTK3 && !withNS && variant != "macport") -> withX || withPgtk;
-
-assert noGui -> !(withX || withGTK3 || withNS || variant == "macport");
-assert withAcl -> stdenv.hostPlatform.isLinux;
-assert withAlsaLib -> stdenv.hostPlatform.isLinux;
-assert withGpm -> stdenv.hostPlatform.isLinux;
-assert withNS -> stdenv.hostPlatform.isDarwin && !(withX || variant == "macport");
-assert withPgtk -> withGTK3 && !withX;
-assert withXwidgets -> !noGui && (withGTK3 || withPgtk);
+}@args:
 
 let
   libGccJitLibraryPaths =
@@ -154,13 +132,13 @@ mkDerivation (finalAttrs: {
   pname =
     pname
     + (
-      if noGui then
+      if finalAttrs.noGui then
         "-nox"
       else if variant == "macport" then
         "-macport"
-      else if withPgtk then
+      else if finalAttrs.withPgtk then
         "-pgtk"
-      else if withGTK3 then
+      else if finalAttrs.withGTK3 then
         "-gtk3"
       else
         ""
@@ -171,7 +149,7 @@ mkDerivation (finalAttrs: {
 
   patches =
     patches fetchpatch
-    ++ lib.optionals withNativeCompilation [
+    ++ lib.optionals finalAttrs.withNativeCompilation [
       (replaceVars
         (
           if lib.versionOlder finalAttrs.version "29" then
@@ -209,7 +187,7 @@ mkDerivation (finalAttrs: {
     ];
 
   postPatch = lib.concatStringsSep "\n" [
-    (lib.optionalString srcRepo ''
+    (lib.optionalString finalAttrs.srcRepo ''
       rm -fr .git
     '')
 
@@ -253,11 +231,13 @@ mkDerivation (finalAttrs: {
     ++ lib.optionals (variant == "macport") [
       texinfo
     ]
-    ++ lib.optionals srcRepo [
+    ++ lib.optionals finalAttrs.srcRepo [
       autoreconfHook
       texinfo
     ]
-    ++ lib.optionals (withPgtk || withX && (withGTK3 || withXwidgets)) [ wrapGAppsHook3 ];
+    ++ lib.optionals (
+      finalAttrs.withPgtk || finalAttrs.withX && (finalAttrs.withGTK3 || finalAttrs.withXwidgets)
+    ) [ wrapGAppsHook3 ];
 
   buildInputs =
     [
@@ -265,52 +245,52 @@ mkDerivation (finalAttrs: {
       gnutls
       (lib.getDev harfbuzz)
     ]
-    ++ lib.optionals withJansson [
+    ++ lib.optionals finalAttrs.withJansson [
       jansson
     ]
     ++ [
       libxml2
       ncurses
     ]
-    ++ lib.optionals withAcl [
+    ++ lib.optionals finalAttrs.withAcl [
       acl
     ]
-    ++ lib.optionals withAlsaLib [
+    ++ lib.optionals finalAttrs.withAlsaLib [
       alsa-lib
     ]
-    ++ lib.optionals withGpm [
+    ++ lib.optionals finalAttrs.withGpm [
       gpm
     ]
-    ++ lib.optionals withDbus [
+    ++ lib.optionals finalAttrs.withDbus [
       dbus
     ]
-    ++ lib.optionals withSelinux [
+    ++ lib.optionals finalAttrs.withSelinux [
       libselinux
     ]
-    ++ lib.optionals (!stdenv.hostPlatform.isDarwin && withGTK3) [
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin && finalAttrs.withGTK3) [
       gsettings-desktop-schemas
     ]
-    ++ lib.optionals (stdenv.hostPlatform.isLinux && withX) [
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && finalAttrs.withX) [
       libotf
       m17n_lib
     ]
-    ++ lib.optionals (withX && withGTK3) [
+    ++ lib.optionals (finalAttrs.withX && finalAttrs.withGTK3) [
       gtk3-x11
     ]
-    ++ lib.optionals (withX && withMotif) [
+    ++ lib.optionals (finalAttrs.withX && finalAttrs.withMotif) [
       motif
     ]
-    ++ lib.optionals withGlibNetworking [
+    ++ lib.optionals finalAttrs.withGlibNetworking [
       glib-networking
     ]
-    ++ lib.optionals withNativeCompilation [
+    ++ lib.optionals finalAttrs.withNativeCompilation [
       libgccjit
       zlib
     ]
-    ++ lib.optionals withImageMagick [
+    ++ lib.optionals finalAttrs.withImageMagick [
       imagemagick
     ]
-    ++ lib.optionals withPgtk [
+    ++ lib.optionals finalAttrs.withPgtk [
       giflib
       gtk3
       libXpm
@@ -319,19 +299,19 @@ mkDerivation (finalAttrs: {
       librsvg
       libtiff
     ]
-    ++ lib.optionals withSQLite3 [
+    ++ lib.optionals finalAttrs.withSQLite3 [
       sqlite
     ]
-    ++ lib.optionals withSystemd [
+    ++ lib.optionals finalAttrs.withSystemd [
       systemd
     ]
-    ++ lib.optionals withTreeSitter [
+    ++ lib.optionals finalAttrs.withTreeSitter [
       tree-sitter
     ]
-    ++ lib.optionals withWebP [
+    ++ lib.optionals finalAttrs.withWebP [
       libwebp
     ]
-    ++ lib.optionals withX [
+    ++ lib.optionals finalAttrs.withX [
       Xaw3d
       cairo
       giflib
@@ -342,16 +322,16 @@ mkDerivation (finalAttrs: {
       librsvg
       libtiff
     ]
-    ++ lib.optionals withXinput2 [
+    ++ lib.optionals finalAttrs.withXinput2 [
       libXi
     ]
-    ++ lib.optionals withXwidgets [
+    ++ lib.optionals finalAttrs.withXwidgets [
       webkitgtk_4_0
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       sigtool
     ]
-    ++ lib.optionals withNS [
+    ++ lib.optionals finalAttrs.withNS [
       librsvg
       AppKit
       GSS
@@ -377,7 +357,7 @@ mkDerivation (finalAttrs: {
     ];
 
   # Emacs needs to find movemail at run time, see info (emacs) Movemail
-  propagatedUserEnvPkgs = lib.optionals withMailutils [
+  propagatedUserEnvPkgs = lib.optionals finalAttrs.withMailutils [
     mailutils
   ];
 
@@ -389,17 +369,17 @@ mkDerivation (finalAttrs: {
       (lib.withFeature true "modules")
     ]
     ++ (
-      if withNS then
+      if finalAttrs.withNS then
         [
           (lib.enableFeature false "ns-self-contained")
         ]
-      else if withX then
+      else if finalAttrs.withX then
         [
-          (lib.withFeatureAs true "x-toolkit" toolkit)
+          (lib.withFeatureAs true "x-toolkit" finalAttrs.toolkit)
           (lib.withFeature true "cairo")
           (lib.withFeature true "xft")
         ]
-      else if withPgtk then
+      else if finalAttrs.withPgtk then
         [
           (lib.withFeature true "pgtk")
         ]
@@ -420,24 +400,24 @@ mkDerivation (finalAttrs: {
       (lib.withFeature true "xml2")
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      (lib.withFeature withNS "ns")
+      (lib.withFeature finalAttrs.withNS "ns")
     ]
     ++ [
-      (lib.withFeature withCompressInstall "compress-install")
-      (lib.withFeature withToolkitScrollBars "toolkit-scroll-bars")
-      (lib.withFeature withNativeCompilation "native-compilation")
-      (lib.withFeature withImageMagick "imagemagick")
-      (lib.withFeature withMailutils "mailutils")
-      (lib.withFeature withSmallJaDic "small-ja-dic")
-      (lib.withFeature withTreeSitter "tree-sitter")
-      (lib.withFeature withXinput2 "xinput2")
-      (lib.withFeature withXwidgets "xwidgets")
-      (lib.withFeature withDbus "dbus")
-      (lib.withFeature withSelinux "selinux")
+      (lib.withFeature finalAttrs.withCompressInstall "compress-install")
+      (lib.withFeature finalAttrs.withToolkitScrollBars "toolkit-scroll-bars")
+      (lib.withFeature finalAttrs.withNativeCompilation "native-compilation")
+      (lib.withFeature finalAttrs.withImageMagick "imagemagick")
+      (lib.withFeature finalAttrs.withMailutils "mailutils")
+      (lib.withFeature finalAttrs.withSmallJaDic "small-ja-dic")
+      (lib.withFeature finalAttrs.withTreeSitter "tree-sitter")
+      (lib.withFeature finalAttrs.withXinput2 "xinput2")
+      (lib.withFeature finalAttrs.withXwidgets "xwidgets")
+      (lib.withFeature finalAttrs.withDbus "dbus")
+      (lib.withFeature finalAttrs.withSelinux "selinux")
     ];
 
   env =
-    lib.optionalAttrs withNativeCompilation {
+    lib.optionalAttrs finalAttrs.withNativeCompilation {
       NATIVE_FULL_AOT = "1";
       LIBRARY_PATH = lib.concatStringsSep ":" libGccJitLibraryPaths;
     }
@@ -457,7 +437,7 @@ mkDerivation (finalAttrs: {
   postInstall =
     ''
       mkdir -p $out/share/emacs/site-lisp
-      cp ${siteStart} $out/share/emacs/site-lisp/site-start.el
+      cp ${finalAttrs.siteStart} $out/share/emacs/site-lisp/site-start.el
 
       $out/bin/emacs --batch -f batch-byte-compile $out/share/emacs/site-lisp/site-start.el
 
@@ -465,7 +445,7 @@ mkDerivation (finalAttrs: {
 
       rm -r $out/share/emacs/$siteVersionDir/site-lisp
     ''
-    + lib.optionalString withCsrc ''
+    + lib.optionalString finalAttrs.withCsrc ''
       for srcdir in src lisp lwlib ; do
         dstdir=$out/share/emacs/$siteVersionDir/$srcdir
         mkdir -p $dstdir
@@ -474,14 +454,16 @@ mkDerivation (finalAttrs: {
         echo '((nil . ((tags-file-name . "TAGS"))))' > $dstdir/.dir-locals.el
       done
     ''
-    + lib.optionalString withNS ''
+    + lib.optionalString finalAttrs.withNS ''
       mkdir -p $out/Applications
       mv nextstep/Emacs.app $out/Applications
     ''
-    + lib.optionalString (withNativeCompilation && (withNS || variant == "macport")) ''
-      ln -snf $out/lib/emacs/*/native-lisp $out/Applications/Emacs.app/Contents/native-lisp
-    ''
-    + lib.optionalString withNativeCompilation ''
+    +
+      lib.optionalString (finalAttrs.withNativeCompilation && (finalAttrs.withNS || variant == "macport"))
+        ''
+          ln -snf $out/lib/emacs/*/native-lisp $out/Applications/Emacs.app/Contents/native-lisp
+        ''
+    + lib.optionalString finalAttrs.withNativeCompilation ''
       echo "Generating native-compiled trampolines..."
       # precompile trampolines in parallel, but avoid spawning one process per trampoline.
       # 1000 is a rough lower bound on the number of trampolines compiled.
@@ -496,20 +478,91 @@ mkDerivation (finalAttrs: {
         -f batch-native-compile $out/share/emacs/site-lisp/site-start.el
     '';
 
-  postFixup = lib.optionalString (stdenv.hostPlatform.isLinux && withX && toolkit == "lucid") ''
-    patchelf --add-rpath ${lib.makeLibraryPath [ libXcursor ]} $out/bin/emacs
-    patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
-  '';
+  postFixup =
+    lib.optionalString
+      (stdenv.hostPlatform.isLinux && finalAttrs.withX && finalAttrs.toolkit == "lucid")
+      ''
+        patchelf --add-rpath ${lib.makeLibraryPath [ libXcursor ]} $out/bin/emacs
+        patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
+      '';
+
+  # these "args.withFoo or" are for backward compatibility (.override)
+  withNativeCompilation =
+    args.withNativeCompilation or stdenv.buildPlatform.canExecute
+      stdenv.hostPlatform;
+  noGui = args.noGui or false;
+  srcRepo = args.srcRepo or true;
+  withAcl = args.withAcl or false;
+  withAlsaLib = args.withAlsaLib or false;
+  withAthena = args.withAthena or false;
+  withCsrc = args.withCsrc or true;
+  withDbus = args.withDbus or stdenv.hostPlatform.isLinux;
+  withGTK3 = args.withGTK3 or finalAttrs.withPgtk && !finalAttrs.noGui;
+  withGlibNetworking =
+    args.withGlibNetworking or finalAttrs.withPgtk
+    || finalAttrs.withGTK3
+    || (finalAttrs.withX && finalAttrs.withXwidgets);
+  withGpm = args.withGpm or stdenv.hostPlatform.isLinux;
+  withImageMagick =
+    args.withImageMagick or lib.versionOlder finalAttrs.version "27"
+    && (finalAttrs.withX || finalAttrs.withNS);
+  withJansson = args.withJansson or lib.versionOlder finalAttrs.version "30";
+  withMailutils = args.withMailutils or true;
+  withMotif = args.withMotif or false;
+  withNS = args.withNS or stdenv.hostPlatform.isDarwin && !(variant == "macport" || finalAttrs.noGui);
+  withPgtk = args.withPgtk or false;
+  withSelinux = args.withSelinux or stdenv.hostPlatform.isLinux;
+  withSQLite3 = args.withSQLite3 or lib.versionAtLeast finalAttrs.version "29";
+  withSystemd = args.withSystemd or lib.meta.availableOn stdenv.hostPlatform systemd;
+  withToolkitScrollBars = args.withToolkitScrollBars or true;
+  withTreeSitter = args.withTreeSitter or lib.versionAtLeast finalAttrs.version "29";
+  withWebP = args.withWebP or lib.versionAtLeast finalAttrs.version "29";
+  withX = args.withX or (!(stdenv.hostPlatform.isDarwin || finalAttrs.noGui || finalAttrs.withPgtk));
+  withXinput2 = args.withXinput2 or finalAttrs.withX && lib.versionAtLeast finalAttrs.version "29";
+  withXwidgets =
+    args.withXwidgets or (!stdenv.hostPlatform.isDarwin)
+    && !finalAttrs.noGui
+    && (finalAttrs.withGTK3 || finalAttrs.withPgtk)
+    && (lib.versionOlder finalAttrs.version "30"); # XXX: upstream bug 66068 precludes newer versions of webkit2gtk (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html)
+  withSmallJaDic = args.withSmallJaDic or false;
+  withCompressInstall = args.withCompressInstall or true;
+
+  siteStart = args.siteStart or ./site-start.el;
+  toolkit =
+    args.toolkit or (
+      if finalAttrs.withGTK3 then
+        "gtk3"
+      else if finalAttrs.withMotif then
+        "motif"
+      else if finalAttrs.withAthena then
+        "athena"
+      else
+        "lucid"
+    );
+
+  # FIXME handle assertions better
+  assertions =
+    assert
+      (finalAttrs.withGTK3 && !finalAttrs.withNS && variant != "macport")
+      -> finalAttrs.withX || finalAttrs.withPgtk;
+    assert
+      finalAttrs.noGui
+      -> !(finalAttrs.withX || finalAttrs.withGTK3 || finalAttrs.withNS || variant == "macport");
+    assert finalAttrs.withAcl -> stdenv.hostPlatform.isLinux;
+    assert finalAttrs.withAlsaLib -> stdenv.hostPlatform.isLinux;
+    assert finalAttrs.withGpm -> stdenv.hostPlatform.isLinux;
+    assert
+      finalAttrs.withNS -> stdenv.hostPlatform.isDarwin && !(finalAttrs.withX || variant == "macport");
+    assert finalAttrs.withPgtk -> finalAttrs.withGTK3 && !finalAttrs.withX;
+    assert finalAttrs.withXwidgets -> !finalAttrs.noGui && (finalAttrs.withGTK3 || finalAttrs.withPgtk);
+    true; # dummy value to make syntax right
 
   passthru = {
-    inherit withNativeCompilation;
-    inherit withTreeSitter;
-    inherit withXwidgets;
     pkgs = recurseIntoAttrs (emacsPackagesFor finalAttrs.finalPackage);
     tests = { inherit (nixosTests) emacs-daemon; };
   };
 
   meta = meta // {
-    broken = withNativeCompilation && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+    broken = finalAttrs.withNativeCompilation && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
   };
 })


### PR DESCRIPTION
Previously, the normal way to override src and version led to wrong default values of withFoo flags.

Here is an minimal reproducible example for withXwidgets which should default to false when version >= 30.

```console
$ nix eval --include nixpkgs=$PWD --impure --expr '
let pkgs = import <nixpkgs> { config = { }; overlays = [ ]; };
in (pkgs.emacs29-pgtk.overrideAttrs { version = "30"; }).withXwidgets
'
true
```

This fix keeps backward compatibility for the .override interface.

Fixes: https://github.com/nix-community/emacs-overlay/issues/455


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
