### PR TITLE
python3Packages.types-jinja2: init at 2.11.9

### DIFF
--- a/pkgs/development/python-modules/types-jinja2/default.nix
+++ b/pkgs/development/python-modules/types-jinja2/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  types-markupsafe,
+}:
+
+buildPythonPackage rec {
+  pname = "types-jinja2";
+  version = "2.11.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "types-Jinja2";
+    inherit version;
+    hash = "sha256-29x0pAq6eu1SC35Niejw/kKGUYSUIIs1EjvPCE1LjIE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    types-markupsafe
+  ];
+
+  meta = {
+    description = "Typing stubs for Jinja2";
+    homepage = "https://pypi.org/project/types-Jinja2/";
+    changelog = "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/MarkupSafe.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/types-markupsafe/default.nix
+++ b/pkgs/development/python-modules/types-markupsafe/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "types-markupsafe";
+  version = "1.1.10";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "types-MarkupSafe";
+    inherit version;
+    hash = "sha256-hbOocmg9Aq6jpawqjvWQGTw0QJIDL1hFcof7+OBnEbE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  meta = {
+    description = "Typing stubs for MarkupSafe";
+    homepage = "https://pypi.org/project/types-markupsafe";
+    changelog = "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/MarkupSafe.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/types-xxhash/default.nix
+++ b/pkgs/development/python-modules/types-xxhash/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "types-xxhash";
+  version = "3.0.5.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mfJ/CvFGvrovEIZ30reYCv6N33NZtEUYG/xxOdt2SC4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  meta = {
+    description = "Typing stubs for xxhash";
+    homepage = "https://pypi.org/project/types-xxhash";
+    changelog = "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/xxhash.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17289,6 +17289,8 @@ self: super: with self; {
 
   types-urllib3 = callPackage ../development/python-modules/types-urllib3 { };
 
+  types-xxhash = callPackage ../development/python-modules/types-xxhash { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typeshed-client = callPackage ../development/python-modules/typeshed-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17245,6 +17245,8 @@ self: super: with self; {
 
   types-markdown = callPackage ../development/python-modules/types-markdown { };
 
+  types-markupsafe = callPackage ../development/python-modules/types-markupsafe { };
+
   types-mock = callPackage ../development/python-modules/types-mock { };
 
   types-pillow = callPackage ../development/python-modules/types-pillow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17241,6 +17241,8 @@ self: super: with self; {
 
   types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
 
+  types-jinja2 = callPackage ../development/python-modules/types-jinja2 { };
+
   types-lxml = callPackage ../development/python-modules/types-lxml { };
 
   types-markdown = callPackage ../development/python-modules/types-markdown { };


### PR DESCRIPTION
Hi,

This add type hints for jinja2, and its dependency, markupsafe.

Edit: while here, also types-xxhash

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
