### PR TITLE
[staging-next] sunshine: use boost-186 (fix eval)

### DIFF
--- a/pkgs/by-name/su/sunshine/boost-186.patch
+++ b/pkgs/by-name/su/sunshine/boost-186.patch
@@ -1,0 +1,191 @@
+port of https://github.com/LizardByte/Sunshine/commit/e90b71ce62b7744bb18ffc7823b1e895786ffb0a
+
+diff --git a/src/platform/common.h b/src/platform/common.h
+index 007f7ec..498becb 100644
+--- a/src/platform/common.h
++++ b/src/platform/common.h
+@@ -39,13 +39,13 @@ namespace boost {
+   namespace filesystem {
+     class path;
+   }
+-  namespace process {
++  namespace process::inline v1 {
+     class child;
+     class group;
+     template <typename Char>
+     class basic_environment;
+     typedef basic_environment<char> environment;
+-  }  // namespace process
++  }  // namespace process::inline v1
+ }  // namespace boost
+ namespace video {
+   struct config_t;
+@@ -585,8 +585,8 @@ namespace platf {
+   bool
+   needs_encoder_reenumeration();
+ 
+-  boost::process::child
+-  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::environment &env, FILE *file, std::error_code &ec, boost::process::group *group);
++  boost::process::v1::child
++  run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::v1::environment &env, FILE *file, std::error_code &ec, boost::process::v1::group *group);
+ 
+   enum class thread_priority_e : int {
+     low,
+diff --git a/src/platform/linux/misc.cpp b/src/platform/linux/misc.cpp
+index 980c080..49a884c 100644
+--- a/src/platform/linux/misc.cpp
++++ b/src/platform/linux/misc.cpp
+@@ -15,7 +15,7 @@
+ // lib includes
+ #include <arpa/inet.h>
+ #include <boost/asio/ip/address.hpp>
+-#include <boost/process.hpp>
++#include <boost/process/v1.hpp>
+ #include <dlfcn.h>
+ #include <fcntl.h>
+ #include <ifaddrs.h>
+@@ -269,7 +269,7 @@ namespace platf {
+     auto working_dir = boost::filesystem::path(std::getenv("HOME"));
+     std::string cmd = R"(xdg-open ")" + url + R"(")";
+ 
+-    boost::process::environment _env = boost::this_process::environment();
++    boost::process::v1::environment _env = boost::this_process::environment();
+     std::error_code ec;
+     auto child = run_command(false, false, cmd, working_dir, _env, nullptr, ec, nullptr);
+     if (ec) {
+diff --git a/src/platform/macos/misc.mm b/src/platform/macos/misc.mm
+index 20c2247..0415d13 100644
+--- a/src/platform/macos/misc.mm
++++ b/src/platform/macos/misc.mm
+@@ -23,7 +23,7 @@
+ #include "src/platform/common.h"
+ 
+ #include <boost/asio/ip/address.hpp>
+-#include <boost/process.hpp>
++#include <boost/process/v1.hpp>
+ 
+ using namespace std::literals;
+ namespace fs = std::filesystem;
+@@ -197,7 +197,7 @@ namespace platf {
+     boost::filesystem::path working_dir;
+     std::string cmd = R"(open ")" + url + R"(")";
+ 
+-    boost::process::environment _env = boost::this_process::environment();
++    boost::process::v1::environment _env = boost::this_process::environment();
+     std::error_code ec;
+     auto child = run_command(false, false, cmd, working_dir, _env, nullptr, ec, nullptr);
+     if (ec) {
+diff --git a/src/process.cpp b/src/process.cpp
+index 89dc4dc..83a73ff 100644
+--- a/src/process.cpp
++++ b/src/process.cpp
+@@ -40,7 +40,6 @@
+ 
+ namespace proc {
+   using namespace std::literals;
+-  namespace bp = boost::process;
+   namespace pt = boost::property_tree;
+ 
+   proc_t proc;
+@@ -68,7 +67,7 @@ namespace proc {
+    * @param exit_timeout The timeout to wait for the process group to gracefully exit.
+    */
+   void
+-  terminate_process_group(bp::child &proc, bp::group &group, std::chrono::seconds exit_timeout) {
++  terminate_process_group(boost::process::v1::child &proc, boost::process::v1::group &group, std::chrono::seconds exit_timeout) {
+     if (group.valid() && platf::process_group_running((std::uintptr_t) group.native_handle())) {
+       if (exit_timeout.count() > 0) {
+         // Request processes in the group to exit gracefully
+@@ -109,7 +108,7 @@ namespace proc {
+   }
+ 
+   boost::filesystem::path
+-  find_working_directory(const std::string &cmd, bp::environment &env) {
++  find_working_directory(const std::string &cmd, boost::process::v1::environment &env) {
+     // Parse the raw command string into parts to get the actual command portion
+ #ifdef _WIN32
+     auto parts = boost::program_options::split_winmain(cmd);
+@@ -131,7 +130,7 @@ namespace proc {
+     // If the cmd path is not an absolute path, resolve it using our PATH variable
+     boost::filesystem::path cmd_path(parts.at(0));
+     if (!cmd_path.is_absolute()) {
+-      cmd_path = boost::process::search_path(parts.at(0));
++      cmd_path = boost::process::v1::search_path(parts.at(0));
+       if (cmd_path.empty()) {
+         BOOST_LOG(error) << "Unable to find executable ["sv << parts.at(0) << "]. Is it in your PATH?"sv;
+         return boost::filesystem::path();
+@@ -311,8 +310,8 @@ namespace proc {
+     std::error_code ec;
+     placebo = false;
+     terminate_process_group(_process, _process_group, _app.exit_timeout);
+-    _process = bp::child();
+-    _process_group = bp::group();
++    _process = boost::process::v1::child();
++    _process_group = boost::process::v1::group();
+ 
+     for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
+       auto &cmd = *(_app_prep_it - 1);
+@@ -413,7 +412,7 @@ namespace proc {
+   }
+ 
+   std::string
+-  parse_env_val(bp::native_environment &env, const std::string_view &val_raw) {
++  parse_env_val(boost::process::v1::native_environment &env, const std::string_view &val_raw) {
+     auto pos = std::begin(val_raw);
+     auto dollar = std::find(pos, std::end(val_raw), '$');
+ 
+diff --git a/src/process.h b/src/process.h
+index c875499..0344c1c 100644
+--- a/src/process.h
++++ b/src/process.h
+@@ -11,7 +11,7 @@
+ #include <optional>
+ #include <unordered_map>
+ 
+-#include <boost/process.hpp>
++#include <boost/process/v1.hpp>
+ 
+ #include "config.h"
+ #include "platform/common.h"
+@@ -68,7 +68,7 @@ namespace proc {
+     KITTY_DEFAULT_CONSTR_MOVE_THROW(proc_t)
+ 
+     proc_t(
+-      boost::process::environment &&env,
++      boost::process::v1::environment &&env,
+       std::vector<ctx_t> &&apps):
+         _app_id(0),
+         _env(std::move(env)),
+@@ -99,7 +99,7 @@ namespace proc {
+   private:
+     int _app_id;
+ 
+-    boost::process::environment _env;
++    boost::process::v1::environment _env;
+     std::vector<ctx_t> _apps;
+     ctx_t _app;
+     std::chrono::steady_clock::time_point _app_launch_time;
+@@ -107,8 +107,8 @@ namespace proc {
+     // If no command associated with _app_id, yet it's still running
+     bool placebo {};
+ 
+-    boost::process::child _process;
+-    boost::process::group _process_group;
++    boost::process::v1::child _process;
++    boost::process::v1::group _process_group;
+ 
+     file_t _pipe;
+     std::vector<cmd_t>::const_iterator _app_prep_it;
+diff --git a/src/system_tray.cpp b/src/system_tray.cpp
+index c34c3d7..17e1c0f 100644
+--- a/src/system_tray.cpp
++++ b/src/system_tray.cpp
+@@ -33,7 +33,7 @@
+   // lib includes
+   #include "tray/tray.h"
+   #include <boost/filesystem.hpp>
+-  #include <boost/process/environment.hpp>
++  #include <boost/process/v1/environment.hpp>
+ 
+   // local includes
+   #include "confighttp.h"

--- a/pkgs/by-name/su/sunshine/package.nix
+++ b/pkgs/by-name/su/sunshine/package.nix
@@ -68,6 +68,10 @@ stdenv'.mkDerivation rec {
     # fix(upnp): support newer miniupnpc library (#2782)
     # Manually cherry-picked on to 0.23.1.
     ./0001-fix-upnp-support-newer-miniupnpc-library-2782.patch
+
+    # port of https://github.com/LizardByte/Sunshine/commit/e90b71ce62b7744bb18ffc7823b1e895786ffb0a
+    # remove on update
+    ./boost-186.patch
   ];
 
   # build webui

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18711,10 +18711,6 @@ with pkgs;
 
   sieveshell = with python3.pkgs; toPythonApplication managesieve;
 
-  sunshine = callPackage ../by-name/su/sunshine/package.nix {
-    boost = boost185;
-  };
-
   jami = qt6Packages.callPackage ../applications/networking/instant-messengers/jami {
     # TODO: remove once `udev` is `systemdMinimal` everywhere.
     udev = systemdMinimal;


### PR DESCRIPTION
boost-185 will be removed soon on master and already is gone on staging-next. Apply the upstream patch
https://github.com/LizardByte/Sunshine/commit/e90b71ce62b7744bb18ffc7823b1e895786ffb0a

with some minor adjustments to drop windows specific files, files that don't yet exist, and hand apply the changes in `process.cpp`

fixes eval in staging-next https://github.com/NixOS/nixpkgs/pull/364438#issuecomment-2556090416

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@devusb
@thiagokokada 