### PR TITLE
hyprsunset: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/hy/hyprsunset/package.nix
+++ b/pkgs/by-name/hy/hyprsunset/package.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-SVkcePzX9PAlWsPSGBaxiNFCouiQmGOezhMo0+zhDIQ=";
   };
 
+  postPatch = ''
+    # hyprwayland-scanner is not required at runtime
+    substituteInPlace CMakeLists.txt --replace-fail "hyprwayland-scanner>=0.4.0" ""
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -36,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
     wayland-scanner
   ];
+
+  strictDeps = true;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
hyprwayland-scanner is incorrectly required as regular pkg-config dependency. The upstream build blindly executes hyprwayland-scanner anyway, so we can just remove the requirement.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).