### PR TITLE
xfce.xfce4-screensaver: 4.18.3 -> 4.18.4

### DIFF
--- a/nixos/tests/xfce-wayland.nix
+++ b/nixos/tests/xfce-wayland.nix
@@ -23,8 +23,6 @@ import ./make-test-python.nix (
 
         services.xserver.desktopManager.xfce.enable = true;
         services.xserver.desktopManager.xfce.enableWaylandSession = true;
-        # https://gitlab.xfce.org/apps/xfce4-screensaver/-/merge_requests/28
-        services.xserver.desktopManager.xfce.enableScreensaver = false;
         environment.systemPackages = [ pkgs.wlrctl ];
       };
 

--- a/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
@@ -16,6 +16,7 @@
   python3,
   systemd,
   xfconf,
+  xfdesktop,
   lib,
 }:
 
@@ -26,9 +27,9 @@ in
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-screensaver";
-  version = "4.18.3";
+  version = "4.18.4";
 
-  sha256 = "sha256-hOhWJoiKoeRgkhXaR8rnDpcJpStMD4BBdll4nwSA+EQ=";
+  sha256 = "sha256-vkxkryi7JQg1L/JdWnO9qmW6Zx6xP5Urq4kXMe7Iiyc=";
 
   nativeBuildInputs = [
     gobject-introspection
@@ -55,6 +56,11 @@ mkXfceDerivation {
   configureFlags = [ "--without-console-kit" ];
 
   makeFlags = [ "DBUS_SESSION_SERVICE_DIR=$(out)/etc" ];
+
+  preFixup = ''
+    # For default wallpaper.
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${xfdesktop}/share")
+  '';
 
   meta = with lib; {
     description = "Screensaver for Xfce";


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-screensaver/-/compare/xfce4-screensaver-4.18.3...xfce4-screensaver-4.18.4

* This now exits early on Wayland sessions.
* xfdesktop no longer does `xfce_workspace_migrate_backdrop_image` so we need to take care missing last-image.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

