### PR TITLE
luarocks-packages-updater: errors don't crash script

### DIFF
--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -21,8 +21,28 @@ from pathlib import Path
 import pluginupdate
 from pluginupdate import FetchConfig, update_plugins
 
+
+class ColoredFormatter(logging.Formatter):
+    # Define color codes
+    COLORS = {
+        "DEBUG": "\033[94m",  # Blue
+        "INFO": "\033[92m",  # Green
+        "WARNING": "\033[93m",  # Yellow
+        "ERROR": "\033[91m",  # Red
+        "CRITICAL": "\033[95m",  # Magenta
+    }
+    RESET = "\033[0m"
+
+    def format(self, record):
+        log_color = self.COLORS.get(record.levelname, self.RESET)
+        record.msg = f"{log_color}{record.msg}{self.RESET}"
+        return super().format(record)
+
+
+handler = logging.StreamHandler()
+handler.setFormatter(ColoredFormatter("%(levelname)s: %(message)s"))
 log = logging.getLogger()
-log.addHandler(logging.StreamHandler())
+log.handlers = [handler]
 
 ROOT = Path(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))).parent.parent  # type: ignore
 
@@ -127,7 +147,7 @@ class LuaEditor(pluginupdate.Editor):
         config: FetchConfig,
         # TODO: implement support for adding/updating individual plugins
         to_update: list[str] | None,
-        ):
+    ):
         if to_update is not None:
             raise NotImplementedError("For now, lua updater doesn't support updating individual packages.")
         _prefetch = generate_pkg_nix

--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -127,7 +127,7 @@ class LuaEditor(pluginupdate.Editor):
         config: FetchConfig,
         # TODO: implement support for adding/updating individual plugins
         to_update: list[str] | None,
-    ):
+        ):
         if to_update is not None:
             raise NotImplementedError("For now, lua updater doesn't support updating individual packages.")
         _prefetch = generate_pkg_nix
@@ -142,7 +142,15 @@ class LuaEditor(pluginupdate.Editor):
             finally:
                 pass
 
-            self.generate_nix(results, output_file)
+            successful_results = [(plug, nix_expr) for plug, nix_expr, error in results if nix_expr is not None]
+            errors = [(plug, error) for plug, nix_expr, error in results if error is not None]
+
+            self.generate_nix(successful_results, output_file)
+
+            if errors:
+                log.error("The following plugins failed to update:")
+                for plug, error in errors:
+                    log.error("%s: %s", plug.name, error)
 
             redirects = {}
             return redirects
@@ -171,39 +179,43 @@ def generate_pkg_nix(plug: LuaPlugin):
     """
     log.debug("Generating nix expression for %s", plug.name)
 
-    cmd = ["luarocks", "nix"]
+    try:
+        cmd = ["luarocks", "nix"]
 
-    if plug.maintainers:
-        cmd.append(f"--maintainers={plug.maintainers}")
+        if plug.maintainers:
+            cmd.append(f"--maintainers={plug.maintainers}")
 
-    if plug.rockspec != "":
-        if plug.ref or plug.version:
-            msg = "'version' and 'ref' will be ignored as the rockspec is hardcoded for package %s" % plug.name
-            log.warning(msg)
+        if plug.rockspec != "":
+            if plug.ref or plug.version:
+                msg = "'version' and 'ref' will be ignored as the rockspec is hardcoded for package %s" % plug.name
+                log.warning(msg)
 
-        log.debug("Updating from rockspec %s", plug.rockspec)
-        cmd.append(plug.rockspec)
+            log.debug("Updating from rockspec %s", plug.rockspec)
+            cmd.append(plug.rockspec)
 
-    # update the plugin from luarocks
-    else:
-        cmd.append(plug.name)
-        if plug.version and plug.version != "src":
-            cmd.append(plug.version)
+        # update the plugin from luarocks
+        else:
+            cmd.append(plug.name)
+            if plug.version and plug.version != "src":
+                cmd.append(plug.version)
 
-    if plug.server != "src" and plug.server:
-        cmd.append(f"--only-server={plug.server}")
+        if plug.server != "src" and plug.server:
+            cmd.append(f"--only-server={plug.server}")
 
-    if plug.luaversion:
-        cmd.append(f"--lua-version={plug.luaversion}")
-        luaver = plug.luaversion.replace(".", "")
-        if luaver := os.getenv(f"LUA_{luaver}"):
-            cmd.append(f"--lua-dir={luaver}")
+        if plug.luaversion:
+            cmd.append(f"--lua-version={plug.luaversion}")
+            luaver = plug.luaversion.replace(".", "")
+            if luaver := os.getenv(f"LUA_{luaver}"):
+                cmd.append(f"--lua-dir={luaver}")
 
-    log.debug("running %s", " ".join(cmd))
+        log.debug("running %s", " ".join(cmd))
 
-    output = subprocess.check_output(cmd, text=True)
-    output = "callPackage(" + output.strip() + ") {};\n\n"
-    return (plug, output)
+        output = subprocess.check_output(cmd, text=True)
+        output = "callPackage(" + output.strip() + ") {};\n\n"
+        return (plug, output, None)
+    except subprocess.CalledProcessError as e:
+        log.error("Failed to generate nix expression for %s: %s", plug.name, e)
+        return (plug, None, str(e))
 
 
 def main():


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Just skipping over errors when we are running updates so that we don't prevent all packages from updating when we have issues with troublesome packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
