### PR TITLE
tre: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/tr/tre/package.nix
+++ b/pkgs/by-name/tr/tre/package.nix
@@ -1,30 +1,55 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  darwin,
+  gettext,
+  libiconv,
+  libtool,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tre";
-  version = "0.8.0";
-  src = fetchurl {
-    url = "https://laurikari.net/tre/${pname}-${version}.tar.gz";
-    sha256 = "1pd7qsa7vc3ybdc6h2gr4pm9inypjysf92kab945gg4qa6jp11my";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "laurikari";
+    repo = "tre";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5O8yqzv+SR8x0X7GtC2Pjo94gp0799M2Va8wJ4EKyf8=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tre/0.8.0-6/debian/patches/03-cve-2016-8859";
-      sha256 = "0navhizym6qxd4gngrsslbij8x9r3s67p1jzzhvsnq6ky49j7w3p";
-    })
+  outputs = [
+    "out"
+    "dev"
   ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+  ];
+
+  buildInputs =
+    [
+      gettext
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libiconv
+    ];
+
+  preConfigure = ''
+    ./utils/autogen.sh
+  '';
 
   meta = {
     description = "Lightweight and robust POSIX compliant regexp matching library";
     homepage = "https://laurikari.net/tre/";
+    changelog = "https://github.com/laurikari/tre/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     mainProgram = "agrep";
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description

Update `tre` to its latest released version, 0.9.0. This change dictates a new upstream, [per this blog post by the author](https://laurikari.net/tre/tre-on-github/).

On macOS, `CoreFoundation` and `libiconv` is needed when linking, but the way it's specified might not be proper. Let me know :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
