### PR TITLE
config.boot.loader:  Add timestampFormat

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -809,6 +809,7 @@ in
             utillinux = pkgs.util-linux;
             btrfsprogs = pkgs.btrfs-progs;
             inherit (config.system.nixos) distroName;
+            inherit (config.boot.loader) timestampFormat;
             # targets of a replacement in code
             bootPath = null;
             bootRoot = null;

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -541,7 +541,7 @@ sub addGeneration {
 
         my $cfgName = readFile("$link/configuration-name");
 
-        my $date = strftime("%F", localtime(lstat($link)->mtime));
+        my $date = strftime("@timestampFormat@", localtime(lstat($link)->mtime));
         my $version =
             -e "$link/nixos-version"
             ? readFile("$link/nixos-version")
@@ -592,7 +592,7 @@ sub addProfile {
             warn "skipping corrupt system profile entry ‘$link’\n";
             next;
         }
-        my $date = strftime("%F", localtime(lstat($link)->mtime));
+        my $date = strftime("@timestampFormat@", localtime(lstat($link)->mtime));
         my $version =
             -e "$link/nixos-version"
             ? readFile("$link/nixos-version")

--- a/nixos/modules/system/boot/loader/init-script/init-script-builder.sh
+++ b/nixos/modules/system/boot/loader/init-script/init-script-builder.sh
@@ -65,7 +65,7 @@ addEntry "@distroName@ - Default" $defaultConfig ""
 # Add all generations of the system profile to the menu, in reverse
 # (most recent to least recent) order.
 for link in $((ls -d $defaultConfig/specialisation/* ) | sort -n); do
-    date=$(stat --printf="%y\n" $link | sed 's/\..*//')
+    date=$(stat --printf="%y\n" $link | sed 's/\..*//') # FIXME: This seems redundant, variable isn't used
     addEntry "@distroName@ - variation" $link ""
 done
 
@@ -74,7 +74,7 @@ for generation in $(
     | sed 's/system-\([0-9]\+\)-link/\1/' \
     | sort -n -r); do
     link=/nix/var/nix/profiles/system-$generation-link
-    date=$(stat --printf="%y\n" $link | sed 's/\..*//')
+    date=$(date "+@timestampFormat@" -d "@$(stat --printf="%Y\n" $link | sed 's/\..*//')")
     if [ -d $link/kernel ]; then
       kernelVersion=$(cd $(dirname $(readlink -f $link/kernel))/lib/modules && echo *)
       suffix="($date - $kernelVersion)"

--- a/nixos/modules/system/boot/loader/init-script/init-script.nix
+++ b/nixos/modules/system/boot/loader/init-script/init-script.nix
@@ -15,6 +15,7 @@ let
     replacements = {
       inherit (pkgs) bash;
       inherit (config.system.nixos) distroName;
+      inherit (config.boot.loader) timestampFormat;
       path = lib.makeBinPath [
         pkgs.coreutils
         pkgs.gnused

--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -312,7 +312,7 @@ def config_entry(levels: int, bootspec: BootSpec, label: str, time: str) -> str:
 
 
 def generate_config_entry(profile: str, gen: str, special: bool) -> str:
-    time = datetime.datetime.fromtimestamp(os.stat(get_system_path(profile,gen), follow_symlinks=False).st_mtime).strftime("%F %H:%M:%S")
+    time = datetime.datetime.fromtimestamp(os.stat(get_system_path(profile,gen), follow_symlinks=False).st_mtime).strftime("@timestampFormat@")
     boot_json = json.load(open(os.path.join(get_system_path(profile, gen), 'boot.json'), 'r'))
     boot_spec = bootjson_to_bootspec(boot_json)
 

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -397,6 +397,7 @@ in
           replacements = {
             python3 = pkgs.python3.withPackages (python-packages: [ python-packages.psutil ]);
             configPath = limineInstallConfig;
+            inherit (config.boot.loader) timestampFormat;
           };
         };
       };

--- a/nixos/modules/system/boot/loader/loader.nix
+++ b/nixos/modules/system/boot/loader/loader.nix
@@ -8,12 +8,21 @@ with lib;
     (mkRenamedOptionModule [ "boot" "loader" "gummiboot" "timeout" ] [ "boot" "loader" "timeout" ])
   ];
 
-  options = {
-    boot.loader.timeout = mkOption {
+  options.boot.loader = {
+    timeout = mkOption {
       default = 5;
       type = types.nullOr types.int;
       description = ''
         Timeout (in seconds) until loader boots the default menu item. Use null if the loader menu should be displayed indefinitely.
+      '';
+    };
+
+    timestampFormat = mkOption {
+      default = "%F";
+      example = "%F %H:%M";
+      type = types.str;
+      description = ''
+        How to display timestamps in the boot menu, in strftime format. See [the strftime manpage](https://www.man7.org/linux/man-pages/man3/strftime.3.html)
       '';
     };
   };

--- a/nixos/modules/system/boot/loader/refind/refind-install.py
+++ b/nixos/modules/system/boot/loader/refind/refind-install.py
@@ -141,7 +141,7 @@ def config_entry(is_sub: bool, bootspec: BootSpec, label: str, time: str) -> str
 
 
 def generate_config_entry(profile: str, gen: str, special: bool, group_name: str) -> str:
-    time = datetime.datetime.fromtimestamp(os.stat(get_system_path(profile,gen), follow_symlinks=False).st_mtime).strftime("%F %H:%M:%S")
+    time = datetime.datetime.fromtimestamp(os.stat(get_system_path(profile,gen), follow_symlinks=False).st_mtime).strftime("@timestampFormat@")
     boot_json = json.load(open(os.path.join(get_system_path(profile, gen), 'boot.json'), 'r'))
     boot_spec = bootjson_to_bootspec(boot_json)
 

--- a/nixos/modules/system/boot/loader/refind/refind.nix
+++ b/nixos/modules/system/boot/loader/refind/refind.nix
@@ -110,6 +110,7 @@ in
         replacements = {
           python3 = pkgs.python3.withPackages (python-packages: [ python-packages.psutil ]);
           configPath = refindInstallConfig;
+          inherit (config.boot.loader) timestampFormat;
         };
       };
     };

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -20,6 +20,7 @@ BOOT_MOUNT_POINT = Path("@bootMountPoint@")
 LOADER_CONF = EFI_SYS_MOUNT_POINT / "loader/loader.conf"  # Always stored on the ESP
 NIXOS_DIR = Path("@nixosDir@".strip("/")) # Path relative to the XBOOTLDR or ESP mount point
 TIMEOUT = "@timeout@"
+TIMESTAMP_FORMAT = "@timestampFormat@"
 EDITOR = "@editor@" == "1" # noqa: PLR0133
 CONSOLE_MODE = "@consoleMode@"
 BOOTSPEC_TOOLS = "@bootspecTools@"
@@ -205,7 +206,7 @@ def write_entry(profile: str | None, generation: int, specialisation: str | None
 
     kernel_params = kernel_params + " ".join(bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
-    build_date = datetime.datetime.fromtimestamp(build_time).strftime('%F')
+    build_date = datetime.datetime.fromtimestamp(build_time).strftime(TIMESTAMP_FORMAT)
 
     with tmp_path.open("w") as f:
         f.write(BOOT_ENTRY.format(title=title,

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -53,6 +53,8 @@ let
 
       timeout = if config.boot.loader.timeout == null then "menu-force" else config.boot.loader.timeout;
 
+      inherit (config.boot.loader) timestampFormat;
+
       configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
       inherit (cfg)


### PR DESCRIPTION
Adds the option `config.boot.loadertimestampFormat` to change how the build timestamp is displayed in bootloaders, as discussed here <https://www.reddit.com/r/NixOS/comments/17ilg97/anyone_know_how_to_show_the_time_of_configuration/>

This is my first pull request so I'm not sure if it's alright that I skipped some things, like I don't think it needs test (I can't find any existing tests for the modules anyway), and so I need to update the changelog?
Thanks :) 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Add option to `loader`
- Inherit option into params of `substituteAll` in .nix files
- Add template strings to build scripts
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Build settings tested
  - All on UEFI x86_64-linux VM
  - Grub
    - `timestampFormat = "%F %H:%M"`;
    - `timestampFormat` unset;
  - systemd-boot
    - `timestampFormat = "%F %H:%M"`;
    - `timestampFormat` unset;

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
