### PR TITLE
{itk_5_2, python312Packages.itk}: unbreak by disabling RTK cmake module

### DIFF
--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -32,6 +32,7 @@
   zlib,
   Cocoa,
   enablePython ? false,
+  enableRtk ? true,
 }:
 
 let
@@ -129,6 +130,8 @@ stdenv.mkDerivation {
       "-DModule_MGHIO=ON"
       "-DModule_AdaptiveDenoising=ON"
       "-DModule_GenericLabelInterpolator=ON"
+    ]
+    ++ lib.optionals enableRtk [
       "-DModule_RTK=ON"
     ]
     ++ lib.optionals enablePython [
@@ -166,20 +169,23 @@ stdenv.mkDerivation {
   # These deps were propagated from VTK 9 in https://github.com/NixOS/nixpkgs/pull/206935,
   # so we simply propagate them again from ITK.
   # This admittedly is a hack and seems like an issue with VTK 9's CMake configuration.
-  propagatedBuildInputs = [
-    # The dependencies we've un-vendored from ITK, such as GDCM, must be propagated,
-    # otherwise other software built against ITK fails to configure since ITK headers
-    # refer to these previously vendored libraries:
-    expat
-    fftw
-    gdcm
-    hdf5-cpp
-    libjpeg
-    libminc
-    libpng
-    libtiff
-    zlib
-  ] ++ lib.optionals withVtk vtk.propagatedBuildInputs ++ lib.optionals enablePython [ numpy ];
+  propagatedBuildInputs =
+    [
+      # The dependencies we've un-vendored from ITK, such as GDCM, must be propagated,
+      # otherwise other software built against ITK fails to configure since ITK headers
+      # refer to these previously vendored libraries:
+      expat
+      fftw
+      gdcm
+      hdf5-cpp
+      libjpeg
+      libminc
+      libpng
+      libtiff
+      zlib
+    ]
+    ++ lib.optionals withVtk vtk.propagatedBuildInputs
+    ++ lib.optionals enablePython [ numpy ];
 
   postInstall = lib.optionalString enablePython ''
     substitute \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9566,6 +9566,7 @@ with pkgs;
 
   itk_5_2 = callPackage ../development/libraries/itk/5.2.x.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
+    enableRtk = false;
   };
 
   itk_5 = callPackage ../development/libraries/itk/5.x.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6474,6 +6474,7 @@ self: super: with self; {
   itk = toPythonModule (pkgs.itk.override {
     inherit python numpy;
     enablePython = true;
+    enableRtk = false;
   });
 
 


### PR DESCRIPTION
In #353018 the RTK cmake module was enabled in the building of ITK, but unfortunately this broke `itk_5_2` (due to the version of RTK in Nixpkgs being incompatible with older RTK) and `python312Packages.itk`.

RTK is expensive to compile and unlikely to be needed at least for itk_5_2 (which is only in tree in order to build `ezminc` and `mirtk`), so disable for now.

@purepani 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
