### PR TITLE
grow-partition test fixes

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -279,10 +279,9 @@ let
       "legacy+gpt" = ''
         parted --script $diskImage -- \
           mklabel gpt \
-          mkpart no-fs 1MB 2MB \
+          mkpart no-fs 1MiB 2MiB \
           set 1 bios_grub on \
-          align-check optimal 1 \
-          mkpart primary ext4 2MB 100% \
+          mkpart primary ext4 2MiB 100% \
           align-check optimal 2 \
           print
         ${lib.optionalString deterministic ''
@@ -340,7 +339,6 @@ let
           align-check optimal 1 \
           mkpart no-fs 0 1024KiB \
           set 2 bios_grub on \
-          align-check optimal 2 \
           mkpart primary ext4 $bootSizeMiB 100% \
           align-check optimal 3 \
           print
@@ -535,7 +533,7 @@ let
               ''
                 # Add the GPT at the end
                 gptSpace=$(( 512 * 34 * 1 ))
-                # And include the bios_grub partition; the ext4 partition starts at 2MB exactly.
+                # And include the bios_grub partition; the ext4 partition starts at 2MiB exactly.
                 reservedSpace=$(( gptSpace + 2 * mebibyte ))
               ''
             else if partitionTableType == "legacy" then

--- a/nixos/tests/grow-partition.nix
+++ b/nixos/tests/grow-partition.nix
@@ -32,6 +32,9 @@ let
         "/".device = rootFsDevice;
       };
 
+      # Needed for installing bootloader
+      system.switch.enable = true;
+
       system.build.diskImage = import ../lib/make-disk-image.nix {
         inherit config lib pkgs;
         label = rootFslabel;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Handle fallout from https://github.com/NixOS/nixpkgs/pull/356818
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
