### PR TITLE
polyglot: 3.5.1 -> 3.6

### DIFF
--- a/pkgs/by-name/po/polyglot/package.nix
+++ b/pkgs/by-name/po/polyglot/package.nix
@@ -6,18 +6,19 @@
   maven,
   libGL,
   xdg-utils,
+  libXxf86vm,
   zip,
   zlib,
 }:
 maven.buildMavenPackage rec {
   pname = "polyglot";
-  version = "3.5.1";
+  version = "3.6";
 
   src = fetchFromGitHub {
     owner = "DraqueT";
     repo = "PolyGlot";
-    rev = version;
-    hash = "sha256-E7wLhohOpWGzXe1zEO9a8aFIVT7/34Wr0dsRzpuf+eY=";
+    rev = "v${version}";
+    hash = "sha256-fAeYrj5x2kGGz+LPnlhR3j+0RSh4akPfN+ZyMMyrndE=";
   };
 
   preBuild = ''
@@ -29,7 +30,7 @@ maven.buildMavenPackage rec {
     cd ../..
   '';
 
-  mvnHash = "sha256-T7es44oNI9EXnpJd/DvYTb4LaJvR3rIdlhD4s/+Bfks=";
+  mvnHash = "sha256-nQScNCkA+eaeL3tcLCec1qIoYO6ct28FLxGp/Cm4nn4=";
   mvnParameters = "-DskipTests";
 
   nativeBuildInputs = [
@@ -49,7 +50,12 @@ maven.buildMavenPackage rec {
     makeWrapper ${jre}/bin/java $out/bin/PolyGlot \
       --add-flags "-Djpackage.app-version=${version}" \
       --add-flags "-jar $out/share/PolyGlotLinA/PolyGlotLinA-${version}-jar-with-dependencies.jar" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}"
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libGL
+          libXxf86vm
+        ]
+      }"
 
     runHook postInstall
   '';


### PR DESCRIPTION
I'm aware of the warnings that occur when starting up from javafx. This seems to be due to the build creating a fat .jar file as opposed to splitting javafx into its own separate module and adding that to the runtime. It's a harmless warning, so I've decided to ignore it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
