### PR TITLE
libcef: install more of the prebuilt binaries into the output

### DIFF
--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -93,15 +93,20 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   installPhase = ''
-    mkdir -p $out/lib/ $out/share/cef/
+    mkdir -p $out/lib/ $out/share/cef/ $out/libexec/cef/
     cp libcef_dll_wrapper/libcef_dll_wrapper.a $out/lib/
     cp ../Release/libcef.so $out/lib/
     cp ../Release/libEGL.so $out/lib/
     cp ../Release/libGLESv2.so $out/lib/
+    cp ../Release/libvk_swiftshader.so $out/lib/
+    cp ../Release/libvulkan.so.1 $out/lib/
+    cp ../Release/chrome-sandbox $out/libexec/cef/
     patchelf --set-rpath "${rpath}" $out/lib/libcef.so
     patchelf --set-rpath "${gl_rpath}" $out/lib/libEGL.so
     patchelf --set-rpath "${gl_rpath}" $out/lib/libGLESv2.so
-    cp ../Release/*.bin $out/share/cef/
+    patchelf --set-rpath "${gl_rpath}" $out/lib/libvk_swiftshader.so
+    patchelf --set-rpath "${gl_rpath}" $out/lib/libvulkan.so.1
+    cp ../Release/*.bin ../Release/*.json $out/share/cef/
     cp -r ../Resources/* $out/share/cef/
     cp -r ../include $out/
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The new OBS build system (which we're not using yet, but is required by 31.0.0 cc @jb55 @materusPL @fpletz) expects to find more of the CEF prebuilt binary bits.

I'm sort-of +/- 0 on this. I'm not sure if we should provide these, or replace them with our own built versions (vulkan-loader and swiftshader_vk). We probably do need the `chrome-sandbox` binary, though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
