### PR TITLE
[staging-next] csdr: fix build with GCC 14 for ARM

### DIFF
--- a/pkgs/by-name/cs/csdr/package.nix
+++ b/pkgs/by-name/cs/csdr/package.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LdVzeTTIvDQIXRdcz/vpQu/fUgtE8nx1kIEfoiwxrUg=";
   };
 
+  postPatch = ''
+    # function is not defined in any headers but used in libcsdr.c
+    echo "int errhead();" >> src/predefined.h
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
Logging function is only used on ARM, but only ever defined in another file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular build, cross build to ARM
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).