### PR TITLE
python3Packages.chime: init at 0.7-unstable-2023-03-06

### DIFF
--- a/pkgs/development/python-modules/chime/default.nix
+++ b/pkgs/development/python-modules/chime/default.nix
@@ -1,0 +1,40 @@
+{
+  alsa-utils,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  poetry-core,
+  stdenv,
+  unstableGitUpdater,
+}:
+
+buildPythonPackage {
+  pname = "chime";
+  version = "0.7-unstable-2023-03-06";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MaxHalford";
+    repo = "chime";
+    rev = "083654b8886463acaff64f72224081a10260373b";
+    hash = "sha256-t+ri/1JuczUFP7txRU8+5MaETMcsjLnuXbacJMzGf98=";
+  };
+
+  build-system = [ poetry-core ];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ alsa-utils ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  postInstall = ''
+    substituteInPlace $out/bin/chime \
+      --replace "/usr/lib/syslinux" "${alsa-utils}/bin/aplay" \
+  '';
+
+  meta = {
+    description = "Python sound notifications made easy";
+    homepage = "https://github.com/MaxHalford/chime";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ PopeRigby ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2560,6 +2560,8 @@ self: super: with self; {
 
   chex = callPackage ../development/python-modules/chex { };
 
+  chime = callPackage ../development/python-modules/chime { };
+
   chirpstack-api = callPackage ../development/python-modules/chirpstack-api { };
 
   chispa = callPackage ../development/python-modules/chispa { };


### PR DESCRIPTION
Added [chime](https://github.com/MaxHalford/chime)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
