### PR TITLE
inkscape-with-extensions: actually use all extensions by default

### DIFF
--- a/pkgs/applications/graphics/inkscape/with-extensions.nix
+++ b/pkgs/applications/graphics/inkscape/with-extensions.nix
@@ -11,7 +11,7 @@ let
   allExtensions = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (
     lib.attrValues inkscape-extensions
   );
-  selectedExtensions = if inkscapeExtensions == null then allExtensions else inkscapeExtensions;
+  selectedExtensions = if inkscapeExtensions == [ ] then allExtensions else inkscapeExtensions;
 in
 
 symlinkJoin {


### PR DESCRIPTION
## Things done
`inkscape-with-extensions` now uses all extensions by default, which I believe was the goal.
The 'use all extensions'-behavior relied on `[] == null`, which is not the case.
This comparison is fixed, and now all extensions are included automatically.

Additional Notes:

- tested by watching the log output, and checking if rebuild on change in an extension (in testing: inkstitch) is triggered
- The inkstitch extension used for testing builds, but is broken.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable: (none)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

