### PR TITLE
vlc: pin ffmpeg to 4.x to fix VAAPI

### DIFF
--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -12,7 +12,11 @@
   fetchpatch,
   fetchurl,
   # Please unpin FFmpeg on the next upstream release.
-  ffmpeg_6,
+  # Currently FFmpeg is pinned to 4.x because VAAPI acceleration is broken when
+  # building with newer versions:
+  # https://code.videolan.org/videolan/vlc/-/issues/26772
+  # This is intentional by upstream but VLC 4.0 will support newer FFmpeg.
+  ffmpeg_4,
   flac,
   fluidsynth,
   freefont_ttf,
@@ -139,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
       avahi
       dbus
       faad2
-      ffmpeg_6
+      ffmpeg_4
       flac
       fluidsynth
       fribidi


### PR DESCRIPTION
It turns out that https://github.com/NixOS/nixpkgs/pull/343567 did not go far enough. It appears that in fact, this is an upstream bug that Fedora people found:
https://discussion.fedoraproject.org/t/vlc-not-exposing-va-api-as-a-hardware-acceleration-option/101133
Upstream bug in VLC: https://code.videolan.org/videolan/vlc/-/issues/26772

I don't like this change. However, I have tested it, and it does fix VAAPI on my machine, making it reappear in the menu as an acceleration option and seemingly working propery.

 » result/bin/vlc ~/test.mp4
VLC media player 3.0.21 Vetinari (revision 3.0.21-0-gdd8bfdbabe8) [000000002efd0520] main libvlc: Running vlc with the default interface. Use 'cvlc' to use vlc without interface. [00007f35c4004e00] gl gl: Initialized libplacebo v5.264.1 (API v264) libva info: VA-API version 1.22.0
libva info: Trying to open /run/opengl-driver/lib/dri/iHD_drv_video.so libva info: Found init function __vaDriverInit_1_22 libva info: va_openDriver() returns 0
[00007f35dcc1b710] avcodec decoder: Using Intel iHD driver for Intel(R) Gen Graphics - 24.3.4 () for hardware decoding


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
