### PR TITLE
various: fix hostPlatform.canExecute buildPlatform

### DIFF
--- a/pkgs/by-name/li/libnvme/package.nix
+++ b/pkgs/by-name/li/libnvme/package.nix
@@ -14,7 +14,7 @@
   swig,
   systemd,
   # ImportError: cannot import name 'mlog' from 'mesonbuild'
-  withDocs ? stdenv.hostPlatform.canExecute stdenv.buildPlatform,
+  withDocs ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/re/repgrep/package.nix
+++ b/pkgs/by-name/re/repgrep/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
       installManPage rgr.1
       popd
     ''
-    + lib.optionalString (stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       # As it can be seen here: https://github.com/acheronfail/repgrep/blob/0.15.0/.github/workflows/release.yml#L206, the completions are just the same as ripgrep
       installShellCompletion --cmd rgr \
         --bash <(${lib.getExe ripgrep} --generate complete-bash | sed 's/-c rg/-c rgr/') \

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -251,7 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
           ${freefont_ttf}/share/fonts/truetype
     ''
     # Upstream luac can't cross compile, so we have to install the lua sources
-    # instead of bytecode:
+    # instead of bytecode, which was built for buildPlatform:
     # https://www.lua.org/wshop13/Jericke.pdf#page=39
     + lib.optionalString (!stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
       substituteInPlace share/Makefile.am \

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -407,6 +407,9 @@ let
         # resulting LLVM IR isn't platform-independent this doesn't give you much.
         # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
         # a query, postgres would coredump with `Illegal instruction`.
+        #
+        # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
+        # to do JIT at **runtime**.
         broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
       };
     });


### PR DESCRIPTION
It doesn't matter whether the hostPlatform could execute stuff from the buildPlatform - we need it the other way around: Certain things during a build process can only happen when, as part of the build, the **buildPlatform** can execute the code it just created for the **hostPlatform**.

Unless we are talking about compilation at run-time, as in the case of PostgreSQL. Extend the comment there to make it clear that this is on purpose.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
