### PR TITLE
vimPlugins.cord-nvim: move to separate folder; vimPlugins.cord-nvim: 0-unstable-2024-09-26 -> 0-unstable-2024-12-17

### DIFF
--- a/pkgs/applications/editors/vim/plugins/cord-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/cord-nvim/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  vimUtils,
+}:
+let
+  version = "0-unstable-2024-09-26";
+  src = fetchFromGitHub {
+    owner = "vyfor";
+    repo = "cord.nvim";
+    rev = "a26b00d58c42174aadf975917b49cec67650545f";
+    hash = "sha256-jUxBvWnj0+axuw2SZ2zLzlhZS0tu+Bk8+wHtXENofkw=";
+  };
+  extension = if stdenv.hostPlatform.isDarwin then "dylib" else "so";
+  cord-nvim-rust = rustPlatform.buildRustPackage {
+    pname = "cord.nvim-rust";
+    inherit version src;
+
+    cargoHash = "sha256-M5mTdBACTaUVZhPpMOf1KQ3BcQpEoD2isAKRn+iAWjc=";
+
+    installPhase =
+      let
+        cargoTarget = stdenv.hostPlatform.rust.cargoShortTarget;
+      in
+      ''
+        install -D target/${cargoTarget}/release/libcord.${extension} $out/lib/cord.${extension}
+      '';
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "cord.nvim";
+  inherit version src;
+
+  nativeBuildInputs = [
+    cord-nvim-rust
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    install -D ${cord-nvim-rust}/lib/cord.${extension} cord.${extension}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D cord $out/lua/cord.${extension}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nvimRequireCheck = "cord";
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+      attrPath = "vimPlugins.cord-nvim.cord-nvim-rust";
+    };
+
+    # needed for the update script
+    inherit cord-nvim-rust;
+  };
+
+  meta = {
+    homepage = "https://github.com/vyfor/cord.nvim";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/applications/editors/vim/plugins/cord-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/cord-nvim/default.nix
@@ -7,19 +7,19 @@
   vimUtils,
 }:
 let
-  version = "0-unstable-2024-09-26";
+  version = "0-unstable-2024-12-17";
   src = fetchFromGitHub {
     owner = "vyfor";
     repo = "cord.nvim";
-    rev = "a26b00d58c42174aadf975917b49cec67650545f";
-    hash = "sha256-jUxBvWnj0+axuw2SZ2zLzlhZS0tu+Bk8+wHtXENofkw=";
+    rev = "c82ab475e7bb198d6fac20833a3468de1a1d14d0";
+    hash = "sha256-GVy8q9Fxb3mzx6mUQyIMumjnwZ7W08dPz1O3ckzVvdE=";
   };
   extension = if stdenv.hostPlatform.isDarwin then "dylib" else "so";
   cord-nvim-rust = rustPlatform.buildRustPackage {
     pname = "cord.nvim-rust";
     inherit version src;
 
-    cargoHash = "sha256-M5mTdBACTaUVZhPpMOf1KQ3BcQpEoD2isAKRn+iAWjc=";
+    cargoHash = "sha256-unE600Uo8fXaFV0UWRhBenhQaXftDH7K+HyQ/9xo7JY=";
 
     installPhase =
       let

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -843,54 +843,7 @@ in
     nvimRequireCheck = "coq";
   };
 
-  cord-nvim =
-    let
-      version = "0-unstable-2024-09-26";
-      src = fetchFromGitHub {
-        owner = "vyfor";
-        repo = "cord.nvim";
-        rev = "a26b00d58c42174aadf975917b49cec67650545f";
-        hash = "sha256-jUxBvWnj0+axuw2SZ2zLzlhZS0tu+Bk8+wHtXENofkw=";
-      };
-      extension = if stdenv.hostPlatform.isDarwin then "dylib" else "so";
-      rustPackage = rustPlatform.buildRustPackage {
-        pname = "cord.nvim-rust";
-        inherit version src;
-
-        cargoHash = "sha256-M5mTdBACTaUVZhPpMOf1KQ3BcQpEoD2isAKRn+iAWjc=";
-
-        installPhase =
-          let
-            cargoTarget = stdenv.hostPlatform.rust.cargoShortTarget;
-          in
-          ''
-            install -D target/${cargoTarget}/release/libcord.${extension} $out/lib/cord.${extension}
-          '';
-      };
-    in
-    buildVimPlugin {
-      pname = "cord.nvim";
-      inherit version src;
-
-      nativeBuildInputs = [
-        rustPackage
-      ];
-
-      buildPhase = ''
-        install -D ${rustPackage}/lib/cord.${extension} cord.${extension}
-      '';
-
-      installPhase = ''
-        install -D cord $out/lua/cord.${extension}
-      '';
-
-      doInstallCheck = true;
-      nvimRequireCheck = "cord";
-
-      meta = {
-        homepage = "https://github.com/vyfor/cord.nvim";
-      };
-    };
+  cord-nvim = callPackage ./cord-nvim { };
 
   cornelis = super.cornelis.overrideAttrs {
     dependencies = [ self.vim-textobj-user ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Split off https://github.com/NixOS/nixpkgs/pull/366698

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
