### PR TITLE
replaceVars is not needed on setup.sh since 15103e5e5

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -80,9 +80,7 @@ mkDerivation {
     "buildPhase"
     "fixupPhase"
   ];
-  setupNew = replaceVars ../../stdenv/generic/setup.sh {
-    inherit gcc;
-  };
+  setupNew = ../../stdenv/generic/setup.sh;
 
   buildPhase =
     let

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -66,7 +66,6 @@
   name,
   buildInputs ? [ ],
   propagatedBuildInputs ? [ ],
-  gcc ? stdenv.cc,
   extraCmds ? "",
   cleanupCmds ? "",
   shell ? "${pkgs.bashInteractive}/bin/bash --norc",


### PR DESCRIPTION
Since the change in ebd18cf115cc212d9780092e9207e19b800f67a0 on Dec 14, `myEnvFun` no longer evaluates because `replaceVars` is more strict about attempting to replace variables that do not exist in the source file.

This PR removes the replacement of a variable that hasn't existed in `setup.sh` since 2014 (in 15103e5e5).