### PR TITLE
[staging-next] dev86: unstable-2022-07-19 -> 1.0.1

### DIFF
--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -1,6 +1,7 @@
-{ lib
-, stdenv
-, fetchFromGitea
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,10 +20,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://codeberg.org/jbruchon/dev86";
-    description =
-      "C compiler, assembler and linker environment for the production of 8086 executables";
+    description = "C compiler, assembler and linker environment for the production of 8086 executables";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres sigmasquadron ];
+    maintainers = with lib.maintainers; [
+      AndersonTorres
+      sigmasquadron
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -1,31 +1,24 @@
 { lib
 , stdenv
-, fetchFromGitHub
+, fetchFromGitea
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dev86";
-  version = "unstable-2022-07-19";
+  version = "1.0.1";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "jbruchon";
     repo = "dev86";
-    rev = "f5cd3e5c17a0d3cd8298bac8e30bed6e59c4e57a";
-    hash = "sha256-CWeboFkJkpKHZ/wkuvMj5a+5qB2uzAtoYy8OdyYErMg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xeOtESc0X7RZWCIpNZSHE8au9+opXwnHsAcayYLSX7w=";
   };
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-  # Parallel builds are not supported due to build process structure: tools are
-  # built sequentially in submakefiles and are reusing the same targets as
-  # dependencies. Building dependencies in parallel from different submakes is
-  # not synchronized and fails:
-  #     make[3]: Entering directory '/build/dev86-0.16.21/libc'
-  #     Unable to execute as86.
-  enableParallelBuilding = false;
-
   meta = {
-    homepage = "https://github.com/jbruchon/dev86";
+    homepage = "https://codeberg.org/jbruchon/dev86";
     description =
       "C compiler, assembler and linker environment for the production of 8086 executables";
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
Fixes build with gcc-14.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
