### PR TITLE
watchman: family's executable scripts

### DIFF
--- a/pkgs/by-name/wa/watchman/package.nix
+++ b/pkgs/by-name/wa/watchman/package.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     # TODO: Do this in `fmt` rather than downstream.
     remove-references-to -t ${folly.fmt.dev} $out/bin/*
   '';
-  
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/wa/watchman/package.nix
+++ b/pkgs/by-name/wa/watchman/package.nix
@@ -29,7 +29,8 @@
   nix-update-script,
   python3,
   stateDir ? "",
-}: stdenv.mkDerivation (finalAttrs: {
+}:
+stdenv.mkDerivation (finalAttrs: {
   pname = "watchman";
   version = "2024.11.18.00";
 
@@ -71,7 +72,7 @@
     (darwinMinVersionHook "11.0")
   ];
 
-  checkInputs = [gtest];
+  checkInputs = [ gtest ];
 
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_INSTALL_RPATH_USE_LINK_PATH" true)
@@ -110,7 +111,7 @@
     remove-references-to -t ${folly.fmt.dev} $out/bin/*
   '';
 
-  passthru.updateScript = nix-update-script {};
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Watches files and takes action when they change";

--- a/pkgs/by-name/wa/watchman/package.nix
+++ b/pkgs/by-name/wa/watchman/package.nix
@@ -1,10 +1,8 @@
 {
   lib,
   stdenv,
-
   fetchFromGitHub,
   fetchpatch,
-
   cmake,
   ninja,
   pkg-config,
@@ -13,7 +11,6 @@
   rustPlatform,
   ensureNewerSourcesForZipFilesHook,
   removeReferencesTo,
-
   pcre2,
   openssl,
   gflags,
@@ -28,16 +25,11 @@
   cpptoml,
   apple-sdk_11,
   darwinMinVersionHook,
-
   gtest,
-
   nix-update-script,
   python3,
-
   stateDir ? "",
-}:
-
-stdenv.mkDerivation (finalAttrs: {
+}: stdenv.mkDerivation (finalAttrs: {
   pname = "watchman";
   version = "2024.11.18.00";
 
@@ -60,34 +52,29 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  buildInputs =
-    [
-      pcre2
-      openssl
-      gflags
-      glog
-      libevent
-      edencommon
-      folly
-      fizz
-      wangle
-      fbthrift
-      fb303
-      cpptoml
-      python3
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_11
-      (darwinMinVersionHook "11.0")
-    ];
-
-  checkInputs = [
-    gtest
+  buildInputs = [
+    pcre2
+    openssl
+    gflags
+    glog
+    libevent
+    edencommon
+    folly
+    fizz
+    wangle
+    fbthrift
+    fb303
+    cpptoml
+    python3
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_11
+    (darwinMinVersionHook "11.0")
   ];
+
+  checkInputs = [gtest];
 
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_INSTALL_RPATH_USE_LINK_PATH" true)
-
     (lib.cmakeFeature "WATCHMAN_STATE_DIR" stateDir)
     (lib.cmakeFeature "WATCHMAN_VERSION_OVERRIDE" finalAttrs.version)
   ];
@@ -117,13 +104,13 @@ stdenv.mkDerivation (finalAttrs: {
       fi
     done
   '';
-  
+
   postFixup = ''
     # TODO: Do this in `fmt` rather than downstream.
     remove-references-to -t ${folly.fmt.dev} $out/bin/*
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {};
 
   meta = {
     description = "Watches files and takes action when they change";


### PR DESCRIPTION
for issue  #367156

1. Added python3 to both nativeBuildInputs and buildInputs to ensure Python is available during build and runtime.

2. Added a postInstall phase that:
- Creates the necessary bin directory
- Installs all Python scripts from watchman/python/bin/
- Updates the shebangs to use the correct Python path from Nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
