### PR TITLE
nixos/repart-verity-store: small cleanup

### DIFF
--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -81,7 +81,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    boot.initrd.systemd.dmVerity.enable = true;
+    boot.initrd = {
+      systemd.dmVerity.enable = true;
+      supportedFilesystems = {
+        ${config.image.repart.partitions.${cfg.partitionIds.store}.repartConfig.Format} =
+          lib.mkDefault true;
+      };
+    };
 
     image.repart.partitions = {
       # dm-verity hash partition

--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -92,7 +92,7 @@ in
     image.repart.partitions = {
       # dm-verity hash partition
       ${cfg.partitionIds.store-verity}.repartConfig = {
-        Type = partitionTypes.usr-verity;
+        Type = lib.mkDefault partitionTypes.usr-verity;
         Verity = "hash";
         VerityMatchKey = lib.mkDefault verityMatchKey;
         Label = lib.mkDefault "store-verity";
@@ -101,7 +101,7 @@ in
       ${cfg.partitionIds.store} = {
         storePaths = [ config.system.build.toplevel ];
         repartConfig = {
-          Type = partitionTypes.usr;
+          Type = lib.mkDefault partitionTypes.usr;
           Verity = "data";
           Format = lib.mkDefault "erofs";
           VerityMatchKey = lib.mkDefault verityMatchKey;

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -29,13 +29,6 @@
           options = [ "mode=0755" ];
         };
 
-        "/usr" = {
-          device = "/dev/mapper/usr";
-          # explicitly mount it read-only otherwise systemd-remount-fs will fail
-          options = [ "ro" ];
-          fsType = config.image.repart.partitions.${partitionIds.store}.repartConfig.Format;
-        };
-
         # bind-mount the store
         "/nix/store" = {
           device = "/usr/nix/store";


### PR DESCRIPTION
- dropped unneeded `fileSystems` entry from test that caused an error message on startup but wasn't fatal
- lowered priority for partition types for easier switch between veritysetup generators

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
