### PR TITLE
thorium: init at 126.0.6478.231

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18496,6 +18496,12 @@
     githubId = 39039420;
     name = "Quinn Dougherty";
   };
+  quinneden = {
+    email = "quinnyxboy@gmail.com";
+    github = "quinneden";
+    githubId = 125415641;
+    name = "Quinn Edenfield";
+  };
   quodlibetor = {
     email = "quodlibetor@gmail.com";
     github = "quodlibetor";

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  fetchurl,
+  undmg,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "thorium";
+  version = "M126.0.6478.231";
+
+  src = fetchurl {
+    url = "https://github.com/Alex313031/Thorium-MacOS/releases/download/M126.0.6478.231/Thorium_MacOS_ARM64.dmg";
+    hash = "sha256-BBqkNbQ7QjCMfU8yQkiRqV3g9ipjco1XKxR7VYVWhig=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    undmg ${src}
+    rm ./Applications
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r ./Thorium.app $out/Applications
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90.";
+    homepage = "https://thorium.rocks/";
+    license = lib.licenses.bsd3;
+    mainProgram = "thorium";
+    maintainers = [ lib.maintainers.quinneden ];
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -24,8 +24,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/Applications
+
+    mkdir -p "$out/Applications"
     cp -r ./Thorium.app $out/Applications
+
+    mkdir -p "$out/bin"
+    ln -sr "$out/Applications/Thorium.app/Contents/MacOS/Thorium" "$out/bin/thorium"
+
     runHook postInstall
   '';
 
@@ -33,9 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90.";
     homepage = "https://thorium.rocks/";
     license = lib.licenses.bsd3;
+    mainProgram = "thorium";
     maintainers = [ lib.maintainers.quinneden ];
     platforms = [ "aarch64-darwin" ]; # Upstream issue with building on x86_64-darwin, latest version only aarch64-darwin currently.
-
     # undmg has a problem reading the dmg file during the unpack phase on systems other than aarch64-darwin.
     # TODO: another way to unpack with this dependency?
     badPlatforms = [

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -33,14 +33,14 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90.";
     homepage = "https://thorium.rocks/";
     license = lib.licenses.bsd3;
-    mainProgram = "thorium";
     maintainers = [ lib.maintainers.quinneden ];
     platforms = [ "aarch64-darwin" ]; # Upstream issue with building on x86_64-darwin, latest version only aarch64-darwin currently.
+
+    # undmg has a problem reading the dmg file during the unpack phase on systems other than aarch64-darwin.
+    # TODO: another way to unpack with this dependency?
     badPlatforms = [
       "aarch64-linux"
       "x86_64-linux"
     ];
-    # undmg has a problem reading the dmg file during the unpack phase on systems other than aarch64-darwin.
-    # TODO: another way to unpack with this dependency?
   };
 })

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -6,10 +6,10 @@
 }:
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "thorium";
-  version = "M126.0.6478.231";
+  version = "126.0.6478.231";
 
   src = fetchurl {
-    url = "https://github.com/Alex313031/Thorium-MacOS/releases/download/M126.0.6478.231/Thorium_MacOS_ARM64.dmg";
+    url = "https://github.com/Alex313031/Thorium-MacOS/releases/download/M${finalAttrs.version}/Thorium_MacOS_ARM64.dmg";
     hash = "sha256-BBqkNbQ7QjCMfU8yQkiRqV3g9ipjco1XKxR7VYVWhig=";
   };
 

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -4,7 +4,7 @@
   undmg,
   lib,
 }:
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "thorium";
   version = "126.0.6478.231";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   unpackPhase = ''
     runHook preUnpack
-    undmg ${src}
+    undmg "$src"
     rm ./Applications
     runHook postUnpack
   '';

--- a/pkgs/by-name/th/thorium/package.nix
+++ b/pkgs/by-name/th/thorium/package.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation (finalAttrs: rec {
     license = lib.licenses.bsd3;
     mainProgram = "thorium";
     maintainers = [ lib.maintainers.quinneden ];
-    platforms = [ "aarch64-darwin" ];
+    platforms = [ "aarch64-darwin" ]; # Upstream issue with building on x86_64-darwin, latest version only aarch64-darwin currently.
+    badPlatforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    # undmg has a problem reading the dmg file during the unpack phase on systems other than aarch64-darwin.
+    # TODO: another way to unpack with this dependency?
   };
 })


### PR DESCRIPTION
Thorium browser for aarch64-darwin. [thorium](https://github.com/Alex313031/thorium) [thorium-macos](https://github.com/Alex313031/Thorium-MacOS)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
