### PR TITLE
soarca: init at 1.1.0-beta-1-unstable-2024-12-19

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -44,6 +44,8 @@
 
 - [Whoogle Search](https://github.com/benbusby/whoogle-search), a self-hosted, ad-free, privacy-respecting metasearch engine. Available as [services.whoogle-search](options.html#opt-services.whoogle-search.enable).
 
+- [SOARCA](https://github.com/COSSAS/SOARCA), an open source CACAO-based security orchestrator. Available as [services.soarca](options.html#opt-services.soarca.enable).
+
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).
 
 - [waagent](https://github.com/Azure/WALinuxAgent), the Microsoft Azure Linux Agent (waagent) manages Linux provisioning and VM interaction with the Azure Fabric Controller. Available with [services.waagent](options.html#opt-services.waagent.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1365,6 +1365,7 @@
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
+  ./services/security/soarca.nix
   ./services/security/sshguard.nix
   ./services/security/sslmate-agent.nix
   ./services/security/step-ca.nix

--- a/nixos/modules/services/security/soarca.nix
+++ b/nixos/modules/services/security/soarca.nix
@@ -1,0 +1,117 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.soarca;
+in
+{
+  options.services.soarca = {
+    enable = lib.mkEnableOption "SOARCA";
+    package = lib.mkPackageOption pkgs "soarca" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType =
+          with lib.types;
+          attrsOf (
+            nullOr (oneOf [
+              bool
+              int
+              str
+            ])
+          );
+        options = { };
+      };
+      default = { };
+      example = {
+        PORT = 9000;
+        GIN_MODE = "release";
+        DATABASE = false;
+      };
+      description = ''
+        See [the wiki](https://cossas.github.io/SOARCA/docs/installation-configuration/) for available settings.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "soarca";
+      description = "User under which SOARCA will run.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "soarca";
+      description = "Group under which SOARCA will run.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+
+    systemd.services.soarca = {
+      description = "SOARCA Service";
+      wantedBy = [ "multi-user.target" ];
+      restartIfChanged = true;
+
+      environment = lib.mapAttrs (
+        _: v: if lib.isBool v then lib.boolToString v else toString v
+      ) cfg.settings;
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+        RestartSec = "5";
+
+        # hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        ProtectSystem = "strict";
+        ProtectHome = "true";
+        ProtectProc = "invisible";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock @swap @reboot @raw-io @privileged @obsolete @mount @module @debug @cpu-emulation"
+        ];
+        CapabilityBoundingSet = [ "" ];
+        RestrictNamespaces = true;
+        ProcSubset = "pid";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+      };
+    };
+
+    users.users = lib.optionalAttrs (cfg.user == "soarca") {
+      soarca = {
+        group = cfg.group;
+        isNormalUser = true;
+      };
+    };
+
+    users.groups = lib.optionalAttrs (cfg.group == "soarca") {
+      soarca = { };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ _13621 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -949,6 +949,7 @@ in {
   snapper = handleTest ./snapper.nix {};
   snipe-it = runTest ./web-apps/snipe-it.nix;
   soapui = handleTest ./soapui.nix {};
+  soarca = handleTest ./soarca.nix {};
   soft-serve = handleTest ./soft-serve.nix {};
   sogo = handleTest ./sogo.nix {};
   soju = handleTest ./soju.nix {};

--- a/nixos/tests/soarca.nix
+++ b/nixos/tests/soarca.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "soarca";
+    meta.maintainers = with lib.maintainers; [ _13621 ];
+
+    nodes.machine = {
+      services.soarca = {
+        package = pkgs.soarca;
+        enable = true;
+        settings.PORT = 8475;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("soarca.service")
+      machine.wait_for_open_port(8475)
+
+      machine.succeed("curl --fail http://localhost:8475/status/ping | grep 'pong'")
+    '';
+  }
+)

--- a/pkgs/by-name/so/soarca/package.nix
+++ b/pkgs/by-name/so/soarca/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go-swag,
+  nixosTests,
+  nix-update-script,
+}:
+
+buildGoModule {
+  pname = "soarca";
+  version = "1.1.0-beta-1-unstable-2024-12-19";
+
+  src = fetchFromGitHub {
+    owner = "COSSAS";
+    repo = "SOARCA";
+    rev = "fe560ac6d5c7b372c81cec16937782758a089f26";
+    hash = "sha256-4QN6zx2TajUIERH+YqmuNUb/ZbJHUWKrHdrOiyHXsWc=";
+  };
+
+  vendorHash = "sha256-pATXKcPbAvh8Hsa3v2TkQq8AqN+RVNirT1OegdShWwQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  preBuild = ''
+    mkdir -p api
+    ${lib.getExe go-swag} init -g cmd/soarca/main.go -o api
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # require internet access
+        "TestHttpConnection"
+        "TestHttpOAuth2"
+        "TestHttpBasicAuth"
+        "TestHttpBearerToken"
+        "TestHttpPostWithContentConnection"
+        "TestHttpPostWithBase64ContentConnection"
+        "TestHttpPostConnection"
+        "TestHttpPutConnection"
+        "TestHttpDeleteConnection"
+        "TestHttpStatus200"
+        "TestHttpGetConnection"
+        "TestInsecureHTTPConnection"
+        "TestSshConnection"
+        "TestConnect" # times out
+        # integrations
+        "TestPowershellConnection"
+        "TestTheHiveConnection"
+        "TestTheHiveReporting"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  passthru = {
+    tests.soarca = nixosTests.soarca;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Open Source CACAO-based Security Orchestrator";
+    homepage = "https://github.com/COSSAS/SOARCA";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ _13621 ];
+    mainProgram = "soarca";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added SOARCA, an open source security orchestrator for CACAO playbooks written in Go. Includes package and NixOS module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
