### PR TITLE
qt6: don't treat absolute paths without known suffix as library

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -228,6 +228,11 @@ stdenv.mkDerivation rec {
     ./qmlimportscanner-import-path.patch
     # don't pass qtbase's QML directory to qmlimportscanner if it's empty
     ./skip-missing-qml-directory.patch
+
+    # Qt treats linker flags without known suffix as libraries since 6.7.2 (see qt/qtbase commit ea0f00d).
+    # Don't do this for absolute paths (like `/nix/store/…/QtMultimedia.framework/Versions/A/QtMultimedia`).
+    # Upcoming upstream fix: https://codereview.qt-project.org/c/qt/qtbase/+/613683.
+    ./dont-treat-abspaths-without-suffix-as-libraries.patch
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/development/libraries/qt-6/modules/qtbase/dont-treat-abspaths-without-suffix-as-libraries.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/dont-treat-abspaths-without-suffix-as-libraries.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/QtGenerateLibHelpers.cmake b/cmake/QtGenerateLibHelpers.cmake
+index 96675267d2..c9d4a69497 100644
+--- a/cmake/QtGenerateLibHelpers.cmake
++++ b/cmake/QtGenerateLibHelpers.cmake
+@@ -10,7 +10,7 @@ function(qt_get_library_name_without_prefix_and_suffix out_var file_path)
+     if(NOT file_path MATCHES "^-") # not a linker flag
+         get_filename_component(basename "${file_path}" NAME_WE)
+         get_filename_component(ext "${file_path}" EXT)
+-        if(NOT ext) # seems like a library name without prefix and suffix
++        if(NOT ext AND NOT IS_ABSOLUTE "${file_path}")
+             # seems like a library name without prefix and suffix
+             set(${out_var} "${file_path}" PARENT_SCOPE)
+             return()
+         endif()


### PR DESCRIPTION
Fixes issue #366069 (broken sioyek darwin build) by adapting an upstream change when Qt was updated from 6.7.2 to 6.7.3 in PR #344928. Might fix other similar issues (e.g., for packages depending on `qt6.qtspeech`).

I submitted [the same fix upstream](https://codereview.qt-project.org/c/qt/qtbase/+/613683) which has been accepted and is currently in the staging/integration phase.

## Details

(Note: Take the following with a grain of salt, as I've not much experience with cmake/qmake/Qt.)

[This upstream commit](https://github.com/qt/qtbase/commit/ea0f00d5d47db9ac242c914dd479bebf6737f22b) changed how Qt treats linker flags without a suffix (like `.so`) when generating `.pri`/`.prl` files. Until 6.7.2, a linker flag like `ws2_32` was left untouched. The above commit changed it such that such flags are converted to `-lws2_32` (seemingly in order to better support FFmpeg, according to the commit message).

Now, nixpkgs on darwin links some libraries, like `QtMultimedia` via framwork paths like `/nix/store/wmm6s68wk9ygg84ibzdf95yp22lcg4ay-qtmultimedia-6.7.3/lib/QtMultimedia.framework/Versions/A/QtMultimedia`. As long as these are part of the current build dir or of Qt's `$prefix/lib` dir, they [are recognized as frameworks](https://github.com/qt/qtbase/blob/b839e9b36db3a4e50dfb34521d8ef8de1fd01969/cmake/QtFinishPrlFile.cmake#L48-L53) and handled accordingly. This works, e.g., for something like `/nix/store/rdjd1nqlr1ncr4616dcyqdf6ymqy82xc-qtbase-6.7.3/lib/QtGui.framework/Versions/A/QtGui` since it is part of `qt6.qtbase`.

However, QtMultimedia is not part of `qt6.qtbase`, so `/nix/store/wmm6s68wk9ygg84ibzdf95yp22lcg4ay-qtmultimedia-6.7.3/lib/QtMultimedia.framework/Versions/A/QtMultimedia` is not recognized as a framework path and, instead, treated like a [non-Qt library](https://github.com/qt/qtbase/blob/b839e9b36db3a4e50dfb34521d8ef8de1fd01969/cmake/QtFinishPrlFile.cmake#L54-L61). Now, before the [above mentioned upstream commit](https://github.com/qt/qtbase/commit/ea0f00d5d47db9ac242c914dd479bebf6737f22b), the linker flag was handed over to `clang++` unchanged. After the upstream commit, it is transformed into `-l/nix/store/wmm6s68wk9ygg84ibzdf95yp22lcg4ay-qtmultimedia-6.7.3/lib/QtMultimedia.framework/Versions/A/QtMultimedia`, which causes a linker error since it's not a valid linker flag (the file is a dylib).

This commit adds a patch that slightly adapts the [upstream commit](https://github.com/qt/qtbase/commit/ea0f00d5d47db9ac242c914dd479bebf6737f22b). Namely, it only prepends flags without a suffix (like `ws2_32`) with an `-l` if they are not given as an absolute path.

## Additional Remarks

WIth this fix, the generated `prl` files look again exactly as before the update from Qt 6.7.2 to 6.7.3 and linking of packages like sioyek works again. However, I'm not sure whether this is actually the correct way to fix the issue.

It seems to me that instead of handing `/nix/store/wmm6s68wk9ygg84ibzdf95yp22lcg4ay-qtmultimedia-6.7.3/lib/QtMultimedia.framework/Versions/A/QtMultimedia` through to `clang++`, it should be converted into `-framework QtMultimedia` (with a suitable `-F …` flag). In fact,  somehow these flags do end up in the actual linker command, not sure how though (maybe due to the recent Apple SDK improvements?). ~~Also, I am surprised that `clang++` does not choke on getting simply a directory as an argument.~~ I misinterpreted the output path, `/nix/store/wmm6s68wk9ygg84ibzdf95yp22lcg4ay-qtmultimedia-6.7.3/lib/QtMultimedia.framework/Versions/A/QtMultimedia` is actually a dylib file. So the absolute path makes sense for linking. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Pinging Maintainers etc.

* @K900 (as they created the PR that updated Qt from 6.7.2 to 6.7.3 and probably know they're way around Qt)
* @milahu, @NickCao, @LunNova (qt6.qtbase maintainers)
* @b-fein (as the creator of the sioyek issue #366069)
* @podocarp, @stephen-huan, @xyven1 (sioyek maintainers)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
