### PR TITLE
nixos-rebuild-ng: add nix-output-monitor as an optional dependency

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -23,6 +23,7 @@ _nixos-rebuild_ \[--verbose] [--max-jobs MAX_JOBS] [--cores CORES] [--log-format
 	\[--no-build-output] [--use-substitutes] [--help] [--file FILE] [--attr ATTR] [--flake [FLAKE]] [--no-flake] [--install-bootloader] [--profile-name PROFILE_NAME]++
 	\[--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--fast]++
 	\[--build-host BUILD_HOST] [--target-host TARGET_HOST]++
+	\[--build-graph {nix,nom}]
 	\[{switch,boot,test,build,edit,repl,dry-build,dry-run,dry-activate,build-vm,build-vm-with-bootloader,list-generations}]
 
 # DESCRIPTION
@@ -277,6 +278,10 @@ It must be one of the following:
 	Do not imply *--flake* if _/etc/nixos/flake.nix exists_. With this
 	option, it is possible to build non-flake NixOS configurations even if
 	the current NixOS systems uses flakes.
+
+*--build-graph* _{nix,nom}_
+	When set to _nom_, it will use _nix-output-monitor_ instead of _nix_
+	to show the progress of the build process.
 
 In addition, *nixos-rebuild* accepts following options from nix commands that
 the tool calls:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -5,5 +5,6 @@ EXECUTABLE = "@executable@"
 # Use either `== "true"` if the default (e.g.: `python -m nixos_rebuld`) is
 # `False` or `!= "false"` if the default is `True`
 WITH_NIX_2_18 = "@withNix218@" != "false"  # type: ignore
+WITH_NOM = "@withNom@" == "true"
 WITH_REEXEC = "@withReexec@" == "true"  # type: ignore
 WITH_SHELL_FILES = "@withShellFiles@" == "true"  # type: ignore

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 def build(
     attr: str,
     build_attr: BuildAttr,
+    nom: bool = False,
     **build_flags: Args,
 ) -> Path:
     """Build NixOS attribute using classic Nix.
@@ -39,7 +40,7 @@ def build(
     Returns the built attribute as path.
     """
     run_args = [
-        "nix-build",
+        "nom-build" if nom else "nix-build",
         build_attr.path,
         "--attr",
         build_attr.to_attr(attr),
@@ -52,15 +53,17 @@ def build(
 def build_flake(
     attr: str,
     flake: Flake,
+    nom: bool = False,
     **flake_build_flags: Args,
 ) -> Path:
     """Build NixOS attribute using Flakes.
 
     Returns the built attribute as path.
     """
+    flake_flags = FLAKE_FLAGS if not nom else []
     run_args = [
-        "nix",
-        *FLAKE_FLAGS,
+        "nom" if nom else "nix",
+        *flake_flags,
         "build",
         "--print-out-paths",
         flake.to_attr(attr),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -43,6 +43,16 @@ def test_build(mock_run: Any, monkeypatch: Any) -> None:
         stdout=PIPE,
     )
 
+    assert n.build(
+        "config.system.build.attr",
+        m.BuildAttr(Path("file"), "preAttr"),
+        nom=True,
+    ) == Path("/path/to/file")
+    mock_run.assert_called_with(
+        ["nom-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
+        stdout=PIPE,
+    )
+
 
 @patch(
     get_qualified_name(n.run_wrapper, n),
@@ -69,6 +79,19 @@ def test_build_flake(mock_run: Any) -> None:
             "--no-link",
             "--nix-flag",
             "foo",
+        ],
+        stdout=PIPE,
+    )
+
+    assert n.build_flake("config.system.build.toplevel", flake, nom=True) == Path(
+        "/path/to/file"
+    )
+    mock_run.assert_called_with(
+        [
+            "nom",
+            "build",
+            "--print-out-paths",
+            ".#nixosConfigurations.hostname.config.system.build.toplevel",
         ],
         stdout=PIPE,
     )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`nix-output-monitor`](https://github.com/maralorn/nix-output-monitor) prints the progress of nix builds in a way that is much better to understand. This PR integrates `nix-output-monitor` in `nixos-rebuild-ng` as an optional dependency.

This is most a PR to collect feedback and see if there is interest. This is why it is marked as draft right now.

Caveats:
- Only works for local builds for now. It could also work for remote Flake builds as long as `nom` is available in remote PATH, but it wouldn't work for remote non-Flake builds (since `nom` doesn't have `nom-store` that would be needed for this case)
- The easiest way to add this to your configuration would be via `environment.systemPackages = [ (pkgs.nixos-rebuild-ng.override { withNom = true; }) ]`. If you want to replace the `config.system.build.nixos-rebuild`, you need to set `system.rebuild.enableNg = true` and `nixpkgs.overlays = final: prev: { nixos-rebuild-ng = nixos-rebuild-ng.override { withNom = true; } }`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
