### PR TITLE
[Backport release-24.11]: String fixes

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -133,7 +133,7 @@ llvmPackages.stdenv.mkDerivation rec {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "v(\d\.\d)"
+        "v(\\d\\.\\d)"
       ];
     };
     # Let the user access the chosen uClibc outside the derivation.

--- a/pkgs/applications/science/logic/klee/klee-uclibc.nix
+++ b/pkgs/applications/science/logic/klee/klee-uclibc.nix
@@ -99,7 +99,7 @@ llvmPackages.stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "v(\d\.\d)"
+      "v(\\d\\.\\d)"
     ];
   };
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -719,7 +719,7 @@ rec {
           (name: value:
             {
               inherit value;
-              name = lib.head (builtins.match "${builtins.storeDir}/[${nixHashChars}]+-(.*)\.drv" name);
+              name = lib.head (builtins.match "${builtins.storeDir}/[${nixHashChars}]+-(.*)\\.drv" name);
             })
           derivations;
       # The syntax of output paths differs between outputs named `out`

--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "'^(\d*\.\d*\.\d*)$'"
+        "'^(\\d*\\.\\d*\\.\\d*)$'"
       ];
     };
   };

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -171,7 +171,7 @@ py.pkgs.buildPythonApplication rec {
       # Excludes 1.x versions from the Github tags list
       extraArgs = [
         "--version-regex"
-        "^(2\.(.*))"
+        "^(2\\.(.*))"
       ];
     };
     tests.version = testers.testVersion {

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -63,17 +63,17 @@ stdenv.mkDerivation rec {
         #    https://github.com/NixOS/nixpkgs/issues/214945 discusses this issue.
         #
         # As a temporary fix, we disabled these tests when using clang stdenv
-        lib.optionals stdenv.cc.isClang [ "CIRCT :: Target/ExportSystemC/.*\.mlir" ]
+        lib.optionals stdenv.cc.isClang [ "CIRCT :: Target/ExportSystemC/.*\\.mlir" ]
         # Disable some tests on x86_64-darwin
         ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-darwin") [
           # These test seem to pass on hydra (rosetta) but not on x86_64-darwin machines
-          "CIRCT :: Target/ExportSMTLIB/.*\.mlir"
-          "CIRCT :: circt-bmc/.*\.mlir"
+          "CIRCT :: Target/ExportSMTLIB/.*\\.mlir"
+          "CIRCT :: circt-bmc/.*\\.mlir"
           # These tests were having issues on rosetta
-          "CIRCT :: Dialect/.*/Reduction/.*\.mlir"
-          "CIRCT :: Dialect/SMT/.*\.mlir"
-          "CIRCT :: circt-as-dis/.*\.mlir"
-          "CIRCT :: circt-reduce/.*\.mlir"
+          "CIRCT :: Dialect/.*/Reduction/.*\\.mlir"
+          "CIRCT :: Dialect/SMT/.*\\.mlir"
+          "CIRCT :: circt-as-dis/.*\\.mlir"
+          "CIRCT :: circt-reduce/.*\\.mlir"
           "CIRCT :: circt-test/basic.mlir"
         ];
     in

--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -156,7 +156,7 @@ let
       updateScript = nix-update-script {
         extraArgs = [
           "--version-regex"
-          "rel\.(.*)"
+          "rel\\.(.*)"
         ];
       };
 

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -6,7 +6,7 @@ import ./generic.nix {
   lts = true;
   nixUpdateExtraArgs = [
     "--version-regex"
-    "v(7\.[0-9.]+)"
+    "v(7\\.[0-9.]+)"
     "--override-filename"
     "pkgs/by-name/fo/forgejo/lts.nix"
   ];

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -73,7 +73,7 @@ buildGoModule rec {
 
   passthru = {
     updateScript = nix-update-script {
-      extraArgs = [ "--version-regex" "^v(9\.11\.[0-9]+)$" ];
+      extraArgs = [ "--version-regex" "^v(9\\.11\\.[0-9]+)$" ];
     };
     tests.mattermost = nixosTests.mattermost;
   };

--- a/pkgs/by-name/pk/pkcs11-provider/package.nix
+++ b/pkgs/by-name/pk/pkcs11-provider/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "v(\d\.\d)"
+      "v(\\d\\.\\d)"
     ];
   };
 

--- a/pkgs/by-name/re/renode-unstable/package.nix
+++ b/pkgs/by-name/re/renode-unstable/package.nix
@@ -16,7 +16,7 @@ renode.overrideAttrs (
 
     passthru.updateScript =
       let
-        versionRegex = "[0-9\.\+]+[^\+]*.";
+        versionRegex = "[0-9\\.\\+]+[^\\+]*.";
       in
       writeScript "${finalAttrs.pname}-updater" ''
         #!/usr/bin/env nix-shell

--- a/pkgs/by-name/te/teams/package.nix
+++ b/pkgs/by-name/te/teams/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     zcat < Teams_osx_app.pkg/Payload | cpio -i
   '';
 
-  sourceRoot = "Microsoft\ Teams.app";
+  sourceRoot = "Microsoft\\ Teams.app";
   dontPatch = true;
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/by-name/tu/turbo-unwrapped/package.nix
+++ b/pkgs/by-name/tu/turbo-unwrapped/package.nix
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "'v(\d+\.\d+\.\d+)'"
+        "'v(\\d+\\.\\d+\\.\\d+)'"
       ];
     };
   };

--- a/pkgs/by-name/uu/uuu/package.nix
+++ b/pkgs/by-name/uu/uuu/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "uuu_\([0-9.]+\)"
+      "uuu_\\([0-9.]+\\)"
     ];
   };
 

--- a/pkgs/by-name/vs/vscode-js-debug/package.nix
+++ b/pkgs/by-name/vs/vscode-js-debug/package.nix
@@ -59,7 +59,7 @@ buildNpmPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "v((?!\d{4}\.\d\.\d{3}).*)"
+      "v((?!\\d{4}\\.\\d\\.\\d{3}).*)"
     ];
   };
 

--- a/pkgs/pkgs-lib/formats/hocon/test/comprehensive/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/test/comprehensive/default.nix
@@ -37,7 +37,7 @@ let
         "b"
       ]
     ];
-    nasty_string = "\"@\n\\\t^*\b\f\n\0\";'''$";
+    nasty_string = "\"@\n\\\t^*bf\n0\";'''$";
 
     "misc attrs" = {
       x = 1;

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation {
   );
 
   src = lib.sourceByRegex ./. [
-    ".*\.java"
+    ".*\\.java"
   ];
   # On Linux, this can be C.UTF-8, but darwin + zulu requires en_US.UTF-8
   LANG = "en_US.UTF-8";

--- a/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/test/comprehensive/default.nix
@@ -58,7 +58,7 @@ let
         1
       ])
     ];
-    nasty_string = "\"@\n\\\t^*\b\f\n\0\";'''$";
+    nasty_string = "\"@\n\\\t^*bf\n0\";'''$";
 
     weirderTypes = {
       _includes = [ include_file ];


### PR DESCRIPTION
Backport of #365186

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
