### PR TITLE
restate: init at 1.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15563,6 +15563,12 @@
     githubId = 9636071;
     name = "Myrl Hex";
   };
+  myypo = {
+    email = "nikirsmcgl@gmail.com";
+    github = "myypo";
+    githubId = 110892040;
+    name = "Mykyta Polchanov";
+  };
   mzacho = {
     email = "nixpkgs@martinzacho.net";
     github = "mzacho";

--- a/pkgs/by-name/re/restate/package.nix
+++ b/pkgs/by-name/re/restate/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  stdenv,
+  testers,
+  versionCheckHook,
+  nix-update-script,
+  rustPlatform,
+  fetchFromGitHub,
+  protobuf,
+  restate,
+  pkg-config,
+  openssl,
+  perl,
+  cmake,
+  cacert,
+  rdkafka,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "restate";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "restatedev";
+    repo = "restate";
+    tag = "v${version}";
+    hash = "sha256-uDNPIL9Ox5rwWVzqWe74elHPGy6lSvWR1S7HsY6ATjc=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-z7VAKU4bi6pX2z4jCKWDfQt8FFLN7ugnW2LOy6IHz/w=";
+
+  env = {
+    PROTOC = lib.getExe protobuf;
+    PROTOC_INCLUDE = "${protobuf}/include";
+
+    VERGEN_GIT_COMMIT_DATE = "2024-12-23";
+    VERGEN_GIT_SHA = "v${version}";
+
+    # rustflags as defined in the upstream's .cargo/config.toml
+    RUSTFLAGS =
+      let
+        target = stdenv.hostPlatform.config;
+        targetFlags = rec {
+          build = [
+            "-C force-unwind-tables"
+            "-C debug-assertions"
+            "--cfg uuid_unstable"
+            "--cfg tokio_unstable"
+          ];
+
+          "aarch64-unknown-linux-gnu" = build ++ [
+            # Enable frame pointers to support Parca (https://github.com/parca-dev/parca-agent/pull/1805)
+            "-C force-frame-pointers=yes"
+          ];
+
+          "x86_64-unknown-linux-musl" = build ++ [
+            "-C link-self-contained=yes"
+          ];
+
+          "aarch64-unknown-linux-musl" = build ++ [
+            # Enable frame pointers to support Parca (https://github.com/parca-dev/parca-agent/pull/1805)
+            "-C force-frame-pointers=yes"
+            "-C link-self-contained=yes"
+          ];
+        };
+      in
+      lib.concatStringsSep " " (lib.attrsets.attrByPath [ target ] targetFlags.build targetFlags);
+
+    # Have to be set to dynamically link librdkafka
+    CARGO_FEATURE_DYNAMIC_LINKING = 1;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    openssl
+    perl
+    rustPlatform.bindgenHook
+    cmake
+  ];
+  buildInputs = [ rdkafka ];
+  nativeCheckInputs = [
+    cacert
+  ];
+
+  useNextest = true;
+  # Feature resolution seems to be failing due to this https://github.com/rust-lang/cargo/issues/7754
+  auditable = false;
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    tests.restateCliVersion = testers.testVersion {
+      package = restate;
+      command = "restate --version";
+    };
+    tests.restateServerVersion = testers.testVersion {
+      package = restate;
+      command = "restate-server --version";
+    };
+    tests.restateCtlVersion = testers.testVersion {
+      package = restate;
+      command = "restatectl --version";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Restate is a platform for developing distributed fault-tolerant applications.";
+    homepage = "https://restate.dev";
+    changelog = "https://github.com/restatedev/restate/releases/tag/v${version}";
+    mainProgram = "restate";
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [ myypo ];
+  };
+}


### PR DESCRIPTION
[Restate is a tool for developing durable workflows](https://restate.dev/)

Closes #325360

Have tried running several official examples and it seems to be working fine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
