### PR TITLE
linuxManualConfig: forbid config errors on aarch64

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -89,7 +89,9 @@ let
       # Enable CPU lockup detection
       LOCKUP_DETECTOR = yes;
       SOFTLOCKUP_DETECTOR = yes;
-      HARDLOCKUP_DETECTOR = yes;
+      HARDLOCKUP_DETECTOR = lib.mkIf (
+        with stdenv.hostPlatform; isPower || isx86 || lib.versionAtLeast version "6.5"
+      ) yes;
 
       # Enable streaming logs to a remote device over a network
       NETCONSOLE = module;
@@ -214,7 +216,7 @@ let
         MEMORY_FAILURE = yes;
 
         # Collect ECC errors and retire pages that fail too often
-        RAS_CEC = yes;
+        RAS_CEC = lib.mkIf stdenv.hostPlatform.isx86 yes;
       }
       // lib.optionalAttrs (stdenv.hostPlatform.is32bit) {
         # Enable access to the full memory range (aka PAE) on 32-bit architectures
@@ -432,7 +434,7 @@ let
       FB_SIS_300 = yes;
       FB_SIS_315 = yes;
       FB_3DFX_ACCEL = yes;
-      FB_VESA = yes;
+      FB_VESA = lib.mkIf stdenv.hostPlatform.isx86 yes;
       FRAMEBUFFER_CONSOLE = yes;
       FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER = yes;
       FRAMEBUFFER_CONSOLE_ROTATION = yes;
@@ -458,7 +460,7 @@ let
       in
       {
         # compile in DRM so simpledrm can load before initrd if necessary
-        AGP = yes;
+        AGP = lib.mkIf (with stdenv.hostPlatform; isPower || isx86) yes;
         DRM = yes;
 
         DRM_LEGACY = whenOlder "6.8" no;
@@ -472,11 +474,11 @@ let
 
         # Allow specifying custom EDID on the kernel command line
         DRM_LOAD_EDID_FIRMWARE = yes;
-        VGA_SWITCHEROO = yes; # Hybrid graphics support
-        DRM_GMA500 = whenAtLeast "5.12" module;
-        DRM_GMA600 = whenOlder "5.13" yes;
-        DRM_GMA3600 = whenOlder "5.12" yes;
-        DRM_VMWGFX_FBCON = whenOlder "6.1" yes;
+        VGA_SWITCHEROO = lib.mkIf stdenv.hostPlatform.isx86 yes; # Hybrid graphics support
+        DRM_GMA500 = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "5.12" module);
+        DRM_GMA600 = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "5.13" yes);
+        DRM_GMA3600 = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "5.12" yes);
+        DRM_VMWGFX_FBCON = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "6.1" yes);
         # (experimental) amdgpu support for verde and newer chipsets
         DRM_AMDGPU_SI = yes;
         # (stable) amdgpu support for bonaire and newer chipsets
@@ -488,8 +490,10 @@ let
         DRM_AMD_DC_DCN1_0 = whenOlder "5.6" yes;
         DRM_AMD_DC_DCN2_0 = whenOlder "5.6" yes;
         DRM_AMD_DC_DCN2_1 = whenOlder "5.6" yes;
-        DRM_AMD_DC_DCN3_0 = whenBetween "5.9" "5.11" yes;
-        DRM_AMD_DC_DCN = whenBetween "5.11" "6.4" yes;
+        DRM_AMD_DC_DCN3_0 = lib.mkIf (with stdenv.hostPlatform; isx86) (whenBetween "5.9" "5.11" yes);
+        DRM_AMD_DC_DCN = lib.mkIf (with stdenv.hostPlatform; isx86 || isPower64) (
+          whenBetween "5.11" "6.4" yes
+        );
         DRM_AMD_DC_FP = whenAtLeast "6.4" yes;
         DRM_AMD_DC_HDCP = whenBetween "5.5" "6.4" yes;
         DRM_AMD_DC_SI = whenAtLeast "5.10" yes;
@@ -498,7 +502,13 @@ let
         DRM_AMD_ACP = yes;
 
         # Enable AMD secure display when available
-        DRM_AMD_SECURE_DISPLAY = whenAtLeast "5.13" yes;
+        DRM_AMD_SECURE_DISPLAY = lib.mkIf (
+          with stdenv.hostPlatform;
+          (lib.versionAtLeast version "5.13" && (isx86 || isPower64))
+          || (lib.versionAtLeast version "6.2" && isAarch64 && !stdenv.cc.isClang)
+          || (lib.versionAtLeast version "6.5" && isLoongarch64 && !stdenv.cc.isClang)
+          || (lib.versionAtLeast version "6.10" && isRiscV64 && !stdenv.cc.isClang)
+        ) yes;
 
         # Enable AMD image signal processor
         DRM_AMD_ISP = whenAtLeast "6.11" yes;
@@ -824,9 +834,9 @@ let
       };
 
     microcode = {
-      MICROCODE = yes;
-      MICROCODE_INTEL = whenOlder "6.6" yes;
-      MICROCODE_AMD = whenOlder "6.6" yes;
+      MICROCODE = lib.mkIf stdenv.hostPlatform.isx86 yes;
+      MICROCODE_INTEL = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "6.6" yes);
+      MICROCODE_AMD = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "6.6" yes);
       # Write Back Throttling
       # https://lwn.net/Articles/682582/
       # https://bugzilla.kernel.org/show_bug.cgi?id=12309#c655
@@ -887,12 +897,12 @@ let
     virtualisation = {
       PARAVIRT = option yes;
 
-      HYPERVISOR_GUEST = yes;
+      HYPERVISOR_GUEST = lib.mkIf stdenv.hostPlatform.isx86 yes;
       PARAVIRT_SPINLOCKS = option yes;
 
-      KVM_ASYNC_PF = yes;
+      KVM_ASYNC_PF = lib.mkIf (with stdenv.hostPlatform; isS390 || isx86) yes;
       KVM_GENERIC_DIRTYLOG_READ_PROTECT = yes;
-      KVM_GUEST = yes;
+      KVM_GUEST = lib.mkIf (with stdenv.hostPlatform; isPower || isx86) yes;
       KVM_MMIO = yes;
       KVM_VFIO = yes;
       KSM = yes;
@@ -903,7 +913,7 @@ let
         tristate = lib.mkIf (!stdenv.hostPlatform.is64bit) "y";
       };
 
-      VFIO_PCI_VGA = lib.mkIf stdenv.hostPlatform.is64bit yes;
+      VFIO_PCI_VGA = lib.mkIf stdenv.hostPlatform.isx86_64 yes;
 
       UDMABUF = yes;
 
@@ -1013,7 +1023,7 @@ let
 
       # Allows soft-dirty tracking on pages, used by CRIU.
       # See https://docs.kernel.org/admin-guide/mm/soft-dirty.html
-      MEM_SOFT_DIRTY = lib.mkIf (!stdenv.hostPlatform.isx86_32) yes;
+      MEM_SOFT_DIRTY = lib.mkIf (with stdenv.hostPlatform; isS390 || isPower64 || isx86_64) yes;
     };
 
     misc =
@@ -1026,7 +1036,11 @@ let
         # stdenv.hostPlatform.linux-kernel.target assumes uncompressed on RISC-V.
         KERNEL_UNCOMPRESSED = lib.mkIf stdenv.hostPlatform.isRiscV yes;
         KERNEL_XZ = lib.mkIf (!stdenv.hostPlatform.isRiscV && !useZstd) yes;
-        KERNEL_ZSTD = lib.mkIf (!stdenv.hostPlatform.isRiscV && useZstd) yes;
+        KERNEL_ZSTD = lib.mkIf (
+          with stdenv.hostPlatform;
+          (isMips || isS390 || isx86 || (lib.versionAtLeast version "6.1" && isAarch64 || isLoongArch64))
+          && useZstd
+        ) yes;
 
         HID_BATTERY_STRENGTH = yes;
         # enabled by default in x86_64 but not arm64, so we do that here
@@ -1070,7 +1084,7 @@ let
 
         # Allows debugging systems that get stuck during suspend/resume
         PM_TRACE = yes;
-        PM_TRACE_RTC = yes;
+        PM_TRACE_RTC = lib.mkIf stdenv.hostPlatform.isx86 yes;
 
         ACCESSIBILITY = yes; # Accessibility support
         AUXDISPLAY = yes; # Auxiliary Display support
@@ -1142,13 +1156,15 @@ let
         POSIX_MQUEUE = yes;
         FRONTSWAP = whenOlder "6.6" yes;
         FUSION = yes; # Fusion MPT device support
-        IDE = whenOlder "5.14" no; # deprecated IDE support, removed in 5.14
+        IDE = lib.mkIf (with stdenv.hostPlatform; isAarch32 || isM68k || isMips || isPower || isx86) (
+          whenOlder "5.14" no
+        ); # deprecated IDE support, removed in 5.14
         IDLE_PAGE_TRACKING = yes;
 
         JOYSTICK_XPAD_FF = option yes; # X-Box gamepad rumble support
         JOYSTICK_XPAD_LEDS = option yes; # LED Support for Xbox360 controller 'BigX' LED
 
-        KEYBOARD_APPLESPI = module;
+        KEYBOARD_APPLESPI = lib.mkIf stdenv.hostPlatform.isx86 module;
 
         KEXEC_FILE = option yes;
         KEXEC_JUMP = option yes;
@@ -1184,16 +1200,16 @@ let
 
         MOUSE_ELAN_I2C_SMBUS = yes;
         MOUSE_PS2_ELANTECH = yes; # Elantech PS/2 protocol extension
-        MOUSE_PS2_VMMOUSE = yes;
-        MTRR_SANITIZER = yes;
+        MOUSE_PS2_VMMOUSE = lib.mkIf stdenv.hostPlatform.isx86 yes;
+        MTRR_SANITIZER = lib.mkIf stdenv.hostPlatform.isx86 yes;
         NET_FC = yes; # Fibre Channel driver support
         # Needed for touchpads to work on some AMD laptops
         PINCTRL_AMD = whenAtLeast "5.19" yes;
         # GPIO on Intel Bay Trail, for some Chromebook internal eMMC disks
-        PINCTRL_BAYTRAIL = yes;
+        PINCTRL_BAYTRAIL = lib.mkIf stdenv.hostPlatform.isx86 yes;
         # GPIO for Braswell and Cherryview devices
         # Needs to be built-in to for integrated keyboards to function properly
-        PINCTRL_CHERRYVIEW = yes;
+        PINCTRL_CHERRYVIEW = lib.mkIf stdenv.hostPlatform.isx86 yes;
         # 8 is default. Modern gpt tables on eMMC may go far beyond 8.
         MMC_BLOCK_MINORS = freeform "32";
 
@@ -1222,8 +1238,8 @@ let
         UEVENT_HELPER = no;
 
         USERFAULTFD = yes;
-        X86_CHECK_BIOS_CORRUPTION = yes;
-        X86_MCE = yes;
+        X86_CHECK_BIOS_CORRUPTION = lib.mkIf stdenv.hostPlatform.isx86 yes;
+        X86_MCE = lib.mkIf stdenv.hostPlatform.isx86 yes;
 
         RAS = yes; # Needed for EDAC support
 
@@ -1252,9 +1268,9 @@ let
         PREEMPT = no;
         PREEMPT_VOLUNTARY = yes;
 
-        X86_AMD_PLATFORM_DEVICE = yes;
-        X86_PLATFORM_DRIVERS_DELL = whenAtLeast "5.12" yes;
-        X86_PLATFORM_DRIVERS_HP = whenAtLeast "6.1" yes;
+        X86_AMD_PLATFORM_DEVICE = lib.mkIf stdenv.hostPlatform.isx86 yes;
+        X86_PLATFORM_DRIVERS_DELL = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "5.12" yes);
+        X86_PLATFORM_DRIVERS_HP = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "6.1" yes);
 
         LIRC = yes;
 
@@ -1338,8 +1354,6 @@ let
             CROS_EC = module;
             CROS_EC_I2C = module;
             CROS_EC_SPI = module;
-            CROS_EC_LPC = module;
-            CROS_EC_ISHTP = module;
             CROS_KBD_LED_BACKLIGHT = module;
             TCG_TIS_SPI_CR50 = whenAtLeast "5.5" yes;
           }
@@ -1396,6 +1410,9 @@ let
             CP15_BARRIER_EMULATION = lib.mkIf (stdenv.hostPlatform.system == "aarch64-linux") yes;
           }
       // lib.optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux") {
+        CROS_EC_LPC = module;
+        CROS_EC_ISHTP = module;
+
         CHROMEOS_LAPTOP = module;
         CHROMEOS_PSTORE = module;
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1375,7 +1375,7 @@ let
 
             # Add debug interfaces for CMA
             CMA_DEBUGFS = yes;
-            CMA_SYSFS = yes;
+            CMA_SYSFS = whenAtLeast "5.13" yes;
 
             # https://docs.kernel.org/arch/arm/mem_alignment.html
             # tldr:

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1083,7 +1083,6 @@ let
         BLK_DEV_INITRD = yes;
 
         # Allows debugging systems that get stuck during suspend/resume
-        PM_TRACE = yes;
         PM_TRACE_RTC = lib.mkIf stdenv.hostPlatform.isx86 yes;
 
         ACCESSIBILITY = yes; # Accessibility support

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -754,7 +754,7 @@ let
         # This does not have any effect if a program does not support it
         SECURITY_LANDLOCK = whenAtLeast "5.13" yes;
 
-        DEVKMEM = whenOlder "5.13" no; # Disable /dev/kmem
+        DEVKMEM = lib.mkIf (!stdenv.hostPlatform.isAarch64) (whenOlder "5.13" no); # Disable /dev/kmem
 
         USER_NS = yes; # Support for user namespaces
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -686,6 +686,7 @@ let
       NFSD_V4 = yes;
       NFSD_V4_SECURITY_LABEL = yes;
 
+      NFS_FS = module;
       NFS_FSCACHE = yes;
       NFS_SWAP = yes;
       NFS_V3_ACL = yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -106,6 +106,7 @@ let
       {
         CPU_FREQ_DEFAULT_GOV_SCHEDUTIL = yes;
         CPU_FREQ_GOV_SCHEDUTIL = yes;
+        PM_DEBUG = yes;
         PM_ADVANCED_DEBUG = yes;
         PM_WAKELOCKS = yes;
         POWERCAP = yes;
@@ -282,6 +283,7 @@ let
         CGROUP_BPF = option yes;
         CGROUP_NET_PRIO = yes; # Required by systemd
         IP_ROUTE_VERBOSE = yes;
+        IP_MROUTE = yes;
         IP_MROUTE_MULTIPLE_TABLES = yes;
         IP_MULTICAST = yes;
         IP_MULTIPLE_TABLES = yes;
@@ -1037,6 +1039,7 @@ let
         DRAGONRISE_FF = yes;
         GREENASIA_FF = yes;
         HOLTEK_FF = yes;
+        INPUT_JOYSTICK = yes;
         JOYSTICK_PSXPAD_SPI_FF = yes;
         LOGIG940_FF = yes;
         NINTENDO_FF = whenAtLeast "5.16" yes;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -60,7 +60,8 @@ lib.makeOverridable ({ # The kernel source tarball.
   # symbolic name and `patch' is the actual patch.  The patch may
   # optionally be compressed with gzip or bzip2.
   kernelPatches ? []
-, ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name != "pc"
+, ignoreConfigErrors ?
+  !lib.elem stdenv.hostPlatform.linux-kernel.name [ "aarch64-multiplatform" "pc" ]
 , extraMeta ? {}
 
 , isZen      ? false


### PR DESCRIPTION
It's not a nice experience to wait for a kernel build, only to notice the options you set didn't actually do anything, because Nixpkgs' kernel configuration script just prints a warning if an option that should have been set isn't set in the final kernel config.

Ideally, I think we'd never allow config errors, but we certainly don't have to torelate them for aarch64, when CI for kernel changes can ensure we don't accidentally break the build with x86-specific options.

I've tested that configuration of all mainline kernels still works on aarch64.

Further details of the required config cleanups in the commit messages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
