### PR TITLE
apitrace: add enableGui option

### DIFF
--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -13,6 +13,7 @@
   libglvnd,
   gtest,
   brotli,
+  enableGui ? true,
 }:
 
 stdenv.mkDerivation rec {
@@ -32,17 +33,23 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libX11
     procps
-    python3
     libdwarf
-    qtbase
     gtest
     brotli
+  ] ++ lib.optionals enableGui [
+    qtbase
   ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
+    python3
+  ] ++ lib.optionals enableGui [
     wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_GUI" enableGui)
   ];
 
   # Don't automatically wrap all binaries, I prefer to explicitly only wrap
@@ -83,6 +90,7 @@ stdenv.mkDerivation rec {
       patchelf --set-rpath "${lib.makeLibraryPath [ libglvnd ]}:$(patchelf --print-rpath $i)" $i
     done
 
+  '' + lib.optionalString enableGui ''
     wrapQtApp $out/bin/qapitrace
   '';
 

--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -30,23 +30,27 @@ stdenv.mkDerivation rec {
 
   # LD_PRELOAD wrappers need to be statically linked to work against all kinds
   # of games -- so it's fine to use e.g. bundled snappy.
-  buildInputs = [
-    libX11
-    procps
-    libdwarf
-    gtest
-    brotli
-  ] ++ lib.optionals enableGui [
-    qtbase
-  ];
+  buildInputs =
+    [
+      libX11
+      procps
+      libdwarf
+      gtest
+      brotli
+    ]
+    ++ lib.optionals enableGui [
+      qtbase
+    ];
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    python3
-  ] ++ lib.optionals enableGui [
-    wrapQtAppsHook
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      python3
+    ]
+    ++ lib.optionals enableGui [
+      wrapQtAppsHook
+    ];
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_GUI" enableGui)
@@ -56,43 +60,45 @@ stdenv.mkDerivation rec {
   # `qapitrace`.
   dontWrapQtApps = true;
 
-  postFixup = ''
+  postFixup =
+    ''
 
-    # Since https://github.com/NixOS/nixpkgs/pull/60985, we add `/run-opengl-driver[-32]`
-    # to the `RUNPATH` of dispatcher libraries `dlopen()` ing OpenGL drivers.
-    # `RUNPATH` doesn't propagate throughout the whole application, but only
-    # from the module performing the `dlopen()`.
-    #
-    # Apitrace wraps programs by running them with `LD_PRELOAD` pointing to `.so`
-    # files in $out/lib/apitrace/wrappers.
-    #
-    # Theses wrappers effectively wrap the `dlopen()` calls from `libglvnd`
-    # and other dispatcher libraries, and run `dlopen()`  by themselves.
-    #
-    # As `RUNPATH` doesn't propagate through the whole library, and they're now the
-    # library doing the real `dlopen()`, they also need to have
-    # `/run-opengl-driver[-32]` added to their `RUNPATH`.
-    #
-    # To stay simple, we add paths for 32 and 64 bits unconditionally.
-    # This doesn't have an impact on closure size, and if the 32 bit drivers
-    # are not available, that folder is ignored.
-    for i in $out/lib/apitrace/wrappers/*.so
-    do
-      echo "Patching OpenGL driver path for $i"
-      patchelf --set-rpath "/run/opengl-driver/lib:/run/opengl-driver-32/lib:$(patchelf --print-rpath $i)" $i
-    done
+      # Since https://github.com/NixOS/nixpkgs/pull/60985, we add `/run-opengl-driver[-32]`
+      # to the `RUNPATH` of dispatcher libraries `dlopen()` ing OpenGL drivers.
+      # `RUNPATH` doesn't propagate throughout the whole application, but only
+      # from the module performing the `dlopen()`.
+      #
+      # Apitrace wraps programs by running them with `LD_PRELOAD` pointing to `.so`
+      # files in $out/lib/apitrace/wrappers.
+      #
+      # Theses wrappers effectively wrap the `dlopen()` calls from `libglvnd`
+      # and other dispatcher libraries, and run `dlopen()`  by themselves.
+      #
+      # As `RUNPATH` doesn't propagate through the whole library, and they're now the
+      # library doing the real `dlopen()`, they also need to have
+      # `/run-opengl-driver[-32]` added to their `RUNPATH`.
+      #
+      # To stay simple, we add paths for 32 and 64 bits unconditionally.
+      # This doesn't have an impact on closure size, and if the 32 bit drivers
+      # are not available, that folder is ignored.
+      for i in $out/lib/apitrace/wrappers/*.so
+      do
+        echo "Patching OpenGL driver path for $i"
+        patchelf --set-rpath "/run/opengl-driver/lib:/run/opengl-driver-32/lib:$(patchelf --print-rpath $i)" $i
+      done
 
-    # Theses open the OpenGL driver at runtime, but it is not listed as NEEDED libraries. They need
-    # a reference to libglvnd.
-    for i in $out/bin/eglretrace $out/bin/glretrace
-    do
-      echo "Patching RPath for $i"
-      patchelf --set-rpath "${lib.makeLibraryPath [ libglvnd ]}:$(patchelf --print-rpath $i)" $i
-    done
+      # Theses open the OpenGL driver at runtime, but it is not listed as NEEDED libraries. They need
+      # a reference to libglvnd.
+      for i in $out/bin/eglretrace $out/bin/glretrace
+      do
+        echo "Patching RPath for $i"
+        patchelf --set-rpath "${lib.makeLibraryPath [ libglvnd ]}:$(patchelf --print-rpath $i)" $i
+      done
 
-  '' + lib.optionalString enableGui ''
-    wrapQtApp $out/bin/qapitrace
-  '';
+    ''
+    + lib.optionalString enableGui ''
+      wrapQtApp $out/bin/qapitrace
+    '';
 
   meta = with lib; {
     homepage = "https://apitrace.github.io";


### PR DESCRIPTION
The motivation for this change is to be able to cross-compile apitrace, at least without the GUI. Fixing GUI cross-compilation is blocked by #269756.

Note that we also move `python3` into `nativeBuildInputs`, which is also required to make cross-compilation work.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux -> aarch64-linux cross (with `enableGui = false`)
  - [x] aarch64-linux -> i686-linux cross (with `enableGui = false`)
  - [x] aarch64-linux
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] Tested `qapitrace` and `apitrace replay` on x86_64-linux and aarch64-linux
  - [x] Tested `glxtrace.so` on i686-linux (under fex-emu)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
