### PR TITLE
dotnet-sdk-setup-hook: add nuget.org as a package source when there is no <clear/>

### DIFF
--- a/pkgs/by-name/ps/ps3-disc-dumper/package.nix
+++ b/pkgs/by-name/ps/ps3-disc-dumper/package.nix
@@ -27,12 +27,6 @@ buildDotnetModule rec {
   projectFile = "UI.Avalonia/UI.Avalonia.csproj";
   nugetDeps = ./deps.json;
 
-  preConfigureNuGet = ''
-    # This should really be in the upstream nuget.config
-    dotnet nuget add source https://api.nuget.org/v3/index.json \
-      -n nuget.org --configfile nuget.config
-  '';
-
   runtimeDeps = [
     zlib
     openssl

--- a/pkgs/by-name/re/recyclarr/package.nix
+++ b/pkgs/by-name/re/recyclarr/package.nix
@@ -1,22 +1,12 @@
 {
   lib,
   openssl,
-  writeText,
   git,
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
   testers,
 }:
-let
-  nuget-config = writeText "nuget.config" ''
-    <configuration>
-      <packageSources>
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-      </packageSources>
-    </configuration>
-  '';
-in
 buildDotnetModule (finalAttrs: {
   pname = "recyclarr";
   version = "7.4.1";
@@ -46,8 +36,6 @@ buildDotnetModule (finalAttrs: {
   patches = [ ./001-Git-Version.patch ];
 
   enableParallelBuilding = false;
-
-  dotnetRestoreFlags = [ "--configfile=${nuget-config}" ];
 
   doCheck = false;
 


### PR DESCRIPTION
Fixes #363497

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
