### PR TITLE
newlib: add installation of libgloss for embedded targets

### DIFF
--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
       (
         cd $out${finalAttrs.passthru.libdir}
 
-        for f in librdimon.a libc.a libg.a; do
+        for f in librdimon.a libc.a libm.a libg.a libgloss.a; do
           # Some libraries are only available for specific architectures.
           # For example, librdimon.a is only available on ARM.
           [ -f "$f" ] && cp "$f" "''${f%%\.a}_nano.a"


### PR DESCRIPTION
I was trying to get an embedded RISC-V toolchain working, by following pretty much a documented workflow:

```
pkgsCross = import pkgs.path {
  localSystem = pkgs.stdenv.buildPlatform.system;
  crossSystem = {
    config = "riscv32-none-elf";
    libc = "newlib-nano";
    gcc.arch = "rv32im";
  };
};
```

This is supposed to work for compiling programs that target "bare-metal". But when I tried to compile my project, GCC complained that it can't fild `-lgloss`. If you're curious what libgloss is, in very simple terms it's a glue layer that allows you to provide implementation for the bare minimum functionality that would get the rest of the libc working. (such as `_sbrk`, `_open`, `_read` and friends).

After digging into it for a while, I've figured out that newlib which is shipped by nixpkgs doesn't contain libgloss as part of the build resuts. So this isn't just me misconfiguring the search paths.

You may be wondering - why didn't anyone else find this issue? My current guess is that nobody really uses this combination (newlib-nano plus a bare-metal deployment). Most people who use the cross toolchains likely target an operating system which provides syscalls already and don't implement the stubs themselves.

If you really want to try and reproduce the bug, you need to pass this as a flag to gcc: `--specs=nano.specs`.

Also, this bug is not really specific to NixOS, but happened in ArchLinux as well. Here's a relevant bug report:
https://bugs.archlinux.org/task/66548. This is where I've found the fix. Adding the fix in the way I did seems to fix the problem for good.

The fix itself doesn't seem to be dangerous because in case libgloss is absent, it would be skipped and not copied to the build results.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
