### PR TITLE
percona: several package updates

### DIFF
--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  gitUpdater,
   bison,
   cmake,
   pkg-config,
@@ -182,7 +183,13 @@ stdenv.mkDerivation (finalAttrs: {
     connector-c = finalAttrs.finalPackage;
     server = finalAttrs.finalPackage;
     mysqlVersion = lib.versions.majorMinor finalAttrs.version;
-    tests.percona-server = nixosTests.mysql.percona-server_8_0;
+    tests.percona-server =
+      nixosTests.mysql."percona-server_${lib.versions.major finalAttrs.version}_${lib.versions.minor finalAttrs.version}";
+    updateScript = gitUpdater {
+      url = "https://github.com/percona/percona-server";
+      rev-prefix = "Percona-Server-";
+      allowedVersions = "${lib.versions.major finalAttrs.version}\\.${lib.versions.minor finalAttrs.version}\\..+";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -51,11 +51,11 @@ assert !(withJemalloc && withTcmalloc);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "percona-server";
-  version = "8.4.2-2";
+  version = "8.4.3-3";
 
   src = fetchurl {
     url = "https://downloads.percona.com/downloads/Percona-Server-${lib.versions.majorMinor finalAttrs.version}/Percona-Server-${finalAttrs.version}/source/tarball/percona-server-${finalAttrs.version}.tar.gz";
-    hash = "sha256-KdaF2+vZfWf6fW8HWi+c97SHW+WqmlcpdPzUUgX94EY=";
+    hash = "sha256-37W0b8zYKErToJBU+aYtCmQjorcDtvuG0YbOwJzuZgo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  gitUpdater,
   bison,
   cmake,
   pkg-config,
@@ -204,7 +205,13 @@ stdenv.mkDerivation (finalAttrs: {
     connector-c = finalAttrs.finalPackage;
     server = finalAttrs.finalPackage;
     mysqlVersion = lib.versions.majorMinor finalAttrs.version;
-    tests.percona-server = nixosTests.mysql.percona-server_8_4;
+    tests.percona-server =
+      nixosTests.mysql."percona-server_${lib.versions.major finalAttrs.version}_${lib.versions.minor finalAttrs.version}";
+    updateScript = gitUpdater {
+      url = "https://github.com/percona/percona-server";
+      rev-prefix = "Percona-Server-";
+      allowedVersions = "${lib.versions.major finalAttrs.version}\\.${lib.versions.minor finalAttrs.version}\\..+";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/tools/backup/percona-xtrabackup/8_4.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_4.nix
@@ -3,8 +3,8 @@
 callPackage ./generic.nix (
   args
   // {
-    version = "8.4.0-1";
-    hash = "sha256-2tWRRYH0P0HZsWTxeuvDeVWvDwqjjdv6J7YiZwoTKtM=";
+    version = "8.4.0-2";
+    hash = "sha256-ClW/B175z/sxF/MT9iHW1Wtr0ere63tIgUpcMp1IfTs=";
 
     # includes https://github.com/Percona-Lab/libkmip.git
     fetchSubmodules = true;


### PR DESCRIPTION
Updates the 8.4.x release packages of percona-server and percona-xtrabackup to the latest version.
release notes:
- https://docs.percona.com/percona-xtrabackup/8.4/release-notes/8.4.0-2.html
- https://docs.percona.com/percona-server/8.4/release-notes/8.4.3-3.html

For percona-server packages, an update script is added to enable future automated updates.
For percona-xtrabackup, the `generic.nix` packaging pattern confuses the common update script tools like nix-update, nixpkgs-update, or git-updater. For now, the update was done manually, coming up with a custom updateScript or restructuring the package is left as a future task.

Fixed CVEs, taken from 2d69ebbc4ec95f0b5b2cd4fca76cb20ff7e15996:

Fixes:
* https://github.com/advisories/GHSA-m6rg-98pc-7rxm
* https://github.com/advisories/GHSA-97c4-2w4v-c7r8
* https://github.com/advisories/GHSA-m7rw-p49v-xvr4
* https://github.com/advisories/GHSA-cgw6-mmr2-9474
* https://github.com/advisories/GHSA-m2x9-pvwq-m49p
* https://github.com/advisories/GHSA-w76f-wfx3-5qjq
* https://github.com/advisories/GHSA-vqmm-339w-hc7c
* https://github.com/advisories/GHSA-2rhg-4865-8qfj
* https://github.com/advisories/GHSA-vggh-55p7-p625
* https://github.com/advisories/GHSA-j5r3-hxmp-cxpr
* https://github.com/advisories/GHSA-c72q-9j4p-2mp4
* https://github.com/advisories/GHSA-cj7p-fg4w-qrvh
* https://github.com/advisories/GHSA-fv75-hjwp-hmcm
* https://github.com/advisories/GHSA-xhf9-m56c-xh6w
* https://github.com/advisories/GHSA-c494-hg27-rg85
* https://github.com/advisories/GHSA-r97q-xhcv-9xx9
* https://github.com/advisories/GHSA-h3ph-4h6g-xqfq
* https://github.com/advisories/GHSA-mffh-p59m-fv66
* https://github.com/advisories/GHSA-vchj-ggm5-9rcm
* https://github.com/advisories/GHSA-jv2x-g26c-46cq
* https://github.com/advisories/GHSA-xcwx-vhj6-p7m7
* https://github.com/advisories/GHSA-6vrv-p2wx-g2fg
* https://github.com/advisories/GHSA-6pjm-6xcx-c94q
* https://github.com/advisories/GHSA-36gq-2499-pq9x
* https://github.com/advisories/GHSA-6477-mq9q-6867

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
