### PR TITLE
Bump/jetbrains 2024.3.1.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -3,42 +3,42 @@
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://download.jetbrains.com/aqua/aqua-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "b408823bd819077961064f2a82b1556f112171da5eccb11748fab79fc0c33840",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.tar.gz",
-      "build_number": "243.22562.117"
+      "version": "2024.3.1",
+      "sha256": "e304d8f900881d18865010819dc035d59be00b1364baa2b98ef47d923907ce57",
+      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.1.tar.gz",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "5320b7a6b3bc49b8c798c6f06f1b108a8b1b3c37ab12763efc23907b2639be65",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.tar.gz",
-      "build_number": "243.22562.155"
+      "version": "2024.3.1.1",
+      "sha256": "054eff2dcdb7779b97d940b5425ae7c56bfafd657367e3a749275ef6a0a40368",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "8375752c0b24a363b982862af91d65b573aebabc36b55b16fbeff2c208176f61",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.2.tar.gz",
-      "build_number": "243.22562.115"
+      "version": "2024.3.3",
+      "sha256": "84158baba8040ea4a6fac4663b9205c410ff7f04d803c2af1e9b4746a6270445",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.3.tar.gz",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "3407a15cf9a90f45567c5994eea4755d5462fa3dc59c41ce98ed4b00aa1ff4cf",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.tar.gz",
-      "build_number": "243.22562.185"
+      "version": "2024.3.1.1",
+      "sha256": "37e0985cd3bac79cc74962edba726ccdde61101fc4e8876ed060396584332aa3",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "d672a5552e7cf0387e1fb93a6cadf3a4ca1d5d942de1c3d1adc0af3f092d1780",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.tar.gz",
-      "build_number": "243.22562.160"
+      "version": "2024.3.1.1",
+      "sha256": "625bd0794b535b40926f3fed15b50e1df8ee181acd5a1a8fb174f19cd450cef0",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -51,18 +51,18 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "b3fbdba793ba9e7800ac1ee4ceedf4726f86d5320c7c0d4e155b5bd10a296777",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.tar.gz",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "b183b126de2cd457475eea184874b5da2fa33ba5ae2ff874bdc8c1d534156428",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "f427f4eea252d574f6135c020113f02c6d880e428265b943be26ee6110876610",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.tar.gz",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "d80684aa73fe9dee14ea405058d54a34340266cf675bfbaf4c760da6eb2d3fe9",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,109 +75,109 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "acbd2adda79817cbe508e89b8a431bd0ec390c4ab19a78e04e1ef101843dddf1",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.tar.gz",
-      "build_number": "243.22562.164",
+      "version": "2024.3.1.1",
+      "sha256": "8bb909b6322f296d4e44265223cffca2649e4344d1233b670f751c5b2d7ae698",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "b262750532c2655482bee77dbb2dea7e4d0604ab7413cc622f32fdc24458a58c",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.tar.gz",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "36b9332262815099d0b86d2689fcf91b379730cb838623d82c0845969bb6470f",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "7bd9ea5c4eae1d1fc71cd538b1443c809c77c05fb8c793f3ebb5b1abd898a70f",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.tar.gz",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "5698131d93d00a261c720a31ec54ef1c850581c274be6938dd923e8c0383da25",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "7c716bad550067960222bf1d97c5ac7c40d0ceba6cafd754065038f4d23b2a9e",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.2.tar.gz",
-      "build_number": "243.22562.171"
+      "version": "2024.3.3",
+      "sha256": "3185826c0d85c06bf18c5ece3f5f9698acef006932b7a92b6cb190fd4d8e2807",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.3.tar.gz",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "d288557a95b8f28b2bec32a749bf104ae33d2b0e899c164772856b82c1a51380",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.tar.gz",
-      "build_number": "243.22562.151"
+      "version": "2024.3.1.1",
+      "sha256": "fe849fd90725f12c6dabb20973f1d5eb6fc9baddd692961197527326639d7def",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "0d20cffc2ab1e698c515e5a1f9753245db373ed721fa3d4f9dab715fc28e910b",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.1.tar.gz",
-      "build_number": "243.22562.187"
+      "version": "2024.3.2",
+      "sha256": "c6549572baa913c9842b0227257f7477531269393d5989622a3d0b802b999bf8",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2.tar.gz",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "f9122a02312bee9d06c77774cad37b32ac0dcbc460af4ac8b8059a1780d16018",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.tar.gz",
-      "build_number": "243.22562.112"
+      "version": "2024.3.1.1",
+      "sha256": "275999ca069658257d6f06875f283abf9c0b102bdf812cf7eefe86a1dda90c1b",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.tar.gz",
       "version": "2024.3 EAP",
-      "sha256": "90cf02ed5803040a0aefaa3c8e8a938e6e462c1bcc7ce48902b2933f79ca92bb",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.163.tar.gz",
-      "build_number": "243.22562.163"
+      "sha256": "d49e58020d51ec4ccdbdffea5d42b5a2d776a809fc00789cef5abda7b23bd3f6",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371.tar.gz",
+      "build_number": "243.22562.371"
     }
   },
   "aarch64-linux": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://download.jetbrains.com/aqua/aqua-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "81227e4863b8d00fa368db052d5b4ddb9c3fc817e19965f81493495aedfc59e3",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3-aarch64.tar.gz",
-      "build_number": "243.22562.117"
+      "version": "2024.3.1",
+      "sha256": "4895ad44a456f56121cc4e78be45b6a4ccae8080ab7251cd434304465d01f7c4",
+      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.1-aarch64.tar.gz",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "da6e06b379f823a744e368935d84848c69b54cd8936153bba3cc8b51a4473920",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.155"
+      "version": "2024.3.1.1",
+      "sha256": "dacd54a45145ed65b2c40520706432449e4bc3ff2bb23be6cb1fb4c73d9db223",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "f7ce542c197030b8390cbb21fb86394dc0158924815e3ed94a754d35ddede3b6",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.2-aarch64.tar.gz",
-      "build_number": "243.22562.115"
+      "version": "2024.3.3",
+      "sha256": "b6413cb0855f1beb64b7095f2e21c856e367319440f11ffad787ae88bc80af66",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.3-aarch64.tar.gz",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "61c830a307fe5e4191da88596c63483d64fd12a5ea248128921ca99c5d7c39b5",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.185"
+      "version": "2024.3.1.1",
+      "sha256": "31a564e58285a84b226017f18e658684720aa0a615f068447edbe817e6337f76",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "75b49b6f95e7c136ec6a27dc6c3b84f41e8d5149a6776c1a7e35c21e8363027d",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.160"
+      "version": "2024.3.1.1",
+      "sha256": "d5481582f8448659a293bc101b9ce2355368c60ab5a18370d4ba09a2eeebf458",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -190,18 +190,18 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "dc3427884cc1b98cd79d152b9d808a72b99f751dc627063148dce862853819d4",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "8e82e9c1ff8bc561df88d9c6ef3b83498aecdac6f980b9df0cb183bc6dca0c90",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "f6f328b4a088f1254a1cbac76149c8afa07ff86ed921663392172af070117bce",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "b3487662edf0904de4bfcd069231068350f7d8e964c0718b88ecbc18a83e5f47",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,109 +214,109 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "c9def2cfb2193bbe9f70d1831af1f2d69bd886b68f3094edbceda73afe49027b",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.164",
+      "version": "2024.3.1.1",
+      "sha256": "d6f0cb476f3a83636b14e7b678d2e0a7f47e060c63bf31a5d645ee7e18adb0fa",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "fe90ad8fa15e4a5ce3ed1d7d6e95c3578bdb10e5f0cd94b2fa9c8d51cc13e9db",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "cbc36953b6943e70468e1908bef9adddc2a9597124e5d794f294095888b0914c",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "2483768c690f6caa9c1c3e3ef948fbd88e2b1ebb6f77ebd3f6c80e12e406e6c9",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "a301f7316b17ace60c9e765f50ae0987262e99da3feb222c9abf761fda10cff3",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "f1eff56a298f58bd25fcce7f7d572b2ba9e3bd1b51ff6457ab5f6dfe7f789b4a",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.2-aarch64.tar.gz",
-      "build_number": "243.22562.171"
+      "version": "2024.3.3",
+      "sha256": "8ca14eeae6a9164da955f9e292dda788bda53a031c24ef6c2fab505e3e2f175b",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.3-aarch64.tar.gz",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "6c714429a73afce55ec1dff15ac78c31b0e3f719496dfa33d966f53f47076992",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.151"
+      "version": "2024.3.1.1",
+      "sha256": "af3cf7b5e8ac4306a4f5f03bcfc3425aa7ed3aa71f61213d85fd4f5a3d425b75",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "53f1ba0ccb661e1405878587f81a869675e7e3196719e590ccf8f7d35a514305",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.187"
+      "version": "2024.3.2",
+      "sha256": "d5187d7d449d1b1ec6ff2699c0ccdb3c3280841360d3f43c0318a41b865064c8",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "e1b34cf2456233f6a7aa079e7c2af23bc88d4b29bbddcf6d7a5b4e0432e38db3",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.112"
+      "version": "2024.3.1.1",
+      "sha256": "b136ec6696a47511a7396eb5416ff055964a040d72ed29eb6c362e1b37ce0ab5",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.tar.gz",
       "version": "2024.3 EAP",
-      "sha256": "b6e04707d2774e064d8fa793b78da0bd64245d9c468095d07d0eb23ea54ae9d8",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.163-aarch64.tar.gz",
-      "build_number": "243.22562.163"
+      "sha256": "6067f6f73c4a178e2d0ae42bd18669045d85b5b5ed2c9115c2488ba7aa2a3d88",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371-aarch64.tar.gz",
+      "build_number": "243.22562.371"
     }
   },
   "x86_64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://download.jetbrains.com/aqua/aqua-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "65c4c3b38443a3b7b9e2d44619be090d0a594d7d63331044cec998860278cfea",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.dmg",
-      "build_number": "243.22562.117"
+      "version": "2024.3.1",
+      "sha256": "2efd04de1b67a394529fb154e63c58e34654af42a5fb12b5989ab8d5a784483b",
+      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.1.dmg",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "dedf67707acb6183aadf9607d16f926f3233616ca610f85a294405536c2f2eee",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.dmg",
-      "build_number": "243.22562.155"
+      "version": "2024.3.1.1",
+      "sha256": "276ae335421b6eddd1d7fbdc27fc826bf7ffa68e32a23f9335ff8be88d89b747",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1.dmg",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2024.3.2",
-      "sha256": "2098f0056478c8ce86294bef246ba204fd6ea0332c0ca4fd96bd09b2f1bdf1a6",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.2.dmg",
-      "build_number": "243.22562.115"
+      "version": "2024.3.3",
+      "sha256": "e266609ab3555bbf213edd35f9c0b032dd4c27012334066212b391a5bc972ca4",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.3.dmg",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "a64eabb192181f81700f0c46c65ba7e6951f249f2f2055986c9e39b3dda911c0",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.dmg",
-      "build_number": "243.22562.185"
+      "version": "2024.3.1.1",
+      "sha256": "eb5fd54f193f2c94de46c91957a4d36eedce8009cd272c5d8e4fc4763d9dafe3",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.1.dmg",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "709bd2cc759eb29d88726a0c24db2f11eb2fc87ee1975d8e101a03226b919ebf",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.dmg",
-      "build_number": "243.22562.160"
+      "version": "2024.3.1.1",
+      "sha256": "f31962a284ec68e175d6f5678c0e4fe33c0948514f92673bb7989b38c3622951",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.1.dmg",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -329,18 +329,18 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "0429e493747063ba65d2700f546a1ff08c537169499b9cb957f3c71c580fe7da",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.dmg",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "505d978a27d0691a7ad8070c005e74bb13862fbb880b75ae924aa4f4558047a0",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1.dmg",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "5a5f12b802a70f9cad196a2089176b7e428cd6c06183b48b87625df12b7b90d0",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.dmg",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "eca0be9cd1d35df6453075dd447c8945d97134b90d1de4313e9b98069d3a39a3",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1.dmg",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,109 +353,109 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "18d45cdde46fdd3fd55685ad9c76d5ad8117d7bb335ee24ed70d881e68fa85db",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.dmg",
-      "build_number": "243.22562.164",
+      "version": "2024.3.1.1",
+      "sha256": "30a6f0cffa15034578bd026a80d3faf4469c2123d319a805cc31bfc59f2097a8",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1.dmg",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "2b00641155946efe3b8b32e6eb08664ad316d90aa2d7cf9c0360b3c9d7849cc4",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.dmg",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "72cf007a2f5505544b821c97b34f61f6195f32beaf3bfd032370ee7f03cb5046",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.1.dmg",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "3edc97c7137fe744715a9073388334b3a8eef84ae9af756a11ebf1a2906a3751",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.dmg",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "d0329b017d21c25426f625c31fb9e193b9dc0be17150675c1010d3bfd27f2ca2",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.1.dmg",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2024.3.2",
-      "sha256": "8ad665e16509e7e3ed32265a2b6c8843bcbd2588f7768eb102c735f2b28b1584",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.2.dmg",
-      "build_number": "243.22562.171"
+      "version": "2024.3.3",
+      "sha256": "55e851ef7dcfde75bc8e81a9650577ffa2b3c1fed4f49c529b5bac766e8e734e",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.3.dmg",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "13d48b50c8f614496045a93ef168f4b2895447b328095934e7a2a32af0510364",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.dmg",
-      "build_number": "243.22562.151"
+      "version": "2024.3.1.1",
+      "sha256": "6762f4987be03eb4d6adccc8b9e093598a86c77d341695792c985d9a35b84703",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1.dmg",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "9ef8ae40734c7d817154a0bb8f418027bdca23c3e9db05d54f698d6027bc4589",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.1.dmg",
-      "build_number": "243.22562.187"
+      "version": "2024.3.2",
+      "sha256": "85ba87fc294d957c3e8efe51633589fd252bc9e6608eb2dbe4b8e5492ef75788",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2.dmg",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "92ef1b0682de2c0aca51bd613fe45dbf4fa6178c33d63f30eda33b68d6a5be93",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.dmg",
-      "build_number": "243.22562.112"
+      "version": "2024.3.1.1",
+      "sha256": "cff8b644670fc36aea9f37cd26dbfc1418177b835dd455beb99b8fa483d68063",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1.dmg",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.dmg",
       "version": "2024.3 EAP",
-      "sha256": "5ab49b342f940f931cbd55feeafaf7b0d3cae64e2ca66f0906c00a57089e5083",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.163.dmg",
-      "build_number": "243.22562.163"
+      "sha256": "0c78b8035497c855aea5666256716778abd46dadf68f51e4f91c0db01f62b280",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371.dmg",
+      "build_number": "243.22562.371"
     }
   },
   "aarch64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://download.jetbrains.com/aqua/aqua-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "67c96db5b29bc355d7d695a78d4bf29d83191aa08008d155050f8d0949a28ef8",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3-aarch64.dmg",
-      "build_number": "243.22562.117"
+      "version": "2024.3.1",
+      "sha256": "ee6ae8231315aff5908d240449be182c9bab58a09ec03bc3afb302b7d7e597d2",
+      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.1-aarch64.dmg",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "a10b9ab9bcffb691d0a3f91c4ffd008ccbda7b628abbdff50f43136cb0689fd5",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.155"
+      "version": "2024.3.1.1",
+      "sha256": "57d7040f197dc1859ab16636bbb7006acc542eb15d1892692e78dc205bae2502",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2024.3.2",
-      "sha256": "aa7776cf0a7c39e1968b28ea3977f381fa63c83854b9e647ac0ec93eb9c10e4b",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.2-aarch64.dmg",
-      "build_number": "243.22562.115"
+      "version": "2024.3.3",
+      "sha256": "56a31779b85e53da711a47bf3a6b801e7dd7565057f5feceb67fa456350f7830",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.3.3-aarch64.dmg",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "2c98c572e2eea113448758e70df5ceaba99291af66f28e10e8bf84d08a2526e2",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.185"
+      "version": "2024.3.1.1",
+      "sha256": "cd2d146b54036d657b68343efb9c5f7cf234353f5ffdc9af85e05f63dbf7777c",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "0463fe8a955c61df0120c4b2b78f82c092f4b8da011d7d439b3862ee53441c91",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.160"
+      "version": "2024.3.1.1",
+      "sha256": "f4ff084d4054f75d3b10110b2abaddecbac30204d80c39dcb7a5925f2278c41a",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -468,18 +468,18 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "ef06b0b1eaf3a4c22dbdfda8d1a2a14a534f7f8d6c48b6fcb26bf2087062266b",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "ea8c050308c46e276055193d882daa6d965f33256a447c05d5ad9f22b54e5d14",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "7c4062bfb48e167eca585dfbce9334749f4f83079f068fb26bd5968d78ec87e3",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.145"
+      "version": "2024.3.1.1",
+      "sha256": "308773c0f5d15754fbdf1bbaf2155e34b8808880afdee55e5ac8bad8d477162d",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,67 +492,67 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "424b8a2efa1ca76ba0608c00bc1b1e4cfbaab1ef94073a6e3248259cbcdaa46c",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.164",
+      "version": "2024.3.1.1",
+      "sha256": "8d9a3251fea4611c8b90d010571965993836ff1738bc55c2c3692f37f6169eed",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "16376ceb0f6cc0be1bbb2705513d9cd1449d150f97b2926e9fb34d51616d0a6e",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "ad894fdd3f56260afde718bf8f8dd342780e5a5ecfdbf3c66772a4e1562376fe",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "43cb744fa5308715f31c83add100fbc4a32b8d5c6fa54992f7984e775e13931b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.180"
+      "version": "2024.3.1.1",
+      "sha256": "b2afcf6bb9a9a2fb6c516815ce08073429ea506f44c7cafa9503c59da310caae",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2024.3.2",
-      "sha256": "8134c06510bdee910620bbf013d3a5bb3f230ddddf4b7340a1a2920c70b346e4",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.2-aarch64.dmg",
-      "build_number": "243.22562.171"
+      "version": "2024.3.3",
+      "sha256": "139f8444b48c89745216616bc7a263259a95105892233651fb08b14cc18953a1",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.3-aarch64.dmg",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "e9642a76c2c174833442de0a8f4249e15045ee9a4d4153aa291bfc262539918e",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.151"
+      "version": "2024.3.1.1",
+      "sha256": "1e96dcbaf0b6d6821de44f394a671780b21e88fbb05a3cf67d90fcfb9dcbc559",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "3e45cbfe48f42aac6be5808c42160dc5d711e258e020824259961cf08db92fb4",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.187"
+      "version": "2024.3.2",
+      "sha256": "2d715c9a4137815a45abcd208121ef5d66f2b89d3f041d5e905e45c487834985",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2-aarch64.dmg",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "1e17aea814f6168d0c0a7c519dada50486c0c09cb8f9b5c58fe3bf8f051a8a14",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.112"
+      "version": "2024.3.1.1",
+      "sha256": "afa44c3603ecdf093ab701b19e6bfc5379a45f27c0df54a507d48c20b7941bb8",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.dmg",
       "version": "2024.3 EAP",
-      "sha256": "29f78599e6896080ca714ad65fd3713afd69a90ecd8d848ddad1c0b42a32aed9",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.163-aarch64.dmg",
-      "build_number": "243.22562.163"
+      "sha256": "9d86ef50b4c6d2a07d236219e9b05c0557241fb017d52ac395719bdb425130f5",
+      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371-aarch64.dmg",
+      "build_number": "243.22562.371"
     }
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -19,16 +19,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip"
       },
       "name": "ideavim"
     },
@@ -37,7 +38,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/631/646610/python-243.22562.145.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/631/654554/python-243.22562.218.zip"
       },
       "name": "python"
     },
@@ -47,7 +48,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/1347/652338/scala-intellij-bin-2024.3.23.zip"
+        "243.22562.145": "https://plugins.jetbrains.com/files/1347/652338/scala-intellij-bin-2024.3.23.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/1347/652338/scala-intellij-bin-2024.3.23.zip"
       },
       "name": "scala"
     },
@@ -70,16 +72,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -102,16 +105,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": null,
-        "243.22562.112": null,
-        "243.22562.115": null,
         "243.22562.145": null,
-        "243.22562.151": null,
-        "243.22562.155": null,
-        "243.22562.164": null,
-        "243.22562.171": null,
-        "243.22562.180": null,
         "243.22562.186": null,
-        "243.22562.187": null
+        "243.22562.213": null,
+        "243.22562.218": null,
+        "243.22562.220": null,
+        "243.22562.222": null,
+        "243.22562.225": null,
+        "243.22562.230": null,
+        "243.22562.233": null,
+        "243.22562.250": null,
+        "243.23654.19": null
       },
       "name": "kotlin"
     },
@@ -134,16 +138,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": "https://plugins.jetbrains.com/files/6981/633889/ini-243.21565.208.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.145": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip"
+        "243.22562.145": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.186": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.213": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/6981/654857/ini-243.23654.19.zip"
       },
       "name": "ini"
     },
@@ -166,16 +171,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -185,8 +191,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
       },
       "name": "symfony-support"
     },
@@ -196,8 +202,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
       },
       "name": "php-annotations"
     },
@@ -215,14 +221,15 @@
       ],
       "builds": {
         "243.21565.199": "https://plugins.jetbrains.com/files/7322/634169/python-ce-243.21565.211.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip"
       },
       "name": "python-community-edition"
     },
@@ -244,17 +251,18 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip",
-        "243.21565.199": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.145": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip"
+        "243.21565.199": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.145": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.186": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.213": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
       },
       "name": "asciidoc"
     },
@@ -276,15 +284,16 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": null,
-        "243.22562.112": null,
-        "243.22562.115": null,
         "243.22562.145": null,
-        "243.22562.151": null,
-        "243.22562.155": null,
-        "243.22562.164": null,
-        "243.22562.171": null,
-        "243.22562.180": null,
-        "243.22562.186": null
+        "243.22562.186": null,
+        "243.22562.213": null,
+        "243.22562.218": null,
+        "243.22562.220": null,
+        "243.22562.222": null,
+        "243.22562.225": null,
+        "243.22562.233": null,
+        "243.22562.250": null,
+        "243.23654.19": null
       },
       "name": "-deprecated-rust"
     },
@@ -306,15 +315,16 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": null,
-        "243.22562.112": null,
-        "243.22562.115": null,
         "243.22562.145": null,
-        "243.22562.151": null,
-        "243.22562.155": null,
-        "243.22562.164": null,
-        "243.22562.171": null,
-        "243.22562.180": null,
-        "243.22562.186": null
+        "243.22562.186": null,
+        "243.22562.213": null,
+        "243.22562.218": null,
+        "243.22562.220": null,
+        "243.22562.222": null,
+        "243.22562.225": null,
+        "243.22562.233": null,
+        "243.22562.250": null,
+        "243.23654.19": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -337,16 +347,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": "https://plugins.jetbrains.com/files/8554/633920/featuresTrainer-243.21565.204.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.145": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip"
+        "243.22562.145": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.186": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.213": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/8554/654851/featuresTrainer-243.23654.19.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -369,16 +380,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip"
       },
       "name": "nixidea"
     },
@@ -388,8 +400,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/9568/646604/go-plugin-243.22562.145.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/9568/646604/go-plugin-243.22562.145.zip"
+        "243.22562.186": "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip"
       },
       "name": "go"
     },
@@ -411,17 +423,18 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip",
-        "243.21565.199": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.145": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip"
+        "243.21565.199": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.145": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.186": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.213": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -444,16 +457,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/11349/653392/aws-toolkit-jetbrains-standalone-3.46-241.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip"
       },
       "name": "aws-toolkit"
     },
@@ -476,16 +490,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
       },
       "name": "vscode-keymap"
     },
@@ -508,16 +523,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -540,16 +556,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -572,16 +589,17 @@
       "builds": {
         "241.19072.1155": null,
         "243.21565.199": "https://plugins.jetbrains.com/files/14004/629971/protoeditor-243.21565.122.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
       },
       "name": "protocol-buffers"
     },
@@ -604,16 +622,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.21565.199": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.112": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.115": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.145": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.151": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.155": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.164": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.171": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.180": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.186": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.187": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "243.22562.213": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.220": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.222": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.225": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.230": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.233": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.22562.250": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.19": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -634,18 +653,19 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.21565.199": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.145": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip"
+        "241.19072.1155": "https://plugins.jetbrains.com/files/17718/654596/github-copilot-intellij-1.5.30-231.zip",
+        "243.21565.199": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.145": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.186": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.213": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip"
       },
       "name": "github-copilot"
     },
@@ -668,16 +688,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -700,16 +721,17 @@
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
         "243.21565.199": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.112": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.115": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.145": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.151": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.164": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.171": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.180": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.186": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
+        "243.22562.213": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.222": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.233": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
       },
       "name": "mermaid"
     },
@@ -720,16 +742,16 @@
         "rust-rover"
       ],
       "builds": {
-        "243.22562.145": "https://plugins.jetbrains.com/files/22407/649101/intellij-rust-243.22562.187.zip",
-        "243.22562.155": "https://plugins.jetbrains.com/files/22407/649101/intellij-rust-243.22562.187.zip",
-        "243.22562.187": "https://plugins.jetbrains.com/files/22407/649101/intellij-rust-243.22562.187.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip",
+        "243.22562.225": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip",
+        "243.22562.230": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip"
       },
       "name": "rust"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip": "sha256-QwguD4ENrL7GxmX+CGEyCPowbAPNpYgntVGAbHxOlyQ=",
-    "https://plugins.jetbrains.com/files/10037/646414/intellij-csv-validator-4.0.1.zip": "sha256-CtBwMIR78LlFcFVc/RScXShIaibyxjFp/weenl+PzK8=",
+    "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
     "https://plugins.jetbrains.com/files/11349/653392/aws-toolkit-jetbrains-standalone-3.46-241.zip": "sha256-oaD/caqrSYNPy579UeswUNKCr6R7Nzj/1ZXLjVY3Q6w=",
     "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip": "sha256-5dTE4THfqFutMNbGe11CvQkPaXWwB/EuxBzlDzbRJ1s=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
@@ -742,15 +764,17 @@
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip": "sha256-uMIrYoZE16X/K96HuDJx8QMh6wUbi4+qSw+HJAq7ukI=",
     "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip": "sha256-ESbvyp66+X2Ko+bol3mk8aLIf8xjG7Qa0vz8k/zYl4A=",
-    "https://plugins.jetbrains.com/files/17718/631741/github-copilot-intellij-1.5.29.7524.zip": "sha256-ljVGVi/i36EnLxzK7IVGiKVF8EyQTeNVCVKBtGlYNmg=",
+    "https://plugins.jetbrains.com/files/17718/654596/github-copilot-intellij-1.5.30-231.zip": "sha256-xrZJBCGPT1s5+fyWsMSEC69vILM+BkKef2wKxzbTCM4=",
+    "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip": "sha256-bWrtG3cE6qAqXiQ4mtgRLutt8XaTqts+kyClDWVcMO4=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip": "sha256-DUiIQYIzYoXmgtBakSLtMB+xxJMaR70Jgg9erySa3wQ=",
     "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
-    "https://plugins.jetbrains.com/files/22407/649101/intellij-rust-243.22562.187.zip": "sha256-9oi0QzKYZ1p62RBdC6n6H1D7+9DWGsuz7NJziJy38jc=",
-    "https://plugins.jetbrains.com/files/631/646610/python-243.22562.145.zip": "sha256-yStRdrh7gtKB56b0qBNfjlFlkLhWKgeULcJtETMnHGw=",
+    "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip": "sha256-80iFSJoUMunKj7iiXxOC2OuoUxYNeTt/E/MMLM5FsDU=",
+    "https://plugins.jetbrains.com/files/631/654554/python-243.22562.218.zip": "sha256-hI+f5TXP6B7LDBmvrRYrDJ/XKYIl7Tjv9gEda3EsU0c=",
     "https://plugins.jetbrains.com/files/6981/633889/ini-243.21565.208.zip": "sha256-CJjUYj3GR9MrNhrejrxJ4reZX/80XQ+gkZffFKd0nhc=",
-    "https://plugins.jetbrains.com/files/6981/648802/ini-243.22562.180.zip": "sha256-1t6E5rVDOOuWmbYsOI21fMx68OA1o2P4EBw9vI2lvMM=",
+    "https://plugins.jetbrains.com/files/6981/654857/ini-243.23654.19.zip": "sha256-w/uvHVEOuP9a2tvvH8XUxiahqMMbTIZuDu3TS/kg920=",
+    "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip": "sha256-kL/A2R8j2JKMU61T/xJahPwKPYmwFCFy55NPSoBh/Xc=",
     "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip": "sha256-kVUEgfEKUupV/qlB4Dpzi5pFHjhVvX74XIPetKtjysM=",
     "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip": "sha256-Qp24juITBXEF5izdzayWq28Ioy4/kgT0qz6snZ0dND0=",
     "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip": "sha256-drNmhJMe+kuY2fcHjY+SQmkACvFk0rVI4vAhyZ/bgLc=",
@@ -758,10 +782,11 @@
     "https://plugins.jetbrains.com/files/7322/634169/python-ce-243.21565.211.zip": "sha256-B+kpVTE2UEplClCyLX0T2r3yf8u8IMwjS3gMYsL3NkM=",
     "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip": "sha256-45UtQRZMtKF6addrrB3A+goeyICMfcZ2FKcJvJSqgg4=",
     "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip": "sha256-oKczkLHAk2bJRNRgToVe0ySEJGF8+P4oWqQ33olwzWw=",
-    "https://plugins.jetbrains.com/files/7391/634204/asciidoctor-intellij-plugin-0.43.3.zip": "sha256-lwUvD2Ehs1kUWGdZFQZILDLIq73rNBm/8yT1rJgKU5g=",
+    "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
     "https://plugins.jetbrains.com/files/8554/633920/featuresTrainer-243.21565.204.zip": "sha256-3MCG1SNEy2Mf9r+nTLcRwJ+rIJRvtO0kYKFNjIan86E=",
-    "https://plugins.jetbrains.com/files/8554/649092/featuresTrainer-243.22562.187.zip": "sha256-dYT0y5eeqcx6ix+fPnpwzi3z+NOB0u7L83gS9S9LiV8=",
+    "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip": "sha256-JugbJM8Lr2kbhP9hdLE3kUStl2vOMUB5wGTwNLxAZd0=",
+    "https://plugins.jetbrains.com/files/8554/654851/featuresTrainer-243.23654.19.zip": "sha256-2z9QMebAjCuddPawPUaFdT2U3CN0YYyDqiP0zDoK7Ig=",
     "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip": "sha256-9GMqs/hSavcw1E4ZJTLDH1lx3HEeQ5NR8BT+Q9pN3io=",
-    "https://plugins.jetbrains.com/files/9568/646604/go-plugin-243.22562.145.zip": "sha256-7UBnL3+belHgt1oNOyD8Oo4CHQPUx0/w6guZxts84ck="
+    "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip": "sha256-dEPywEl/uboDTTv9k8G8sACOrC5HBcMqkxf0CsDmZfg="
   }
 }


### PR DESCRIPTION
Bump jetbrains IDEs to latest:
```
    jetbrains: 2024.3 -> 2024.3.3
    
    jetbrains.aqua: 2024.3 -> 2024.3.1
    jetbrains.clion: 2024.3.1 -> 2024.3.1.1
    jetbrains.datagrip: 2024.3.2 -> 2024.3.3
    jetbrains.dataspell: 2024.3.1 -> 2024.3.1.1
    jetbrains.gateway: 2024.3.1 -> 2024.3.1.1
    jetbrains.idea-community: 2024.3.1 -> 2024.3.1.1
    jetbrains.idea-ultimate: 2024.3.1 -> 2024.3.1.1
    jetbrains.phpstorm: 2024.3.1 -> 2024.3.1.1
    jetbrains.pycharm-community: 2024.3.1 -> 2024.3.1.1
    jetbrains.pycharm-professional: 2024.3.1 -> 2024.3.1.1
    jetbrains.rider: 2024.3.2 -> 2024.3.3
    jetbrains.ruby-mine: 2024.3.1 -> 2024.3.1.1
    jetbrains.rust-rover: 2024.3.1 -> 2024.3.2
    jetbrains.webstorm: 2024.3.1 -> 2024.3.1.1
    jetbrains.writerside: 2024.3 EAP -> 2024.3 EAP
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
