### PR TITLE
warp-terminal: 0.2024.12.10.15.55.stable_04 -> 0.2024.12.18.08.02.stable_03

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -6,6 +6,7 @@
   autoPatchelfHook,
   undmg,
   zstd,
+  alsa-lib,
   curl,
   fontconfig,
   libglvnd,
@@ -48,6 +49,7 @@ let
     ];
 
     buildInputs = [
+      alsa-lib # libasound.so.2
       curl
       fontconfig
       (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-NK9/YhnEWdoxF8fkGJvYVFCsNh0XPSheXbw89wNkaio=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-CrRt7fLoZ9LR3fD7xXBzlRFf4CAjQjokU5UaHNJnVNA=",
+    "version": "0.2024.12.18.08.02.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-wAzPAaigjaHl5JhuS92rkHXLZRAQtq7p8IB67sqPDlY=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-0A9EPkDp77tpfrRuXV2rVPaXMYbY7erbKBd6IT9CTFQ=",
+    "version": "0.2024.12.18.08.02.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-GbirEK2Jhfunj9ORWp5uW/QHUzSnJRQRh1ezApr1p00=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-IlqpK8IbtSMKGNspKj2Rq2Jzlyc7RYcfRaoYY9Akhdk=",
+    "version": "0.2024.12.18.08.02.stable_03"
   }
 }


### PR DESCRIPTION
Changelog: https://docs.warp.dev/getting-started/changelog#id-2024.12.19-v0.2024.12.18.08.02

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
