### PR TITLE
llvmPackages: remove `_IMPORT_PREFIX` replacements for `clang`

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -103,16 +103,6 @@ let
       moveToOutput "lib/libclang.*" "$lib"
       moveToOutput "lib/libclang-cpp.*" "$lib"
     '' + (if lib.versionOlder release_version "15" then ''
-      substituteInPlace $out/lib/cmake/clang/ClangTargets-release.cmake \
-          --replace-fail "\''${_IMPORT_PREFIX}/lib/libclang." "$lib/lib/libclang." \
-          --replace-fail "\''${_IMPORT_PREFIX}/lib/libclang-cpp." "$lib/lib/libclang-cpp."
-    '' else ''
-      substituteInPlace $dev/lib/cmake/clang/ClangTargets-release.cmake \
-          --replace-fail "\''${_IMPORT_PREFIX}/lib/libclang." "$lib/lib/libclang." \
-          --replace-fail "\''${_IMPORT_PREFIX}/lib/libclang-cpp." "$lib/lib/libclang-cpp."
-    '') + ''
-
-    '' + (if lib.versionOlder release_version "15" then ''
       mkdir -p $python/bin $python/share/{clang,scan-view}
     '' else ''
       mkdir -p $python/bin $python/share/clang/


### PR DESCRIPTION
These strings do not show up in the files where they are attempting to be replaced.

This fixes the build for `clang_15`, `clang_16`, `clang_17`, `clang_18`, and `clang_19`. The remaining three (`clang_12`, `clang_13`, and `clang_14`) are broken due to `llvmPackages_12.tblgen`, `llvmPackages_13.tblgen`, and `llvmPackages_14.tblgen` errors.

Resolves the issue that @trofi found in https://github.com/NixOS/nixpkgs/pull/356120. 

CC @pwaller 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).