### PR TITLE
[Backport release-24.11] k3s_1_31: 1.31.2+k3s1 -> 1.31.4+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1hq8bj2hlzbq9rhpx9ifidfkrzy1pknizksq641kazl7kv44wldy"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1dykfk58sp4phf125jfrzx031pp1mj0g8q0kliis139sig14vagp"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "1mp8k98mzzn7fpyqjyvia13v2jri37nn3fdqdq3gmxrbcqvkh15g"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "0z4h9yd8843q58hhm8jw072k1ixxnmprp9c30pwb796iy1mpirbm"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1gg30iln9grrw3qdwlqwcb0k1zafiwr2lj7vd64mmsm1fj057skw"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "0xsq095dkf89c6jjd126rrdl7k0zy7cxb38rimzpacb8zfj4ss82"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-images.txt",
-    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-images.txt",
+    "sha256": "1gqiaszfw49hsbn7xkkadykaf028vys13ykqvpkqar0f7hwwbja6"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.31.1+k3s1";
-  k3sCommit = "452dbbc14c747a0070fdf007ef2239a6e5d8d934";
-  k3sRepoSha256 = "012j78bxhmjq7d0z0yzxzbvlhgzx9qi254cpk6s6mi3k60ay6bx2";
-  k3sVendorHash = "sha256-CnfnyqrBQ9W1G6NORGSA5jB75Dvd1Hgu+KVITYrb6Mc=";
+  k3sVersion = "1.31.4+k3s1";
+  k3sCommit = "a562d090b05cf8d55b6a8b57556787c24c8ce21a";
+  k3sRepoSha256 = "1kgw3jnaqh8lnbljgdvyl14vdlyvy8gw2jsqqj3qv1kv1m3qqsjw";
+  k3sVendorHash = "sha256-OtIQ3pmN4V3qJODF5/fSespbKvucvzi4ykdmGkRVlf4=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
-  k3sRootVersion = "0.14.0";
-  k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.5.1-k3s1";
-  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
-  containerdVersion = "1.7.21-k3s2";
-  containerdSha256 = "0kp93fhmw2kiy46hw3ag05z8xwhw7kqp4wcbhsxshsdf0929g539";
+  k3sRootVersion = "0.14.1";
+  k3sRootSha256 = "0svbi42agqxqh5q2ri7xmaw2a2c70s7q5y587ls0qkflw5vx4sl7";
+  k3sCNIVersion = "1.6.0-k3s1";
+  k3sCNISha256 = "0g7zczvwba5xqawk37b0v96xysdwanyf1grxn3l3lhxsgjjsmkd7";
+  containerdVersion = "1.7.23-k3s2";
+  containerdSha256 = "0lp9vxq7xj74wa7hbivvl5hwg2wzqgsxav22wa0p1l7lc1dqw8dm";
   criCtlVersion = "1.31.0-k3s2";
 }


### PR DESCRIPTION
https://github.com/k3s-io/k3s/releases/tag/v1.31.4%2Bk3s1
(cherry picked from commit 16be5207b9326b3c3278a101fd57fa8f6d9a0563)

Manuel backport due to conflicts. Parent pull request here: https://github.com/NixOS/nixpkgs/pull/365873

This is affected by the same problem as other k3s backports, release-24.11 skipped a k3s version so automatic backport and the cherry pick checker fail.

@NixOS/k3s

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
