### PR TITLE
firefox: extend compile flag "--enable-lto=cross" with parameter "full"

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -406,7 +406,7 @@ buildStdenv.mkDerivation {
   ]
   # LTO is done using clang and lld on Linux.
   ++ lib.optionals ltoSupport [
-     "--enable-lto=cross" # Cross-Language LTO
+     "--enable-lto=cross,full" # Cross-Language LTO
      "--enable-linker=lld"
   ]
   ++ lib.optional (isElfhackPlatform stdenv) (enableFeature elfhackSupport "elf-hack")


### PR DESCRIPTION
This fixes a regression in the discord web app. The issue was reported in https://github.com/NixOS/nixpkgs/issues/332540.

The regression was introduced in commit 23d4f834 via an upgrade of the rust compiler from 1.77.2 to 1.78.0. 


## Things done

The fix is based on a comparison between the generated firefox build script generated by  `pkgs/applications/networking/browsers/firefox/common.nix`  and the firefox build script of archlinux found in [their repository](https://gitlab.archlinux.org/archlinux/packaging/packages/firefox/-/blob/1376cddc7e29fe049fd4afc15fc3b7da5e5fc99b/PKGBUILD).

Enabling "full" link time optimization fixed the regression in the discord web app. Further compile flags where not ported from the archlinux build script.



- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Additional Infos
In addition to this PR I've also provided a [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1938634) upstream to firefox.

This is both my first pull request to the nixOS project (or any project of this size) and my first bug report to firefox. In case I've missed something, or you need additional information, please let me know.