### PR TITLE
sfcgal: update patch to build process from upstream

### DIFF
--- a/pkgs/by-name/sf/sfcgal/cmake-fix.patch
+++ b/pkgs/by-name/sf/sfcgal/cmake-fix.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3babfae..11ea637c 100644
+index 07a6c2e5..37c33d92 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -209,7 +209,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+@@ -221,7 +221,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
    set(CMAKE_INSTALL_LIBDIR "${_LIBDIR_DEFAULT}" CACHE PATH "object code libraries (${_LIBDIR_DEFAULT})")
  endif()
  
@@ -11,6 +11,17 @@ index a3babfae..11ea637c 100644
  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  #SET(CMAKE_MACOSX_RPATH ON)
  
+@@ -260,6 +260,10 @@ if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+ else()
+   set( SFCGAL_LIB_NAME "SFCGAL" )
+ endif()
++
++if ( UNIX )
++  include(GNUInstallDirs)
++endif()
+ #set( SFCGAL_LIB_NAME ${${CMAKE_BUILD_TYPE}
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sfcgal-config.in ${CMAKE_CURRENT_BINARY_DIR}/sfcgal-config @ONLY)
+ install( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/sfcgal-config DESTINATION bin )
 diff --git a/sfcgal-config.in b/sfcgal-config.in
 index a0e992c5..49615c13 100755
 --- a/sfcgal-config.in

--- a/pkgs/by-name/sf/sfcgal/package.nix
+++ b/pkgs/by-name/sf/sfcgal/package.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  patches = [ ./cmake-fix.patch ];
+  patches = [
+    # https://gitlab.com/sfcgal/SFCGAL/-/merge_requests/384
+    ./cmake-fix.patch
+  ];
 
   meta = {
     description = "C++ wrapper library around CGAL with the aim of supporting ISO 191007:2013 and OGC Simple Features for 3D operations";

--- a/pkgs/by-name/sf/sfcgal/package.nix
+++ b/pkgs/by-name/sf/sfcgal/package.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/sfcgal/SFCGAL/-/releases/v${finalAttrs.version}";
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.fqidz ];
+    maintainers = with lib; teams.geospatial.members ++ [ maintainers.fqidz ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This updates the patch to build correctly sfcgal_config, which in turn is necessary to build postgis with sfcgal support (in the next PR ;-)).


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
