### PR TITLE
arpack: use openblas on darwin; fix build; enable eigen

### DIFF
--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     "-DINTERFACE64=${if blas.isILP64 then "1" else "0"}"
     "-DMPI=${if useMpi then "ON" else "OFF"}"
     "-DICB=ON"
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # prevent cmake from using Accelerate, which causes single precision tests
+    # to segfault
+    "-DBLA_VENDOR=Generic"
   ];
 
   preCheck = ''

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -30,10 +30,14 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = lib.optional useMpi openssh;
 
+  # a couple tests fail when run in parallel
   doCheck = true;
+  enableParallelChecking = false;
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" stdenv.hostPlatform.hasSharedLibraries)
+    (lib.cmakeBool "EIGEN" true)
+    (lib.cmakeBool "EXAMPLES" true)
     (lib.cmakeBool "ICB" true)
     (lib.cmakeBool "INTERFACE64" blas.isILP64)
     (lib.cmakeBool "MPI" useMpi)
@@ -42,11 +46,6 @@ stdenv.mkDerivation rec {
     # to segfault
     "-DBLA_VENDOR=Generic"
   ];
-
-  preCheck = ''
-    # Prevent tests from using all cores
-    export OMP_NUM_THREADS=2
-  '';
 
   passthru = {
     inherit (blas) isILP64;


### PR DESCRIPTION
change 07cdea2ae5005c6396eafd9d87e1cdec6c0c2a4b uncovered a misconfiguration in the darwin build resulting in some tests failing / segfaulting. Switch to using openblas which has no issues with the tests. Additionally, enable eigen as it was part of the build inputs but was unused as `EIGEN=ON` was not set in the build flags. Finally, added an option to use Accelerate building with the flags `-ff2c -fno-second-underscore` found https://github.com/opencollab/arpack-ng/blob/804fa3149a0f773064198a8e883bd021832157ca/.github/workflows/jobs.yml#L184-L192.

FWIW: homebrew also uses openblas. https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/arpack.rb


https://github.com/NixOS/nixpkgs/pull/357259
https://hydra.nixos.org/build/282505341


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

