### PR TITLE
python312Packages.taichi: init at 1.7.2

### DIFF
--- a/pkgs/development/python-modules/taichi/bin.nix
+++ b/pkgs/development/python-modules/taichi/bin.nix
@@ -1,0 +1,141 @@
+{
+  config,
+  lib,
+  autoPatchelfHook,
+  autoAddDriverRunpath,
+  buildPythonPackage,
+  fetchPypi,
+  stdenv,
+  python,
+  # python dependencies:
+  dill,
+  numpy,
+  colorama,
+  matplotlib,
+  rich,
+  # lib dependencies
+  # vulkan-headers,
+  vulkan-loader,
+  libX11,
+  libGL,
+  libGLU,
+  libz,
+  # Options:
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+}:
+
+let
+  pname = "taichi";
+  version = "1.7.2";
+  format = "wheel";
+  inherit (python) pythonVersion;
+
+  packages =
+    let
+      getSrcFromPypi =
+        {
+          platform,
+          dist,
+          hash,
+        }:
+        fetchPypi {
+          inherit
+            pname
+            version
+            format
+            platform
+            dist
+            ;
+          # See the `disabled` attr comment below.
+          sha256 = hash;
+          python = dist;
+          abi = dist;
+        };
+    in
+    {
+      "3.12-x86_64-linux" = getSrcFromPypi {
+        platform = "manylinux_2_27_x86_64";
+        dist = "cp312";
+        hash = "6faa8d505b207807dc4e42e137dd6af76b0bfdedbd2aefa5ad59a231f355f104";
+      };
+      "3.12-x86_64-darwin" = getSrcFromPypi {
+        platform = "macosx_11_0_x86_64";
+        dist = "cp312";
+        hash = "dca5b3ac63cc0369034d75c7fd1fee93288bd964fa2464778f1cc40540ab928a";
+      };
+      "3.12-aarch64-darwin" = getSrcFromPypi {
+        platform = "macosx_11_0_arm64";
+        dist = "cp312";
+        hash = "5e02427f2f5109ce52e3a2c2a3a41e745a4a3e415a125386b12f2e7f9e45c9ff";
+      };
+      "3.11-x86_64-linux" = getSrcFromPypi {
+        platform = "manylinux_2_27_x86_64";
+        dist = "cp312";
+        hash = "4d97a5d87839aabbe93083227cbd9049c1df03469f758209bdc516156d2f60d5";
+      };
+      "3.11-x86_64-darwin" = getSrcFromPypi {
+        platform = "macosx_11_0_x86_64";
+        dist = "cp312";
+        hash = "53b037529268a4401f72aac9821b2f9b167b352697f392b19c93c946f14ad9a5";
+      };
+      "3.11-aarch64-darwin" = getSrcFromPypi {
+        platform = "macosx_11_0_arm64";
+        dist = "cp312";
+        hash = "706148dfdf50cec5c9c70ae00b8d1689ca3b10b50447213f8b46de5465845f67";
+      };
+    };
+
+  libPath = lib.makeLibraryPath (
+    [
+      libGL
+      vulkan-loader
+    ]
+    ++ lib.optionals cudaSupport [ cudaPackages.cudatoolkit ]
+  );
+in
+buildPythonPackage {
+  inherit pname version format;
+  src =
+    packages."${pythonVersion}-${stdenv.hostPlatform.system}"
+      or (throw "taichi-bin is not supported on ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ] ++ lib.optionals cudaSupport [ autoAddDriverRunpath ];
+
+  preInstallCheck = ''
+    shopt -s globstar
+
+    for file in $out/**/*.so; do
+      patchelf --add-rpath "${libPath}" "$file"
+    done
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    colorama
+    dill
+    matplotlib
+    rich
+
+    # vulkan-headers
+    vulkan-loader
+    libGL
+    libGLU
+    libX11
+    libz
+  ];
+
+  meta = with lib; {
+    description = "Productive, portable, and performant GPU programming in Python.";
+    homepage = "https://github.com/taichi-dev/taichi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ arunoruto ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15335,6 +15335,10 @@ self: super: with self; {
 
   tahoma-api = callPackage ../development/python-modules/tahoma-api { };
 
+  taichi = callPackage ../development/python-modules/taichi/bin.nix {
+    inherit (pkgs.config) cudaSupport;
+  };
+
   tailer = callPackage ../development/python-modules/tailer { };
 
   tailscale = callPackage ../development/python-modules/tailscale { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Packaging [taichi](https://github.com/taichi-dev/taichi) from PyPI with CUDA, Vulkan, and OpenGL support. I used [jaxlib-bin](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/development/python-modules/jaxlib/bin.nix) as an inspiration on how to package taichi from PyPI, and in the future the default library should point to a build compiled from source.

Problems:
1. When running `ti example` and selecting, for example, `16`, i.e., `fractal3d_ggui`, it crashes with the following response:
```log
Running example fractal3d_ggui ...
[Taichi] Starting on arch=vulkan
RHI Error: (2) vkAcquireNextImageKHR failed
python3.12: /home/dev/taichi/taichi/rhi/vulkan/vulkan_device.cpp:2808: virtual taichi::lang::StreamSemaphore taichi::lang::vulkan::VulkanSurface::acquire_next_image(): Assertion `false && "Error without return code"' failed.
fish: Job 1, 'ti example' terminated by signal SIGABRT (Abort)
```

Continuation of #233365
Closes #143181

TODO:
- [x] Test on Nvidia machine
- [x] Include hashes for 3.11 and x86/arm darwin systems
- [ ] Fix `RHI Error: (2) vkAcquireNextImageKHR failed` if vulkan is set as arch
- [x] ~~Find out how to enable `amdgpu` support using ROCm, i.e., which library needs to be added~~ It seems like the package needs to be built using llvm from ROCm according to [this](https://github.com/taichi-dev/taichi/issues/6434#issuecomment-1760105316) issue -> not meant for this release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
