### PR TITLE
[staging-next] testdisk: fix gcc-14 build

### DIFF
--- a/pkgs/tools/system/testdisk/default.nix
+++ b/pkgs/tools/system/testdisk/default.nix
@@ -33,6 +33,10 @@ assert enableQt -> qwt != null;
     sha256 = "1zlh44w67py416hkvw6nrfmjickc2d43v51vcli5p374d5sw84ql";
   };
 
+  patches = [
+    ./gcc-14-fixes.diff
+  ];
+
   postPatch = ''
     substituteInPlace linux/qphotorec.desktop \
       --replace "/usr" "$out"

--- a/pkgs/tools/system/testdisk/gcc-14-fixes.diff
+++ b/pkgs/tools/system/testdisk/gcc-14-fixes.diff
@@ -1,0 +1,15 @@
+diff --git a/src/ntfs_io.c b/src/ntfs_io.c
+index 7f57edd..4b718bb 100644
+--- a/src/ntfs_io.c
++++ b/src/ntfs_io.c
+@@ -154,8 +154,8 @@ static int ntfs_device_testdisk_io_stat(struct ntfs_device *dev, struct stat *bu
+ 	return -1;
+ }
+ 
+-static int ntfs_device_testdisk_io_ioctl(struct ntfs_device *dev, int request,
+-		void *argp)
++static int ntfs_device_testdisk_io_ioctl(struct ntfs_device *dev,
++                                         unsigned long request, void *argp)
+ {
+ 	log_warning( "ntfs_device_testdisk_io_ioctl() unimplemented\n");
+ #ifdef ENOTSUP


### PR DESCRIPTION
fix incompatible pointer type by updating a function definition ntfs_device_testdisk_io_ioctl to take an unsigned long rather than an int. The function implementation is empty and just returns error so the updated argument type has no effect.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
@philiptaron 