### PR TITLE
ani-cli: 4.8 -> 4.9

### DIFF
--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -1,55 +1,45 @@
-{
-  fetchFromGitHub,
-  makeWrapper,
-  stdenvNoCC,
-  lib,
-  gnugrep,
-  gnused,
-  curl,
-  catt,
-  syncplay,
-  ffmpeg,
-  fzf,
-  aria2,
-  withMpv ? true,
-  mpv,
-  withVlc ? false,
-  vlc,
-  withIina ? false,
-  iina,
-  chromecastSupport ? false,
-  syncSupport ? false,
+{ fetchFromGitHub
+, makeWrapper
+, stdenvNoCC
+, lib
+, gnugrep
+, gnused
+, curl
+, catt
+, syncplay
+, ffmpeg
+, fzf
+, aria2
+, withMpv ? true, mpv
+, withVlc ? false, vlc
+, withIina ? false, iina
+, chromecastSupport ? false
+, syncSupport ? false
 }:
 
 assert withMpv || withVlc || withIina;
 
 stdenvNoCC.mkDerivation rec {
   pname = "ani-cli";
-  version = "4.8";
+  version = "4.9";
 
   src = fetchFromGitHub {
     owner = "pystardust";
     repo = "ani-cli";
     rev = "v${version}";
-    hash = "sha256-vntCiWaONndjU622c1BoCoASQxQf/i7yO0x+70OxzPU=";
+    hash = "sha256-7zuepWTtrFp9RW3zTSjPzyJ9e+09PdKgwcnV+DqPEUY=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   runtimeDependencies =
-    let
-      player = [ ] ++ lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
-    in
-    [
-      gnugrep
-      gnused
-      curl
-      fzf
-      ffmpeg
-      aria2
-    ]
-    ++ player
-    ++ lib.optional chromecastSupport catt
-    ++ lib.optional syncSupport syncplay;
+    let player = []
+        ++ lib.optional withMpv mpv
+        ++ lib.optional withVlc vlc
+        ++ lib.optional withIina iina;
+    in [ gnugrep gnused curl fzf ffmpeg aria2 ]
+      ++ player
+      ++ lib.optional chromecastSupport catt
+      ++ lib.optional syncSupport syncplay;
 
   installPhase = ''
     runHook preInstall
@@ -64,7 +54,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/pystardust/ani-cli";
-    description = "A cli tool to browse and play anime";
+    description = "Cli tool to browse and play anime";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ skykanin ];
     platforms = platforms.unix;

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -1,20 +1,24 @@
-{ fetchFromGitHub
-, makeWrapper
-, stdenvNoCC
-, lib
-, gnugrep
-, gnused
-, curl
-, catt
-, syncplay
-, ffmpeg
-, fzf
-, aria2
-, withMpv ? true, mpv
-, withVlc ? false, vlc
-, withIina ? false, iina
-, chromecastSupport ? false
-, syncSupport ? false
+{
+  fetchFromGitHub,
+  makeWrapper,
+  stdenvNoCC,
+  lib,
+  gnugrep,
+  gnused,
+  curl,
+  catt,
+  syncplay,
+  ffmpeg,
+  fzf,
+  aria2,
+  withMpv ? true,
+  mpv,
+  withVlc ? false,
+  vlc,
+  withIina ? false,
+  iina,
+  chromecastSupport ? false,
+  syncSupport ? false,
 }:
 
 assert withMpv || withVlc || withIina;

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  runtimeDependencies =    
+  runtimeDependencies =
     let
       player = [ ] ++ lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
     in

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/pystardust/ani-cli";
-    description = "Cli tool to browse and play anime";
+    description = "CLI tool to browse and play anime";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ skykanin ];
     platforms = platforms.unix;

--- a/pkgs/applications/video/ani-cli/default.nix
+++ b/pkgs/applications/video/ani-cli/default.nix
@@ -35,15 +35,21 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  runtimeDependencies =
-    let player = []
-        ++ lib.optional withMpv mpv
-        ++ lib.optional withVlc vlc
-        ++ lib.optional withIina iina;
-    in [ gnugrep gnused curl fzf ffmpeg aria2 ]
-      ++ player
-      ++ lib.optional chromecastSupport catt
-      ++ lib.optional syncSupport syncplay;
+  runtimeDependencies =    
+    let
+      player = [ ] ++ lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
+    in
+    [
+      gnugrep
+      gnused
+      curl
+      fzf
+      ffmpeg
+      aria2
+    ]
+    ++ player
+    ++ lib.optional chromecastSupport catt
+    ++ lib.optional syncSupport syncplay;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
# Adding support for 24.05

**Tests**: Ran it multiple times and is already present in NisOS 24.11

## Package Information

- Package name: ani-cli
- Latest released version: 4.9 (for 24.05)
- Current version on the unstable channel: 4.9
- Current version on the stable/release channel: 4.8

Changes: Minor changes so Latest version works in 24.05 stable



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Maintainer ping:
@skykanin