### PR TITLE
gnomeExtensions.gsconnect: patch also gsconnect-preferences executable script

### DIFF
--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -32,6 +32,19 @@ index 53ecd5fc..78782357 100644
  import Gio from 'gi://Gio';
  import GObject from 'gi://GObject';
  
+diff --git i/src/gsconnect-preferences w/src/gsconnect-preferences
+index b16ddc7d..263dfb04 100755
+--- a/src/gsconnect-preferences
++++ b/src/gsconnect-preferences
+@@ -6,6 +6,8 @@
+ 
+ // -*- mode: js; -*-
+ 
++import './__nix-prepend-search-paths.js';
++
+ import Gdk from 'gi://Gdk?version=3.0';
+ import 'gi://GdkPixbuf?version=2.0';
+ import Gio from 'gi://Gio?version=2.0';
 diff --git a/src/prefs.js b/src/prefs.js
 index dd20fd20..5f82c53a 100644
 --- a/src/prefs.js


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
