### PR TITLE
perlPackages.Tirex: fix build with recent mapnik

### DIFF
--- a/pkgs/development/perl-modules/Tirex/default.nix
+++ b/pkgs/development/perl-modules/Tirex/default.nix
@@ -10,6 +10,7 @@
   mapnik,
   boost,
   nix-update-script,
+  pkg-config,
 }:
 
 buildPerlPackage rec {
@@ -30,12 +31,12 @@ buildPerlPackage rec {
       url = "https://github.com/openstreetmap/tirex/commit/5f131231c9c12e88793afba471b150ca8af8d587.patch";
       hash = "sha256-bnL1ZGy8ZNSZuCRbZn59qRVLg3TL0GjFYnhRKroeVO0=";
     })
-    # Support Mapnik >= v4.0.0 (boost:filesystem no longer indirectly linked)
-    # https://github.com/openstreetmap/tirex/pull/59
-    (fetchpatch {
-      url = "https://github.com/openstreetmap/tirex/commit/137903be9b7b35dde4c7010e65faa16bcf6ad476.patch";
-      hash = "sha256-JDqwWVnzExPwLpzv4LbSmGYah956uko+Zdicahua9oQ=";
-    })
+    # Support Mapnik >= v4.0.0 (no more mapnik-config)
+    ./use-pkg-config.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/development/perl-modules/Tirex/use-pkg-config.patch
+++ b/pkgs/development/perl-modules/Tirex/use-pkg-config.patch
@@ -1,0 +1,13 @@
+--- a/backend-mapnik/Makefile
++++ b/backend-mapnik/Makefile
+@@ -1,8 +1,7 @@
+ INSTALLOPTS=-g root -o root
+-CFLAGS += -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+-CXXFLAGS = `mapnik-config --cflags` $(CFLAGS)
++CXXFLAGS += `pkg-config --cflags libmapnik` -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+ CXXFLAGS += -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wold-style-cast
+-LDFLAGS= `mapnik-config --libs --ldflags --dep-libs`
++LDFLAGS += `pkg-config --libs libmapnik` -lboost_filesystem
+
+ backend-mapnik: renderd.o metatilehandler.o networklistener.o networkmessage.o networkrequest.o networkresponse.o debuggable.o requesthandler.o
+        $(CXX) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
Patch is taken from Debian.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).