### PR TITLE
genemichaels: 0.5.7 -> 0.5.13

### DIFF
--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "genemichaels";
-  version = "0.5.7";
+  version = "0.5.13";
 
   src = fetchFromGitHub {
     owner = "andrewbaxter";
     repo = "genemichaels";
     rev = "genemichaels-v${version}";
-    hash = "sha256-qPyIC9AbRQI+inBft7Dd5R5v+tXtJcZdiV4lBIBwpyM=";
+    hash = "sha256-pzGTKswETm7RR0up1eSWC+X633rsVmEAJ3DYM8z6paQ=";
   };
 
-  cargoHash = "sha256-yPxgYf8N3Dqns/uKhdM++jpzG7zTPhCVVq+7WA9G/SM=";
+  cargoHash = "sha256-FjggpBTzxj9AOJjUq5PmbuE/ImmTMpxN0se9uxRy4KQ=";
 
   cargoBuildFlags = [ "--package ${pname}" ];
 

--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -18,6 +18,11 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-FjggpBTzxj9AOJjUq5PmbuE/ImmTMpxN0se9uxRy4KQ=";
 
   cargoBuildFlags = [ "--package ${pname}" ];
+  # cargoTestFlags is not used because genemichaels is tightly coupled to the
+  # other crates in the workspace and by not setting it, we run all the tests.
+  # If a dependency crate is failing its tests, we want to know about it. For
+  # example, between versions 0.5.8 and 0.5.12, there was a failing test in one
+  # of the other workspace members that genemichaels depends on.
 
   meta = {
     description = "Even formats macros";


### PR DESCRIPTION
Bumps to the latest working version of genemichaels. Includes an update
so that files are not written if they are already formatted correctly.
Removes a failing test that was present from version 0.5.8 to 0.5.12.

Adds a rationale about why cargoTestFlags is not used.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
