### PR TITLE
[Backport release-24.11] ente-auth: 4.0.2 -> 4.1.6

### DIFF
--- a/pkgs/by-name/en/ente-auth/0001-disable-updates.patch
+++ b/pkgs/by-name/en/ente-auth/0001-disable-updates.patch
@@ -1,0 +1,15 @@
+diff --git a/auth/lib/services/update_service.dart b/auth/lib/services/update_service.dart
+index 716d553f1b..3946d87a7d 100644
+--- a/lib/services/update_service.dart
++++ b/lib/services/update_service.dart
+@@ -134,9 +134,7 @@ class UpdateService {
+   }
+ 
+   bool isIndependent() {
+-    return flavor == "independent" ||
+-        _packageInfo.packageName.endsWith("independent") ||
+-        PlatformUtil.isDesktop();
++    return false;
+   }
+ }
+ 

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -7,7 +7,6 @@
   libayatana-appindicator,
   makeDesktopItem,
   copyDesktopItems,
-  imagemagick,
   makeWrapper,
   xdg-user-dirs,
 }:
@@ -47,7 +46,6 @@ flutter324.buildFlutterApplication rec {
 
   nativeBuildInputs = [
     copyDesktopItems
-    imagemagick
     makeWrapper
   ];
 
@@ -78,15 +76,8 @@ flutter324.buildFlutterApplication rec {
   ];
 
   postInstall = ''
-    FAV=$out/app/ente-auth/data/flutter_assets/assets/icons/auth-icon.png
-    ICO=$out/share/icons
-
-    install -D $FAV $ICO/ente-auth.png
-    for size in 24 32 42 64 128 256 512; do
-      D=$ICO/hicolor/''${size}x''${size}/apps
-      mkdir -p $D
-      magick $FAV -resize ''${size}x''${size} $D/ente-auth.png
-    done
+    mkdir -p $out/share/pixmaps
+    ln -s $out/app/ente-auth/data/flutter_assets/assets/icons/auth-icon.png $out/share/pixmaps/ente-auth.png
 
     install -Dm444 linux/packaging/ente_auth.appdata.xml -t $out/share/metainfo
 

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -32,7 +32,7 @@ flutter324.buildFlutterApplication rec {
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
 
-  patchPhase = ''
+  postPatch = ''
     rmdir assets/simple-icons
     ln -s ${simple-icons} assets/simple-icons
   '';

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -14,17 +14,18 @@ let
   # fetch simple-icons directly to avoid cloning with submodules,
   # which would also clone a whole copy of flutter
   simple-icons = fetchFromGitHub (lib.importJSON ./simple-icons.json);
+  desktopId = "io.ente.auth";
 in
 flutter324.buildFlutterApplication rec {
   pname = "ente-auth";
-  version = "4.0.2";
+  version = "4.1.6";
 
   src = fetchFromGitHub {
     owner = "ente-io";
     repo = "ente";
     sparseCheckout = [ "auth" ];
-    rev = "auth-v${version}";
-    hash = "sha256-me+fT79vwqBBNsRWWo58GdzBf58LNB4Mk+pmCLvn/ik=";
+    tag = "auth-v${version}";
+    hash = "sha256-6LsHKK+IvMgxgih0u04dbpzesyQgwLvkGK0a1NcgpTg=";
   };
 
   sourceRoot = "${src.name}/auth";
@@ -41,7 +42,7 @@ flutter324.buildFlutterApplication rec {
     ente_crypto_dart = "sha256-XBzQ268E0cYljJH6gDS5O0Pmie/GwuhMDlQPfopSqJM=";
     flutter_local_authentication = "sha256-r50jr+81ho+7q2PWHLf4VnvNJmhiARZ3s4HUpThCgc0=";
     flutter_secure_storage_linux = "sha256-x45jrJ7pvVyhZlpqRSy3CbwT4Lna6yi/b2IyAilWckg=";
-    sqflite = "sha256-TdvCtEO7KL1R2oOSwGWllmS5kGCIU5CkvvUqUJf3tUc=";
+    sqflite = "sha256-+XTVtkFJ94VifwnutvUuAqqiyWwrcEiZ3Uz0H4D9zWA=";
   };
 
   nativeBuildInputs = [
@@ -56,12 +57,12 @@ flutter324.buildFlutterApplication rec {
   ];
 
   # Based on https://github.com/ente-io/ente/blob/main/auth/linux/packaging/rpm/make_config.yaml
-  # and https://github.com/ente-io/ente/blob/main/auth/linux/packaging/ente_auth.appdata.xml
+  # and https://github.com/ente-io/ente/blob/main/auth/linux/packaging/enteauth.appdata.xml
   desktopItems = [
     (makeDesktopItem {
-      name = "ente_auth";
-      exec = "ente_auth";
-      icon = "ente-auth";
+      name = desktopId;
+      exec = "enteauth";
+      icon = "enteauth";
       desktopName = "Ente Auth";
       genericName = "Ente Authentication";
       comment = "Open source 2FA authenticator, with end-to-end encrypted backups";
@@ -77,12 +78,18 @@ flutter324.buildFlutterApplication rec {
 
   postInstall = ''
     mkdir -p $out/share/pixmaps
-    ln -s $out/app/ente-auth/data/flutter_assets/assets/icons/auth-icon.png $out/share/pixmaps/ente-auth.png
+    ln -s $out/app/ente-auth/data/flutter_assets/assets/icons/auth-icon.png $out/share/pixmaps/enteauth.png
 
-    install -Dm444 linux/packaging/ente_auth.appdata.xml -t $out/share/metainfo
+    install -Dm444 linux/packaging/enteauth.appdata.xml $out/share/metainfo/${desktopId}.metainfo.xml
+    substituteInPlace $out/share/metainfo/${desktopId}.metainfo.xml \
+      --replace-fail '<id>enteauth</id>' '<id>${desktopId}</id>' \
+      --replace-fail 'enteauth.desktop' '${desktopId}.desktop'
 
-    wrapProgram $out/bin/ente_auth \
+    wrapProgram $out/bin/enteauth \
       --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+
+    # For backwards compatibility
+    ln -s $out/bin/enteauth $out/bin/ente_auth
   '';
 
   passthru.updateScript = ./update.sh;
@@ -101,7 +108,7 @@ flutter324.buildFlutterApplication rec {
       zi3m5f
       gepbird
     ];
-    mainProgram = "ente_auth";
+    mainProgram = "enteauth";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -32,6 +32,11 @@ flutter324.buildFlutterApplication rec {
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
 
+  patches = [
+    # Disable update notifications and auto-update functionality
+    ./0001-disable-updates.patch
+  ];
+
   postPatch = ''
     rmdir assets/simple-icons
     ln -s ${simple-icons} assets/simple-icons

--- a/pkgs/by-name/en/ente-auth/pubspec.lock.json
+++ b/pkgs/by-name/en/ente-auth/pubspec.lock.json
@@ -4,11 +4,17 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7",
+        "sha256": "f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "67.0.0"
+      "version": "72.0.0"
+    },
+    "_macros": {
+      "dependency": "transitive",
+      "description": "dart",
+      "source": "sdk",
+      "version": "0.3.2"
     },
     "adaptive_theme": {
       "dependency": "direct main",
@@ -24,31 +30,31 @@
       "dependency": "transitive",
       "description": {
         "name": "analyzer",
-        "sha256": "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d",
+        "sha256": "b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.4.1"
+      "version": "6.7.0"
     },
     "ansicolor": {
       "dependency": "transitive",
       "description": {
         "name": "ansicolor",
-        "sha256": "8bf17a8ff6ea17499e40a2d2542c2f481cd7615760c6d34065cb22bfd22e6880",
+        "sha256": "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "app_links": {
       "dependency": "direct main",
       "description": {
         "name": "app_links",
-        "sha256": "f04c3ca96426baba784c736a201926bd4145524c36a1b38942a351b033305e21",
+        "sha256": "ad1a6d598e7e39b46a34f746f9a8b011ee147e4c275d407fa457e7a62f84dd99",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.2.1"
+      "version": "6.3.2"
     },
     "app_links_linux": {
       "dependency": "transitive",
@@ -204,21 +210,21 @@
       "dependency": "direct dev",
       "description": {
         "name": "build_runner",
-        "sha256": "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7",
+        "sha256": "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.11"
+      "version": "2.4.13"
     },
     "build_runner_core": {
       "dependency": "transitive",
       "description": {
         "name": "build_runner_core",
-        "sha256": "e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe",
+        "sha256": "f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.3.1"
+      "version": "7.3.2"
     },
     "built_collection": {
       "dependency": "transitive",
@@ -314,11 +320,11 @@
       "dependency": "direct main",
       "description": {
         "name": "confetti",
-        "sha256": "979aafde2428c53947892c95eb244466c109c129b7eee9011f0a66caaca52267",
+        "sha256": "79376a99648efbc3f23582f5784ced0fe239922bd1a0fb41f582051eba750751",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.0"
+      "version": "0.8.0"
     },
     "connectivity_plus": {
       "dependency": "direct main",
@@ -364,11 +370,11 @@
       "dependency": "transitive",
       "description": {
         "name": "crypto",
-        "sha256": "ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab",
+        "sha256": "ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.3"
+      "version": "3.0.5"
     },
     "csslib": {
       "dependency": "transitive",
@@ -384,11 +390,11 @@
       "dependency": "transitive",
       "description": {
         "name": "dart_style",
-        "sha256": "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9",
+        "sha256": "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.6"
+      "version": "2.3.7"
     },
     "dbus": {
       "dependency": "transitive",
@@ -399,17 +405,6 @@
       },
       "source": "hosted",
       "version": "0.7.10"
-    },
-    "desktop_webview_window": {
-      "dependency": "direct main",
-      "description": {
-        "path": "packages/desktop_webview_window",
-        "ref": "main",
-        "resolved-ref": "726d8281a244d56ab36e843f0427c48de6d9cc56",
-        "url": "https://github.com/MixinNetwork/flutter-plugins"
-      },
-      "source": "git",
-      "version": "0.2.4"
     },
     "device_info_plus": {
       "dependency": "direct main",
@@ -425,21 +420,31 @@
       "dependency": "transitive",
       "description": {
         "name": "device_info_plus_platform_interface",
-        "sha256": "d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64",
+        "sha256": "282d3cf731045a2feb66abfe61bbc40870ae50a3ed10a4d3d217556c35c8c2ba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.0.0"
+      "version": "7.0.1"
     },
     "dio": {
       "dependency": "direct main",
       "description": {
         "name": "dio",
-        "sha256": "11e40df547d418cc0c4900a9318b26304e665da6fa4755399a9ff9efd09034b5",
+        "sha256": "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.4.3+1"
+      "version": "5.7.0"
+    },
+    "dio_web_adapter": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dio_web_adapter",
+        "sha256": "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
     },
     "dotted_border": {
       "dependency": "direct main",
@@ -486,11 +491,11 @@
       "dependency": "direct main",
       "description": {
         "name": "event_bus",
-        "sha256": "44baa799834f4c803921873e7446a2add0f3efa45e101a054b1f0ab9b95f8edc",
+        "sha256": "1a55e97923769c286d295240048fc180e7b0768902c3c2e869fe059aafa15304",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "expandable": {
       "dependency": "direct main",
@@ -526,11 +531,11 @@
       "dependency": "direct main",
       "description": {
         "name": "ffi",
-        "sha256": "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21",
+        "sha256": "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "file": {
       "dependency": "transitive",
@@ -556,11 +561,11 @@
       "dependency": "direct main",
       "description": {
         "name": "file_saver",
-        "sha256": "bdebc720e17b3e01aba59da69b6d47020a7e5ba7d5c75bd9194f9618d5f16ef4",
+        "sha256": "017a127de686af2d2fbbd64afea97052d95f2a0f87d19d25b87e097407bf9c1e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.12"
+      "version": "0.2.14"
     },
     "fixnum": {
       "dependency": "direct main",
@@ -642,21 +647,21 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_inappwebview",
-        "sha256": "3e9a443a18ecef966fb930c3a76ca5ab6a7aafc0c7b5e14a4a850cf107b09959",
+        "sha256": "93cfcca02bdda4b26cd700cf70d9ddba09d8348e3e8f2857638c23ed23a4fcb4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.0.0"
+      "version": "6.1.4"
     },
     "flutter_inappwebview_android": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_inappwebview_android",
-        "sha256": "d247f6ed417f1f8c364612fa05a2ecba7f775c8d0c044c1d3b9ee33a6515c421",
+        "sha256": "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.13"
+      "version": "1.1.3"
     },
     "flutter_inappwebview_internal_annotations": {
       "dependency": "transitive",
@@ -672,51 +677,61 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_inappwebview_ios",
-        "sha256": "f363577208b97b10b319cd0c428555cd8493e88b468019a8c5635a0e4312bd0f",
+        "sha256": "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.13"
+      "version": "1.1.2"
     },
     "flutter_inappwebview_macos": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_inappwebview_macos",
-        "sha256": "b55b9e506c549ce88e26580351d2c71d54f4825901666bd6cfa4be9415bb2636",
+        "sha256": "c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.11"
+      "version": "1.1.2"
     },
     "flutter_inappwebview_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_inappwebview_platform_interface",
-        "sha256": "545fd4c25a07d2775f7d5af05a979b2cac4fbf79393b0a7f5d33ba39ba4f6187",
+        "sha256": "cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.10"
+      "version": "1.3.0+1"
     },
     "flutter_inappwebview_web": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_inappwebview_web",
-        "sha256": "d8c680abfb6fec71609a700199635d38a744df0febd5544c5a020bd73de8ee07",
+        "sha256": "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.8"
+      "version": "1.1.2"
+    },
+    "flutter_inappwebview_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_inappwebview_windows",
+        "sha256": "95ebc65aecfa63b2084c822aec6ba0545f0a0afaa3899f2c752ec96c09108db5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.0+2"
     },
     "flutter_launcher_icons": {
       "dependency": "direct main",
       "description": {
         "name": "flutter_launcher_icons",
-        "sha256": "526faf84284b86a4cb36d20a5e45147747b7563d921373d4ee0559c54fcdbcea",
+        "sha256": "619817c4b65b322b5104b6bb6dfe6cda62d9729bd7ad4303ecc8b4e690a67a77",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.13.1"
+      "version": "0.14.1"
     },
     "flutter_local_authentication": {
       "dependency": "direct main",
@@ -733,11 +748,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_local_notifications",
-        "sha256": "c500d5d9e7e553f06b61877ca6b9c8b92c570a4c8db371038702e8ce57f8a50f",
+        "sha256": "49eeef364fddb71515bc78d5a8c51435a68bccd6e4d68e25a942c5e47761ae71",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "17.2.2"
+      "version": "17.2.3"
     },
     "flutter_local_notifications_linux": {
       "dependency": "transitive",
@@ -769,21 +784,21 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_native_splash",
-        "sha256": "edf39bcf4d74aca1eb2c1e43c3e445fd9f494013df7f0da752fefe72020eedc0",
+        "sha256": "aa06fec78de2190f3db4319dd60fdc8d12b2626e93ef9828633928c2dcaea840",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.0"
+      "version": "2.4.1"
     },
     "flutter_plugin_android_lifecycle": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e",
+        "sha256": "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.20"
+      "version": "2.0.22"
     },
     "flutter_secure_storage": {
       "dependency": "direct main",
@@ -800,7 +815,7 @@
       "description": {
         "path": "flutter_secure_storage_linux",
         "ref": "develop",
-        "resolved-ref": "cb30953edc029dc4059b72700270b4cd3a3afade",
+        "resolved-ref": "5a5692b609b3886cdd49b2ed06b9c079ecdff996",
         "url": "https://github.com/mogol/flutter_secure_storage.git"
       },
       "source": "git",
@@ -850,11 +865,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_shaders",
-        "sha256": "02750b545c01ff4d8e9bbe8f27a7731aa3778402506c67daa1de7f5fc3f4befe",
+        "sha256": "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "flutter_speed_dial": {
       "dependency": "direct main",
@@ -880,11 +895,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_svg",
-        "sha256": "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2",
+        "sha256": "54900a1a1243f3c4a5506d853a2b5c2dbc38d5f27e52a52618a8054401431123",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.10+1"
+      "version": "2.0.16"
     },
     "flutter_test": {
       "dependency": "direct dev",
@@ -912,11 +927,11 @@
       "dependency": "transitive",
       "description": {
         "name": "freezed_annotation",
-        "sha256": "c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d",
+        "sha256": "c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "2.4.4"
     },
     "frontend_server_client": {
       "dependency": "transitive",
@@ -962,11 +977,11 @@
       "dependency": "transitive",
       "description": {
         "name": "graphs",
-        "sha256": "aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19",
+        "sha256": "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.1"
+      "version": "2.3.2"
     },
     "gtk": {
       "dependency": "transitive",
@@ -982,21 +997,21 @@
       "dependency": "transitive",
       "description": {
         "name": "hashlib",
-        "sha256": "67e640e19cc33070113acab3125cd48ebe480a0300e15554dec089b8878a729f",
+        "sha256": "f572f2abce09fc7aee53f15927052b9732ea1053e540af8cae211111ee0b99b1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.16.0"
+      "version": "1.21.0"
     },
     "hashlib_codecs": {
       "dependency": "transitive",
       "description": {
         "name": "hashlib_codecs",
-        "sha256": "a1c7b5d89ff29e81fd8e8c0b35966db4c935e149fc4ebe1ebf71e358c15863ab",
+        "sha256": "8cea9ccafcfeaa7324d2ae52c61c69f7ff71f4237507a018caab31b9e416e3b1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.0"
+      "version": "2.6.0"
     },
     "hex": {
       "dependency": "transitive",
@@ -1069,7 +1084,7 @@
       "version": "0.19.0"
     },
     "io": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "io",
         "sha256": "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e",
@@ -1142,11 +1157,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "lints",
-        "sha256": "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235",
+        "sha256": "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.0"
+      "version": "5.0.0"
     },
     "local_auth": {
       "dependency": "direct main",
@@ -1162,21 +1177,21 @@
       "dependency": "direct main",
       "description": {
         "name": "local_auth_android",
-        "sha256": "48dfb2d954da8ef6a77adfc93a29998f7729e9308eaa817e91dea4500317b2c8",
+        "sha256": "5351c7eea8823de28e37d8b7b3e386d944b80f2a77edb91a5707fb97a41fc1b1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.39"
+      "version": "1.0.45"
     },
     "local_auth_darwin": {
       "dependency": "direct main",
       "description": {
         "name": "local_auth_darwin",
-        "sha256": "7ba5738c874ca2b910d72385d00d2bebad9d4e807612936cf5e32bc01a048c71",
+        "sha256": "6d2950da311d26d492a89aeb247c72b4653ddc93601ea36a84924a396806d49c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "local_auth_platform_interface": {
       "dependency": "transitive",
@@ -1192,11 +1207,11 @@
       "dependency": "transitive",
       "description": {
         "name": "local_auth_windows",
-        "sha256": "505ba3367ca781efb1c50d3132e44a2446bccc4163427bc203b9b4d8994d97ea",
+        "sha256": "bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.10"
+      "version": "1.0.11"
     },
     "logging": {
       "dependency": "direct main",
@@ -1207,6 +1222,16 @@
       },
       "source": "hosted",
       "version": "1.2.0"
+    },
+    "macros": {
+      "dependency": "transitive",
+      "description": {
+        "name": "macros",
+        "sha256": "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2-main.4"
     },
     "matcher": {
       "dependency": "transitive",
@@ -1252,11 +1277,11 @@
       "dependency": "transitive",
       "description": {
         "name": "mime",
-        "sha256": "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2",
+        "sha256": "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.5"
+      "version": "1.0.6"
     },
     "mocktail": {
       "dependency": "direct dev",
@@ -1392,21 +1417,21 @@
       "dependency": "direct main",
       "description": {
         "name": "path_provider",
-        "sha256": "c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161",
+        "sha256": "fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.3"
+      "version": "2.1.4"
     },
     "path_provider_android": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_android",
-        "sha256": "9c96da072b421e98183f9ea7464898428e764bc0ce5567f27ec8693442e72514",
+        "sha256": "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.5"
+      "version": "2.2.10"
     },
     "path_provider_foundation": {
       "dependency": "transitive",
@@ -1442,11 +1467,11 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_windows",
-        "sha256": "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170",
+        "sha256": "bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.3.0"
     },
     "petitparser": {
       "dependency": "transitive",
@@ -1562,11 +1587,11 @@
       "dependency": "transitive",
       "description": {
         "name": "qr",
-        "sha256": "64957a3930367bf97cc211a5af99551d630f2f4625e38af10edd6b19131b64b3",
+        "sha256": "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.1"
+      "version": "3.0.2"
     },
     "qr_code_scanner": {
       "dependency": "direct main",
@@ -1602,21 +1627,21 @@
       "dependency": "direct main",
       "description": {
         "name": "sentry",
-        "sha256": "0f787e27ff617e4f88f7074977240406a9c5509444bac64a4dfa5b3200fb5632",
+        "sha256": "033287044a6644a93498969449d57c37907e56f5cedb17b88a3ff20a882261dd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.7.0"
+      "version": "8.9.0"
     },
     "sentry_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "sentry_flutter",
-        "sha256": "fbbb47d72ccca48be25bf3c2ced6ab6e872991af3a0ba78e54be8d138f2e053f",
+        "sha256": "3780b5a0bb6afd476857cfbc6c7444d969c29a4d9bd1aa5b6960aa76c65b737a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.7.0"
+      "version": "8.9.0"
     },
     "share_plus": {
       "dependency": "direct main",
@@ -1642,71 +1667,71 @@
       "dependency": "direct main",
       "description": {
         "name": "shared_preferences",
-        "sha256": "d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180",
+        "sha256": "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.3"
+      "version": "2.3.2"
     },
     "shared_preferences_android": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "93d0ec9dd902d85f326068e6a899487d1f65ffcd5798721a95330b26c8131577",
+        "sha256": "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.3"
+      "version": "2.3.2"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_foundation",
-        "sha256": "0a8a893bf4fd1152f93fec03a415d11c27c74454d96e2318a7ac38dd18683ab7",
+        "sha256": "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.0"
+      "version": "2.5.3"
     },
     "shared_preferences_linux": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_linux",
-        "sha256": "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa",
+        "sha256": "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.2"
+      "version": "2.4.1"
     },
     "shared_preferences_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b",
+        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.2"
+      "version": "2.4.1"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_web",
-        "sha256": "d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf",
+        "sha256": "d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.4.2"
     },
     "shared_preferences_windows": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_windows",
-        "sha256": "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59",
+        "sha256": "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.2"
+      "version": "2.4.1"
     },
     "shelf": {
       "dependency": "transitive",
@@ -1758,11 +1783,11 @@
       "dependency": "transitive",
       "description": {
         "name": "sodium_libs",
-        "sha256": "441444f6f433032bae3444c2ef5ed2cf5bc0def77f104abdff20aedcf79a7c7a",
+        "sha256": "aa764acd6ccc6113e119c2d99471aeeb4637a9a501639549b297d3a143ff49b3",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1+5"
+      "version": "2.2.1+6"
     },
     "source_gen": {
       "dependency": "transitive",
@@ -1809,31 +1834,31 @@
       "description": {
         "path": "sqflite",
         "ref": "HEAD",
-        "resolved-ref": "3309d399dd7d695bbfa7c05f643bb16765cef4ee",
+        "resolved-ref": "699aaafa282d823b89ca568aac7a68d2c29ddab6",
         "url": "https://github.com/tekartik/sqflite"
       },
       "source": "git",
-      "version": "2.3.3+1"
+      "version": "2.3.3+2"
     },
     "sqflite_common": {
       "dependency": "transitive",
       "description": {
         "name": "sqflite_common",
-        "sha256": "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4",
+        "sha256": "2d8e607db72e9cb7748c9c6e739e2c9618320a5517de693d5a24609c4671b1a4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.4"
+      "version": "2.5.4+4"
     },
     "sqflite_common_ffi": {
       "dependency": "direct main",
       "description": {
         "name": "sqflite_common_ffi",
-        "sha256": "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5",
+        "sha256": "a6057d4c87e9260ba1ec436ebac24760a110589b9c0a859e128842eb69a7ef04",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.3"
+      "version": "2.3.3+1"
     },
     "sqlite3": {
       "dependency": "direct main",
@@ -1859,11 +1884,11 @@
       "dependency": "direct main",
       "description": {
         "name": "steam_totp",
-        "sha256": "3c09143c983f6bb05bb53e9232f9d40bbcc01c596ba0273c3e6bb246729abfa1",
+        "sha256": "f47163df9be533024cecb97ca9bb1f29bb5575409a22fe4acdd9d70288d38d0d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.0.1"
+      "version": "0.0.2"
     },
     "step_progress_indicator": {
       "dependency": "direct main",
@@ -1919,11 +1944,11 @@
       "dependency": "transitive",
       "description": {
         "name": "synchronized",
-        "sha256": "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558",
+        "sha256": "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.0+1"
+      "version": "3.3.0+3"
     },
     "term_glyph": {
       "dependency": "transitive",
@@ -1949,11 +1974,11 @@
       "dependency": "transitive",
       "description": {
         "name": "timezone",
-        "sha256": "a6ccda4a69a442098b602c44e61a1e2b4bf6f5516e875bbf0f427d5df14745d5",
+        "sha256": "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.9.3"
+      "version": "0.9.4"
     },
     "timing": {
       "dependency": "transitive",
@@ -1969,11 +1994,11 @@
       "dependency": "direct main",
       "description": {
         "name": "tray_manager",
-        "sha256": "c9a63fd88bd3546287a7eb8ccc978d707eef82c775397af17dda3a4f4c039e64",
+        "sha256": "bdc3ac6c36f3d12d871459e4a9822705ce5a1165a17fa837103bc842719bf3f7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     "tuple": {
       "dependency": "direct main",
@@ -2029,41 +2054,41 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf",
+        "sha256": "a4e5f34f2fadf1fa7b4e69db89189056e313c9c98e8ad420e6b53677b6abc334",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.3"
+      "version": "6.3.11"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_ios",
-        "sha256": "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89",
+        "sha256": "e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.0"
+      "version": "6.3.1"
     },
     "url_launcher_linux": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_linux",
-        "sha256": "ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811",
+        "sha256": "e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.1"
+      "version": "3.2.0"
     },
     "url_launcher_macos": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_macos",
-        "sha256": "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de",
+        "sha256": "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.0"
+      "version": "3.2.1"
     },
     "url_launcher_platform_interface": {
       "dependency": "transitive",
@@ -2099,21 +2124,21 @@
       "dependency": "direct main",
       "description": {
         "name": "uuid",
-        "sha256": "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8",
+        "sha256": "a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.4.0"
+      "version": "4.5.1"
     },
     "vector_graphics": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics",
-        "sha256": "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3",
+        "sha256": "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.11+1"
+      "version": "1.1.15"
     },
     "vector_graphics_codec": {
       "dependency": "transitive",
@@ -2129,11 +2154,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics_compiler",
-        "sha256": "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81",
+        "sha256": "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.11+1"
+      "version": "1.1.16"
     },
     "vector_math": {
       "dependency": "transitive",
@@ -2169,11 +2194,11 @@
       "dependency": "transitive",
       "description": {
         "name": "web",
-        "sha256": "d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062",
+        "sha256": "cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "web_socket": {
       "dependency": "transitive",
@@ -2199,21 +2224,21 @@
       "dependency": "direct main",
       "description": {
         "name": "win32",
-        "sha256": "a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4",
+        "sha256": "4d45dc9069dba4619dc0ebd93c7cec5e66d8482cb625a370ac806dcc8165f2ec",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.5.1"
+      "version": "5.5.5"
     },
     "win32_registry": {
       "dependency": "transitive",
       "description": {
         "name": "win32_registry",
-        "sha256": "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb",
+        "sha256": "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.3"
+      "version": "1.1.5"
     },
     "window_manager": {
       "dependency": "direct main",
@@ -2226,14 +2251,14 @@
       "version": "0.4.2"
     },
     "xdg_directories": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "xdg_directories",
-        "sha256": "faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d",
+        "sha256": "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.4"
+      "version": "1.1.0"
     },
     "xml": {
       "dependency": "transitive",
@@ -2267,7 +2292,7 @@
     }
   },
   "sdks": {
-    "dart": ">=3.4.0 <4.0.0",
-    "flutter": ">=3.22.0"
+    "dart": ">=3.5.0 <4.0.0",
+    "flutter": ">=3.24.0"
   }
 }

--- a/pkgs/by-name/en/ente-auth/simple-icons.json
+++ b/pkgs/by-name/en/ente-auth/simple-icons.json
@@ -1,6 +1,6 @@
 {
     "owner": "simple-icons",
     "repo": "simple-icons",
-    "rev": "bffc992b7d1365ee44b1683f8397e9f7a44d0c2c",
-    "hash": "sha256-aqX6X/UsXXprWYU0xYK+wM9vWULYI8enCbVFebEM0yw="
+    "rev": "954790ce652942533e9e59bfb9c8cc7e99962f88",
+    "hash": "sha256-mNqiWA/wvJxAMwzzeWXb/77JAFvJL707ktEdRHJctO4="
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backport of #357503 with resolved conflicts. The `ente_auth` symlink will be kept throughout 24.11 for compatibility but might be removed from unstable before 25.05 branch-off. Unlike my previous assumption, the data directory remains unchanged with this update, making it safe to update back and forth between 4.0.2 and 4.1.6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
