### PR TITLE
whisper-ctranslate2: 0.4.6 -> 0.5.1

### DIFF
--- a/pkgs/by-name/wh/whisper-ctranslate2/package.nix
+++ b/pkgs/by-name/wh/whisper-ctranslate2/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   pname = "whisper-ctranslate2";
-  version = "0.4.6";
+  version = "0.5.1";
 in
 python3Packages.buildPythonApplication {
   inherit pname version;
@@ -16,8 +16,8 @@ python3Packages.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "Softcatala";
     repo = "whisper-ctranslate2";
-    rev = "refs/tags/${version}";
-    hash = "sha256-sIkZIzSGqPbjg9BMkcciGFr024Pd8ohXl/NdbsxhjH0=";
+    tag = version;
+    hash = "sha256-y1xCycWUxrLwmnk6tlyag0uN0oo6DRQFeIIBw555VjY=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/development/python-modules/faster-whisper/default.nix
+++ b/pkgs/development/python-modules/faster-whisper/default.nix
@@ -19,15 +19,14 @@
 
 buildPythonPackage rec {
   pname = "faster-whisper";
-  version = "unstable-2024-07-26";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "SYSTRAN";
     repo = "faster-whisper";
-    # rev = "refs/tags/v${version}";
-    rev = "d57c5b40b06e59ec44240d93485a95799548af50";
-    hash = "sha256-C/O+wt3dykQJmH+VsVkpQwEAdyW8goMUMKR0Z3Y7jdo=";
+    tag = "v${version}";
+    hash = "sha256-oJBCEwTfon80XQ9XIgnRw0SLvpwX0L5jnezwG0jv3Eg=";
   };
 
   build-system = [
@@ -59,7 +58,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    changelog = "https://github.com/SYSTRAN/faster-whisper/releases/tag/v${version}";
+    changelog = "https://github.com/SYSTRAN/faster-whisper/releases/tag/${src.tag}";
     description = "Faster Whisper transcription with CTranslate2";
     homepage = "https://github.com/SYSTRAN/faster-whisper";
     license = licenses.mit;


### PR DESCRIPTION
## Things done

- **python312Packages.faster-whisper: unstable-2024-07-26 -> 1.1.0**
- **whisper-ctranslate2: 0.4.6 -> 0.5.1**

cc @hexa @happysalada 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
