### PR TITLE
ungoogled-chromium: 131.0.6778.139-1 -> 131.0.6778.204-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -766,7 +766,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "131.0.6778.139",
+    "version": "131.0.6778.204",
     "deps": {
       "depot_tools": {
         "rev": "20b9bdcace7ed561d6a75728c85373503473cb6b",
@@ -777,16 +777,16 @@
         "hash": "sha256-a8yCdBsl0nBMPS+pCLwrkAvQNP/THx/z/GySyOgx4Jk="
       },
       "ungoogled-patches": {
-        "rev": "131.0.6778.139-1",
-        "hash": "sha256-6ehqckNitebDNEiY9qgbk8XMLADhpayxodpSFjlUDTA="
+        "rev": "131.0.6778.204-1",
+        "hash": "sha256-08XBobDtEuVG/tli7SXJ3Ca/aFM4kybuk043sVswPj8="
       },
       "npmHash": "sha256-b1l8SwjAfoColoa3zhTMPEF/rRuxzT3ATHE77rWU5EA="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "c35bbcbd7c2775a12a3f320e05ac0022939b1a8a",
-        "hash": "sha256-oJ4y9W51RMiUk40Uz8b3LJH0kMD5GMDG2V//Tng4/4A=",
+        "rev": "52183f9e99a61056f9b78535f53d256f1516f2a0",
+        "hash": "sha256-D7+Ji8Y1vw1Sgt9njbZDGbgbzT8eAvx/95M8SsHyiN4=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1526,8 +1526,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "b97fcc24b3523da5e389d2a6d76857f134be09c5",
-        "hash": "sha256-5Es9Zot/DH+UKq3+aCgeQC+Llgj7/lmPXUYvar/hX7I="
+        "rev": "7f72bbed40ca85a6b68ca2f15feca342c9c256d0",
+        "hash": "sha256-QJcC6T2IOCXhObwND0jPQTUl84lotcYRCIQe4GTtczc="
       }
     }
   }


### PR DESCRIPTION
Same update as in #366589

https://chromereleases.googleblog.com/2024/12/stable-channel-update-for-desktop_18.html

This update includes 5 security fixes.

CVEs:
CVE-2024-12692 CVE-2024-12693 CVE-2024-12694 CVE-2024-12695

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
