### PR TITLE
fedistar: init at 1.11.0

### DIFF
--- a/pkgs/by-name/fe/fedistar/package.nix
+++ b/pkgs/by-name/fe/fedistar/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix-update-script,
+
+  pnpm_10,
+  nodejs,
+
+  rustPlatform,
+  cargo-tauri,
+  wrapGAppsHook4,
+  pkg-config,
+  glib-networking,
+  webkitgtk_4_1,
+  openssl,
+}:
+let
+  pnpm = pnpm_10;
+  pname = "fedistar";
+  version = "1.11.0";
+  src = fetchFromGitHub {
+    owner = "h3poteto";
+    repo = "fedistar";
+    tag = "v${version}";
+    hash = "sha256-x7PljFqxC3Zht3ZEAZTA6/BClZ0g7VH2HpQLGKqQ8qo=";
+  };
+  fedistar-frontend = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "fedistar-frontend";
+    inherit version src;
+    pnpmDeps = pnpm.fetchDeps {
+      inherit pname version src;
+      hash = "sha256-LurQqfd2r3ggqfBttZTOz2bhQ/r7pqEINkY16ZaIr8I=";
+    };
+    nativeBuildInputs = [
+      pnpm.configHook
+      pnpm
+      nodejs
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r out/* $out/
+      runHook postInstall
+    '';
+  });
+
+in
+rustPlatform.buildRustPackage {
+  inherit
+    pname
+    version
+    src
+    fedistar-frontend
+    ;
+  sourceRoot = "${src.name}/src-tauri";
+
+  cargoHash = "sha256-gn92yrz/6/WNBGVGXXSskSqty3qP+atzu1LB8P882KA=";
+  postPatch = ''
+    substituteInPlace ./tauri.conf.json \
+      --replace-fail '"frontendDist": "../out",' '"frontendDist": "${fedistar-frontend}",' \
+      --replace-fail '"beforeBuildCommand": "pnpm build",' '"beforeBuildCommand": "",'
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+      glib-networking
+      webkitgtk_4_1
+    ];
+
+  doCheck = false; # This version's tests do not pass
+
+  # A fix for a problem with Tauri (tauri-apps/tauri#9304)
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
+    )
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "fedistar-frontend"
+    ];
+  };
+
+  meta = {
+    description = "Multi-column Fediverse client application for desktop";
+    homepage = "https://fedistar.net/";
+    mainProgram = "fedistar";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ noodlez1232 ];
+    changelog = "https://github.com/h3poteto/fedistar/releases/tag/v${version}";
+  };
+}


### PR DESCRIPTION
It's worth noting that if they ever decide to add tray icons to the program, it will most likely suffer the same fate as cinny-desktop, where it will not be supported (see #357482)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
