### PR TITLE
zlib: use default configure script on windows

### DIFF
--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-mpOyt9/ax3zrpaVYpYDnRmfdb+3kWFuR7vtg8Dty3yM=";
     };
 
+  patches = [
+    ./mingw-shared.patch
+  ];
+
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace configure \
       --replace '/usr/bin/libtool' '${stdenv.cc.targetPrefix}ar' \
@@ -57,8 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optional splitStaticOutput "static";
   setOutputFlags = false;
   outputDoc = "dev"; # single tiny man3 page
-
-  dontConfigure = stdenv.hostPlatform.isMinGW;
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export CHOST=${stdenv.hostPlatform.config}
@@ -104,7 +106,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Non-typical naming confuses libtool which then refuses to use zlib's DLL
     # in some cases, e.g. when compiling libpng.
     + lib.optionalString (stdenv.hostPlatform.isMinGW && shared) ''
-      ln -s zlib1.dll $out/bin/libz.dll
+      mkdir -p $out/bin
+      mv $out/lib/*.dll* $out/bin
     '';
 
   env =
@@ -113,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
       # to the bootstrap-tools libgcc (as uses to happen on arm/mips)
       NIX_CFLAGS_COMPILE = "-static-libgcc";
     }
-    // lib.optionalAttrs (stdenv.hostPlatform.linker == "lld") {
+    // lib.optionalAttrs (stdenv.hostPlatform.linker == "lld" && !stdenv.hostPlatform.isWindows) {
       # lld 16 enables --no-undefined-version by default
       # This makes configure think it can't build dynamic libraries
       # this may be removed when a version is packaged with https://github.com/madler/zlib/issues/960 fixed
@@ -137,10 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags =
     [
       "PREFIX=${stdenv.cc.targetPrefix}"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isMinGW [
-      "-f"
-      "win32/Makefile.gcc"
     ]
     ++ lib.optionals shared [
       # Note that as of writing (zlib 1.2.11), this flag only has an effect

--- a/pkgs/development/libraries/zlib/mingw-shared.patch
+++ b/pkgs/development/libraries/zlib/mingw-shared.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index c55098a..07f7c08 100755
+--- a/configure
++++ b/configure
+@@ -243,6 +243,8 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
+         echo "If this doesn't work for you, try win32/Makefile.gcc." | tee -a configure.log
+         LDSHARED=${LDSHARED-"$cc -shared"}
+         LDSHAREDLIBC=""
++        shared_ext='.dll'
++        SHAREDLIB='libz.dll'
+         EXE='.exe' ;;
+   QNX*) # This is for QNX6. I suppose that the QNX rule below is for QNX2,QNX4
+         # (alain.bonnefoy@icbt.com)


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/366427

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
