### PR TITLE
workflows/eval: Catch empty conclusion

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -165,7 +165,7 @@ jobs:
           runId=$(jq .id <<< "$run")
           conclusion=$(jq -r .conclusion <<< "$run")
 
-          while [[ "$conclusion" == null ]]; do
+          while [[ "$conclusion" == null || "$conclusion" == "" ]]; do
             echo "Workflow not done, waiting 10 seconds before checking again"
             sleep 10
             conclusion=$(gh api /repos/"$REPOSITORY"/actions/runs/"$runId" --jq '.conclusion')


### PR DESCRIPTION
Sometimes the conclusion is empty when it's still
running/pending or so, which needs to be caught, otherwise it can exit preemptively: https://github.com/NixOS/nixpkgs/pull/364308#issuecomment-2550179941

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
