### PR TITLE
nixos/ustreamer: init; ustreamer: 6.12 -> 6.18

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -42,6 +42,8 @@
 
 - [Bat](https://github.com/sharkdp/bat), a {manpage}`cat(1)` clone with wings. Available as [programs.bat](options.html#opt-programs.bat).
 
+- [µStreamer](https://github.com/pikvm/ustreamer), a lightweight MJPEG-HTTP streamer. Available as [services.ustreamer](options.html#opt-services.ustreamer).
+
 - [Whoogle Search](https://github.com/benbusby/whoogle-search), a self-hosted, ad-free, privacy-respecting metasearch engine. Available as [services.whoogle-search](options.html#opt-services.whoogle-search.enable).
 
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1416,6 +1416,7 @@
   ./services/video/mirakurun.nix
   ./services/video/photonvision.nix
   ./services/video/mediamtx.nix
+  ./services/video/ustreamer.nix
   ./services/video/v4l2-relayd.nix
   ./services/video/wivrn.nix
   ./services/wayland/cage.nix

--- a/nixos/modules/services/video/ustreamer.nix
+++ b/nixos/modules/services/video/ustreamer.nix
@@ -1,0 +1,110 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionals
+    types
+    ;
+
+  cfg = config.services.ustreamer;
+in
+{
+  options.services.ustreamer = {
+    enable = mkEnableOption "µStreamer, a lightweight MJPEG-HTTP streamer";
+
+    package = mkPackageOption pkgs "ustreamer" { };
+
+    autoStart = mkOption {
+      description = ''
+        Wether to start µStreamer on boot. Disabling this will use socket
+        activation. The service will stop gracefully after some inactivity.
+        Disabling this will set `--exit-on-no-clients=300`
+      '';
+      type = types.bool;
+      default = true;
+      example = false;
+    };
+
+    listenAddress = mkOption {
+      description = ''
+        Address to expose the HTTP server. This accepts values for
+        ListenStream= defined in {manpage}`systemd.socket(5)`
+      '';
+      type = types.str;
+      default = "0.0.0.0:8080";
+      example = "/run/ustreamer.sock";
+    };
+
+    device = mkOption {
+      description = ''
+        The v4l2 device to stream.
+      '';
+      type = types.path;
+      default = "/dev/video0";
+      example = "/dev/v4l/by-id/usb-0000_Dummy_abcdef-video-index0";
+    };
+
+    extraArgs = mkOption {
+      description = ''
+        Extra arguments to pass to `ustreamer`. See {manpage}`ustreamer(1)`
+      '';
+      type = with types; listOf str;
+      default = [ ];
+      example = [ "--resolution=1920x1080" ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.ustreamer.extraArgs =
+      [
+        "--device=${cfg.device}"
+      ]
+      ++ optionals (!cfg.autoStart) [
+        "--exit-on-no-clients=300"
+      ];
+
+    systemd.services."ustreamer" = {
+      description = "µStreamer, a lightweight MJPEG-HTTP streamer";
+      after = [ "network.target" ];
+      requires = [ "ustreamer.socket" ];
+      wantedBy = mkIf cfg.autoStart [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            (getExe cfg.package)
+            "--systemd"
+          ]
+          ++ cfg.extraArgs
+        );
+        Restart = if cfg.autoStart then "always" else "on-failure";
+
+        DynamicUser = true;
+        SupplementaryGroups = [ "video" ];
+
+        NoNewPrivileges = true;
+        ProcSubset = "pid";
+        ProtectProc = "noaccess";
+        ProtectClock = "yes";
+        DeviceAllow = [ cfg.device ];
+      };
+    };
+
+    systemd.sockets."ustreamer" = {
+      wantedBy = [ "sockets.target" ];
+      partOf = [ "ustreamer.service" ];
+      socketConfig = {
+        ListenStream = cfg.listenAddress;
+      };
+    };
+  };
+}

--- a/nixos/tests/ustreamer.nix
+++ b/nixos/tests/ustreamer.nix
@@ -46,22 +46,13 @@ import ./make-test-python.nix (
           '';
         in
         {
-          environment.systemPackages = [ pkgs.ustreamer ];
-          networking.firewall.enable = false;
-          systemd.services.ustreamer = {
-            description = "ustreamer service";
-            wantedBy = [ "multi-user.target" ];
-            serviceConfig = {
-              DynamicUser = true;
-              ExecStart = "${pkgs.ustreamer}/bin/ustreamer --host=0.0.0.0 --port 8000 --device /dev/video9 --device-timeout=8";
-              PrivateTmp = true;
-              BindReadOnlyPaths = "/dev/video9";
-              SupplementaryGroups = [
-                "video"
-              ];
-              Restart = "always";
-            };
+          services.ustreamer = {
+            enable = true;
+            device = "/dev/video9";
+            extraArgs = [ "--device-timeout=8" ];
           };
+          networking.firewall.allowedTCPPorts = [ 8080 ];
+
           boot.extraModulePackages = [ config.boot.kernelPackages.akvcam ];
           boot.kernelModules = [ "akvcam" ];
           boot.extraModprobeConfig = ''
@@ -74,10 +65,10 @@ import ./make-test-python.nix (
       start_all()
 
       camera.wait_for_unit("ustreamer.service")
-      camera.wait_for_open_port(8000)
+      camera.wait_for_open_port(8080)
 
       client.wait_for_unit("multi-user.target")
-      client.succeed("curl http://camera:8000")
+      client.succeed("curl http://camera:8080")
     '';
   }
 )

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -14,6 +14,8 @@
   jansson,
   libopus,
   nixosTests,
+  systemdLibs,
+  withSystemd ? true,
   withJanus ? true,
 }:
 stdenv.mkDerivation rec {
@@ -34,6 +36,9 @@ stdenv.mkDerivation rec {
       libjpeg
       libdrm
     ]
+    ++ lib.optionals withSystemd [
+      systemdLibs
+    ]
     ++ lib.optionals withJanus [
       janus-gateway
       glib
@@ -49,6 +54,9 @@ stdenv.mkDerivation rec {
     [
       "PREFIX=${placeholder "out"}"
       "WITH_V4P=1"
+    ]
+    ++ lib.optionals withSystemd [
+      "WITH_SYSTEMD=1"
     ]
     ++ lib.optionals withJanus [
       "WITH_JANUS=1"

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -15,18 +15,19 @@
   libopus,
   nixosTests,
   systemdLibs,
+  which,
   withSystemd ? true,
   withJanus ? true,
 }:
 stdenv.mkDerivation rec {
   pname = "ustreamer";
-  version = "6.12";
+  version = "6.18";
 
   src = fetchFromGitHub {
     owner = "pikvm";
     repo = "ustreamer";
     rev = "v${version}";
-    hash = "sha256-iaCgPHgklk7tbhJhQmyjKggb1bMWBD+Zurgfk9sCQ3E=";
+    hash = "sha256-VzhTfr0Swrv3jZUvBYYy5l0+iSokIztpeyA1CuG/roY=";
   };
 
   buildInputs =
@@ -48,7 +49,10 @@ stdenv.mkDerivation rec {
       libopus
     ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    which
+  ];
 
   makeFlags =
     [

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -77,5 +77,6 @@ stdenv.mkDerivation rec {
       matthewcroughan
     ];
     platforms = platforms.linux;
+    mainProgram = "ustreamer";
   };
 }


### PR DESCRIPTION
This updates ustreamer to 6.18 (which requires which as a native build input) and a new NixOS module

https://github.com/pikvm/ustreamer/compare/v6.12...v6.18


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
