### PR TITLE
cunicu: 0.5.68 -> 0.5.72

### DIFF
--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
   protobuf,
   protoc-gen-go,
   protoc-gen-go-grpc,
@@ -28,6 +29,10 @@ buildGoModule rec {
     protoc-gen-go-grpc
   ];
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
   CGO_ENABLED = 0;
 
   # These packages contain networking dependent tests which fail in the sandbox
@@ -42,6 +47,9 @@ buildGoModule rec {
     "-X cunicu.li/cunicu/pkg/buildinfo.Version=${version}"
     "-X cunicu.li/cunicu/pkg/buildinfo.BuiltBy=Nix"
   ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
 
   preBuild = ''
     go generate ./...

--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -8,6 +8,7 @@
   protobuf,
   protoc-gen-go,
   protoc-gen-go-grpc,
+  nix-update-script,
 }:
 buildGoModule rec {
   pname = "cunicu";
@@ -50,6 +51,8 @@ buildGoModule rec {
 
   doInstallCheck = true;
   versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
 
   preBuild = ''
     go generate ./...

--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -10,14 +10,16 @@
 }:
 buildGoModule rec {
   pname = "cunicu";
-  version = "0.5.68";
+  version = "0.5.72";
 
   src = fetchFromGitHub {
     owner = "cunicu";
     repo = "cunicu";
     rev = "v${version}";
-    hash = "sha256-bSX9Mf+7BNX37DrFut3c6HKdjBPh6xgdr8X2hNBjV54=";
+    hash = "sha256-W6EoFlRr8WVg5k5bk9L9RAMLLazd1uzufXmzP82WIiU=";
   };
+
+  vendorHash = "sha256-gLvTLXNJkgqmDr08kH0dg0MBVMRawBG7lJjIFy2US14=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -27,8 +29,6 @@ buildGoModule rec {
   ];
 
   CGO_ENABLED = 0;
-
-  vendorHash = "sha256-ATIDio2C71gm5/Ex3Ys9izJSxx4rb1jQU5snGS8idVU=";
 
   # These packages contain networking dependent tests which fail in the sandbox
   excludedPackages = [


### PR DESCRIPTION
Updates cunicu to 0.5.72 as well as performs some minor housekeeping.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
