### PR TITLE
gradle: add toolchain paths to gradle.properties

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -91,15 +91,9 @@ rec {
       installPhase =
         with builtins;
         let
-          toolchain = rec {
-            prefix = x: "JAVA_TOOLCHAIN_NIX_${toString x}";
-            varDefs = (lib.imap0 (i: x: "${prefix i} ${x}") javaToolchains);
-            varNames = lib.imap0 (i: x: prefix i) javaToolchains;
-            property = " -Porg.gradle.java.installations.fromEnv='${concatStringsSep "," varNames}'";
-          };
-          varDefs = concatStringsSep "\n" (
-            map (x: "  --set ${x} \\") ([ "JAVA_HOME ${java}" ] ++ toolchain.varDefs)
-          );
+          # set toolchains via installations.path property in gradle.properties.
+          # See https://docs.gradle.org/current/userguide/toolchains.html#sec:custom_loc
+          toolchainPaths = "org.gradle.java.installations.paths=${concatStringsSep "," javaToolchains}";
           jnaLibraryPath = if stdenv.hostPlatform.isLinux then lib.makeLibraryPath [ udev ] else "";
           jnaFlag =
             if stdenv.hostPlatform.isLinux then "--add-flags \"-Djna.library.path=${jnaLibraryPath}\"" else "";
@@ -111,9 +105,11 @@ rec {
           gradle_launcher_jar=$(echo $out/lib/gradle/lib/gradle-launcher-*.jar)
           test -f $gradle_launcher_jar
           makeWrapper ${java}/bin/java $out/bin/gradle \
-            ${varDefs}
+            --set JAVA_HOME ${java} \
             ${jnaFlag} \
-            --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain${toolchain.property}"
+            --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain"
+
+          echo "${toolchainPaths}" > $out/lib/gradle/gradle.properties
         '';
 
       dontFixup = !stdenv.hostPlatform.isLinux;


### PR DESCRIPTION
This way IntelliJ IDEA uses the overridden javaToolchains.

Fix #207153


I ran the package internal tests (`nix-build --attr pkgs.gradle.passthru.tests`) and verified success with IDEA.

```
nix-repl> :b local.pkgs.gradle.override { javaToolchains = [ pkgs.openjdk21 pkgs.openjdk23 ]; }

This derivation produced the following outputs:
  out -> /nix/store/j7b4bki0x0yswanah8l78xgad0c12i8d-gradle-8.10.2
```
the resulting change looks like this:
```
$ cat /nix/store/j7b4bki0x0yswanah8l78xgad0c12i8d-gradle-8.10.2/lib/gradle/gradle.properties 

org.gradle.java.installations.paths=/nix/store/f042x32jfm94d3cgaga8d6xl8vy6sg46-openjdk-21.0.5+11,/nix/store/wkyv98s8q4wqdzpjd34z4hk0lk8fmww5-openjdk-23.0.1+11
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc