### PR TITLE
treewide: replace pythonImportCheck(s) with pythonImportsCheck

### DIFF
--- a/pkgs/development/python-modules/django-cms/default.nix
+++ b/pkgs/development/python-modules/django-cms/default.nix
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     });
   };
 
-  pythonImportCheck = [ "cms" ];
+  pythonImportsCheck = [ "cms" ];
 
   meta = {
     description = "Lean enterprise content management powered by Django";

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -120,7 +120,7 @@ buildPythonPackage rec {
     export PLAYWRIGHT_BROWSERS_PATH="${playwright-driver.browsers}"
   '';
 
-  pythonImportCheck = [ "filingcabinet" ];
+  pythonImportsCheck = [ "filingcabinet" ];
 
   meta = {
     description = "Django app that manages documents with pages, annotations and collections";

--- a/pkgs/development/python-modules/django-json-widget/default.nix
+++ b/pkgs/development/python-modules/django-json-widget/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     export DJANGO_SETTINGS_MODULE=tests.settings
   '';
 
-  pythonImportCheck = [ "django_json_widget" ];
+  pythonImportsCheck = [ "django_json_widget" ];
 
   meta = {
     description = "Alternative widget that makes it easy to edit the jsonfield field of django";

--- a/pkgs/development/python-modules/djangocms-admin-style/default.nix
+++ b/pkgs/development/python-modules/djangocms-admin-style/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     });
   };
 
-  pythonImportCheck = [ "djangocms_admin_style" ];
+  pythonImportsCheck = [ "djangocms_admin_style" ];
 
   meta = {
     description = "Django Theme tailored to the needs of django CMS";

--- a/pkgs/development/python-modules/djangocms-alias/default.nix
+++ b/pkgs/development/python-modules/djangocms-alias/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   # Disable tests because dependency djangocms-versioning isn't packaged yet.
   doCheck = false;
 
-  pythonImportCheck = [ "djangocms_alias" ];
+  pythonImportsCheck = [ "djangocms_alias" ];
 
   meta = {
     description = "Lean enterprise content management powered by Django";

--- a/pkgs/development/python-modules/djangocms-text-ckeditor/default.nix
+++ b/pkgs/development/python-modules/djangocms-text-ckeditor/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   # Tests require module "djangocms-helper" which is not yet packaged
   doCheck = false;
 
-  pythonImportCheck = [ "djangocms_text_ckeditor" ];
+  pythonImportsCheck = [ "djangocms_text_ckeditor" ];
 
   meta = {
     description = "Text Plugin for django CMS using CKEditor 4";

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -126,7 +126,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mpiCheckPhaseHook
   ];
-  pythonImportCheck = [
+  pythonImportsCheck = [
     "meep.mpb"
   ];
   checkPhase = ''

--- a/pkgs/development/python-modules/picologging/default.nix
+++ b/pkgs/development/python-modules/picologging/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     hypothesis
   ];
 
-  pythonImportCheck = [ "picologging" ];
+  pythonImportsCheck = [ "picologging" ];
 
   meta = {
     homepage = "https://github.com/microsoft/picologging";

--- a/pkgs/development/python-modules/pycangjie/default.nix
+++ b/pkgs/development/python-modules/pycangjie/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     sqlite
   ];
 
-  pythonImportCheck = [ "cangjie" ];
+  pythonImportsCheck = [ "cangjie" ];
 
   # `buildPythonApplication` skips checkPhase
   postInstallCheck = ''

--- a/pkgs/development/python-modules/python-poppler/default.nix
+++ b/pkgs/development/python-modules/python-poppler/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportCheck = [ "poppler" ];
+  pythonImportsCheck = [ "poppler" ];
 
   meta = {
     description = "Python binding to poppler-cpp";

--- a/pkgs/development/python-modules/qtile-bonsai/default.nix
+++ b/pkgs/development/python-modules/qtile-bonsai/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     "tests/integration/test_widget.py"
   ];
 
-  pythonImportCheck = [ "qtile_bonsai" ];
+  pythonImportsCheck = [ "qtile_bonsai" ];
 
   meta = {
     changelog = "https://github.com/aravinda0/qtile-bonsai/releases/tag/${version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


Resurgence of #340809


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>chatgpt-retrieval-plugin</li>
    <li>chatgpt-retrieval-plugin.dist</li>
  </ul>
</details>
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>python311Packages.meep</li>
    <li>python311Packages.pycangjie</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 43 packages built:</summary>
  <ul>
    <li>ibus-engines.cangjie</li>
    <li>litestar</li>
    <li>litestar.dist</li>
    <li>python311Packages.django-cms</li>
    <li>python311Packages.django-cms.dist</li>
    <li>python311Packages.django-filingcabinet</li>
    <li>python311Packages.django-filingcabinet.dist</li>
    <li>python311Packages.django-json-widget</li>
    <li>python311Packages.django-json-widget.dist</li>
    <li>python311Packages.djangocms-admin-style</li>
    <li>python311Packages.djangocms-admin-style.dist</li>
    <li>python311Packages.djangocms-alias</li>
    <li>python311Packages.djangocms-alias.dist</li>
    <li>python311Packages.djangocms-text-ckeditor</li>
    <li>python311Packages.djangocms-text-ckeditor.dist</li>
    <li>python311Packages.picologging</li>
    <li>python311Packages.picologging.dist</li>
    <li>python311Packages.python-poppler</li>
    <li>python311Packages.python-poppler.dist</li>
    <li>python311Packages.qtile-bonsai</li>
    <li>python311Packages.qtile-bonsai.dist</li>
    <li>python312Packages.django-cms</li>
    <li>python312Packages.django-cms.dist</li>
    <li>python312Packages.django-filingcabinet</li>
    <li>python312Packages.django-filingcabinet.dist</li>
    <li>python312Packages.django-json-widget</li>
    <li>python312Packages.django-json-widget.dist</li>
    <li>python312Packages.djangocms-admin-style</li>
    <li>python312Packages.djangocms-admin-style.dist</li>
    <li>python312Packages.djangocms-alias</li>
    <li>python312Packages.djangocms-alias.dist</li>
    <li>python312Packages.djangocms-text-ckeditor</li>
    <li>python312Packages.djangocms-text-ckeditor.dist</li>
    <li>python312Packages.meep</li>
    <li>python312Packages.picologging</li>
    <li>python312Packages.picologging.dist</li>
    <li>python312Packages.pycangjie</li>
    <li>python312Packages.python-poppler</li>
    <li>python312Packages.python-poppler.dist</li>
    <li>python312Packages.qtile-bonsai</li>
    <li>python312Packages.qtile-bonsai.dist</li>
    <li>python312Packages.weaviate-client</li>
    <li>python312Packages.weaviate-client.dist</li>
  </ul>
</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
