### PR TITLE
[staging] libajantv2: 16.2-bugfix5 -> 17.1.0

### DIFF
--- a/pkgs/by-name/li/libajantv2/device-info-list.patch
+++ b/pkgs/by-name/li/libajantv2/device-info-list.patch
@@ -1,0 +1,13 @@
+diff --git a/ajantv2/src/ntv2devicescanner.cpp b/ajantv2/src/ntv2devicescanner.cpp
+index 448e48d372..6b46f9f69d 100644
+--- a/ajantv2/src/ntv2devicescanner.cpp
++++ b/ajantv2/src/ntv2devicescanner.cpp
+@@ -137,7 +137,7 @@
+ 		}
+ 	#endif	//	!defined(NTV2_DEPRECATE_16_3)
+ 
+-NTV2DeviceInfoList	GetDeviceInfoList (void)
++NTV2DeviceInfoList	CNTV2DeviceScanner::GetDeviceInfoList (void)
+ {
+ 	AJAAutoLock tmpLock(&sDevInfoListLock);
+ 	return sDevInfoList;

--- a/pkgs/by-name/li/libajantv2/package.nix
+++ b/pkgs/by-name/li/libajantv2/package.nix
@@ -5,21 +5,24 @@
   cmake,
   ninja,
   pkg-config,
+  mbedtls,
+  udev,
 }:
 
-# Warning: We are aware that the upstream changed and there are new releases,
-# this got initally packaged for obs-studio which appears to fail to build even upstream with the new version.
-# https://github.com/NixOS/nixpkgs/pull/296191 / https://github.com/obsproject/obs-studio/pull/10037
 stdenv.mkDerivation rec {
   pname = "libajantv2";
-  version = "16.2-bugfix5";
+  version = "17.1.0";
 
   src = fetchFromGitHub {
     owner = "aja-video";
-    repo = "ntv2";
-    rev = "v${version}";
-    sha256 = "sha256-h5PKWMwqTeI5/EaTWkjYojuvDU0FyMpzIjWB98UOJwc=";
+    repo = "libajantv2";
+    rev = "ntv2_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-n9j98r1E9E0hv5gA8jCg/eQyqGuyU9JlZYm/zlcTQOo=";
   };
+  patches = [
+    ./use-system-mbedtls.patch
+    ./device-info-list.patch
+  ];
 
   outputs = [
     "out"
@@ -31,27 +34,35 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
   ];
+  buildInputs = [
+    mbedtls
+    udev
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "AJANTV2_BUILD_SHARED" true)
+  ];
 
   postInstall = ''
     mkdir -p "$out/lib/pkgconfig"
     cat >"$out/lib/pkgconfig/libajantv2.pc" <<EOF
     prefix=$out
     libdir=\''${prefix}/lib
-    includedir=\''${prefix}/include/ajalibraries
+    includedir=\''${prefix}/include/libajantv2
 
     Name: libajantv2
     Description: Library for controlling AJA NTV2 video devices
     Version: ${version}
     Libs: -L\''${libdir} -lajantv2
-    Cflags: -I\''${includedir} -I\''${includedir}/ajantv2/includes
+    Cflags: -I\''${includedir} -I\''${includedir}/ajantv2/includes -I\''${includedir}/ajantv2/src/lin -DAJALinux -DAJA_LINUX -DAJA_USE_CPLUSPLUS11 -DNDEBUG -DNTV2_USE_CPLUSPLUS11
     EOF
   '';
 
   meta = with lib; {
     description = "AJA NTV2 Open Source Static Libs and Headers for building applications that only wish to statically link against";
-    homepage = "https://github.com/aja-video/ntv2";
+    homepage = "https://github.com/aja-video/libajantv2";
     license = with licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.lukegb ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/li/libajantv2/package.nix
+++ b/pkgs/by-name/li/libajantv2/package.nix
@@ -7,6 +7,7 @@
   pkg-config,
   mbedtls,
   udev,
+  linuxPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -57,6 +58,10 @@ stdenv.mkDerivation rec {
     Cflags: -I\''${includedir} -I\''${includedir}/ajantv2/includes -I\''${includedir}/ajantv2/src/lin -DAJALinux -DAJA_LINUX -DAJA_USE_CPLUSPLUS11 -DNDEBUG -DNTV2_USE_CPLUSPLUS11
     EOF
   '';
+
+  passthru.tests = {
+    inherit (linuxPackages) ajantv2;
+  };
 
   meta = with lib; {
     description = "AJA NTV2 Open Source Static Libs and Headers for building applications that only wish to statically link against";

--- a/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
+++ b/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
@@ -1,0 +1,86 @@
+Commit ID: 1aeee534119a22e717ce3d0e9f62c8791cd825b9
+Change ID: pzyrusopmyvtvnwnruvrltqtpqtzxrpo
+Author: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:16)
+Committer: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:25)
+
+    Use system mbedtls, rather than downloading from a random Git branch...
+
+diff --git a/ajantv2/CMakeLists.txt b/ajantv2/CMakeLists.txt
+index ffa572e9c8..74c23e8e4e 100644
+--- a/ajantv2/CMakeLists.txt
++++ b/ajantv2/CMakeLists.txt
+@@ -52,49 +52,13 @@
+ else()
+     message(STATUS "NTV2 SDK will load signed 3rd-party plugins")
+ 
+-    set(MBEDTLS_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/mbedtls-install)
+-    set(MBEDTLS_INCLUDE_DIR ${MBEDTLS_INSTALL_DIR}/include)
+-    set(MBEDTLS_LIBRARY_DIR ${MBEDTLS_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR})
+-
+-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+-        set(MBEDTLS_LIBRARY ${MBEDTLS_LIBRARY_DIR}/mbedtls.lib)
+-        set(MBEDX509_LIBRARY ${MBEDTLS_LIBRARY_DIR}/mbedx509.lib)
+-        set(MBEDCRYPTO_LIBRARY ${MBEDTLS_LIBRARY_DIR}/mbedcrypto.lib)
+-        set(MBEDTLS_EXTRA_CONFIG_FLAGS
+-                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
+-                "-DMSVC_STATIC_RUNTIME=ON"
+-                "-DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}")
+-    elseif (CMAKE_SYSTEM_NAME MATCHES "^(Linux|Darwin)$")
+-        set(MBEDTLS_LIBRARY ${MBEDTLS_LIBRARY_DIR}/libmbedtls.a)
+-        set(MBEDX509_LIBRARY ${MBEDTLS_LIBRARY_DIR}/libmbedx509.a)
+-        set(MBEDCRYPTO_LIBRARY ${MBEDTLS_LIBRARY_DIR}/libmbedcrypto.a)
+-        set(MBEDTLS_C_FLAGS -fPIC)
+-    endif()
+-
+-    # BUILD_BYPRODUCTS informing CMake where the .a files are located is required to make Ninja build work
+-    ExternalProject_Add(
+-        mbedtls
+-        GIT_REPOSITORY https://github.com/aja-video/mbedtls.git
+-        GIT_TAG fix-win-dll-cmake
+-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${MBEDTLS_INSTALL_DIR}
+-                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-                    -DENABLE_TESTING=OFF 
+-                    -DENABLE_PROGRAMS=OFF
+-                    -DCMAKE_C_FLAGS=${MBEDTLS_C_FLAGS}
+-                    -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+-                    -DUSE_STATIC_MBEDTLS_LIBRARY=ON
+-                    -DUSE_SHARED_MBEDTLS_LIBRARY=OFF
+-                    ${MBEDTLS_EXTRA_CONFIG_FLAGS}
+-        BUILD_ALWAYS TRUE
+-        BUILD_BYPRODUCTS ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY}
+-    )
++    find_package(PkgConfig REQUIRED)
++    pkg_check_modules(MBEDTLS REQUIRED mbedtls mbedcrypto mbedx509)
+ 
+     list(APPEND TARGET_INCLUDE_DIRS
+             ${MBEDTLS_INCLUDE_DIR})
+     list(APPEND MBEDTLS_LINK_LIBS
+-            ${MBEDTLS_LIBRARY}
+-            ${MBEDCRYPTO_LIBRARY}
+-            ${MBEDX509_LIBRARY})
++	    ${MBEDTLS_LIBRARIES})
+ endif()
+ 
+ 
+@@ -668,10 +632,6 @@
+         aja_ntv2_log_build_info()
+ 
+         add_library(${PROJECT_NAME} SHARED ${TARGET_SOURCES})
+-        
+-        if (NOT AJANTV2_DISABLE_PLUGIN_LOAD)
+-            add_dependencies(${PROJECT_NAME} mbedtls)
+-        endif()
+ 
+         target_compile_definitions(${PROJECT_NAME} PUBLIC
+             ${TARGET_COMPILE_DEFS_DYNAMIC}
+@@ -687,10 +647,6 @@
+ 
+         add_library(${PROJECT_NAME} STATIC ${TARGET_SOURCES})
+ 
+-        if (NOT AJANTV2_DISABLE_PLUGIN_LOAD)
+-            add_dependencies(${PROJECT_NAME} mbedtls)
+-        endif()
+-
+         target_compile_definitions(${PROJECT_NAME} PUBLIC
+             ${TARGET_COMPILE_DEFS_STATIC}
+             ${AJANTV2_TARGET_COMPILE_DEFS})

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , meson
 , ninja
@@ -46,6 +47,7 @@
 , flite
 , gsm
 , json-glib
+, ajaSupport ? lib.meta.availableOn stdenv.hostPlatform libajantv2
 , libajantv2
 , libaom
 , libdc1394
@@ -128,6 +130,12 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit (addDriverRunpath) driverLink;
+    })
+    # Add support for newer AJA SDK from next GStreamer release
+    (fetchpatch {
+      url = "https://github.com/GStreamer/gstreamer/commit/d68ac0db571f44cae42b57c876436b3b09df616b.patch";
+      hash = "sha256-ZXwlHzuPT8kUKt5+HkqFH5tzL9l5NusDXImabj4fBbI=";
+      relative = "subprojects/${pname}";
     })
   ];
 
@@ -214,6 +222,8 @@ stdenv.mkDerivation rec {
     libmicrodns
   ] ++ lib.optionals openh264Support [
     openh264
+  ] ++ lib.optionals ajaSupport [
+    libajantv2
   ] ++ lib.optionals (gst-plugins-base.waylandEnabled && stdenv.hostPlatform.isLinux) [
     libva # vaapi requires libva -> libdrm -> libpciaccess, which is Linux-only in nixpkgs
     wayland
@@ -224,7 +234,6 @@ stdenv.mkDerivation rec {
 
     chromaprint
     flite
-    libajantv2
     libdrm
     libgudev
     sbc
@@ -300,7 +309,7 @@ stdenv.mkDerivation rec {
     "-Donnx=disabled" # depends on `libonnxruntime` not packaged in nixpkgs as of writing
     "-Dopenaptx=enabled" # since gstreamer-1.20.1 `libfreeaptx` is supported for circumventing the dubious license conflict with `libopenaptx`
     "-Dopencv=${if opencvSupport then "enabled" else "disabled"}" # Reduces rebuild size when `config.cudaSupport = true`
-    "-Daja=disabled" # should pass libajantv2 via aja-sdk-dir instead
+    "-Daja=${if ajaSupport then "enabled" else "disabled"}"
     "-Dmicrodns=${if microdnsSupport then "enabled" else "disabled"}"
     "-Dbluez=${if bluezSupport then "enabled" else "disabled"}"
     (lib.mesonEnable "openh264" openh264Support)

--- a/pkgs/os-specific/linux/ajantv2/default.nix
+++ b/pkgs/os-specific/linux/ajantv2/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  libajantv2,
+}:
+stdenv.mkDerivation {
+  name = "ajantv2-module-${libajantv2.version}-${kernel.version}";
+
+  inherit (libajantv2) src;
+  sourceRoot = "source/driver/linux";
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    chmod -R +w ../../
+  '';
+
+  enableParallelBuilding = true;
+
+  buildFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D ajantv2.ko $out/lib/modules/${kernel.modDirVersion}/misc/ajantv2.ko
+    install -D ajardma.ko $out/lib/modules/${kernel.modDirVersion}/misc/ajardma.ko
+  '';
+
+  meta = {
+    inherit (libajantv2.meta) license homepage maintainers;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    description = "AJA video driver";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -322,6 +322,8 @@ in {
 
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
+    ajantv2 = callPackage ../os-specific/linux/ajantv2 { };
+
     akvcam = callPackage ../os-specific/linux/akvcam { };
 
     amneziawg = callPackage ../os-specific/linux/amneziawg { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Updates libajantv2 to the new repository and packaging scheme, including some bugfixes exposed by use in OBS - the changes to allow OBS to use this aren't included in this PR
* Add the kernel driver, which is required to do anything useful with the library

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
