### PR TITLE
[Backport release-24.11] k3s_1_29: 1.29.10+k3s1 -> 1.29.11+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "0z3k4pc5cg75krk391d9h74ankv20mfcswrhwhhfv208rcndd9w9"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.11%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "0i62dg60090wmiqi2wzqa4jx45dag71y0936hhy00402wdcylmj7"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0iy0xz8ypmgn48jh3b4hbnwl8iszdb35c2f6an115z86lnl7a9a3"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.11%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "0v9wazqiypzpxpc31vi0x3w1jwsny8xcnv67bcjwj5xlwpjlsjz9"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1bjfd63jd7a1yhh796nmdh7jvw9mabsw5gajcx8ssqcxd4wwrdxb"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.11%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "07145gdpgqy49pvinnx0pal9mzsljysgd5zfq565fx5smfxzvbyn"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-images.txt",
-    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.11%2Bk3s1/k3s-images.txt",
+    "sha256": "05229bfg174pvy525dcy7rvmgv9i9v1nnz5ngq80n7zkxj9cp8m8"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.29.9+k3s1";
-  k3sCommit = "e92d3b3ba7a4810e82e38a3d5c6091a3e18caad5";
-  k3sRepoSha256 = "1i4881nv41dpvxmh20qy121d45431xbhkzlywx1rfwqla8wq6bwh";
-  k3sVendorHash = "sha256-JeX9SJw6U1/FMbv9fVQeQvAZKq+Z99ZrLC2bAy1vUkA=";
+  k3sVersion = "1.29.11+k3s1";
+  k3sCommit = "666b590a7512c0baab01c93bf81222fa22565c45";
+  k3sRepoSha256 = "0w9lldvzkd3rrq0gypqnyjmjr73bxay44q2vfcj4my0ryc3bajf4";
+  k3sVendorHash = "sha256-FaOBeUONkeG2CfGUN4VRUzpQl0C6b06kKCnb6ICYHzo=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
-  k3sRootVersion = "0.14.0";
-  k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.5.1-k3s1";
-  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
-  containerdVersion = "1.7.21-k3s2";
-  containerdSha256 = "0kp93fhmw2kiy46hw3ag05z8xwhw7kqp4wcbhsxshsdf0929g539";
+  k3sRootVersion = "0.14.1";
+  k3sRootSha256 = "0svbi42agqxqh5q2ri7xmaw2a2c70s7q5y587ls0qkflw5vx4sl7";
+  k3sCNIVersion = "1.6.0-k3s1";
+  k3sCNISha256 = "0g7zczvwba5xqawk37b0v96xysdwanyf1grxn3l3lhxsgjjsmkd7";
+  containerdVersion = "1.7.23-k3s2";
+  containerdSha256 = "0lp9vxq7xj74wa7hbivvl5hwg2wzqgsxav22wa0p1l7lc1dqw8dm";
   criCtlVersion = "1.29.0-k3s1";
 }


### PR DESCRIPTION
(cherry picked from commit a9e6d7a110d6930ec9d4d88836351ef91cc5d2c8)

Manuel backport due to conflicts. Parent pull request here: https://github.com/NixOS/nixpkgs/pull/364689

This is affected by the same problem as the `k3s_1_30` backport in https://github.com/NixOS/nixpkgs/pull/365394: `release-24.11` skipped a k3s version so automatic backport and the cherry pick checker fail.

@NixOS/k3s 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
