### PR TITLE
python312Packages.jinja2: 3.1.4 -> 3.1.5

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -21,19 +21,29 @@
 
 buildPythonPackage rec {
   pname = "jinja2";
-  version = "3.1.4";
+  version = "3.1.5";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Sjruesu+cwOu3o6WSNE7i/iKQpKCqmEiqZPwrIAMs2k=";
+    hash = "sha256-j+//jcMDTie7gNZ8Zx64qbxCTA70wIJu2/8wTM7/Q7s=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  postPatch = ''
+    # Do not test with trio, it increases jinja2's dependency closure by a lot
+    # and everyone consuming these dependencies cannot rely on sphinxHook,
+    # because sphinx itself depends on jinja2.
+    substituteInPlace tests/test_async{,_filters}.py \
+      --replace-fail "import trio" "" \
+      --replace-fail ", trio.run" "" \
+      --replace-fail ", \"trio\"" ""
+  '';
 
-  propagatedBuildInputs = [ markupsafe ];
+  build-system = [ flit-core ];
+
+  dependencies = [ markupsafe ];
 
   optional-dependencies = {
     i18n = [ babel ];
@@ -44,14 +54,6 @@ buildPythonPackage rec {
   doCheck = !stdenv.hostPlatform.is32bit;
 
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.i18n;
-
-  disabledTests = lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/pallets/jinja/issues/1900
-    "test_custom_async_iteratable_filter"
-    "test_first"
-    "test_loop_errors"
-    "test_package_zip_list"
-  ];
 
   passthru.doc = stdenv.mkDerivation {
     # Forge look and feel of multi-output derivation as best as we can.


### PR DESCRIPTION
https://github.com/pallets/jinja/releases/tag/3.1.5
https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h
https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699

Fixes: CVE-2024-56326, CVE-2024-56201

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
