### PR TITLE
Remove PyroLagus as maintainer from packages and list.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18357,12 +18357,6 @@
     github = "pyle";
     githubId = 7279609;
   };
-  pyrolagus = {
-    email = "pyrolagus@gmail.com";
-    github = "PyroLagus";
-    githubId = 4579165;
-    name = "Danny Bautista";
-  };
   pyrotelekinetic = {
     name = "Clover";
     email = "carter@isons.org";

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -144,7 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Infinite-world block sandbox game";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ pyrolagus fpletz fgaz ];
+    maintainers = with maintainers; [ fpletz fgaz ];
     mainProgram = if buildClient then "minetest" else "minetestserver";
   };
 })

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -164,7 +164,6 @@ stdenv.mkDerivation rec {
     homepage = "https://supertuxkart.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      pyrolagus
       peterhoeg
     ];
     platforms = with platforms; unix;


### PR DESCRIPTION
Removed PyroLagus as maintainer from minetest and super-tux-kart, as well as from maintainers list.