### PR TITLE
bigpemu: init at 1.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22856,6 +22856,12 @@
     githubId = 178444;
     name = "Thomas Bereknyei";
   };
+  tombert = {
+    email = "thomas@gebert.app";
+    github = "tombert";
+    githubId = 2027925;
+    name = "Thomas Gebert";
+  };
   tomfitzhenry = {
     email = "tom@tom-fitzhenry.me.uk";
     github = "tomfitzhenry";

--- a/pkgs/by-name/bi/bigpemu/package.nix
+++ b/pkgs/by-name/bi/bigpemu/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  SDL2,
+  glui,
+  libGLU,
+  libGL,
+  buildFHSEnv,
+}:
+let
+  bigpemu-unwrapped = stdenv.mkDerivation rec {
+    pname = "BigPEmu";
+    version = "1.17";
+    src = fetchurl {
+      url = "https://www.richwhitehouse.com/jaguar/builds/BigPEmu_Linux64_v${
+        builtins.replaceStrings [ "." ] [ "" ] version
+      }.tar.gz";
+      hash = "sha256-R5f3LD5RcGwdwcZqXGaCSFDyHaJrQ1ghS3kqVvBd38A=";
+    };
+
+    installPhase = ''
+      mkdir -p $out/bin
+      tar -xvf $src -C $out/bin --strip-components=1
+    '';
+
+    meta = {
+      description = "Atari Jaguar Emulator (BigPEmu) by Richard Whitehouse";
+      homepage = "https://www.richwhitehouse.com/jaguar/index.php";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [
+        tombert
+        hughobrien
+      ];
+      platforms = with lib.platforms; [ "x86_64-linux" ];
+    };
+  };
+in
+buildFHSEnv {
+  name = "bigpemu";
+  version = bigpemu-unwrapped.version;
+  targetPkgs = pkgs: [
+    glui
+    libGL
+    libGLU
+    SDL2
+  ];
+  runScript = "${bigpemu-unwrapped}/bin/bigpemu";
+  passthru = {
+    unwrapped = bigpemu-unwrapped;
+    updateScript = ./update.sh;
+  };
+}

--- a/pkgs/by-name/bi/bigpemu/update.sh
+++ b/pkgs/by-name/bi/bigpemu/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+set -eu -o pipefail
+page="https://www.richwhitehouse.com/jaguar/index.php?content=download"
+extractor='font:contains("Current Version") strong text{}'
+lastest_version="$(curl "$page" | pup "$extractor")"
+update-source-version \
+    --ignore-same-version \
+    bigpemu.unwrapped "$lastest_version"


### PR DESCRIPTION
Add a package for BigPEmu. Already tested in a flake (https://github.com/Tombert/BigPEmuFlakeMake). 

Fixes #310593

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
