### PR TITLE
ietf-cli: init at v1.27

### DIFF
--- a/pkgs/by-name/ie/ietf-cli/package.nix
+++ b/pkgs/by-name/ie/ietf-cli/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  rsync,
+  nix-update-script,
+}:
+python3.pkgs.buildPythonApplication rec {
+  name = "ietf-cli";
+  version = "1.27";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "paulehoffman";
+    repo = "ietf-cli";
+    tag = version;
+    hash = "sha256-D62E0aHVwB2e+3ZNNMOB2E93Q2WKhbWrYtnH76ZOepM=";
+  };
+  buildInputs = [ rsync ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./ietf -t $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line interface for accessing IETF documents and other information";
+    mainProgram = "ietf";
+    homepage = "https://github.com/paulehoffman/ietf-cli";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ lilioid ];
+    platforms = lib.lists.intersectLists python3.meta.platforms rsync.meta.platforms;
+  };
+}


### PR DESCRIPTION
This adds the package [ietf-cli](https://github.com/paulehoffman/ietf-cli/tree/main) which is a command-line interface for accessing IETF documents and other information via a local offline copy.

I sometimes use this program when reading standards documentation on a train or other where I don't have a stable internet connection. Because I want to keep using it, I would like it to be available in NixOS.

I am not the original author of the program but do want to maintain the packaging for NixOS.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The added package is a simple python script (albeit without a setup.py) that is just copied to the `$out` dir.
I expect it to just work on any system providing python and rsync (a dependency).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
