### PR TITLE
cura-appimage: init at 5.9.0

### DIFF
--- a/pkgs/applications/misc/cura/appimage.nix
+++ b/pkgs/applications/misc/cura/appimage.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  writeScriptBin,
+  appimageTools,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+let
+  pname = "cura-appimage";
+  version = "5.9.0";
+
+  # Give some good names so the intermediate packages are easy
+  # to recognise by name in the Nix store.
+  appimageBinName = "cura-appimage-tools-output";
+  wrapperScriptName = "${pname}-wrapper-script";
+
+  curaAppimageToolsWrapped = appimageTools.wrapType2 {
+    # For `appimageTools.wrapType2`, `pname` determines the binary's name in `bin/`.
+    pname = appimageBinName;
+    inherit version;
+    src = fetchurl {
+      url = "https://github.com/Ultimaker/Cura/releases/download/${version}/Ultimaker-Cura-${version}-linux-X64.AppImage";
+      hash = "sha256-STtVeM4Zs+PVSRO3cI0LxnjRDhOxSlttZF+2RIXnAp4=";
+    };
+    extraPkgs = _: [ ];
+  };
+
+  # The `QT_QPA_PLATFORM=xcb` fixes Wayland support, see
+  #     https://github.com/NixOS/nixpkgs/issues/186570#issuecomment-2526277637
+  script = writeScriptBin wrapperScriptName ''
+    #!${stdenv.shell}
+    # AppImage version of Cura loses current working directory and treats all paths relateive to $HOME.
+    # So we convert each of the files passed as argument to an absolute path.
+    # This fixes use cases like `cd /path/to/my/files; cura mymodel.stl anothermodel.stl`.
+
+    args=()
+    for a in "$@"; do
+      if [ -e "$a" ]; then
+        a="$(realpath "$a")"
+      fi
+      args+=("$a")
+    done
+    QT_QPA_PLATFORM=xcb exec "${curaAppimageToolsWrapped}/bin/${appimageBinName}" "''${args[@]}"
+  '';
+in
+stdenv.mkDerivation rec {
+  inherit pname version;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ copyDesktopItems ];
+  desktopItems = [
+    # Based on upstream.
+    # https://github.com/Ultimaker/Cura/blob/382b98e8b0c910fdf8b1509557ae8afab38f1817/packaging/AppImage/cura.desktop.jinja
+    (makeDesktopItem {
+      name = "cura";
+      desktopName = "UltiMaker Cura";
+      genericName = "3D Printing Software";
+      comment = meta.longDescription;
+      exec = "cura";
+      icon = "cura-icon";
+      terminal = false;
+      type = "Application";
+      mimeTypes = [
+        "model/stl"
+        "application/vnd.ms-3mfdocument"
+        "application/prs.wavefront-obj"
+        "image/bmp"
+        "image/gif"
+        "image/jpeg"
+        "image/png"
+        "text/x-gcode"
+        "application/x-amf"
+        "application/x-ply"
+        "application/x-ctm"
+        "model/vnd.collada+xml"
+        "model/gltf-binary"
+        "model/gltf+json"
+        "model/vnd.collada+xml+zip"
+      ];
+      categories = [ "Graphics" ];
+      keywords = [
+        "3D"
+        "Printing"
+      ];
+    })
+  ];
+
+  # TODO: Extract cura-icon from AppImage source.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ${script}/bin/${wrapperScriptName} $out/bin/cura
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "3D printing software";
+    homepage = "https://github.com/ultimaker/cura";
+    longDescription = ''
+      Cura converts 3D models into paths for a 3D printer. It prepares your print for maximum accuracy, minimum printing time and good reliability with many extra features that make your print come out great.
+    '';
+    license = lib.licenses.lgpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      nh2
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15541,6 +15541,7 @@ with pkgs;
   };
 
   cura = libsForQt5.callPackage ../applications/misc/cura { };
+  cura-appimage = callPackage ../applications/misc/cura/appimage.nix { };
 
   curaPlugins = callPackage ../applications/misc/cura/plugins.nix { };
 


### PR DESCRIPTION
Current Cura is difficult to build (see #186570), so in the meantime we're providing an AppImage version as well so people at least have some Cura version available.

Adapted from
  https://github.com/NixOS/nixpkgs/issues/186570#issuecomment-1627797219
and the subsequent discussion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
