### PR TITLE
calibre-web: fix ebook conversion missing config_binariesdir setting

### DIFF
--- a/nixos/modules/services/web-apps/calibre-web.nix
+++ b/nixos/modules/services/web-apps/calibre-web.nix
@@ -121,6 +121,7 @@ in
         ]
         ++ optional (cfg.options.calibreLibrary != null) "config_calibre_dir = '${cfg.options.calibreLibrary}'"
         ++ optional cfg.options.enableBookConversion "config_converterpath = '${pkgs.calibre}/bin/ebook-convert'"
+        ++ optional cfg.options.enableBookConversion "config_binariesdir = '${pkgs.calibre}/bin/'"
         ++ optional cfg.options.enableKepubify "config_kepubifypath = '${pkgs.kepubify}/bin/kepubify'"
       );
     in

--- a/nixos/modules/services/web-apps/calibre-web.nix
+++ b/nixos/modules/services/web-apps/calibre-web.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.services.calibre-web;
 
-  inherit (lib) concatStringsSep mkEnableOption mkIf mkOption optional optionalString types;
+  inherit (lib) concatStringsSep mkEnableOption mkIf mkOption optional optionals optionalString types;
 in
 {
   options = {
@@ -120,8 +120,10 @@ in
           "config_reverse_proxy_login_header_name = '${cfg.options.reverseProxyAuth.header}'"
         ]
         ++ optional (cfg.options.calibreLibrary != null) "config_calibre_dir = '${cfg.options.calibreLibrary}'"
-        ++ optional cfg.options.enableBookConversion "config_converterpath = '${pkgs.calibre}/bin/ebook-convert'"
-        ++ optional cfg.options.enableBookConversion "config_binariesdir = '${pkgs.calibre}/bin/'"
+        ++ optionals cfg.options.enableBookConversion [
+          "config_converterpath = '${pkgs.calibre}/bin/ebook-convert'"
+          "config_binariesdir = '${pkgs.calibre}/bin/'"
+        ]
         ++ optional cfg.options.enableKepubify "config_kepubifypath = '${pkgs.kepubify}/bin/kepubify'"
       );
     in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since https://github.com/janeczku/calibre-web/commit/b7aaa0f24dd5142b05fff19b58913930f9910b28 (calibre-web 0.6.22), calibre-web requires a setting `config_binariesdir` to be available which provides access to the `calibredb` binary for metadata management during book export.  Although the nixos module has an `enableBookConversion` setting, it only sets the path to the `convert-ebook` binary and does not set the path required since this change -- as a result, ebook conversions will fail:

```
Dec 19 14:30:59 anxi calibre-web[3385431]: [2024-12-19 14:30:59,975]  INFO {cps.editbooks:320} converting: book id: 1744 from: LRF to: EPUB
Dec 19 14:30:59 anxi calibre-web[3385431]: [2024-12-19 14:30:59,976] DEBUG {cps.services.worker:91} Add Task for user: mfenniak - Convert Book 1744
Dec 19 14:30:59 anxi calibre-web[3385431]: [2024-12-19 14:30:59,978]  INFO {cps.tasks.convert:159} Book id 1744 - target format of .epub does not exist. Moving forward with convert.
Dec 19 14:30:59 anxi calibre-web[3385431]: [2024-12-19 14:30:59,981]  INFO {cps.tasks.convert:206} ebook converter failed with error while converting book
Dec 19 14:30:59 anxi calibre-web[3385431]: [2024-12-19 14:30:59,981] ERROR {cps.tasks.convert:210} Ebook-converter failed: [Errno 2] No such file or directory: 'calibredb'
```

This change populates the `config_binariesdir`, fixing the `enableBookConversion` setting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
  - **(none of these are applicable)** -- performed manual testing by upgrading a server to nixos-24.11 + this patch, and confirmed calibre-web starts, the settings are updated, and ebook conversion works.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

**Backport**: Please backport to 24.11.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
