### PR TITLE
dcp385c-cupswrapper: init at 1.1.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -167,6 +167,13 @@ lib.mapAttrs mkLicense ({
     fullName = "Boost Software License 1.0";
   };
 
+  brotherEula = {
+    fullName = "Brother License Agreement";
+    url = "https://support.brother.com/g/s/agreement/English_eula/agree.html";
+    free = false;
+    redistributable = true;
+  };
+
   beerware = {
     spdxId = "Beerware";
     fullName = "Beerware License";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13747,6 +13747,13 @@
     githubId = 30194994;
     name = "Felix Nilles";
   };
+  marcin-serwin = {
+    name = "Marcin Serwin";
+    github = "marcin-serwin";
+    githubId = 12128106;
+    email = "marcin@serwin.dev";
+    keys = [ { fingerprint = "F311 FA15 1A66 1875 0C4D  A88D 82F5 C70C DC49 FD1D"; } ];
+  };
   marcovergueira = {
     email = "vergueira.marco@gmail.com";
     github = "marcovergueira";

--- a/pkgs/by-name/dc/dcp385c-brprintconf/package.nix
+++ b/pkgs/by-name/dc/dcp385c-brprintconf/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  dcp385c-lpr,
+}:
+stdenv.mkDerivation {
+  pname = "dcp385c-brprintconf";
+  version = "1.1.2+1";
+
+  src = fetchFromSourcehut {
+    owner = "~marcin-serwin";
+    repo = "brprintconf";
+    rev = "6a1b9bf9de86ca15ca030a6a962ae5d9c2db8ad4";
+    hash = "sha256-hgVcFDAnHT3+0Yj276tcwD6xp8YNWN7S0WW8QGCy2hI=";
+  };
+
+  postPatch = ''
+    reldir='local/Brother/Printer/%s/inf'
+
+    substituteInPlace brprintconf_dcp385c.c \
+      --replace-fail "/usr/$reldir/br%sfunc" "${dcp385c-lpr}/$reldir/br%sfunc" \
+      --replace-fail "/usr/$reldir/br%src" "/var/cache/cups/br%src"
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    homepage = "https://git.sr.ht/~marcin-serwin/brprintconf";
+    description = "Decompiled source of brprintconf_dcp385c";
+    license = with lib.licenses; [
+      cc0
+      brotherEula
+    ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/dc/dcp385c-cupswrapper/package.nix
+++ b/pkgs/by-name/dc/dcp385c-cupswrapper/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  makeWrapper,
+  gnused,
+  gnugrep,
+  coreutils,
+  dcp385c-lpr,
+  dcp385c-brprintconf,
+}:
+let
+  version = "1.1.2";
+  model = "dcp385c";
+  installscript = "SCRIPT/cupswrapperdcp385c";
+in
+stdenv.mkDerivation {
+  pname = "${model}-cupswrapper";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://download.brother.com/welcome/dlf006678/brcups_ink4_src_1.1.2-x.tar.gz";
+    hash = "sha256-2XzBF3weIlZ2g2IXFv2PE8jVXkhybrMni6jtNjkmF7I=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  unpackPhase = ''
+    tar xzf $src/cupswrapperdcp385c_src-1.1.2-2.tar.gz
+    sourceRoot=cupswrapperdcp385c_src
+  '';
+
+  patchPhase = ''
+    patch ${installscript} ${./replace-absolute-paths.patch}
+    substituteInPlace ${installscript} \
+      --subst-var out \
+      --subst-var-by lpr ${dcp385c-lpr} \
+  '';
+
+  buildPhase = ''
+    $CC brcupsconfigpt1/brcupsconfig.c -o brcupsconfig
+  '';
+
+  installPhase = ''
+    install -D brcupsconfig $out/local/Brother/Printer/dcp385c/cupswrapper/brcupsconfpt1
+
+    mkdir -p $out/share/cups/model
+    mkdir -p $out/lib/cups/filter
+    sh ${installscript}
+  '';
+
+  fixupPhase = ''
+    wrapProgram $out/lib/cups/filter/brlpdwrapperdcp385c \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gnused
+          gnugrep
+          coreutils
+          dcp385c-brprintconf
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother ${model} printer CUPS wrapper driver";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+  };
+}

--- a/pkgs/by-name/dc/dcp385c-cupswrapper/replace-absolute-paths.patch
+++ b/pkgs/by-name/dc/dcp385c-cupswrapper/replace-absolute-paths.patch
@@ -1,0 +1,162 @@
+--- cupswrapperdcp385c.orig	2008-11-18 10:31:13.000000000 +0100
++++ cupswrapperdcp385c	2024-06-22 21:09:26.993494135 +0200
+@@ -25,11 +25,11 @@
+ device_model="Printer"
+ if [ "$1" = '-e' ]; then
+   lpadmin -x ${printer_name}
+-  rm -f /usr/share/cups/model/br${printer_model}.ppd
+-  rm -f /usr/share/ppd/br${printer_model}.ppd
+-  rm -f /usr/lib/cups/filter/brlpdwrapper${printer_model}
+-  rm -f /usr/lib64/cups/filter/brlpdwrapper${printer_model}
+-  rm -f /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1
++  rm -f @lpr@/share/cups/model/br${printer_model}.ppd
++  rm -f @lpr@/share/ppd/br${printer_model}.ppd
++  rm -f @out@/lib/cups/filter/brlpdwrapper${printer_model}
++  rm -f @out@/lib64/cups/filter/brlpdwrapper${printer_model}
++  rm -f @out@/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1
+ if [  -e /etc/init.d/cups ]; then
+    /etc/init.d/cups restart
+ elif [  -e /etc/init.d/cupsys ]; then
+@@ -55,21 +55,21 @@
+   echo   '       -r : remove printer'
+   exit 0
+ fi
+-#mkdir -p /usr/local/Brother/${device_model}/${printer_model}/filter
+-#mkdir -p /usr/lib/cups/filter
++#mkdir -p @lpr@/local/Brother/${device_model}/${printer_model}/filter
++#mkdir -p @lpr@/lib/cups/filter
+ 
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
++if [ -e "@lpr@/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+   :
+ else
+   echo "ERROR : Brother LPD filter is not installed."
+ fi
+-rm -f /usr/share/cups/model/br${printer_model}.ppd
+-if [ -d "/usr/share/cups/model" ]; then
+-  ppd_file_name=/usr/share/cups/model/br${printer_model}.ppd
++rm -f @out@/share/cups/model/br${printer_model}.ppd
++if [ -d "@out@/share/cups/model" ]; then
++  ppd_file_name=@out@/share/cups/model/br${printer_model}.ppd
+ else
+-  ppd_file_name=/usr/share/ppd/br${printer_model}.ppd
++  ppd_file_name=@out@/share/ppd/br${printer_model}.ppd
+ fi
+-#ppd_file_name=/usr/share/cups/model/br${printer_model}.ppd
++#ppd_file_name=@out@/share/cups/model/br${printer_model}.ppd
+ 
+ cat <<ENDOFPPDFILE1 >$ppd_file_name
+ *PPD-Adobe: "4.3"
+@@ -699,27 +699,27 @@
+ 
+ chmod 644 $ppd_file_name
+ 
+-if [ -d /usr/share/ppd ]
++if [ -d @out@/share/ppd ]
+ then
+-if [ -d /usr/share/cups/model ]
++if [ -d @out@/share/cups/model ]
+ then
+-	cp $ppd_file_name /usr/share/ppd/br${printer_model}.ppd
+-	chmod 644 /usr/share/ppd/br${printer_model}.ppd
++	cp $ppd_file_name @out@/share/ppd/br${printer_model}.ppd
++	chmod 644 @out@/share/ppd/br${printer_model}.ppd
+ fi
+ fi
+ 
+ #################################################
+ 
+-if [ -d /usr/lib/cups/filter ]
++if [ -d @out@/lib/cups/filter ]
+ then
+-	brotherlpdwrapper=/usr/lib/cups/filter/brlpdwrapper${printer_model}
++	brotherlpdwrapper=@out@/lib/cups/filter/brlpdwrapper${printer_model}
+ else
+-	brotherlpdwrapper=/usr/lib64/cups/filter/brlpdwrapper${printer_model}
++	brotherlpdwrapper=@out@/lib64/cups/filter/brlpdwrapper${printer_model}
+ fi
+ 
+ 
+ rm -f  $brotherlpdwrapper
+-#echo 'rm -f /usr/lib/cups/filter/brlpdwrapper${printer_model}'
++#echo 'rm -f @out@/lib/cups/filter/brlpdwrapper${printer_model}'
+ 
+ 
+ cat <<!ENDOFWFILTER! >$brotherlpdwrapper
+@@ -759,7 +759,7 @@
+ PPDC=\`echo \$PPDC | sed -e 's/PPD=//'\`
+ 
+ if [ "\$PPDC" = "" ]; then
+-    PPDC="/usr/share/cups/model/br${printer_model}.ppd"
++    PPDC="@lpr@/share/cups/model/br${printer_model}.ppd"
+ fi
+ 
+ 
+@@ -784,6 +784,10 @@
+     echo "PPD  = \$PPD"                                         >>\$LOGFILE
+ fi
+ 
++if ! [ -e /var/cache/cups/br${printer_model}rc ]; then
++  echo "creating rc file"                                         >>\$LOGFILE
++  cp @lpr@/local/Brother/${device_model}/${printer_model}/inf/br${printer_model}rc /var/cache/cups/br${printer_model}rc
++fi
+ INPUT_TEMP_PS=\`mktemp /tmp/br_input_ps.XXXXXX\`
+ 
+ nup="cat"
+@@ -809,7 +813,7 @@
+ 		nup="cat"
+ 	fi
+ 	echo   "NUP=\$nup"                                      >>\$LOGFILE
+-   if [ -e /usr/bin/psnup ]; then
++   if [ -e @lpr@/bin/psnup ]; then
+        if [ \$# -ge 7 ]; then
+ 	       cat \$6  | \$nup > \$INPUT_TEMP_PS
+        else
+@@ -829,25 +833,25 @@
+       cat    > \$INPUT_TEMP_PS
+    fi
+ fi
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
++if [ -e "@lpr@/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+        :
+ else
+-    echo "ERROR: /usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} does not exist"   >>\$LOGFILE
++    echo "ERROR: @lpr@/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} does not exist"   >>\$LOGFILE
+     errorcode=30
+     exit
+ fi
+ 
+ CUPSOPTION=\`echo "\$5 Copies=\$4" | sed -e 's/BrMirror=OFF/MirrorPrint=OFF/' -e 's/BrMirror=ON/MirrorPrint=ON/' -e 's/BrChain/Chain/' -e 's/BrBrightness/Brightness/' -e 's/BrContrast/Contrast/' -e 's/BrHalfCut/HalfCut/' -e 's/BrAutoTapeCut/AutoCut/' -e 's/BrHalftonePattern/Halftone/' -e 's/Binary/Binary/' -e 's/Dither/Dither/' -e 's/ErrorDiffusion/ErrorDiffusion/' -e 's/PageSize/media/' -e 's/BrSheets/Sheets/' -e 's/multiple-document-handling/Collate/' -e 's/separate-documents-collated-copies/ON/' -e 's/separate-documents-uncollated-copies/OFF/'\`
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1" ]; then
++if [ -e "@out@/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1" ]; then
+   if [ \$DEBUG = 0 ]; then
+-     /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC 0 "\$CUPSOPTION" "${printer_model}">> /dev/null
++     @out@/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC 0 "\$CUPSOPTION" "${printer_model}">> /dev/null
+   else
+-     /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC \$LOGCLEVEL "\$CUPSOPTION" "${printer_model}">>\$LOGFILE
++     @out@/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC \$LOGCLEVEL "\$CUPSOPTION" "${printer_model}">>\$LOGFILE
+   fi
+ fi
+ 
+ if [ \$DEBUG -lt 10 ]; then
+-    cat    \$INPUT_TEMP_PS | /usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} "\$\$" "CUPS" "USB"
++    cat    \$INPUT_TEMP_PS | @lpr@/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} "\$\$" "CUPS" "USB"
+ 
+     if [ \$LOGLEVEL -gt 2 ];  then
+ 	   if [ \$LOGFILE != "/dev/null" ]; then
+@@ -864,12 +868,12 @@
+ !ENDOFWFILTER!
+ 
+ chmod 755 $brotherlpdwrapper
+-#if [ -e /usr/lib64/cups/backend ]; then
++#if [ -e @lpr@/lib64/cups/backend ]; then
+ #   cp $brotherlpdwrapper  $brotherlpdwrapper64
+ #fi
+ 
+-chmod a+w /usr/local/Brother/${device_model}/${printer_model}/inf/br${printer_model}rc
+-chmod a+w /usr/local/Brother/${device_model}/${printer_model}/inf
++chmod a+w @lpr@/local/Brother/${device_model}/${printer_model}/inf/br${printer_model}rc
++chmod a+w @lpr@/local/Brother/${device_model}/${printer_model}/inf
+ if [ -e /etc/init.d/lpd ]; then
+    /etc/init.d/lpd stop
+ fi

--- a/pkgs/by-name/dc/dcp385c-lpr/package.nix
+++ b/pkgs/by-name/dc/dcp385c-lpr/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  pkgsi686Linux,
+  ghostscript,
+  file,
+  a2ps,
+  which,
+}:
+
+let
+  version = "1.1.2";
+  model = "dcp385c";
+in
+stdenv.mkDerivation {
+  pname = "${model}-lpr";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf005395/${model}lpr-${version}-2.i386.deb";
+    hash = "sha256-Y2lBU42fYXLG9D2qeUeG/sTpIIU8iHxyPALJUeZvHEk=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  unpackPhase = ''
+    ar x $src
+    tar xvzf data.tar.gz
+    sourceRoot=usr
+  '';
+
+  patchPhase = ''
+    substituteInPlace local/Brother/Printer/dcp385c/lpd/filterdcp385c \
+      --replace-fail /usr $out \
+      --replace-fail '$BR_PRT_PATH/inf/brPRINTERrc' '/var/cache/cups/brPRINTERrc'
+  '';
+
+  installPhase = ''
+    cp -r . $out
+  '';
+
+  fixupPhase = ''
+    wrapProgram $out/local/Brother/Printer/dcp385c/lpd/filterdcp385c \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          file
+          a2ps
+        ]
+      }
+
+    wrapProgram $out/local/Brother/Printer/dcp385c/lpd/psconvertij2 \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          which
+          ghostscript
+        ]
+      }
+
+    interpreter="${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2"
+
+    patchelf --set-interpreter $interpreter \
+      $out/bin/brprintconf_dcp385c
+
+    patchelf --set-interpreter $interpreter \
+      $out/local/Brother/Printer/dcp385c/lpd/brdcp385cfilter
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother ${model} printer driver";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.brotherEula;
+    platforms = lib.platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add Brother DCP385c drivers from https://support.brother.com/g/b/producttop.aspx?c=us_ot&lang=en&prod=dcp385c_all

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
