### PR TITLE
archivemount: 1 -> 1a

### DIFF
--- a/pkgs/by-name/ar/archivemount/package.nix
+++ b/pkgs/by-name/ar/archivemount/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromSourcehut,
-  fetchpatch,
   pkg-config,
   fuse,
   libarchive,
@@ -10,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "archivemount";
-  version = "1";
+  version = "1a";
 
   src = fetchFromSourcehut {
     owner = "~nabijaczleweli";
     repo = "archivemount-ng";
     rev = finalAttrs.version;
-    hash = "sha256-xuLtbqC9iS86BKz4jG8of4id+GTlBXoohONrkmIzOpY=";
+    hash = "sha256-XfWs8+vYCa9G9aPtXk/s5YYq/CHNOS7XDrGW7WpSWBQ=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -32,16 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
 
-  # Fix missing standard struct stat on Darwin
-  # Already on upstream, but no new release made
-  patches = [
-    (fetchpatch {
-      name = "fix-missing-standard-struct-stat-on-darwin.patch";
-      url = "https://git.sr.ht/~nabijaczleweli/archivemount-ng/commit/53dd70f05fdb6ababe7c1ca70f0f62bcf4930b5a.patch";
-      hash = "sha256-UqoALAJoNXihop6Mem4mu+W8REOV92Zyv7pPW20Ugz8=";
-    })
-  ];
-
   # Fix cross-compilation
   postPatch = ''
     substituteInPlace Makefile --replace-fail pkg-config "$PKG_CONFIG"
@@ -49,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";
+    changelog = "https://git.sr.ht/~nabijaczleweli/archivemount-ng/refs/${finalAttrs.version}";
     mainProgram = "archivemount";
     license = [
       lib.licenses.lgpl2Plus


### PR DESCRIPTION
Update `archivemount` to its latest released version, 1a.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
