### PR TITLE
anydesk: add missing dependencies

### DIFF
--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -10,8 +10,10 @@
   cairo,
   gdk-pixbuf,
   glib,
-  gnome2,
-  gtk2,
+  gtk3,
+  dbus,
+  harfbuzz,
+  libz,
   libGLU,
   libGL,
   pango,
@@ -48,10 +50,12 @@ stdenv.mkDerivation (finalAttrs: {
       cairo
       gdk-pixbuf
       glib
-      gtk2
+      gtk3
+      dbus
+      harfbuzz
+      libz
       stdenv.cc.cc
       pango
-      gnome2.gtkglext
       libGLU
       libGL
       minizip
@@ -112,18 +116,15 @@ stdenv.mkDerivation (finalAttrs: {
       --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}" \
       $out/bin/anydesk
 
-    # pangox is not actually necessary (it was only added as a part of gtkglext)
-    patchelf \
-      --remove-needed libpangox-1.0.so.0 \
-      $out/bin/anydesk
-
     wrapProgram $out/bin/anydesk \
       --prefix PATH : ${
         lib.makeBinPath [
           lsb-release
           pciutils
         ]
-      }
+      } \
+      --prefix GDK_BACKEND : x11 \
+      --set GTK_THEME Adwaita
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Before this, `anydesk` is not runnable due to unsatisfied dynamic library dependencies.
This fixes the issue by adding these dependencies.

The fix also sets `GDK_BACKEND=x11` to resolve issue:

```
(anydesk:76719): Gdk-CRITICAL **: 21:24:19.074: gdk_x11_window_get_xid: assertion 'GDK_IS_X11_WINDOW (window)' failed
```

and invalid scaling.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
