### PR TITLE
win-max-2-fan-control: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/win-max-2-fan-control/default.nix
+++ b/pkgs/tools/misc/win-max-2-fan-control/default.nix
@@ -1,0 +1,31 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  pname = "win-max-2-fan-control";
+  version = "0-unstable-2023-02-16";
+
+  src = fetchFromGitHub {
+    owner = "matega";
+    repo = "win-max-2-fan-control";
+    rev = "a9e65011e0b45d0a76fc5307ad2b7b585410dece";
+    hash = "sha256-rU0n+4glTWHWjbvbc7Se0O53g1mVDwBP5SkH4ftwNWk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 dist/Debug/GNU-Linux/winmax2fancontrol $out/bin/winmax2fancontrol
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fan control for GPD Win Max 2 under Linux";
+    homepage = "https://github.com/matega/win-max-2-fan-control";
+    license = lib.licenses.gpl3;
+    mainProgram = "winmax2fancontrol";
+    maintainers = with lib.maintainers; [ voronind ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Small utility to control fans on GPD Win Max 2 devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
