### PR TITLE
wsjtx: fix and enable strictDeps

### DIFF
--- a/pkgs/applications/radio/wsjtx/default.nix
+++ b/pkgs/applications/radio/wsjtx/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     asciidoctor
     cmake
     gfortran
+    hamlib_4 # rigctl
     libtool
     pkg-config
     qttools
@@ -52,6 +53,8 @@ stdenv.mkDerivation rec {
     qtserialport
     boost
   ];
+
+  strictDeps = true;
 
   meta = with lib; {
     description = "Weak-signal digital communication modes for amateur radio";


### PR DESCRIPTION
rigctl from hamlib_4 is required in the installPhase.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).