### PR TITLE
nixos/jupyter: migrate service to jupyter 7 setup

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -815,6 +815,8 @@
 
 - Kanidm previously had an incorrect systemd service type, causing dependent units with an `after` and `requires` directive to start before `kanidm*` finished startup. The module has now been updated in line with upstream recommendations.
 
+- [`services.jupyter`](#opt-services.jupyter.enable) is now compatible with `Jupyter Notebook 7`. See [the migration guide](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html) for details.
+
 - The kubelet configuration file can now be amended with arbitrary additional content using the `services.kubernetes.kubelet.extraConfig` option.
 
 - The `services.seafile` module was updated to major version 11.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -318,6 +318,8 @@
 
 - GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
+- [`services.jupyter`](#opt-services.jupyter.enable) is now compatible with `Jupyter Notebook 7`. See [the migration guide](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html) for details.
+
 - `networking.wireguard` now has an optional networkd backend. It is enabled by default when `networking.useNetworkd` is enabled, and it can be enabled alongside scripted networking with `networking.wireguard.useNetworkd`. Some `networking.wireguard` options have slightly different behavior with the networkd and script-based backends, documented in each option.
 
 - `services.avahi.ipv6` now defaults to true.

--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -2,13 +2,20 @@
   config,
   lib,
   pkgs,
+  options,
   ...
 }:
 let
 
   cfg = config.services.jupyter;
 
-  package = cfg.package;
+  package = pkgs.python3.withPackages (
+    ps:
+    [
+      cfg.package
+    ]
+    ++ cfg.extraPackages
+  );
 
   kernels = (
     pkgs.jupyter-kernel.create {
@@ -16,15 +23,17 @@ let
     }
   );
 
-  notebookConfig = pkgs.writeText "jupyter_config.py" ''
+  notebookConfig = pkgs.writeText "jupyter_server_config.py" ''
     ${cfg.notebookConfig}
-
-    c.NotebookApp.password = ${cfg.password}
+    c.ServerApp.password = "${cfg.password}"
   '';
 
 in
 {
-  meta.maintainers = with lib.maintainers; [ aborsu ];
+  meta.maintainers = with lib.maintainers; [
+    aborsu
+    b-m-f
+  ];
 
   options.services.jupyter = {
     enable = lib.mkEnableOption "Jupyter development server";
@@ -37,18 +46,42 @@ in
       '';
     };
 
-    # NOTE: We don't use top-level jupyter because we don't
-    # want to pass in JUPYTER_PATH but use .environment instead,
-    # saving a rebuild.
-    package = lib.mkPackageOption pkgs [ "python3" "pkgs" "notebook" ] { };
+    package = lib.mkPackageOption pkgs [
+      "python3"
+      "pkgs"
+      "jupyter"
+    ] { };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          pkgs.python3.pkgs.nbconvert
+          pkgs.python3.pkgs.playwright
+        ]
+      '';
+      description = ''Extra packages to be available in the jupyter runtime enviroment'';
+    };
+    extraEnvironmentVariables = lib.mkOption {
+      description = ''Extra enviroment variables to be set in the runtime context of jupyter notebook'';
+      default = { };
+      example = lib.literalExpression ''
+        {
+          PLAYWRIGHT_BROWSERS_PATH = "''${pkgs.playwright-driver.browsers}";
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+        }
+      '';
+      inherit (options.environment.variables) type apply;
+    };
 
     command = lib.mkOption {
       type = lib.types.str;
-      default = "jupyter-notebook";
-      example = "jupyter-lab";
+      default = "jupyter notebook";
+      example = "jupyter lab";
       description = ''
         Which command the service runs. Note that not all jupyter packages
-        have all commands, e.g. jupyter-lab isn't present in the default package.
+        have all commands, e.g. `jupyter lab` isn't present in the `notebook` package.
       '';
     };
 
@@ -93,16 +126,9 @@ in
       type = lib.types.str;
       description = ''
         Password to use with notebook.
-        Can be generated using:
-          In [1]: from notebook.auth import passwd
-          In [2]: passwd('test')
-          Out[2]: 'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'
-          NOTE: you need to keep the single quote inside the nix string.
-        Or you can use a python oneliner:
-          "open('/path/secret_file', 'r', encoding='utf8').read().strip()"
-        It will be interpreted at the end of the notebookConfig.
+        Can be generated following: https://jupyter-server.readthedocs.io/en/stable/operators/public-server.html#preparing-a-hashed-password
       '';
-      example = "'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'";
+      example = "argon2:$argon2id$v=19$m=10240,t=10,p=8$48hF+vTUuy1LB83/GzNhUg$J1nx4jPWD7PwOJHs5OtDW8pjYK2s0c1R3rYGbSIKB54";
     };
 
     notebookConfig = lib.mkOption {
@@ -110,6 +136,7 @@ in
       default = "";
       description = ''
         Raw jupyter config.
+        Please use the password configuration option to set a password instead of passing it in here.
       '';
     };
 
@@ -175,7 +202,7 @@ in
 
         environment = {
           JUPYTER_PATH = toString kernels;
-        };
+        } // cfg.extraEnvironmentVariables;
 
         serviceConfig = {
           Restart = "always";
@@ -185,7 +212,8 @@ in
                         --ip=${cfg.ip} \
                         --port=${toString cfg.port} --port-retries 0 \
                         --notebook-dir=${cfg.notebookDir} \
-                        --NotebookApp.config_file=${notebookConfig}
+                        --JupyterApp.config_file=${notebookConfig}
+
           '';
           User = cfg.user;
           Group = cfg.group;


### PR DESCRIPTION
The current implementation has problems after the jupyter project introduced changes: https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html

This MR:
- changes the location of the config file for the password setting
- links to the official docs for hashed password generation
- uses `jupyter notebook` command
- allows adding extra packages to the jupyter runtime environment
- allows setting extra environment variables

The last 2 changes come with an example in order to add export to __WebPDF__.

Closes https://github.com/NixOS/nixpkgs/issues/355046

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
