### PR TITLE
home-assistant-custom-components.solis-sensor: 3.7.2 -> 3.8.0 

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
@@ -9,13 +9,13 @@
 buildHomeAssistantComponent rec {
   owner = "hultenvp";
   domain = "solis";
-  version = "3.7.2";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "hultenvp";
     repo = "solis-sensor";
     rev = "v${version}";
-    hash = "sha256-8+KzZCfBYvXO73SrMXLGCUjecxKn49hz0wCXWCUBULU=";
+    hash = "sha256-lExwqJj70iNzjZyTw5udcWx6FB95aqZh7cYtXHWMHK0=";
   };
 
   dependencies = [ aiofiles ];

--- a/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildHomeAssistantComponent,
   aiofiles,
+  nix-update-script,
 }:
 
 buildHomeAssistantComponent rec {
@@ -20,6 +21,8 @@ buildHomeAssistantComponent rec {
   dependencies = [ aiofiles ];
 
   dontCheckManifest = true; # aiofiles version constraint mismatch
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Home Assistant integration for the SolisCloud PV Monitoring portal via SolisCloud API";


### PR DESCRIPTION


## Things done

Bump to latest upstream version ([3.8.0](https://github.com/hultenvp/solis-sensor/releases/tag/v3.8.0) and adds `nix-update-script` so the package can get updated with:

```
nix-shell maintainers/scripts/update.nix --argstr package home-assistant-custom-components.solis-sensor
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
