### PR TITLE
tremor-rs: fix errors caused by new warning

### DIFF
--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -43,8 +43,10 @@ rustPlatform.buildRustPackage rec {
   # error: `log_error` isn't a valid `#[macro_export]` argument
   # note: `#[deny(invalid_macro_export_arguments)]` implied by `#[deny(warnings)]`
   postPatch = ''
-    substituteInPlace src/lib.rs \
-      --replace '#![deny(' '#![warn('
+    shopt -s globstar
+    substituteInPlace **/*.rs \
+      --replace-quiet '#![deny(warnings)]' ""
+    shopt -u globstar
   '';
 
   # TODO export TREMOR_PATH($out/lib) variable


### PR DESCRIPTION
Fixes #365909

The previous replacement of `deny(warnings)` to `warn(warnings)` was a bit silly, so I decided to just remove the statement.

I checked the other uses of `deny(...)`, they are all harmless (as in, either clippy or a specific lint).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).