### PR TITLE
[staging-next] mutter: revert "treewide: mesa -> libgbm (where appropriate)"

### DIFF
--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -49,7 +49,7 @@
   libwacom,
   libSM,
   xwayland,
-  libgbm,
+  mesa,
   meson,
   gnome-settings-daemon,
   xorgserver,
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     desktop-file-utils
     gettext
     libxcvt
-    libgbm
+    mesa
     meson
     ninja
     xvfb-run


### PR DESCRIPTION
Targetting #361878

Unbreaks mutter on staging-next due to the following error:

```
error: builder for '/nix/store/64q5c5p0jf41zrxkssqn78il72f3cwml-mutter-47.3.drv' failed with exit code 1;
       last 25 log lines:
       > ../cogl/cogl/cogl-context.h:52:10: fatal error: EGL/eglmesaext.h: No such file or directory
       >    52 | #include <EGL/eglmesaext.h>
       >       |          ^~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > [51/812] Compiling C object cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-pipeline-vertend-glsl.c.o
       > FAILED: cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-pipeline-vertend-glsl.c.o
       > gcc -Icogl/cogl/libmutter-cogl-15.so.0.0.0.p -Icogl/cogl -I../cogl/cogl -Imtk -I../mtk -Imtk/mtk -I../mtk/mtk -Icogl -I../cogl -I. -I.. -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/gio-unix-2.0 -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/6sqln98iya9ffaj6plbm4p5s343mbfj5-graphene-1.10.8-dev/include/graphene-1.0 -I/nix/store/58svsh7zj92w4z1d8qn5kd4sfp9b5hzj-graphene-1.10.8/lib/graphene-1.0/include -I/nix/store/yan7xnjlp3l7pg82qz46b7z7x9za4flf-wayland-1.23.1-dev/include -I/nix/store/wjpikbgivasi62j96csmdf5w00kkwnf9-libglvnd-1.7.0-dev/include -I/nix/store/h6xil473xysi4lp6xr3mnwcfdd9nsr1b-xorgproto-2024.1/include -I/nix/store/2p1gkzwz2lq6vv67579vh4bllw1psqk8-libX11-1.8.10-dev/include -I/nix/store/5z7yxa99nghyvjrqspzlimgfsydc2an7-pixman-0.44.2/include/pixman-1 -I/nix/store/y29jm0jrvmnmhdr3876hmav1kxczflm2-libsysprof-capture-47.0/include/sysprof-6 -I/nix/store/hydpb5y96v36460hwj66xckxp64qdwcd-libXext-1.3.6-dev/include -I/nix/store/s8sldsib0bcd0l00cxrd92dyz32x646n-libXfixes-6.0.1-dev/include -I/nix/store/ks4zgc18478bizwsia1kng3b4k9pm1yw-libXdamage-1.1.6-dev/include -I/nix/store/ib9zkr8ljl73nva9nhnlvg91yp9kn1mz-libXrandr-1.5.4-dev/include -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -D_GNU_SOURCE -fPIC -pthread -mfpmath=sse -msse -msse2 '-DCOGL_LOCALEDIR="/nix/store/f51rvjbx3vcsgjbprw7rcnhmhgdlbbpx-mutter-47.3/share/locale"' -DCOGL_COMPILATION '-DCOGL_GL_LIBNAME="libGL.so.1"' '-DCOGL_GLES2_LIBNAME="libGLESv2.so.2"' -MD -MQ cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-pipeline-vertend-glsl.c.o -MF cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-pipeline-vertend-glsl.c.o.d -o cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-pipeline-vertend-glsl.c.o -c ../cogl/cogl/driver/gl/cogl-pipeline-vertend-glsl.c
       > In file included from ../cogl/cogl/cogl-context-private.h:33,
       >                  from ../cogl/cogl/driver/gl/cogl-pipeline-vertend-glsl.c:38:
       > ../cogl/cogl/cogl-context.h:52:10: fatal error: EGL/eglmesaext.h: No such file or directory
       >    52 | #include <EGL/eglmesaext.h>
       >       |          ^~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > [52/812] Compiling C object cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-texture-2d-gl.c.o
       > FAILED: cogl/cogl/libmutter-cogl-15.so.0.0.0.p/driver_gl_cogl-texture-2d-gl.c.o
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
