### PR TITLE
lib/types: init defaultComposedFunctor for types.{attrsWith,listOf}

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -71,6 +71,9 @@
   "sec-nixpkgs-release-25.05-lib-breaking": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib-breaking"
   ],
+  "sec-nixpkgs-release-25.05-lib-deprecations": [
+    "release-notes.html#sec-nixpkgs-release-25.05-lib-deprecations"
+  ],
   "sec-overlays-install": [
     "index.html#sec-overlays-install"
   ],

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -23,3 +23,4 @@
 `functor` is an implementation detail and should not be relied upon, but since its status wasn't clear and it has had some use cases without alternatives, changes are being handled as gracefully as possible. Deprecations within functor:
 - `functor.wrapped` is now deprecated for some types and using it will give a warning with migration instructions. It is deprecated for these types:
     - `lib.types.attrsWith`
+    - `lib.types.listOf`

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -17,3 +17,9 @@
 - Structure of the `functor` of some types has changed. `functor` is an implementation detail and should not be relied upon. If you did rely on it let us know in this [PR](https://github.com/NixOS/nixpkgs/pull/363565).
   - [`lib.types.enum`](https://nixos.org/manual/nixos/unstable/#sec-option-types-basic): Previously the `functor.payload` was the list of enum values directly. Now it is an attribute set containing the values in the `values` attribute.
   - [`lib.types.separatedString`](https://nixos.org/manual/nixos/unstable/#sec-option-types-string): Previously the `functor.payload` was the seperator directly. Now it is an attribute set containing the seperator in the `sep` attribute.
+
+### Deprecations {#sec-nixpkgs-release-25.05-lib-deprecations}
+
+`functor` is an implementation detail and should not be relied upon, but since its status wasn't clear and it has had some use cases without alternatives, changes are being handled as gracefully as possible. Deprecations within functor:
+- `functor.wrapped` is now deprecated for some types and using it will give a warning with migration instructions. It is deprecated for these types:
+    - `lib.types.attrsWith`

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -600,7 +600,9 @@ rec {
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["*"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: listOf (elemType.substSubModules m);
-      functor = (defaultFunctor name) // { wrapped = elemType; };
+      functor = (elemTypeFunctor name { inherit elemType; }) // {
+        type = payload: types.listOf payload.elemType;
+      };
       nestedTypes.elemType = elemType;
     };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -71,6 +71,26 @@ let
     let pos = builtins.unsafeGetAttrPos name v; in
     if pos == null then "" else " at ${pos.file}:${toString pos.line}:${toString pos.column}";
 
+  # Internal functor to help for migrating functor.wrapped to functor.payload.elemType
+  # Note that individual attributes can be overriden if needed.
+  elemTypeFunctor = name: { elemType, ... }@payload: {
+    inherit name payload;
+    type    = outer_types.types.${name};
+    binOp   = a: b:
+      let
+        merged = a.elemType.typeMerge b.elemType.functor;
+      in
+        if merged == null
+        then
+          null
+        else
+          { elemType = merged; };
+    wrappedDeprecationMessage = { loc }: lib.warn ''
+      The deprecated `type.functor.wrapped` attribute of the option `${showOption loc}` is accessed, use `type.nestedTypes.elemType` instead.
+    '' payload.elemType;
+  };
+
+
   outer_types =
 rec {
   isType = type: x: (x._type or "") == type;
@@ -664,14 +684,10 @@ rec {
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<${placeholder}>"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: attrsWith { elemType = elemType.substSubModules m; inherit lazy placeholder; };
-      functor = defaultFunctor "attrsWith" // {
-        wrappedDeprecationMessage = { loc }: lib.warn ''
-          The deprecated `type.functor.wrapped` attribute of the option `${showOption loc}` is accessed, use `type.nestedTypes.elemType` instead.
-        '' elemType;
-        payload = {
-          # Important!: Add new function attributes here in case of future changes
+      functor = (elemTypeFunctor "attrsWith" {
           inherit elemType lazy placeholder;
-        };
+      }) // {
+        # Custom type merging required because of the "placeholder" attribute
         inherit binOp;
       };
       nestedTypes.elemType = elemType;

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1904,6 +1904,9 @@
   "sec-nixpkgs-release-25.05-lib-breaking": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib-breaking"
   ],
+  "sec-nixpkgs-release-25.05-lib-deprecations": [
+    "release-notes.html#sec-nixpkgs-release-25.05-lib-deprecations"
+  ],
   "sec-release-24.11": [
     "release-notes.html#sec-release-24.11"
   ],


### PR DESCRIPTION
Overall i think all types.functor should deprecate `functor.wrapped`

This PR introduces a new `defaultFunctor` for composed types that makes the migration easy. 

Additional thoughts:

types should be constructible via `type payload` maybe we want to spread the `{type}With payload` pattern ?
This design thought also went into the default functor:

Compare:

- `attrsWith`
- `listWith` (doesnt exist)
- `submoduleWith`
- `deferredModuleWith`
- `stringWith` (doesnt exist)
- ...

This only internally changes the following for now.

- `listOf` requires overriding the `type` because there is no `listWith` yet.
- `attrsWith` doesn't require any additional attribute overrides. (Only the custom binOp for merging)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
