### PR TITLE
blast: fix and enable strictDeps

### DIFF
--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -88,7 +88,10 @@ stdenv.mkDerivation rec {
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [
+    cpio
+    perl
+  ];
 
   # perl is necessary in buildInputs so that installed perl scripts get patched
   # correctly
@@ -98,13 +101,15 @@ stdenv.mkDerivation rec {
     gawk
     zlib
     bzip2
-    cpio
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ ApplicationServices ];
+
+  strictDeps = true;
+
   hardeningDisable = [ "format" ];
 
   postInstall = ''
     substituteInPlace $out/bin/get_species_taxids.sh \
-        --replace /bin/rm ${coreutils}/bin/rm
+        --replace /bin/rm ${lib.getExe' coreutils "rm"}
   '';
   patches = [ ./no_slash_bin.patch ];
 


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).