### PR TITLE
lib.strings.escapeGlob: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -107,7 +107,7 @@ let
       escapeShellArg escapeShellArgs
       isStorePath isStringLike
       isValidPosixName toShellVar toShellVars trim trimWith
-      escapeRegex escapeURL escapeXML replaceChars lowerChars
+      escapeRegex escapeGlob escapeURL escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion match split

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1064,6 +1064,38 @@ rec {
     replaceStrings (builtins.attrNames toEscape) (lib.mapAttrsToList (_: c: "%${fixedWidthString 2 "0" (lib.toHexString c)}") toEscape);
 
   /**
+    Return a glob string that matches exactly the input string with minimal modification.
+
+    It utilize the `[<char>]` glob syntax which exactly matches `<char>`,
+    and supports both Unix-like globbing and Bash Extended Globbing.
+
+    # Inputs
+
+    `string`
+    : Input string, which the output glob exactly matches.
+
+    # Type
+
+    ```
+    escapeGlob :: string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.escapeGlob` usage example
+    ```nix-repl
+    lib.escapeGlob "Can you *hear* me?.txt"
+    => "Can you [*]hear[*] me[?].txt"
+    lib.escapeGlob "@(hi|hello)"
+    => "[@](hi|hello)"
+    lib.escapeGlob "alice@example.com"
+    => "alice@example.com"
+    ```
+    :::
+  */
+  escapeGlob = replaceStrings [ "*" "?" "[" "]" "+(" "@(" "!(" ] [ "[*]" "[?]" "[[]" "[]]" "[+](" "[@](" "[!](" ];
+
+  /**
     Quote `string` to be used safely within the Bourne shell if it has any
     special characters.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -474,6 +474,24 @@ runTests {
     expected = [ "A" "B" ];
   };
 
+  testEscapeGlobEmpty = {
+    expr = strings.escapeGlob "";
+    expected = "";
+  };
+
+  testEscapeGlobExamples = {
+    expr = map strings.escapeGlob [
+      "Can you *hear* me?.txt"
+      "@(hi|hello)"
+      "alice@example.com"
+    ];
+    expected = [
+      "Can you [*]hear[*] me[?].txt"
+      "[@](hi|hello)"
+      "alice@example.com"
+    ];
+  };
+
   testEscapeShellArg = {
     expr = strings.escapeShellArg "esc'ape\nme";
     expected = "'esc'\\''ape\nme'";


### PR DESCRIPTION
This PR adds a Nixpkgs library function to obtain literal matches when globbing.

When working on the `buildPython{Package,Application}`'s `__structuredAttrs` support, @wolfgangwalther proposes to use PyTest's `--ignore-glob` to handle wildcard path patterns without Bash expansions (https://github.com/NixOS/nixpkgs/pull/347194#discussion_r1823311553). I realized during the documentation update that there's no library function like `lib.escapeRegex` that can "escape" a literal path containing wildcard characters and make it glob literally, hence this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (documentation)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
