### PR TITLE
haskell.compiler.ghc912: init at 9.12.1

### DIFF
--- a/pkgs/development/compilers/ghc/9.12.1.nix
+++ b/pkgs/development/compilers/ghc/9.12.1.nix
@@ -1,0 +1,4 @@
+import ./common-hadrian.nix rec {
+  version = "9.12.1";
+  sha256 = "0m1797hhpwfq062iy3is3gb8ynd6ym5zkf47f1qpa3y7xsyi0x2a";
+}

--- a/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
@@ -42,6 +42,10 @@ let
           directory = final.directory_1_3_9_0;
           # Depends on directory
           process = final.process_1_6_25_0;
+          # Disable checks to avoid infinite recursion
+          file-io = prev.file-io.override (
+            args: args // { mkDerivation = drv: args.mkDerivation (drv // { doCheck = false; }); }
+          );
         }
       )
     else

--- a/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
@@ -21,10 +21,7 @@
 # related packages that are managed in the GHC source tree. Its main job is to
 # expose all possible compile time customization in a common interface and
 # take care of all differences between Hadrian versions.
-{
-  bootPkgs,
-  lib,
-}:
+{ bootPkgs, lib }:
 
 {
   # GHC source tree and version to build hadrian & friends from.
@@ -37,30 +34,24 @@
 }:
 
 let
-  bootPkgs' = if lib.versionAtLeast ghcVersion "9.12" then
-    bootPkgs.extend (final: prev: {
-      # See https://gitlab.haskell.org/ghc/ghc/-/commit/7890f2d8526dd90584eaa181ab10bd30d90e6743
-      directory = final.directory_1_3_9_0;
-      # Depends on directory
-      process = final.process_1_6_25_0;
-    })
-  else
-    bootPkgs;
-  callPackage' =
-    f: args:
-    bootPkgs'.callPackage f (
-      {
-        inherit ghcSrc ghcVersion;
-      }
-      // args
-    );
+  bootPkgs' =
+    if lib.versionAtLeast ghcVersion "9.12" then
+      bootPkgs.extend (
+        final: prev: {
+          # See https://gitlab.haskell.org/ghc/ghc/-/commit/7890f2d8526dd90584eaa181ab10bd30d90e6743
+          directory = final.directory_1_3_9_0;
+          # Depends on directory
+          process = final.process_1_6_25_0;
+        }
+      )
+    else
+      bootPkgs;
+  callPackage' = f: args: bootPkgs'.callPackage f ({ inherit ghcSrc ghcVersion; } // args);
 
   ghc-platform = callPackage' ./ghc-platform.nix { };
-  ghc-toolchain = callPackage' ./ghc-toolchain.nix {
-    inherit ghc-platform;
-  };
-in
+  ghc-toolchain = callPackage' ./ghc-toolchain.nix { inherit ghc-platform; };
 
+in
 callPackage' ./hadrian.nix (
   {
     inherit userSettings;

--- a/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
@@ -37,9 +37,18 @@
 }:
 
 let
+  bootPkgs' = if lib.versionAtLeast ghcVersion "9.12" then
+    bootPkgs.extend (final: prev: {
+      # See https://gitlab.haskell.org/ghc/ghc/-/commit/7890f2d8526dd90584eaa181ab10bd30d90e6743
+      directory = final.directory_1_3_9_0;
+      # Depends on directory
+      process = final.process_1_6_25_0;
+    })
+  else
+    bootPkgs;
   callPackage' =
     f: args:
-    bootPkgs.callPackage f (
+    bootPkgs'.callPackage f (
       {
         inherit ghcSrc ghcVersion;
       }
@@ -64,6 +73,6 @@ callPackage' ./hadrian.nix (
   }
   // lib.optionalAttrs (lib.versionAtLeast ghcVersion "9.11") {
     # See https://gitlab.haskell.org/ghc/ghc/-/commit/145a6477854d4003a07573d5e7ffa0c9a64ae29c
-    Cabal = bootPkgs.Cabal_3_14_0_0;
+    Cabal = bootPkgs'.Cabal_3_14_0_0;
   }
 )

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -412,6 +412,33 @@ in
         llvmPackages = pkgs.llvmPackages_15;
       };
       ghc910 = compiler.ghc9101;
+      ghc9121 = callPackage ../development/compilers/ghc/9.12.1.nix {
+        bootPkgs =
+          # For GHC 9.6 no armv7l bindists are available.
+          if stdenv.buildPlatform.isAarch32 then
+            bb.packages.ghc963
+          else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
+            bb.packages.ghc963
+          else if stdenv.buildPlatform.isDarwin then
+            # it seems like the GHC 9.6.* bindists are built with a different
+            # toolchain than we are using (which I'm guessing from the fact
+            # that 9.6.4 bindists pass linker flags our ld doesn't support).
+            # With both 9.6.3 and 9.6.4 binary it is impossible to link against
+            # the clock package (probably a hsc2hs problem).
+            bb.packages.ghc963
+          else
+            bb.packages.ghc963Binary;
+        inherit (buildPackages.python3Packages) sphinx;
+        # Need to use apple's patched xattr until
+        # https://github.com/xattr/xattr/issues/44 and
+        # https://github.com/xattr/xattr/issues/55 are solved.
+        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+        # 2024-12-20: Support range >= 13 && < 20
+        # See: https://downloads.haskell.org/ghc/9.12.1/docs/users_guide/phases.html#ghc-flag-fllvm
+        buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_15;
+        llvmPackages = pkgs.llvmPackages_15;
+      };
+      ghc912 = compiler.ghc9121;
       ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
         bootPkgs =
           # No suitable bindist packaged yet
@@ -588,6 +615,12 @@ in
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.10.x.nix { };
       };
       ghc910 = packages.ghc9101;
+      ghc9121 = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc9121;
+        ghc = bh.compiler.ghc9101;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.12.x.nix { };
+      };
+      ghc912 = packages.ghc9121;
       ghcHEAD = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghcHEAD;
         ghc = bh.compiler.ghcHEAD;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -80,6 +80,7 @@ let
     ghc983
     ghc984
     ghc9101
+    ghc9121
   ];
 
   # packagePlatforms applied to `haskell.packages.*`


### PR DESCRIPTION
See: <https://www.google.com/search?client=firefox-b-d&q=ghc+9.12+relreased>

This is a bit tricky because hadrian now requires directory > 1.39. But GHC-9.6 comes with an older version. Therefore we need to bump directory, but also make sure everything that has directory as a dependency (process, ghc-toolchain, ghc-platform, Cabal) is also using the same version. The `process` boot library is one such package, so we need to make sure it actually gets built rather than being taken from GHC's pkg-db.
 
I wasn't sure what the best way to do that is. I'm happy to change if folks have ideas.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
