### PR TITLE
zsh-autosuggestions-abbreviations-strategy: init at 1.1.1

### DIFF
--- a/pkgs/by-name/zs/zsh-autosuggestions-abbreviations-strategy/package.nix
+++ b/pkgs/by-name/zs/zsh-autosuggestions-abbreviations-strategy/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "zsh-autosuggestions-abbreviations-strategy";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "olets";
+    repo = "zsh-autosuggestions-abbreviations-strategy";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-j2Xx8EWcSRntY7gqK9X1/rn3siZgNdL7ht4CyfAA+yY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install *.zsh -Dt "$out/share/zsh/site-functions/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Have zsh-autosuggestions suggest your zsh-abbr abbreviations";
+    homepage = "https://github.com/olets/zsh-autosuggestions-abbreviations-strategy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ llakala ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds `zsh-autosuggestions-abbreviations-strategy`, a useful ZSH strategy for `zsh-autosuggestions` that integrates it with `zsh-abbr`. 

Note that I'm currently waiting on a release tag to be made for v1.1.1 (see the relevant [issue](https://github.com/olets/zsh-autosuggestions-abbreviations-strategy/issues/2)). Until then, I just pin to a specific commit. I think it's fine to merge this before that, but if we want to wait, I'm fine with that too. 

While I'm here, some questions on best practices: 
- I see other ZSH plugins packaged with Nix using other `mkDerivation` arguments, like `strictDeps`, `dontConfigure`, `dontBuild`, whatever. The [relevant reference documentation](https://nixos.org/manual/nixpkgs/stable/#sec-using-stdenv) didn't go very in-depth into what each of these did, so I don't have any of them added here. If any of them are recommended, I'm happy to add them. 
- I'm currently adding both the `.zsh` and the `.plugin.zsh` as build artifacts. The `.plugin.zsh` one just seems to call the other one, so I'm not sure if it's necessary. 
- How can I test whether the package works on other platforms? `zsh-abbr` is marked with `platforms.all` while `zsh-autosuggestions` is only marked for `platforms.unix`. Should I be cross-compiling here?
- I may be overusing `pname` for naming the file, grabbing the correct repo, etc. I mainly did this because, with such a long package name, it's easy to slightly misspell and get a frustrating bug. I accidentally did this while creating the package, accidentally naming the folder `zsh-autosuggestions-abbreviation-strategy` instead of `zsh-autosuggestions-abbreviations-strategy`. Notice the difference? Me neither.

If you have any other nitpicks, feel free to let me know!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://gitissuehub.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
