### PR TITLE
zsh-powerlevel10k: add upstream patch to compile with gcc14

### DIFF
--- a/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   replaceVars,
+  fetchpatch,
   gitstatus,
   bash,
 }:
@@ -19,6 +20,16 @@ let
       rev = "refs/tags/v${version}";
       hash = "sha256-mVfB3HWjvk4X8bmLEC/U8SKBRytTh/gjjuReqzN5qTk=";
     };
+
+    patches = (oldAtttrs.patches or [ ]) ++ [
+      # remove when bumped to 1.5.5
+      (fetchpatch {
+        url = "https://github.com/romkatv/gitstatus/commit/62177e89b2b04baf242cd1526cc2661041dda0fb.patch";
+        sha256 = "sha256-DSRYRV89MLR/Eh4MFsXpDKH1xJiAWyJgSqmfjDTXhtU=";
+        name = "drop-Werror.patch";
+      })
+    ];
+
   });
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://hydra.nixos.org/build/281256723/nixlog/1

release version of zsh-powerlevel10k (or better gitstatus 1.5.4) does not compile with gcc14.
Upstream added  https://github.com/romkatv/gitstatus/commit/62177e89b2b04baf242cd1526cc2661041dda0fb in to disable the check.
This PR adds that as patch to unbreak the build.

Alternative would be to bump zsh-powerlevel10k so an unstable version (that is compatible with gitstatus 1.5.5). 

ref: https://github.com/NixOS/nixpkgs/pull/361878

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
