### PR TITLE
nixos/systemd: don't require network-online.target for multi-user.taget v2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -85,6 +85,16 @@
 
 - `gkraken` software and `hardware.gkraken.enable` option have been removed, use `coolercontrol` via `programs.coolercontrol.enable` option instead.
 
+- To avoid delaying user logins unnecessarily the `multi-user.target` is no longer ordered after `network-online.target`.
+  System services requiring a connection to start correctly must explicitly state so, i.e.
+  ```nix
+  systemd.services.<name> = {
+    wants = [ "network-online.target" ];
+    after = [ "network-online.target" ];
+  };
+  ```
+  This changed follows a deprecation period of one year started in NixOS 24.05 (see [PR #283818](https://github.com/NixOS/nixpkgs/pull/283818)).
+
 - `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
 - `containerd` has been updated to v2, which contains breaking changes. See the [containerd

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -675,7 +675,6 @@ in
     systemd.services.systemd-udev-settle.restartIfChanged = false; # Causes long delays in nixos-rebuild
     systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.targets.network-online.wantedBy = [ "multi-user.target" ];
     systemd.services.systemd-importd.environment = proxy_env;
     systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
 


### PR DESCRIPTION
This is another attempt at 62f30634 after the original change was reverted in 0d85bf0e because NetworkManager and other tests were broken.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested via:
  - [x] `nixosTests.networking.scripted`
  - [x] `nixosTests.networking.networkd`
  - [x] `nixosTests.networking.networkmanager`
  - [x] `nixosTests.connman` (fails, unrelated)
  - [x] `nixosTests.wpa_supplicant`
  - [x] `nixosTests.ipv6`
  - [x] `nixosTests.nat`
  - [x] `nixosTests.acme`
  - [x] `nixosTests.custom-ca`
  - [x] `nixosTests.bittorrent`
  - [x] `nixosTests.printing-service`
  - [x] `nixosTests.printing-socket`
  - [x] `nixosTests.printing-service-notcp`
  - [x] `nixosTests.printing-socket-notcp`
  - [x] `nixosTests.openssh`
  - [x] `nixosTests.libreswan`
  - [x] `nixosTests.libreswan-nat`
  - [x] `nixosTests.privoxy`
  - [x] `nixosTests.jool`
  - [x] `nixosTests.tayga`
  - [x] `nixosTests.magnetico`
  - [x] `nixosTests.dnsdist`
  - [x] `nixosTests.gnupg`
  - [x] `nixosTests.nginx`
  - [x] `nixosTests.caddy`
  - [x] `nixosTests.searx`
  - [x] `nixosTests.gitea`
  - [x] `nixosTests.nfs3` (fails, unrelated?)
  - [x] `nixosTests.nfs4`
  - [x] `nixosTests.samba`
  - [x] `nixosTests.fail2ban`
  - [x] `nixosTests.plasma5`
  - [x] `nixosTests.plasma6`
  - [x] `nixosTests.gnome`
  - [x] `nixosTests.gnome-xorg`

- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
