### PR TITLE
asak: add man pages and shell completions

### DIFF
--- a/pkgs/by-name/as/asak/package.nix
+++ b/pkgs/by-name/as/asak/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   rustPlatform,
   pkg-config,
+  installShellFiles,
   alsa-lib,
   libjack2,
 }:
@@ -20,12 +21,22 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-SS4BDhORiTV/HZhL3F9zwF8oBu/VFVYhF5Jzp2j0QFI=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
 
   buildInputs = [
     alsa-lib
     libjack2
   ];
+
+  postInstall = ''
+    installShellCompletion --cmd asak \
+      --bash target/completions/asak.bash \
+      --fish target/completions/asak.fish \
+      --zsh target/completions/_asak
+  '';
 
   meta = {
     description = "Cross-platform audio recording/playback CLI tool with TUI, written in Rust";

--- a/pkgs/by-name/as/asak/package.nix
+++ b/pkgs/by-name/as/asak/package.nix
@@ -32,6 +32,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = ''
+    installManPage target/man/asak.1
+
     installShellCompletion --cmd asak \
       --bash target/completions/asak.bash \
       --fish target/completions/asak.fish \

--- a/pkgs/by-name/as/asak/package.nix
+++ b/pkgs/by-name/as/asak/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "chaosprint";
     repo = "asak";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Kq1WdVcTRdz6vJxUDd0bqb2bfrNGCl611upwYploR7w=";
   };
 
@@ -27,11 +27,8 @@ rustPlatform.buildRustPackage rec {
     libjack2
   ];
 
-  # There is no tests
-  doCheck = false;
-
   meta = {
-    description = "A cross-platform audio recording/playback CLI tool with TUI, written in Rust";
+    description = "Cross-platform audio recording/playback CLI tool with TUI, written in Rust";
     homepage = "https://github.com/chaosprint/asak";
     changelog = "https://github.com/chaosprint/asak/releases/tag/v${version}";
     license = lib.licenses.mit;


### PR DESCRIPTION
https://github.com/chaosprint/asak/pull/18

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
