### PR TITLE
mopidy-local: 3.2.1 -> 3.3.0

### DIFF
--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -2,27 +2,20 @@
   lib,
   mopidy,
   python3Packages,
-  fetchPypi,
+  fetchurl,
   fetchpatch,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "Mopidy-Local";
-  version = "3.2.1";
+  version = "3.3.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "18w39mxpv8p17whd6zfw5653d21q138f8xd6ili6ks2g2dbm25i9";
+  # We can't use fetchPypi here because the name of the file does not match the
+  # name of the package.
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/02/c5/d099a05df7d6b0687071aa7d2d7a3499802b3b4b641531cd46ec8e6e7035/mopidy_local-3.3.0.tar.gz";
+    sha256 = "cba6ed6c693952255a9f5efcc7b77d8eae4e4e728c6ee9621efd1a471b992b7a";
   };
-
-  patches = [
-    # Fix tests with newer Mopidy versions >=3.4.0 -- mopidy/mopidy-local#69
-    (fetchpatch {
-      name = "update-tests-for-mopidy-3.4.0.patch";
-      url = "https://github.com/mopidy/mopidy-local/commit/f2c198f8eb253f62100afc58f652e73a76d5a090.patch";
-      hash = "sha256-jrlZc/pd00S5q9nOfV1OXu+uP/SvH+Xbi7U52aZajj4=";
-    })
-  ];
 
   propagatedBuildInputs = [
     mopidy


### PR DESCRIPTION
## Changes

Upstream release: https://github.com/mopidy/mopidy-local/releases/tag/v3.3.0.

I am no longer actively using Mopidy; the package builds (and so does `mopidy`), but I did not test the behavior. It would be good if a user could verify, and maybe adopt this package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
