### PR TITLE
python312Packages.pytorch: just disable -Werror; fix darwin x64 build

### DIFF
--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -454,59 +454,11 @@ buildPythonPackage rec {
 
   env =
     {
-      # Suppress a weird warning in mkl-dnn, part of ideep in pytorch
-      # (upstream seems to have fixed this in the wrong place?)
-      # https://github.com/intel/mkl-dnn/commit/8134d346cdb7fe1695a2aa55771071d455fae0bc
-      # https://github.com/pytorch/pytorch/issues/22346
-      #
+      # disable warnings as errors as they break the build on every compiler
+      # bump, among other things.
       # Also of interest: pytorch ignores CXXFLAGS uses CFLAGS for both C and C++:
       # https://github.com/pytorch/pytorch/blob/v1.11.0/setup.py#L17
-      NIX_CFLAGS_COMPILE = toString (
-        (
-          lib.optionals (blas.implementation == "mkl") [ "-Wno-error=array-bounds" ]
-          # Suppress gcc regression: avx512 math function raises uninitialized variable warning
-          # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
-          # See also: Fails to compile with GCC 12.1.0 https://github.com/pytorch/pytorch/issues/77939
-          ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12.0.0") [
-            "-Wno-error=maybe-uninitialized"
-            "-Wno-error=uninitialized"
-          ]
-          # Since pytorch 2.0:
-          # gcc-12.2.0/include/c++/12.2.0/bits/new_allocator.h:158:33: error: ‘void operator delete(void*, std::size_t)’
-          # ... called on pointer ‘<unknown>’ with nonzero offset [1, 9223372036854775800] [-Werror=free-nonheap-object]
-          ++ lib.optionals (stdenv.cc.isGNU && lib.versions.major stdenv.cc.version == "12") [
-            "-Wno-error=free-nonheap-object"
-          ]
-          # .../source/torch/csrc/autograd/generated/python_functions_0.cpp:85:3:
-          # error: cast from ... to ... converts to incompatible function type [-Werror,-Wcast-function-type-strict]
-          ++ lib.optionals (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "16") [
-            "-Wno-error=cast-function-type-strict"
-            # Suppresses the most spammy warnings.
-            # This is mainly to fix https://github.com/NixOS/nixpkgs/issues/266895.
-          ]
-          ++ lib.optionals rocmSupport [
-            "-Wno-#warnings"
-            "-Wno-cpp"
-            "-Wno-unknown-warning-option"
-            "-Wno-ignored-attributes"
-            "-Wno-deprecated-declarations"
-            "-Wno-defaulted-function-deleted"
-            "-Wno-pass-failed"
-          ]
-          ++ [
-            "-Wno-unused-command-line-argument"
-            "-Wno-uninitialized"
-            "-Wno-array-bounds"
-            "-Wno-free-nonheap-object"
-            "-Wno-unused-result"
-          ]
-          ++ lib.optionals stdenv.cc.isGNU [
-            "-Wno-maybe-uninitialized"
-            "-Wno-stringop-overflow"
-          ]
-        )
-      );
-
+      NIX_CFLAGS_COMPILE = "-Wno-error";
       USE_VULKAN = setBool vulkanSupport;
     }
     // lib.optionalAttrs vulkanSupport {


### PR DESCRIPTION
pytorch and many of the vendored libs build with -Werror and the derivation meticulously then disables any warning that results in a build failure. Just disable -Werror and fix the x64 darwin build.

https://hydra.nixos.org/build/282440946
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
