### PR TITLE
pfetch: 0.6.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/pf/pfetch/package.nix
+++ b/pkgs/by-name/pf/pfetch/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  gitUpdater,
+  versionCheckHook,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -20,6 +22,16 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     install -Dm755 -t $out/bin pfetch
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
 
   meta = {
     description = "Pretty system information tool written in POSIX sh";

--- a/pkgs/by-name/pf/pfetch/package.nix
+++ b/pkgs/by-name/pf/pfetch/package.nix
@@ -27,7 +27,10 @@ stdenvNoCC.mkDerivation rec {
     changelog = "https://github.com/Un1q32/pfetch/releases/tag/${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ equirosa ];
+    maintainers = with lib.maintainers; [
+      equirosa
+      phanirithvij
+    ];
     mainProgram = "pfetch";
   };
 }

--- a/pkgs/by-name/pf/pfetch/package.nix
+++ b/pkgs/by-name/pf/pfetch/package.nix
@@ -1,18 +1,18 @@
 {
-  stdenvNoCC,
   lib,
+  stdenvNoCC,
   fetchFromGitHub,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "pfetch";
-  version = "0.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
-    owner = "dylanaraps";
+    owner = "Un1q32";
     repo = "pfetch";
-    rev = version;
-    sha256 = "06z0k1naw3k052p2z7241lx92rp5m07zlr0alx8pdm6mkc3c4v8f";
+    tag = version;
+    hash = "sha256-omI1Y1UKxSkg1QUd/GHHuGBwxfNOtxqYpzPbJdG7j3A=";
   };
 
   dontBuild = true;
@@ -21,12 +21,13 @@ stdenvNoCC.mkDerivation rec {
     install -Dm755 -t $out/bin pfetch
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Pretty system information tool written in POSIX sh";
-    homepage = "https://github.com/dylanaraps/pfetch";
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ equirosa ];
+    homepage = "https://github.com/Un1q32/pfetch";
+    changelog = "https://github.com/Un1q32/pfetch/releases/tag/${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ equirosa ];
     mainProgram = "pfetch";
   };
 }


### PR DESCRIPTION
[pfetch](https://github.com/dylanaraps/pfetch) repo is archived.
on [AUR](https://aur.archlinux.org/packages/pfetch) this is the replaced fork.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
