### PR TITLE
prometheus-rasdaemon-exporter: init at unstable-2023-03-15

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -76,6 +76,7 @@ let
     "process"
     "pve"
     "py-air-control"
+    "rasdaemon"
     "redis"
     "restic"
     "rspamd"

--- a/nixos/modules/services/monitoring/prometheus/exporters/rasdaemon.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rasdaemon.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    mkOption
+    types
+    ;
+
+  inherit (utils) escapeSystemdExecArgs;
+
+  cfg = config.services.prometheus.exporters.rasdaemon;
+in
+{
+  port = 10029;
+  extraOpts = with types; {
+    databasePath = mkOption {
+      type = path;
+      default = "/var/lib/rasdaemon/ras-mc_event.db";
+      description = ''
+        Path to the RAS daemon machine check event database.
+      '';
+    };
+
+    enabledCollectors = mkOption {
+      type = listOf (enum [
+        "aer"
+        "mce"
+        "mc"
+        "extlog"
+        "devlink"
+        "disk"
+      ]);
+      default = [
+        "aer"
+        "mce"
+        "mc"
+      ];
+      description = ''
+        List of error types to collect from the event database.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = escapeSystemdExecArgs (
+        [
+          (getExe pkgs.prometheus-rasdaemon-exporter)
+          "--address"
+          cfg.listenAddress
+          "--port"
+          (toString cfg.port)
+          "--db"
+          cfg.databasePath
+        ]
+        ++ map (collector: "--collector-${collector}") cfg.enabledCollectors
+        ++ cfg.extraFlags
+      );
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "prometheus-rasdaemon-exporter";
+  version = "unstable-2023-03-15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sanecz";
+    repo = "prometheus-rasdaemon-exporter";
+    rev = "e37084edeb4d397dd360298cb22f18f83a35ff46";
+    hash = "sha256-O0Zzog+5jDixFRGbqmjPYi6JDpHbxpU4hKfsqTnexS8=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "0.1.dev9+ge37084e";
+
+  dependencies = with python3Packages; [
+    prometheus-client
+  ];
+
+  pythonImportsCheck = [
+    "prometheus_rasdaemon_exporter"
+  ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Rasdaemon exporter for Prometheus";
+    homepage = "https://github.com/sanecz/prometheus-rasdaemon-exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+    mainProgram = "prometheus-rasdaemon-exporter";
+  };
+}


### PR DESCRIPTION
Rasdaemon exporter for Prometheus

No test since injecting a hardware fault to test requires a kernel with CONFIG_EDAC_DEBUG enabled.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
