### PR TITLE
RFC: Add gcc offloading to GPUs

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -167,6 +167,11 @@ rec {
     config = "avr";
   };
 
+  amdgcn = {
+    config = "amdgcn-amdhsa";
+    libc = "newlib";
+  };
+
   vc4 = {
     config = "vc4-elf";
     libc = "newlib";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -163,6 +163,8 @@ rec {
     msp430   = { bits = 16; significantByte = littleEndian; family = "msp430"; };
     avr      = { bits = 8; family = "avr"; };
 
+    amdgcn   = { bits = 64; significantByte = littleEndian; family = "amdgcn"; };
+
     vc4      = { bits = 32; significantByte = littleEndian; family = "vc4"; };
 
     or1k     = { bits = 32; significantByte = bigEndian; family = "or1k"; };
@@ -338,6 +340,7 @@ rec {
     ghcjs    = { execFormat = unknown; families = { }; };
     genode   = { execFormat = elf;     families = { }; };
     mmixware = { execFormat = unknown; families = { }; };
+    amdhsa   = { execFormat = unknown; families = { }; };
   } // { # aliases
     # 'darwin' is the kernel for all of them. We choose macOS by default.
     darwin = kernels.macos;

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -9,6 +9,8 @@
 
 , enableLTO
 , enableMultilib
+, enableOffload
+, offloadTarget
 , enablePlugin
 , disableGdbPlugin ? !enablePlugin
 , enableShared
@@ -161,6 +163,7 @@ let
       "--without-included-gettext"
       "--with-system-zlib"
       "--enable-static"
+      (lib.optionals enableOffload [ "--enable-offload-targets=amdgcn-amdhsa" ] )
       "--enable-languages=${
         lib.concatStringsSep ","
           (  lib.optional langC        "c"
@@ -208,7 +211,9 @@ let
     ++ import ../common/platform-flags.nix { inherit (stdenv)  targetPlatform; inherit lib; }
     ++ lib.optionals (targetPlatform != hostPlatform) crossConfigureFlags
     ++ lib.optional disableBootstrap' "--disable-bootstrap"
-
+    ++ lib.optionals (offloadTarget == "amdgcn-amdhsa") [
+      "--target=amdgcn-amdhsa" "--enable-as-accelerator-for=x86_64-pc-linux-gnu"
+    ]
     # Platform-specific flags
     ++ lib.optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
     ++ lib.optional targetPlatform.isNetBSD "--disable-libssp" # Provided by libc.

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -85,9 +85,11 @@ let
       # See Note [Windows Exception Handling]
       "--enable-sjlj-exceptions"
       "--with-dwarf2"
-    ] else [
-      (if crossDarwin then "--with-sysroot=${lib.getLib libcCross}/share/sysroot"
-       else                "--with-headers=${lib.getDev libcCross}${libcCross.incdir or "/include"}")
+    ] else (
+      lib.optional crossDarwin "--with-sysroot=${lib.getLib libcCross}/share/sysroot"
+      ++ lib.optional (!crossDarwin && targetPlatform.config != "amdgcn-amdhsa")
+        "--with-sysroot=${lib.getLib libcCross}/share/sysroot"
+      ++ [
       "--enable-__cxa_atexit"
       "--enable-long-long"
       "--enable-threads=${if targetPlatform.isUnix then "posix"
@@ -98,9 +100,10 @@ let
       # libsanitizer requires netrom/netrom.h which is not
       # available in uclibc.
       "--disable-libsanitizer"
-    ] ++ lib.optional (targetPlatform.libc == "newlib" || targetPlatform.libc == "newlib-nano") "--with-newlib"
+    ] ++ lib.optional ((targetPlatform.libc == "newlib" || targetPlatform.libc == "newlib-nano") &&
+            targetPlatform.config != "amdgcn-amdhsa") "--with-newlib"
       ++ lib.optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-    );
+    ));
 
   configureFlags =
     # Basic dependencies
@@ -111,7 +114,7 @@ let
       "--with-mpfr-lib=${mpfr.out}/lib"
       "--with-mpc=${libmpc}"
     ]
-    ++ lib.optionals (!withoutTargetLibc) [
+    ++ lib.optionals (!withoutTargetLibc && targetPlatform.config != "amdgcn-amdhsa") [
       (if libcCross == null
        then (
         # GCC will search for the headers relative to SDKROOT on Darwin, so it will find them in the store.
@@ -161,7 +164,12 @@ let
       "--disable-libstdcxx-pch"
       "--without-included-gettext"
       "--with-system-zlib"
+    ] ++ lib.optionals (targetPlatform.config != "amdgcn-amdhsa") [
       "--enable-static"
+    ] ++ lib.optionals (targetPlatform.config == "amdgcn-amdhsa") [
+      "--disable-sjlj-exceptions"
+      "--disable-libquadmath"
+    ] ++ [
       "--enable-languages=${
         lib.concatStringsSep ","
           (  lib.optional langC        "c"
@@ -210,7 +218,7 @@ let
     ++ lib.optionals (targetPlatform != hostPlatform) crossConfigureFlags
     ++ lib.optional disableBootstrap' "--disable-bootstrap"
     ++ lib.optionals (targetPlatform.config == "amdgcn-amdhsa") [
-      "--target=amdgcn--amdhsa" "--enable-as-accelerator-for=x86_64-pc-linux-gnu"
+      "--target=amdgcn-amdhsa" "--enable-as-accelerator-for=x86_64-unknown-linux-gnu"
     ]
     # Platform-specific flags
     ++ lib.optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -55,7 +55,9 @@ in
   # same for all gcc's
   depsBuildTarget =
     (
-      if hostPlatform == buildPlatform then
+      if (targetPlatform.config == "amdgcn-amdhsa") then
+        [ ]
+      else if hostPlatform == buildPlatform then
         [
           targetPackages.stdenv.cc.bintools # newly-built gcc will be used
         ]
@@ -75,7 +77,7 @@ in
       libmpc
     ]
     ++ optionals (lib.versionAtLeast version "10") [ libxcrypt ]
-    ++ [
+    ++ optionals (targetPlatform.config != "amdgcn-amdhsa") [
       targetPackages.stdenv.cc.bintools # For linking code at run-time
     ]
     ++ optionals (isl != null) [ isl ]

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -34,14 +34,17 @@ let
 
   ## llvm18 fails with gcc <14
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114419
-  llvmAmd = buildPackages.runCommand "${buildPackages.llvm.name}-wrapper" {} ''
-    mkdir -p $out/bin
-    for a in ar nm ranlib; do
-      ln -s ${buildPackages.llvmPackages.llvm}/bin/llvm-$a $out/bin/amdgcn-amdhsa-$a
-    done
-    ln -s ${buildPackages.llvmPackages.llvm}/bin/llvm-mc $out/bin/amdgcn-amdhsa-as
-    ln -s ${buildPackages.llvmPackages.lld}/bin/lld $out/bin/amdgcn-amdhsa-ld
-  '';
+  llvmAmd =
+    let
+      llvm = buildPackages.llvmPackages_19;
+    in buildPackages.runCommand "${llvm.llvm.name}-wrapper" {} ''
+      mkdir -p $out/bin
+      for a in ar nm ranlib; do
+        ln -s ${llvm.llvm}/bin/llvm-$a $out/bin/amdgcn-amdhsa-$a
+      done
+      ln -s ${llvm.llvm}/bin/llvm-mc $out/bin/amdgcn-amdhsa-as
+      ln -s ${llvm.lld}/bin/lld $out/bin/amdgcn-amdhsa-ld
+    '';
 in
 
 {

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -23,7 +23,7 @@ in
           [
             "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
           ]
-          ++ lib.optionals (!withoutTargetLibc) [
+          ++ lib.optionals (!withoutTargetLibc && targetPlatform.config != "amdgcn-amdhsa") [
             "-B${lib.getLib dep}${dep.libdir or "/lib"}"
           ]
         );

--- a/pkgs/development/compilers/gcc/common/strip-attributes.nix
+++ b/pkgs/development/compilers/gcc/common/strip-attributes.nix
@@ -57,7 +57,7 @@
         )
         popd
     ''
-    + lib.optionalString (!langJit) ''
+    + lib.optionalString (!langJit && stdenv.targetPlatform.config != "amdgcn-amdhsa") ''
       ${
         # keep indentation
         ""

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -14,7 +14,6 @@
 , enableShared ? stdenv.targetPlatform.hasSharedLibraries
 , enableLTO ? stdenv.hostPlatform.hasSharedLibraries
 , enableOffload ? false
-, offloadTarget ? ""
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
 , gmp, mpfr, libmpc, gettext, which, patchelf, binutils, newlib
@@ -114,7 +113,6 @@ let
         disableGdbPlugin
         enableLTO
         enableOffload
-        offloadTarget
         enableMultilib
         enablePlugin
         enableShared
@@ -361,7 +359,7 @@ pipe ((callFile ./common/builder.nix {}) ({
   '';
 } // optionalAttrs enableMultilib {
   dontMoveLib64 = true;
-} // optionalAttrs (offloadTarget == "amdgcn-amdhsa") {
+} // optionalAttrs (targetPlatform.config == "amdgcn-amdhsa") {
   newlibSrc = newlib.src;
 }
 ))

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -190,7 +190,7 @@ pipe ((callFile ./common/builder.nix {}) ({
 
   inherit patches;
 
-  outputs = [ "out" "man" "info" ] ++ optional (!langJit) "lib";
+  outputs = [ "out" "man" "info" ] ++ optional (!langJit && targetPlatform.config != "amdgcn-amdhsa") "lib";
 
   setOutputFlags = false;
 

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -13,9 +13,11 @@
 , staticCompiler ? false
 , enableShared ? stdenv.targetPlatform.hasSharedLibraries
 , enableLTO ? stdenv.hostPlatform.hasSharedLibraries
+, enableOffload ? false
+, offloadTarget ? ""
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils, newlib
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , libucontext ? null
@@ -111,6 +113,8 @@ let
         disableBootstrap
         disableGdbPlugin
         enableLTO
+        enableOffload
+        offloadTarget
         enableMultilib
         enablePlugin
         enableShared
@@ -152,6 +156,7 @@ let
         threadsCross
         which
         zlib
+        newlib
       ;
     };
 
@@ -356,6 +361,8 @@ pipe ((callFile ./common/builder.nix {}) ({
   '';
 } // optionalAttrs enableMultilib {
   dontMoveLib64 = true;
+} // optionalAttrs (offloadTarget == "amdgcn-amdhsa") {
+  newlibSrc = newlib.src;
 }
 ))
 ([

--- a/pkgs/development/compilers/llvm/common/common-let.nix
+++ b/pkgs/development/compilers/llvm/common/common-let.nix
@@ -17,6 +17,7 @@ rec {
 
     # See llvm/cmake/config-ix.cmake.
     platforms =
+      ["amdgcn-amdhsa" ]++
       lib.platforms.aarch64 ++
       lib.platforms.arm ++
       lib.platforms.mips ++

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "newlib";
-  version = "4.3.0.20230120";
+  version = "4.4.0.20231231";
 
   src = fetchurl {
     url = "ftp://sourceware.org/pub/newlib/newlib-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-g6Yqma9Z4465sMWO0JLuJNcA//Q6IsA+QzlVET7zUVA=";
+    sha256 = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
   };
 
   patches = lib.optionals nanoizeNewlib [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6122,10 +6122,7 @@ with pkgs;
     enableOffload = true;
   });
 
-  gcc_amd = wrapCC (gcc.cc.override {
-    offloadTarget = "amdgcn-amdhsa";
-    withoutTargetLibc = true;
-  });
+  amdgcc = pkgsCross.amdgcn.buildPackages.gcc;
 
   libgccjit = gcc.cc.override {
     name = "libgccjit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6080,6 +6080,17 @@ with pkgs;
 
   gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
 
+  amdgcc = pkgsCross.amdgcn.buildPackages.gcc_latest.cc.override {
+    langCC = true;
+    # enableLTO = false;
+    # enableMultilib = true;
+    withoutTargetLibc = false;
+    enableShared = false;
+    noSysDirs = false;
+    libcCross = binutilsNoLibc.libc;
+    targetPackages.stdenv.cc.bintools = binutilsNoLibc;
+  };
+
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
   gccWithoutTargetLibc = assert stdenv.targetPlatform != stdenv.hostPlatform; let
@@ -6118,11 +6129,12 @@ with pkgs;
 
   gcc_latest = gcc14;
 
-  gcc_offload = wrapCC (gcc.cc.override {
-    enableOffload = true;
-  });
-
-  amdgcc = pkgsCross.amdgcn.buildPackages.gcc;
+  gcc_offload = wrapCCWith {
+    cc = gcc_latest.cc.override {
+      enableOffload = true;
+    };
+    extraCompilerB = [ amdgcc ];
+  };
 
   libgccjit = gcc.cc.override {
     name = "libgccjit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6118,6 +6118,15 @@ with pkgs;
 
   gcc_latest = gcc14;
 
+  gcc_offload = wrapCC (gcc.cc.override {
+    enableOffload = true;
+  });
+
+  gcc_amd = wrapCC (gcc.cc.override {
+    offloadTarget = "amdgcn-amdhsa";
+    withoutTargetLibc = true;
+  });
+
   libgccjit = gcc.cc.override {
     name = "libgccjit";
     langFortran = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Here is a dirty attempt to bring the "amdgcn-amdhsa" gcc offloading to nixpkgs. It's quite dirty but I wanted to have some 'working' base so we can translate to the structures that will handle this well. I was following the instructions in https://gcc.gnu.org/wiki/Offloading#Examples

Some of the difficulties are:
* The offload compiler needs to use its self-built newlib, by putting newlib source into gcc source tree. That isn't nicely supported today; newlib is meant as a separate derivation.
* I skipped the $lib output directory in gcc for simplicity.
* The stages do not fit well enough to the two compilers required I think.
* All is quite hardcoded to the single goal I had about gcc+amd.
* I used noSysDirs=false becasue the gcc configure/makefiles build a FLAGS_FOR_TARGET ideal for building newlib, and overriding them from our makeFlags destroys that internal mechanism. I think we should have something like a libc name "newlib-in-gcc", additional to uclibc, etc. that made gcc build newlib all in one.

With this I could build a simple "openmp target" example code in the clang page about Offloading: https://clang.llvm.org/docs/OffloadingDesign.html#offloading-example

@Ericson2314 what is your opinion how can we make these things fit? Ideally we would want AMD/NVIDIA offload in gcc, and AMD/NVIDIA/Intel offload in clang.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
