### PR TITLE
opentabletdriver: 0.6.4.0-unstable-2024-11-25 -> 0.6.5.0 

### DIFF
--- a/pkgs/by-name/op/opentabletdriver/deps.json
+++ b/pkgs/by-name/op/opentabletdriver/deps.json
@@ -20,6 +20,11 @@
     "hash": "sha256-b8LCEIZCLJdYcJXQqI3TGDmkLrmLhz84eoTq+qP5xvU="
   },
   {
+    "pname": "DiffPlex",
+    "version": "1.7.2",
+    "hash": "sha256-Vsn81duAmPIPkR40h5bEz7hgtF5Kt5nAAGhQZrQbqxE="
+  },
+  {
     "pname": "Eto.Forms",
     "version": "2.5.10",
     "hash": "sha256-51NkW/COGLiGl/+niLJaPJY+ypG1a1OXw65HMunj4bQ="

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -16,6 +16,7 @@
   nixosTests,
   udev,
   wrapGAppsHook3,
+  versionCheckHook,
 }:
 
 buildDotnetModule (finalAttrs: {
@@ -113,6 +114,12 @@ buildDotnetModule (finalAttrs: {
       categories = [ "Utility" ];
     })
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/otd-daemon";
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -70,17 +70,14 @@ buildDotnetModule rec {
   testProjectFile = "OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj";
 
   disabledTests = [
-    # Require networking
-    "OpenTabletDriver.Tests.PluginRepositoryTest.ExpandRepositoryTarballFork"
-    "OpenTabletDriver.Tests.PluginRepositoryTest.ExpandRepositoryTarball"
     # Require networking & unused in Linux build
-    "OpenTabletDriver.Tests.UpdaterTests.UpdaterBase_ProperlyChecks_Version_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_PreventsUpdate_WhenAlreadyUpToDate_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_AllowsReupdate_WhenInstallFailed_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_HasUpdateReturnsFalse_During_UpdateInstall_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_HasUpdateReturnsFalse_After_UpdateInstall_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_Prevents_ConcurrentAndConsecutive_Updates_Async"
-    "OpenTabletDriver.Tests.UpdaterTests.Updater_ProperlyBackups_BinAndAppDataDirectory_Async"
+    "OpenTabletDriver.Tests.UpdaterTests.CheckForUpdates_Returns_Update_When_Available"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_Throws_UpdateAlreadyInstalledException_When_AlreadyInstalled"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_DoesNotThrow_UpdateAlreadyInstalledException_When_PreviousInstallFailed"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_Throws_UpdateInProgressException_When_AnotherUpdate_Is_InProgress"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_Moves_UpdatedBinaries_To_BinDirectory"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_Moves_Only_ToBeUpdated_Binaries"
+    "OpenTabletDriver.Tests.UpdaterTests.Install_Copies_AppDataFiles"
     # Intended only to be run in continuous integration, unnecessary for functionality
     "OpenTabletDriver.Tests.ConfigurationTest.Configurations_DeviceIdentifier_IsNotConflicting"
     # Depends on processor load

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -20,19 +20,16 @@
 
 buildDotnetModule rec {
   pname = "OpenTabletDriver";
-  version = "0.6.4.0-unstable-2024-11-25";
+  version = "0.6.5.0";
 
   src = fetchFromGitHub {
     owner = "OpenTabletDriver";
     repo = "OpenTabletDriver";
-    rev = "8b88b8bdc5144391f10eb61ee77803ba0ee83718"; # 0.6.x branch
-    hash = "sha256-5JKkSqV9owkHgWXfjiyv5QRh86apDCPzpA6qha1i4D4=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ILnwHfcV/tW59TLDpAeDwJK708IQfMFBOYuqRtED0kw=";
   };
 
-  dotnetInstallFlags = [ "--framework=net8.0" ];
-
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   projectFile = [
     "OpenTabletDriver.Console"

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -18,14 +18,14 @@
   wrapGAppsHook3,
 }:
 
-buildDotnetModule rec {
+buildDotnetModule (finalAttrs: {
   pname = "OpenTabletDriver";
   version = "0.6.5.0";
 
   src = fetchFromGitHub {
     owner = "OpenTabletDriver";
     repo = "OpenTabletDriver";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-ILnwHfcV/tW59TLDpAeDwJK708IQfMFBOYuqRtED0kw=";
   };
 
@@ -61,7 +61,7 @@ buildDotnetModule rec {
     udev
   ];
 
-  buildInputs = runtimeDeps;
+  buildInputs = finalAttrs.runtimeDeps;
 
   doCheck = true;
   testProjectFile = "OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj";
@@ -122,7 +122,7 @@ buildDotnetModule rec {
   };
 
   meta = {
-    changelog = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v${version}";
+    changelog = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v${finalAttrs.version}";
     description = "Open source, cross-platform, user-mode tablet driver";
     homepage = "https://github.com/OpenTabletDriver/OpenTabletDriver";
     license = lib.licenses.lgpl3Plus;
@@ -136,4 +136,4 @@ buildDotnetModule rec {
       "aarch64-linux"
     ];
   };
-}
+})

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -122,9 +122,11 @@ buildDotnetModule rec {
   };
 
   meta = {
+    changelog = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v${version}";
     description = "Open source, cross-platform, user-mode tablet driver";
     homepage = "https://github.com/OpenTabletDriver/OpenTabletDriver";
     license = lib.licenses.lgpl3Plus;
+    mainProgram = "otd";
     maintainers = with lib.maintainers; [
       gepbird
       thiagokokada
@@ -133,6 +135,5 @@ buildDotnetModule rec {
       "x86_64-linux"
       "aarch64-linux"
     ];
-    mainProgram = "otd";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v0.6.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
