### PR TITLE
nixos/hadoop: fix hbase, hbase: 2.5.9 -> 2.5.10, 2.6.0 -> 2.6.1

### DIFF
--- a/nixos/modules/services/cluster/hadoop/hbase.nix
+++ b/nixos/modules/services/cluster/hadoop/hbase.nix
@@ -57,7 +57,9 @@ let
       systemd.services."hbase-${lib.toLower name}" = {
         description = "HBase ${name}";
         wantedBy = [ "multi-user.target" ];
-        path = with cfg; [ hbase.package ] ++ optional (with cfg.hbase.master; enable && initHDFS) package;
+        path =
+          with cfg;
+          [ hbase.package ] ++ lib.optional (with cfg.hbase.master; enable && initHDFS) package;
         preStart = lib.mkIf (with cfg.hbase.master; enable && initHDFS) (
           lib.concatStringsSep "\n" (
             map (x: "HADOOP_USER_NAME=hdfs hdfs --config /etc/hadoop-conf ${x}") [

--- a/pkgs/servers/hbase/default.nix
+++ b/pkgs/servers/hbase/default.nix
@@ -51,13 +51,13 @@ in
     tests.standalone = nixosTests.hbase_2_4;
   };
   hbase_2_5 = common {
-    version = "2.5.9";
-    hash = "sha256-rJGeJ9zmUn28q1Sfk5cdEdEZxbAnvFjRjdcTCx9x1Qc=";
+    version = "2.5.10";
+    hash = "sha256-uYc5IZGQdLOm5gAEyyGtJtcgf+GxADEEuxjixZbG3Qs=";
     tests.standalone = nixosTests.hbase_2_5;
   };
   hbase_2_6 = common {
-    version = "2.6.0";
-    hash = "sha256-zjQ5HgUCiHmrMQuyMN4IAuLR0fVrJ+YKDUfPQb05Dp4=";
+    version = "2.6.1";
+    hash = "sha256-dubu/4Ilk82NtNEcKt8uLbcH8n81EncxOvkZOwk2kVA=";
     tests.standalone = nixosTests.hbase2;
   };
   hbase_3_0 = common {


### PR DESCRIPTION
- Fix HBase module broken by https://github.com/NixOS/nixpkgs/pull/335647
- bump HBase packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
