### PR TITLE
freeoffice: 2021.1054 -> 2024.1220; softmaker-office: 2021.1032 -> 2024.1222

### DIFF
--- a/pkgs/applications/office/softmaker/desktop_items.nix
+++ b/pkgs/applications/office/softmaker/desktop_items.nix
@@ -1,4 +1,8 @@
-{ makeDesktopItem, pname, suiteName }:
+{
+  makeDesktopItem,
+  pname,
+  suiteName,
+}:
 
 {
   planmaker = makeDesktopItem {

--- a/pkgs/applications/office/softmaker/freeoffice.nix
+++ b/pkgs/applications/office/softmaker/freeoffice.nix
@@ -1,27 +1,32 @@
-{ callPackage
-, fetchurl
+{
+  callPackage,
+  fetchurl,
 
   # This is a bit unusual, but makes version and hash easily
   # overridable. This is useful when the upstream archive was replaced
   # and nixpkgs is not in sync yet.
-, officeVersion ? {
-  version = "1054";
-  edition = "2021";
-  hash = "sha256-dqmJUm0Qi1/GzGrI4OCHo1LwQ5KxMwZZw5EsYTMF6XU=";
-}
+  officeVersion ? {
+    version = "1054";
+    edition = "2021";
+    hash = "sha256-dqmJUm0Qi1/GzGrI4OCHo1LwQ5KxMwZZw5EsYTMF6XU=";
+  },
 
-, ... } @ args:
+  ...
+}@args:
 
-callPackage ./generic.nix (args // rec {
-  inherit (officeVersion) version edition;
+callPackage ./generic.nix (
+  args
+  // rec {
+    inherit (officeVersion) version edition;
 
-  pname = "freeoffice";
-  suiteName = "FreeOffice";
+    pname = "freeoffice";
+    suiteName = "FreeOffice";
 
-  src = fetchurl {
-    inherit (officeVersion) hash;
-    url = "https://www.softmaker.net/down/softmaker-freeoffice-${edition}-${version}-amd64.tgz";
-  };
+    src = fetchurl {
+      inherit (officeVersion) hash;
+      url = "https://www.softmaker.net/down/softmaker-freeoffice-${edition}-${version}-amd64.tgz";
+    };
 
-  archive = "freeoffice${edition}.tar.lzma";
-})
+    archive = "freeoffice${edition}.tar.lzma";
+  }
+)

--- a/pkgs/applications/office/softmaker/freeoffice.nix
+++ b/pkgs/applications/office/softmaker/freeoffice.nix
@@ -6,9 +6,9 @@
   # overridable. This is useful when the upstream archive was replaced
   # and nixpkgs is not in sync yet.
   officeVersion ? {
-    version = "1054";
-    edition = "2021";
-    hash = "sha256-dqmJUm0Qi1/GzGrI4OCHo1LwQ5KxMwZZw5EsYTMF6XU=";
+    version = "1220";
+    edition = "2024";
+    hash = "sha256-F1Srm3/4UPifYls21MhjbpxSyLaT0gEVzEMQF0gIzi0=";
   },
 
   ...

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -1,18 +1,38 @@
-{ lib, stdenv, autoPatchelfHook, makeDesktopItem, makeWrapper, copyDesktopItems
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  makeDesktopItem,
+  makeWrapper,
+  copyDesktopItems,
 
   # Dynamic Libraries
-, curl, libGL, libX11, libXext, libXmu, libXrandr, libXrender
+  curl,
+  libGL,
+  libX11,
+  libXext,
+  libXmu,
+  libXrandr,
+  libXrender,
 
   # For fixing up execution of /bin/ls, which is necessary for
   # product unlocking.
-, coreutils, libredirect
+  coreutils,
+  libredirect,
 
   # Extra utilities used by the SoftMaker applications.
-, gnugrep, util-linux, which
+  gnugrep,
+  util-linux,
+  which,
 
-, pname, version, edition, suiteName, src, archive
+  pname,
+  version,
+  edition,
+  suiteName,
+  src,
+  archive,
 
-, ...
+  ...
 }:
 
 let
@@ -20,7 +40,8 @@ let
     inherit makeDesktopItem pname suiteName;
   };
   shortEdition = builtins.substring 2 2 edition;
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   inherit pname src;
 
   version = "${edition}.${version}";
@@ -56,66 +77,75 @@ in stdenv.mkDerivation {
     runHook postUnpack
   '';
 
-  installPhase = let
-    # SoftMaker/FreeOffice collects some system information upon
-    # unlocking the product. But in doing so, it attempts to execute
-    # /bin/ls. If the execve syscall fails, the whole unlock
-    # procedure fails. This works around that by rewriting /bin/ls
-    # to the proper path.
-    #
-    # In addition, it expects some common utilities (which, whereis)
-    # to be in the path.
-    #
-    # SoftMaker Office restarts itself upon some operations, such
-    # changing the theme and unlocking. Unfortunately, we do not
-    # have control over its environment then and it will fail
-    # with an error.
-    extraWrapperArgs = ''
-      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
-      --set NIX_REDIRECTS "/bin/ls=${coreutils}/bin/ls" \
-      --prefix PATH : "${lib.makeBinPath [ coreutils gnugrep util-linux which ]}"
+  installPhase =
+    let
+      # SoftMaker/FreeOffice collects some system information upon
+      # unlocking the product. But in doing so, it attempts to execute
+      # /bin/ls. If the execve syscall fails, the whole unlock
+      # procedure fails. This works around that by rewriting /bin/ls
+      # to the proper path.
+      #
+      # In addition, it expects some common utilities (which, whereis)
+      # to be in the path.
+      #
+      # SoftMaker Office restarts itself upon some operations, such
+      # changing the theme and unlocking. Unfortunately, we do not
+      # have control over its environment then and it will fail
+      # with an error.
+      extraWrapperArgs = ''
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS "/bin/ls=${coreutils}/bin/ls" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+            util-linux
+            which
+          ]
+        }"
+      '';
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      cp -r ${pname} $out/share/${pname}${edition}
+
+      # Wrap rather than symlinking, so that the programs can determine
+      # their resource path.
+      mkdir -p $out/bin
+      makeWrapper $out/share/${pname}${edition}/planmaker $out/bin/${pname}-planmaker \
+        ${extraWrapperArgs}
+      makeWrapper $out/share/${pname}${edition}/presentations $out/bin/${pname}-presentations \
+        ${extraWrapperArgs}
+      makeWrapper $out/share/${pname}${edition}/textmaker $out/bin/${pname}-textmaker \
+        ${extraWrapperArgs}
+
+      for size in 16 32 48 64 96 128 256 512 1024; do
+        mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+
+        for app in pml prl tml; do
+          ln -s $out/share/${pname}${edition}/icons/''${app}_''${size}.png \
+            $out/share/icons/hicolor/''${size}x''${size}/apps/${pname}-''${app}.png
+        done
+
+        mkdir -p $out/share/icons/hicolor/''${size}x''${size}/mimetypes
+
+        for mimetype in pmd prd tmd; do
+          ln -s $out/share/${pname}${edition}/icons/''${mimetype}_''${size}.png \
+            $out/share/icons/hicolor/''${size}x''${size}/mimetypes/application-x-''${mimetype}.png
+        done
+      done
+
+      # freeoffice 973 misses the 96x96 application icons, giving broken symbolic links
+      # remove broken symbolic links
+      find $out -xtype l -ls -exec rm {} \;
+
+      # Add mime types
+      install -D -t $out/share/mime/packages ${pname}/mime/softmaker-*office*${shortEdition}.xml
+
+      runHook postInstall
     '';
-  in ''
-    runHook preInstall
-
-    mkdir -p $out/share
-    cp -r ${pname} $out/share/${pname}${edition}
-
-    # Wrap rather than symlinking, so that the programs can determine
-    # their resource path.
-    mkdir -p $out/bin
-    makeWrapper $out/share/${pname}${edition}/planmaker $out/bin/${pname}-planmaker \
-      ${extraWrapperArgs}
-    makeWrapper $out/share/${pname}${edition}/presentations $out/bin/${pname}-presentations \
-      ${extraWrapperArgs}
-    makeWrapper $out/share/${pname}${edition}/textmaker $out/bin/${pname}-textmaker \
-      ${extraWrapperArgs}
-
-    for size in 16 32 48 64 96 128 256 512 1024; do
-      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
-
-      for app in pml prl tml; do
-        ln -s $out/share/${pname}${edition}/icons/''${app}_''${size}.png \
-          $out/share/icons/hicolor/''${size}x''${size}/apps/${pname}-''${app}.png
-      done
-
-      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/mimetypes
-
-      for mimetype in pmd prd tmd; do
-        ln -s $out/share/${pname}${edition}/icons/''${mimetype}_''${size}.png \
-          $out/share/icons/hicolor/''${size}x''${size}/mimetypes/application-x-''${mimetype}.png
-      done
-    done
-
-    # freeoffice 973 misses the 96x96 application icons, giving broken symbolic links
-    # remove broken symbolic links
-    find $out -xtype l -ls -exec rm {} \;
-
-    # Add mime types
-    install -D -t $out/share/mime/packages ${pname}/mime/softmaker-*office*${shortEdition}.xml
-
-    runHook postInstall
-  '';
 
   desktopItems = builtins.attrValues desktopItems;
 

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -8,6 +8,8 @@
 
   # Dynamic Libraries
   curl,
+  glib,
+  gst_all_1,
   libGL,
   libX11,
   libXext,
@@ -54,6 +56,9 @@ stdenv.mkDerivation {
 
   buildInputs = [
     curl
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
     libGL
     libX11
     libXext

--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -1,28 +1,33 @@
-{ callPackage
-, fetchurl
+{
+  callPackage,
+  fetchurl,
 
   # This is a bit unusual, but makes version and hash easily
   # overridable. This is useful when people have an older version of
   # Softmaker Office or when the upstream archive was replaced and
   # nixpkgs is not in sync yet.
-, officeVersion ? {
-  version = "1032";
-  edition = "2021";
-  hash = "sha256-LchSqLVBdkmWJQ8hCEvtwRPgIUSDE0URKPzCkEexGbc=";
-}
+  officeVersion ? {
+    version = "1032";
+    edition = "2021";
+    hash = "sha256-LchSqLVBdkmWJQ8hCEvtwRPgIUSDE0URKPzCkEexGbc=";
+  },
 
-, ... } @ args:
+  ...
+}@args:
 
-callPackage ./generic.nix (args // rec {
-  inherit (officeVersion) version edition;
+callPackage ./generic.nix (
+  args
+  // rec {
+    inherit (officeVersion) version edition;
 
-  pname = "softmaker-office";
-  suiteName = "SoftMaker Office";
+    pname = "softmaker-office";
+    suiteName = "SoftMaker Office";
 
-  src = fetchurl {
-    inherit (officeVersion) hash;
-    url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
-  };
+    src = fetchurl {
+      inherit (officeVersion) hash;
+      url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
+    };
 
-  archive = "office${edition}.tar.lzma";
-})
+    archive = "office${edition}.tar.lzma";
+  }
+)

--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -7,9 +7,9 @@
   # Softmaker Office or when the upstream archive was replaced and
   # nixpkgs is not in sync yet.
   officeVersion ? {
-    version = "1032";
-    edition = "2021";
-    hash = "sha256-LchSqLVBdkmWJQ8hCEvtwRPgIUSDE0URKPzCkEexGbc=";
+    version = "1222";
+    edition = "2024";
+    hash = "sha256-eyYBK5ZxPcBakOvXUQZIU2aftyH6PXh/rtqC/1BJhg4=";
   },
 
   ...


### PR DESCRIPTION
## Things done

- **softmaker: format**
- **freeoffice: 2021.1054 -> 2024.1220**
- **softmaker-office: 2021.1032 -> 2024.1222**

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
