### PR TITLE
flamegraph: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/fl/flamegraph/package.nix
+++ b/pkgs/by-name/fl/flamegraph/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
+  strictDeps = true;
+
   installPhase = ''
     runHook preInstall
 
@@ -31,9 +33,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  nativeCheckInputs = [
+    perl
+  ];
+
   checkPhase = ''
-    patchShebangs ./test.sh
+    runHook preCheck
+    patchShebangs --build ./test.sh
     ./test.sh
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Simple fix.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).