### PR TITLE
workflows/eval: evaluate all systems to completion on failure

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -81,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ attrs, get-merge-commit ]
     strategy:
+      fail-fast: false
       matrix:
         system: ${{ fromJSON(needs.attrs.outputs.systems) }}
     steps:


### PR DESCRIPTION
Failing fast hides system-specific evaluation failures, because all of the currently 4 jobs appear as failed / cancelled.

Example run before this change:
https://github.com/wolfgangwalther/nixpkgs/actions/runs/12445431232

After this change:
https://github.com/wolfgangwalther/nixpkgs/actions/runs/12445515745

Only after this change, I can tell that this failure is darwin-specific.

## Things done

- [x] Tested (see above)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
