### PR TITLE
chromium,chromedriver: 131.0.6778.139 -> 131.0.6778.204, fix cross-"building" of recompressed FODs

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -222,9 +222,10 @@ let
         name = "source.tar.zstd";
         downloadToTemp = false;
         passthru.unpack = true;
+        nativeBuildInputs = [ zstd ];
         postFetch = ''
           tar \
-            --use-compress-program="${lib.getExe zstd} -T$NIX_BUILD_CORES" \
+            --use-compress-program="zstd -T$NIX_BUILD_CORES" \
             --sort=name \
             --mtime="1970-01-01" \
             --owner=root --group=root \

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "131.0.6778.139",
+    "version": "131.0.6778.204",
     "chromedriver": {
-      "hash_darwin": "sha256-QLYUD5SDHoPdiPHX46ps/oBhzDjwxBuQEh0hzbEY73Q=",
-      "hash_darwin_aarch64": "sha256-VZ4nS9H1J1R6OXqqOaFLHM2rD8dyUTTWur5X1CNm4sU="
+      "hash_darwin": "sha256-xxTu1aPNTfGpaPFC55NihzJbcjDL3fBXimQIGBPaU18=",
+      "hash_darwin_aarch64": "sha256-WyNiLNIPPUesDCYYs6Uc0aZDou0N60kZvL31DlqHMtw="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "c35bbcbd7c2775a12a3f320e05ac0022939b1a8a",
-        "hash": "sha256-oJ4y9W51RMiUk40Uz8b3LJH0kMD5GMDG2V//Tng4/4A=",
+        "rev": "52183f9e99a61056f9b78535f53d256f1516f2a0",
+        "hash": "sha256-D7+Ji8Y1vw1Sgt9njbZDGbgbzT8eAvx/95M8SsHyiN4=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -760,8 +760,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "b97fcc24b3523da5e389d2a6d76857f134be09c5",
-        "hash": "sha256-5Es9Zot/DH+UKq3+aCgeQC+Llgj7/lmPXUYvar/hX7I="
+        "rev": "7f72bbed40ca85a6b68ca2f15feca342c9c256d0",
+        "hash": "sha256-QJcC6T2IOCXhObwND0jPQTUl84lotcYRCIQe4GTtczc="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2024/12/stable-channel-update-for-desktop_18.html

This update includes 5 security fixes.

CVEs:
CVE-2024-12692 CVE-2024-12693 CVE-2024-12694 CVE-2024-12695

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross, not native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).