### PR TITLE
[staging-next] python312Packages.pygit2: fix build with GCC 14

### DIFF
--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -6,6 +6,7 @@
   cached-property,
   cffi,
   fetchPypi,
+  fetchpatch,
   isPyPy,
   libgit2,
   pycparser,
@@ -25,6 +26,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-eymmeWuqFfyJ1EOsjVF3VBHZseWwbcQNRYxWyFdrSKI=";
   };
+
+  patches = [
+    # fix for GCC 14
+    (fetchpatch {
+      url = "https://github.com/libgit2/pygit2/commit/eba710e45bb40e18641c6531394bb46631e7f295.patch";
+      hash = "sha256-GFFzGVd/9+AcwicwOtBghhonijMp08svXTUZ/4/LmtI=";
+    })
+  ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export DYLD_LIBRARY_PATH="${libgit2}/lib"


### PR DESCRIPTION
Simple fix

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).