### PR TITLE
xen: patch `libxl` to search for `qemu-system-i386` properly

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -186,6 +186,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     (replaceVars ./0002-scripts-external-executable-calls.patch scriptDeps)
 
+    # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
+    (fetchpatch {
+      url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";
+      hash = "sha256-LH+68kxH/gxdyh45kYCPxKwk+9cztLrScpC2pCNQV2M=";
+    })
+
     # XSA 472
     (fetchpatch {
       url = "https://xenbits.xen.org/xsa/xsa472-1.patch";


### PR DESCRIPTION
This fixes the error on HVM DomUs creation that we initially saw after switching from Fat Xen. It might be too ugly to merge, and I'd open it to discussions in @NixOS/xen-project .

What happened before, was we decided to build the hypervisor with `--with-system-qemu` but without a path to the QEMU binary as its string value. According to [tools/configure.ac](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=tools/configure.ac;h=0dd6d747abb5df6611cca667030525c402851c2a;hb=ccf400846780289ae779c62ef0c94757ff43bb60#l213), that configures `qemu_xen_path` as `qemu-system-i386` (with no clue where) if flagged as `yes`, or if a string value is specified, then configure the given value as is. But we can't wire that to `pkgs.qemu_xen`, since `pkgs.xen` is already a dependency of `pkgs.qemu_xen`, and doing so will make a circular dependency.

However, `access()` is used to check the existence of the QEMU binary. It's not tailored for binaries, and will not search anywhere in `PATH`, instead it searches within the current directory. If there is no executable named `qemu-system-i386`, then [libxl__domain_build_info_setdefault()](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=tools/libs/light/libxl_create.c;h=edeadd57ef5a8badc266bc476aa9e62cf2fe5abe;hb=ccf400846780289ae779c62ef0c94757ff43bb60#l118) will receive a false positive and default to `qemu-xen-traditional` but we don't have one, as the hypervisor itself is built with `--with-system-qemu`. Skipping that check will maintain the value as `qemu-system-i386`, but we still have to take care of another one at [libxl__spawn_local_dm()](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=tools/libs/light/libxl_dm.c;h=ff8ddeec9a37838c32ebfa52bcf9a8e541585daf;hb=ccf400846780289ae779c62ef0c94757ff43bb60#l2907). Since we already have `qemu-system-i386` available at PATH, I temporarily removed those checks.

That is sort of an edge case and I can imagine those regular distros might pass an FHS path to `--with-system-qemu` and carry on, but finding an executable in the current directory is not appropriate anyway. (Maybe worth upstreaming?)

## Update

The patch is now upstreamed via [f628129](https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01), let's pick it and use it here before it's shipped with future versions of Xen.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
