### PR TITLE
librenms: 24.11.0 -> 24.12.0

### DIFF
--- a/pkgs/by-name/li/librenms/broken-binary-paths.diff
+++ b/pkgs/by-name/li/librenms/broken-binary-paths.diff
@@ -1,18 +1,18 @@
-diff --git a/LibreNMS/Config.php b/LibreNMS/Config.php
-index 5ed6b71..de7718a 100644
---- a/LibreNMS/Config.php
-+++ b/LibreNMS/Config.php
-@@ -460,13 +460,6 @@ class Config
-             self::persist('device_display_default', $display_value);
+diff --git a/app/ConfigRepository.php b/app/ConfigRepository.php
+index 2d73cce81..b0110540b 100644
+--- a/app/ConfigRepository.php
++++ b/app/ConfigRepository.php
+@@ -444,13 +444,6 @@ class ConfigRepository
+             $this->persist('device_display_default', $display_value);
          }
- 
+
 -        // make sure we have full path to binaries in case PATH isn't set
 -        foreach (['fping', 'fping6', 'snmpgetnext', 'rrdtool', 'traceroute'] as $bin) {
--            if (! is_executable(self::get($bin))) {
--                self::persist($bin, self::locateBinary($bin));
+-            if (! is_executable($this->get($bin))) {
+-                $this->persist($bin, $this->locateBinary($bin));
 -            }
 -        }
 -
-         if (! self::has('rrdtool_version')) {
-             self::persist('rrdtool_version', Rrd::version());
+         if (! $this->has('rrdtool_version')) {
+             $this->persist('rrdtool_version', (new Version($this))->rrdtool());
          }

--- a/pkgs/by-name/li/librenms/package.nix
+++ b/pkgs/by-name/li/librenms/package.nix
@@ -27,16 +27,16 @@ let
 in
 phpPackage.buildComposerProject rec {
   pname = "librenms";
-  version = "24.11.0";
+  version = "24.12.0";
 
   src = fetchFromGitHub {
     owner = "librenms";
     repo = pname;
     rev = "${version}";
-    sha256 = "sha256-pcUkmcqD/NNedKlpNEBFf9Pmxkq6qXVdagRj/QTePzw=";
+    sha256 = "sha256-/0mc4wTx9WDxgDxqq+Kut8uX/Yr+bxqZ1BeJvmFDxG8=";
   };
 
-  vendorHash = "sha256-0ZMQYODlXLHOjwWYvbrY/VQ2Zm9D7r1NvXRyP0q346M=";
+  vendorHash = "sha256-DNiTSXt/1Qr67BdlTu3ccP4Whw5pyybeFJ045c/e8Dc=";
 
   php = phpPackage;
 


### PR DESCRIPTION
Updates LibreNMS to 24.12.0. The broken binary paths patch needed to be updated, since it was moved to another file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
