### PR TITLE
ocamlPackages.ocamlformat-mlx: init at 0.26.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlformat-mlx/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat-mlx/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  cmdliner,
+  odoc,
+  ocamlformat-mlx-lib,
+  re,
+}:
+buildDunePackage rec {
+  pname = "ocamlformat-mlx";
+  minimalOcamlVersion = "4.08";
+
+  inherit (ocamlformat-mlx-lib) version src meta;
+
+  buildInputs = [
+    cmdliner
+    re
+    odoc
+    ocamlformat-mlx-lib
+  ];
+}

--- a/pkgs/development/ocaml-modules/ocamlformat-mlx/lib.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat-mlx/lib.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  menhir,
+  alcotest,
+  base,
+  dune-build-info,
+  either,
+  fix,
+  fpath,
+  menhirLib,
+  menhirSdk,
+  ocaml-version,
+  ocamlformat-rpc-lib,
+  ocp-indent,
+  stdio,
+  uuseg,
+  csexp,
+  astring,
+  result,
+  camlp-streams,
+  odoc,
+}:
+buildDunePackage rec {
+  pname = "ocamlformat-mlx-lib";
+  version = "0.26.2.0";
+  minimalOcamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-mlx";
+    repo = "ocamlformat-mlx";
+    rev = version;
+    hash = "sha256-I9ZP8Ory/CRFbHUCe5NkZKKYMwtL1gl8xw965k5R718=";
+  };
+
+  propagatedBuildInputs = [
+    alcotest
+    base
+    dune-build-info
+    either
+    fix
+    fpath
+    menhirLib
+    menhirSdk
+    ocaml-version
+    ocamlformat-rpc-lib
+    ocp-indent
+    stdio
+    uuseg
+    csexp
+    astring
+    result
+    camlp-streams
+    odoc
+  ];
+
+  nativeBuildInputs = [
+    menhir
+  ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-mlx/ocamlformat-mlx";
+    description = "OCaml .mlx Code Formatter";
+    maintainers = with lib.maintainers; [
+      Denommus
+    ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1349,7 +1349,7 @@ let
 
     ocamlformat-lib = callPackage ../development/ocaml-modules/ocamlformat/ocamlformat-lib.nix { };
 
-    ocamlformat-mlx = callPackage ../development/ocaml-modules/ocamlformat-mlx/ocamlformat-mlx.nix { };
+    ocamlformat-mlx = callPackage ../development/ocaml-modules/ocamlformat-mlx { };
 
     ocamlformat-mlx-lib = callPackage ../development/ocaml-modules/ocamlformat-mlx/lib.nix { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1349,6 +1349,10 @@ let
 
     ocamlformat-lib = callPackage ../development/ocaml-modules/ocamlformat/ocamlformat-lib.nix { };
 
+    ocamlformat-mlx = callPackage ../development/ocaml-modules/ocamlformat-mlx/ocamlformat-mlx.nix { };
+
+    ocamlformat-mlx-lib = callPackage ../development/ocaml-modules/ocamlformat-mlx/lib.nix { };
+
     ocamlformat-rpc-lib = callPackage ../development/ocaml-modules/ocamlformat/ocamlformat-rpc-lib.nix { };
 
     ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };


### PR DESCRIPTION
ocamlformat-mlx is a fork of ocamlformat to format .mlx files (OCaml files with jsx-like syntax). I'm doing it in a different directory from ocamlformat altogether because it has both a different versioning system and a different src from ocamlformat, so I didn't see a reason to try to adapt it to the `generic.nix` file in ocamlformat.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
