### PR TITLE
ivyterm: 0-unstable-2024-10-23 > 1.0.0

### DIFF
--- a/pkgs/by-name/iv/ivyterm/package.nix
+++ b/pkgs/by-name/iv/ivyterm/package.nix
@@ -4,27 +4,25 @@
   fetchFromGitHub,
   pkg-config,
   wrapGAppsHook4,
-  cairo,
-  gdk-pixbuf,
-  glib,
-  gtk4,
   libadwaita,
-  pango,
   vte-gtk4,
+  openssl,
+  nix-update-script,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "ivyterm";
-  version = "0-unstable-2024-10-23";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "Tomiyou";
     repo = "ivyterm";
-    rev = "13ee76dfc88bc92807e328991c7a8586a5b13ac7";
-    hash = "sha256-RVHGDgaNYhR/eGTu4bhJvEfd14qFP+u8ApItVc00Bm8=";
+    tag = "v${version}";
+    hash = "sha256-2wOTUJRFtT7lJ8Km7J7qT6CIRi7wZmNAp1UHfrksyss=";
   };
 
-  cargoHash = "sha256-tdaI0diwRjqERmAiuKFhMw4AeqxgMq8YMsZWBjsmd0U=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-SyyXpV4BfXFm5SHsrXHVNXFm8xM1gBv9lBRXuHVN+lQ=";
 
   nativeBuildInputs = [
     pkg-config
@@ -32,18 +30,24 @@ rustPlatform.buildRustPackage {
   ];
 
   buildInputs = [
-    cairo
-    gdk-pixbuf
-    glib
-    gtk4
+    openssl
     libadwaita
-    pango
     vte-gtk4
   ];
+
+  postInstall = ''
+    install -D data/com.tomiyou.ivyTerm.desktop -t $out/share/applications
+    install -D data/com.tomiyou.ivyTerm.svg -t $out/share/icons
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Terminal emulator implemented in gtk4-rs and VTE4";
     homepage = "https://github.com/Tomiyou/ivyterm";
+    changelog = "https://github.com/Tomiyou/ivyterm/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ genga898 ];
     mainProgram = "ivyterm";


### PR DESCRIPTION
ivyterm: 0-unstable-2024-10-23 > 1.0.0

Removed unnecessary or duplicate dependencies, updated to the latest stable version and added the changelog to meta.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
