### PR TITLE
gcc: use DWARF exception handling for i686-w64-mingw32

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -40,15 +40,6 @@
 
 assert !enablePlugin -> disableGdbPlugin;
 
-# Note [Windows Exception Handling]
-# sjlj (short jump long jump) exception handling makes no sense on x86_64,
-# it's forcibly slowing programs down as it produces a constant overhead.
-# On x86_64 we have SEH (Structured Exception Handling) and we should use
-# that. On i686, we do not have SEH, and have to use sjlj with dwarf2.
-# Hence it's now conditional on x86_32 (i686 is 32bit).
-#
-# ref: https://stackoverflow.com/questions/15670169/what-is-difference-between-sjlj-vs-dwarf-vs-seh
-
 let
   inherit (stdenv)
     hostPlatform
@@ -69,6 +60,10 @@ let
       "--with-as=${
         if targetPackages.stdenv.cc.bintools.isLLVM then binutils else targetPackages.stdenv.cc.bintools
       }/bin/${targetPlatform.config}-as"
+    ]
+    ++ lib.optionals (crossMingw && targetPlatform.isx86_32) [
+      "--disable-sjlj-exceptions"
+      "--with-dwarf2"
     ]
     ++ (
       if withoutTargetLibc then
@@ -101,11 +96,6 @@ let
           "--disable-nls"
           # To keep ABI compatibility with upstream mingw-w64
           "--enable-fully-dynamic-string"
-        ]
-        ++ lib.optionals (crossMingw && targetPlatform.isx86_32) [
-          # See Note [Windows Exception Handling]
-          "--enable-sjlj-exceptions"
-          "--with-dwarf2"
         ]
       else
         [


### PR DESCRIPTION
This is the default used by MSYS2[^1], ArchLinux[^2] and probably everyone else.
This is required to compile Rust programs as it doesn't support SJLJ[^3].

[^1]: https://github.com/msys2/MINGW-packages/blob/725f262e9f6313e3ee04327a33c16614c970a110/mingw-w64-gcc/PKGBUILD#L185-L186
[^2]: https://gitlab.archlinux.org/archlinux/packaging/packages/mingw-w64-gcc/-/blob/14.2.0-3/PKGBUILD#L62
[^3]: https://github.com/rust-lang/rust/pull/55444#issuecomment-434044002

Effectively a continuation of #89582, but for x86-32.

I also moved the EH flags out of the `withoutTargetLibc` check, which I believe to be a mistake introduced by the previous PR: https://github.com/NixOS/nixpkgs/pull/89582#discussion_r2051529534

I've tested it with a [rust hello world](https://github.com/js6pak/nixpkgs/blob/b93b950e15bc642861e24fd5b6aa5ef9070a9407/pkgs/by-name/he/hello-rust/package.nix) cross compiled for `mingw32`/`mingwW64` with `mcf`/`win32` threading.
*For some reason `-lmcfgthread` doesn't get automatically added with `buildRustPackage` but that's a separate issue.*

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
