### PR TITLE
koboldcpp: update `cudaArches` example, remove `gitUpdater`, drop `openblas`, 1.79.1 -> 1.80.1

### DIFF
--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -24,7 +24,7 @@
   clblast,
   ocl-icd,
 
-  vulkanSupport ? true,
+  vulkanSupport ? (!stdenv.hostPlatform.isDarwin),
   vulkan-loader,
   metalSupport ? stdenv.hostPlatform.isDarwin,
   nix-update-script,

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   stdenv,
   makeWrapper,
-  gitUpdater,
   python3Packages,
   tk,
   addDriverRunpath,

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -41,13 +41,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
-  version = "1.80";
+  version = "1.80.1";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-X91sBw4YmozKwDe9Hzvk4CP3DLvw2Q6XPTBR3TaEwqg=";
+    hash = "sha256-CgJzYF8FnHk0zKdysGJWLnNo/MND24AbQdjRbDtv0II=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -20,7 +20,7 @@
 
   cublasSupport ? config.cudaSupport,
   # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-  # For example if you're on an GTX 1080 that means you're using "Pascal" and you need to pass "sm_60"
+  # For example if you're on an RTX 3060 that means you're using "Ampere" and you need to pass "sm_86"
   cudaArches ? cudaPackages.cudaFlags.realArches or [ ],
 
   clblastSupport ? stdenv.hostPlatform.isLinux,

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -14,9 +14,6 @@
   config,
   cudaPackages ? { },
 
-  openblasSupport ? !stdenv.hostPlatform.isDarwin,
-  openblas,
-
   cublasSupport ? config.cudaSupport,
   # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
   # For example if you're on an RTX 3060 that means you're using "Ampere" and you need to pass "sm_86"
@@ -65,7 +62,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     [ tk ]
     ++ finalAttrs.pythonInputs
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_12 ]
-    ++ lib.optionals openblasSupport [ openblas ]
     ++ lib.optionals cublasSupport [
       cudaPackages.libcublas
       cudaPackages.cuda_nvcc
@@ -81,7 +77,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pythonPath = finalAttrs.pythonInputs;
 
   makeFlags = [
-    (makeBool "LLAMA_OPENBLAS" openblasSupport)
     (makeBool "LLAMA_CUBLAS" cublasSupport)
     (makeBool "LLAMA_CLBLAST" clblastSupport)
     (makeBool "LLAMA_VULKAN" vulkanSupport)

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -40,13 +40,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
-  version = "1.79.1";
+  version = "1.80";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-RHeEI6mJklGF7BQXxLwxSr1xD6GsI9+fio888UxKru0=";
+    hash = "sha256-X91sBw4YmozKwDe9Hzvk4CP3DLvw2Q6XPTBR3TaEwqg=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -8,6 +8,7 @@
   addDriverRunpath,
 
   apple-sdk_12,
+  darwinMinVersionHook,
 
   koboldLiteSupport ? true,
 
@@ -61,7 +62,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [ tk ]
     ++ finalAttrs.pythonInputs
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_12 ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_12
+      (darwinMinVersionHook "10.15")
+    ]
     ++ lib.optionals cublasSupport [
       cudaPackages.libcublas
       cudaPackages.cuda_nvcc


### PR DESCRIPTION
Changelog: https://github.com/LostRuins/koboldcpp/releases/tag/v1.81
Diff: https://github.com/LostRuins/koboldcpp/compare/v1.79.1...v1.80.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc