### PR TITLE
[Backport release-24.11] inkscape: 1.3.2 -> 1.4

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -184,12 +184,14 @@ stdenv.mkDerivation rec {
 
   passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
 
-  meta = with lib; {
+  meta = {
     description = "Vector graphics editor";
     homepage = "https://www.inkscape.org";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.jtojnar ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      jtojnar
+    ];
+    platforms = lib.platforms.all;
     mainProgram = "inkscape";
     longDescription = ''
       Inkscape is a feature-rich vector graphics editor that edits

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -190,6 +190,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       jtojnar
+      x123
     ];
     platforms = lib.platforms.all;
     mainProgram = "inkscape";

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       jtojnar
       x123
+      Luflosi
     ];
     platforms = lib.platforms.all;
     mainProgram = "inkscape";

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -7,7 +7,7 @@
 , cmake
 , desktopToDarwinBundle
 , fetchurl
-, fetchpatch
+, fd
 , gettext
 , ghostscript
 , glib
@@ -27,7 +27,6 @@
 , librevenge
 , librsvg
 , libsigcxx
-, libsoup
 , libvisio
 , libwpg
 , libXft
@@ -40,40 +39,43 @@
 , popt
 , potrace
 , python3
+, runCommand
 , substituteAll
 , wrapGAppsHook3
 , libepoxy
 , zlib
+, yq
 }:
 let
   python3Env = python3.withPackages
     (ps: with ps; [
+      # List taken almost verbatim from the output of nix-build -A inkscape.passthru.pythonDependencies
       appdirs
       beautifulsoup4
       cachecontrol
-    ]
-    # CacheControl requires extra runtime dependencies for FileCache
-    # https://gitlab.com/inkscape/extras/extension-manager/-/commit/9a4acde6c1c028725187ff5972e29e0dbfa99b06
-    ++ cachecontrol.optional-dependencies.filecache
-    ++ [
-      numpy
+      cssselect
+      filelock
+      inkex
       lxml
+      numpy
       packaging
       pillow
-      scour
+      pygobject3
       pyparsing
       pyserial
       requests
-      pygobject3
-    ] ++ inkex.propagatedBuildInputs);
+      scour
+      tinycss2
+      zstandard
+    ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "inkscape";
-  version = "1.3.2";
+  version = "1.4";
 
   src = fetchurl {
-    url = "https://inkscape.org/release/inkscape-${version}/source/archive/xz/dl/inkscape-${version}.tar.xz";
-    sha256 = "sha256-29GETcRD/l4Q0+mohxROX7ciOFL/8ZHPte963qsOCGs=";
+    url = "https://inkscape.org/release/inkscape-${finalAttrs.version}/source/archive/xz/dl/inkscape-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-xZqFRTtpmt3rzVHB3AdoTdlqEMiuxxaxlVHbUFYuE/U=";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -87,28 +89,12 @@ stdenv.mkDerivation rec {
       src = ./fix-python-paths.patch;
       # Python is used at run-time to execute scripts,
       # e.g., those from the "Effects" menu.
-      python3 = "${python3Env}/bin/python";
+      python3 = lib.getExe python3Env;
     })
     (substituteAll {
       # Fix path to ps2pdf binary
       src = ./fix-ps2pdf-path.patch;
       inherit ghostscript;
-    })
-
-    # Fix build with libxml2 2.12
-    # https://gitlab.com/inkscape/inkscape/-/merge_requests/6089
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/694d8ae43d06efff21adebf377ce614d660b24cd.patch";
-      hash = "sha256-9IXJzpZbNU5fnt7XKgqCzUDrwr08qxGwo8TqnL+xc6E=";
-    })
-
-    # Improve distribute along path precision
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
     })
   ];
 
@@ -119,7 +105,7 @@ stdenv.mkDerivation rec {
 
     # double-conversion is a dependency of 2geom
     substituteInPlace CMakeScripts/DefineDependsandFlags.cmake \
-      --replace 'find_package(DoubleConversion REQUIRED)' ""
+      --replace-fail 'find_package(DoubleConversion REQUIRED)' ""
   '';
 
   nativeBuildInputs = [
@@ -155,7 +141,6 @@ stdenv.mkDerivation rec {
     librevenge
     librsvg # for loading icons
     libsigcxx
-    libsoup
     libvisio
     libwpg
     libXft
@@ -182,7 +167,23 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
+  passthru = {
+    tests = {
+      ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
+      inherit (python3.pkgs) inkex;
+    };
+
+    pythonDependencies = runCommand "python-dependency-list" {
+      nativeBuildInputs = [
+        fd
+        yq
+      ];
+      inherit (finalAttrs) src;
+    } ''
+      unpackPhase
+      tomlq --slurp 'map(.tool.poetry.dependencies | to_entries | map(.key)) | flatten | map(ascii_downcase) | unique' $(fd pyproject.toml) > "$out"
+    '';
+  };
 
   meta = {
     description = "Vector graphics editor";
@@ -202,4 +203,4 @@ stdenv.mkDerivation rec {
       If you want to import .eps files install ps2edit.
     '';
   };
-}
+})

--- a/pkgs/by-name/li/lib2geom/package.nix
+++ b/pkgs/by-name/li/lib2geom/package.nix
@@ -1,6 +1,5 @@
 {
   stdenv,
-  fetchpatch,
   fetchFromGitLab,
   cmake,
   ninja,
@@ -16,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lib2geom";
-  version = "1.3";
+  version = "1.4";
 
   outputs = [
     "out"
@@ -27,32 +26,8 @@ stdenv.mkDerivation rec {
     owner = "inkscape";
     repo = "lib2geom";
     rev = "refs/tags/${version}";
-    hash = "sha256-llUpW8VRBD8RKaGfyedzsMbLRb8DIo0ePt6m2T2w7Po=";
+    hash = "sha256-kbcnefzNhUj/ZKZaB9r19bpI68vxUKOLVAwUXSr/zz0=";
   };
-
-  patches = [
-    # Fix compilation with Clang.
-    # https://gitlab.com/inkscape/lib2geom/-/merge_requests/102
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/a5b5ac7d992023f8a80535ede60421e73ecd8e20.patch";
-      hash = "sha256-WJYkk3WRYVyPSvyTbKDUrYvUwFgKA9mmTiEWtYQqM4Q=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/23d9393af4bee17aeb66a3c13bdad5dbed982d08.patch";
-      hash = "sha256-LAaGMIXpDI/Wzv5E2LasW1Y2/G4ukhuEzDmFu3AzZOA=";
-    })
-
-    # Fix ellipses rendering near page corners.
-    # https://gitlab.com/inkscape/lib2geom/-/issues/66
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/039ce8d4af23a0a2a9d48eb970b321d9795dcc08.patch";
-      hash = "sha256-JfgGrqBcYSYKcdl4Bt7vGZ4aTBPSHM6JjZ95IlzxPwI=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/cf523857e48c87f9f6a09217bdf935fff457823d.patch";
-      hash = "sha256-BRg8ANHMSgoi6vt9PNbhwG1fRkzEPXb4gPTPO3sY0XE=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -91,6 +66,17 @@ stdenv.mkDerivation rec {
           # Fails due to rounding differences
           # https://gitlab.com/inkscape/lib2geom/-/issues/70
           "circle-test"
+        ]
+        ++ lib.optionals (stdenv.hostPlatform.system != "x86_64-linux") [
+          # https://gitlab.com/inkscape/lib2geom/-/issues/69
+          "polynomial-test"
+
+          # https://gitlab.com/inkscape/lib2geom/-/issues/75
+          "line-test"
+
+          # Failure observed on aarch64-darwin
+          "bezier-test"
+          "ellipse-test"
         ];
     in
     ''

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   inkscape,
-  fetchpatch,
   poetry-core,
   cssselect,
   lxml,
@@ -14,6 +13,7 @@
   pyparsing,
   pyserial,
   scour,
+  tinycss2,
   gobject-introspection,
   pytestCheckHook,
   gtk3,
@@ -27,17 +27,6 @@ buildPythonPackage {
 
   inherit (inkscape) src;
 
-  patches = [
-    # Fix “distribute along path” test with Python 3.12.
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
-    })
-  ];
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
@@ -46,6 +35,7 @@ buildPythonPackage {
     numpy
     pygobject3
     pyserial
+    tinycss2
   ];
 
   pythonImportsCheck = [ "inkex" ];
@@ -87,8 +77,7 @@ buildPythonPackage {
     cd share/extensions
 
     substituteInPlace pyproject.toml \
-      --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"' \
-      --replace-fail 'lxml = "^4.5.0"' 'lxml = "^4.5.0 || ^5.0.0"'
+      --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"'
   '';
 
   meta = {

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
       dotlambda
       gal_bolle
     ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9766,10 +9766,6 @@ with pkgs;
 
   lcms = lcms2;
 
-  lib2geom = callPackage ../development/libraries/lib2geom {
-    stdenv = if stdenv.cc.isClang then llvmPackages_13.stdenv else stdenv;
-  };
-
   libacr38u = callPackage ../tools/security/libacr38u {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
Backport of #348253.
Fixes #365168.
I'm not sure if this qualifies for backporting, since there are a breaking changes, albeit very minor ones: https://inkscape.org/doc/release_notes/1.4/Inkscape_1.4.html#Breaking_Changes_.2F_Deprecations.
https://github.com/NixOS/nixpkgs/blob/49fbcc0956cfee730d82e50c408fd4b777b882f0/CONTRIBUTING.md#changes-acceptable-for-releases states backporting is ok for "Minor versions with new functionality, but no breaking changes", so technically, this does not qualify, since there are two small breaking changes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
