### PR TITLE
aja-desktop-software: init at 17.1.3

### DIFF
--- a/pkgs/by-name/aj/aja-desktop-software/package.nix
+++ b/pkgs/by-name/aj/aja-desktop-software/package.nix
@@ -1,0 +1,126 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  dpkg,
+  patchelf,
+  buildFHSEnv,
+  writeShellScript,
+  makeBinaryWrapper,
+}:
+
+let
+  pname = "aja-desktop-software";
+  version = "17.1.3";
+  meta = {
+    description = "Graphical utilities for interacting with AJA desktop video cards";
+    homepage = "https://www.aja.com/products/aja-control-room";
+    license = lib.licenses.unfree; # https://www.aja.com/software-license-agreement
+    maintainers = [ lib.maintainers.lukegb ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [
+      lib.sourceTypes.binaryNativeCode
+      lib.sourceTypes.binaryFirmware
+    ];
+  };
+
+  unwrapped = stdenvNoCC.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version;
+
+    src = fetchzip {
+      url = "https://www.aja.com/assets/support/files/9895/en/AJA-Desktop-Software-Installer_Linux-Ubuntu_v${version}_Release.zip";
+      hash = "sha256-TxDcYIhEcpPnpoqpey5vSvUltLT/3xwBfOhAP81Q9+E=";
+    };
+
+    unpackCmd = "dpkg -x $curSrc/ajaretail_*.deb source";
+
+    nativeBuildInputs = [
+      dpkg
+      patchelf
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      mv usr/share/applications $out/share/applications
+      mv usr/share/doc $out/share/doc
+
+      mv etc $out/etc
+
+      mv opt $out/opt
+
+      ln -s $out/opt/aja/bin $out/bin
+
+      # For some reason ajanmos doesn't have /opt/aja/lib in its rpath...
+      patchelf $out/opt/aja/bin/ajanmos --add-rpath $out/opt/aja/lib
+
+      runHook postInstall
+    '';
+
+    dontPatchELF = true;
+
+    inherit meta;
+  };
+in
+buildFHSEnv {
+  inherit pname version;
+
+  targetPkgs =
+    pkgs:
+    [ unwrapped ]
+    ++ (with pkgs; [
+      ocl-icd
+      libGL
+      udev
+      libpulseaudio
+      zstd
+      glib
+      fontconfig
+      freetype
+      xorg.libxcb
+      xorg.libX11
+      xorg.xcbutilwm
+      xorg.xcbutilimage
+      xorg.xcbutilkeysyms
+      xorg.xcbutilrenderutil
+      xorg.libSM
+      xorg.libICE
+      libxkbcommon
+      dbus
+      avahi
+    ]);
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  unshareIpc = false;
+  unsharePid = false;
+
+  runScript = writeShellScript "aja" ''
+    exec_binary="$1"
+    shift
+    export QT_PLUGIN_PATH="${unwrapped}/opt/aja/plugins"
+    exec "${unwrapped}/opt/aja/bin/$exec_binary" "$@"
+  '';
+
+  extraInstallCommands = ''
+    mkdir -p $out/libexec/aja-desktop
+    mv $out/bin/${pname} $out/libexec/aja-desktop/${pname}
+
+    for binary in controlpanel controlroom ajanmos systemtest; do
+      makeWrapper "$out/libexec/aja-desktop/${pname}" "$out/bin/aja-$binary" \
+        --add-flags "$binary"
+    done
+  '';
+
+  passthru = {
+    inherit unwrapped;
+  };
+
+  meta = meta // {
+    mainProgram = "aja-controlpanel";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduces the aja-desktop-software package, which rolls up various AJA utilities for interacting with their video cards (Control Panel, Control Room, NMOS, and their system test utility).

This deliberately renames them, since by default they get slightly unfriendly names for being installed system-wide, so an aja- prefix is added. They're wrapped in an FHS env because it's easier that way: they expect to find various things, like firmware files, installed at /opt/aja/..., and patching that would be challenging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
