### PR TITLE
tailwindcss-language-server: Give main $out/bin +x permission

### DIFF
--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib/tailwindcss-language-server}
     cp -r {packages,node_modules} $out/lib/tailwindcss-language-server
+    chmod +x $out/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server
     ln -s $out/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server $out/bin/tailwindcss-language-server
 
     runHook postInstall


### PR DESCRIPTION
The install phase was changed in
https://github.com/NixOS/nixpkgs/pull/363636 and the executable flag is missing. This causes errors like these when loading from Neovim:

```
...-unwrapped-0.10.2/share/nvim/runtime/lua/vim/lsp/rpc.lua:800:
Spawning language server with cmd: `{ "tailwindcss-language-server",
"--stdio" }` failed with error message:
...-unwrapped-0.10.2/share/nvim/runtime /lua/vim/_system.lua:244:
EACCES: permission denied
```

This is what the file looks like in the Nix store:

```
ls -la
/nix/store/<hash>-tailwindcss-language-server-0.0.27/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server
~/Development/nixpkgs λ ls -la
/nix/store/<hash>-tailwindcss-language-server-0.0.27/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server
.r--r--r-- 4,8M root  1 Jan  1970
/nix/store/<hash>-tailwindcss-language-server-0.0.27/lib/tailwindcss-language-server/packages/tailwindcss-language-server/bin/tailwindcss-language-server
```

Test plan: upgrade and run this:

```sh
 ~/.home.nix λ tailwindcss-language-server --stdio
Content-Length: 99

{"jsonrpc":"2.0","method":"window/logMessage","params":{"type":4,"message":"Setting up server…"}}Content-Length: 104

{"jsonrpc":"2.0","method":"window/logMessage","params":{"type":4,"message":"Listening for messages…"}}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
