### PR TITLE
vendor-reset: fix build on Linux 6.12

### DIFF
--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -17,6 +17,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-Klu2uysbF5tH7SqVl815DwR7W+Vx6PyVDDLwoMZiqBI=";
   };
 
+  patches = [
+    # This is a temporary, vendored version of this upstream PR:
+    # https://github.com/gnif/vendor-reset/pull/86
+    # As soon as it is merged, we should be able to update this
+    # module and remove the patch.
+    ./fix-linux-6.12-build.patch
+  ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/vendor-reset/fix-linux-6.12-build.patch
+++ b/pkgs/os-specific/linux/vendor-reset/fix-linux-6.12-build.patch
@@ -1,0 +1,56 @@
+From ab1b34848097587aca1f248958358ddb1dc90917 Mon Sep 17 00:00:00 2001
+From: mfrischknecht <manuel.frischknecht@gmail.com>
+Date: Sat, 23 Nov 2024 23:43:53 +0100
+Subject: [PATCH 1/2] Import `unaligned.h` from `linux`
+
+`asm/unaligned.h` has been moved to `linux/unaligned.h` since Linux v. 6.12.
+C.f. e.g. https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576
+---
+ src/amd/amdgpu/atom.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/amd/amdgpu/atom.c b/src/amd/amdgpu/atom.c
+index 333961f..d14c849 100644
+--- a/src/amd/amdgpu/atom.c
++++ b/src/amd/amdgpu/atom.c
+@@ -29,7 +29,7 @@
+ #include <linux/slab.h>
+ #include <linux/delay.h>
+ #include <linux/version.h>
+-#include <asm/unaligned.h>
++#include <linux/unaligned.h>
+ 
+ //#include <drm/drm_util.h>
+ //#include <drm/drm_print.h>
+
+From 54ffd6a012e7567b0288bc5fcc3678b545bd5aec Mon Sep 17 00:00:00 2001
+From: mfrischknecht <manuel.frischknecht@gmail.com>
+Date: Wed, 27 Nov 2024 07:09:37 +0100
+Subject: [PATCH 2/2] Make new include path conditional
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+…so the module builds for both kernels below 6.12 and above. Thanks, @VoodaGod!
+
+Co-authored-by: Jason Rensburger <l33tjas.0n@gmail.com>
+---
+ src/amd/amdgpu/atom.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/amd/amdgpu/atom.c b/src/amd/amdgpu/atom.c
+index d14c849..36d45ff 100644
+--- a/src/amd/amdgpu/atom.c
++++ b/src/amd/amdgpu/atom.c
+@@ -29,7 +29,11 @@
+ #include <linux/slab.h>
+ #include <linux/delay.h>
+ #include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++#include <asm/unaligned.h>
++#else
+ #include <linux/unaligned.h>
++#endif
+ 
+ //#include <drm/drm_util.h>
+ //#include <drm/drm_print.h>


### PR DESCRIPTION
`asm/unaligned.h` has been moved to `linux/unaligned.h` since Linux v. 6.12 [^1]. This has broken the build for `vendor-reset` on newer versions.

I've opened a PR with the upstream project [^2], but that has been sitting unmerged on GitHub for a while now, so I decided to add the fix temporarily using `fetchpatch` in the NixOS module for now. When it will (hopefully) eventually be merged, we should be able to remove the patch and just switch to an up-to-date upstream version.

[^1]: https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576
[^2]: https://github.com/gnif/vendor-reset/pull/86


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
