### PR TITLE
podman: backport removing incomplete layers fix

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -5,29 +5,18 @@ let
 
   inherit (lib) mkOption types;
 
-  podmanPackage = pkgs.podman.override {
-    extraPackages = cfg.extraPackages ++ [
-        "/run/wrappers" # setuid shadow
-        config.systemd.package # To allow systemd-based container healthchecks
-      ] ++ lib.optional (config.boot.supportedFilesystems.zfs or false) config.boot.zfs.package;
-    extraRuntimes = [ pkgs.runc ]
-      ++ lib.optionals (config.virtualisation.containers.containersConf.settings.network.default_rootless_network_cmd or "" == "slirp4netns") (with pkgs; [
-      slirp4netns
-    ]);
-  };
-
   # Provides a fake "docker" binary mapping to podman
-  dockerCompat = pkgs.runCommand "${podmanPackage.pname}-docker-compat-${podmanPackage.version}"
+  dockerCompat = pkgs.runCommand "${cfg.package.pname}-docker-compat-${cfg.package.version}"
     {
       outputs = [ "out" "man" ];
-      inherit (podmanPackage) meta;
+      inherit (cfg.package) meta;
       preferLocalBuild = true;
     } ''
     mkdir -p $out/bin
-    ln -s ${podmanPackage}/bin/podman $out/bin/docker
+    ln -s ${cfg.package}/bin/podman $out/bin/docker
 
     mkdir -p $man/share/man/man1
-    for f in ${podmanPackage.man}/share/man/man1/*; do
+    for f in ${cfg.package.man}/share/man/man1/*; do
       basename=$(basename $f | sed s/podman/docker/g)
       ln -s $f $man/share/man/man1/$basename
     done
@@ -137,13 +126,21 @@ in
       };
     };
 
-    package = lib.mkOption {
-      type = types.package;
-      default = podmanPackage;
-      internal = true;
-      description = ''
-        The final Podman package (including extra packages).
+    package = (lib.mkPackageOption pkgs "podman" {
+      extraDescription = ''
+        This package will automatically include extra packages and runtimes.
       '';
+    }) // {
+      apply = pkg: pkg.override {
+        extraPackages = cfg.extraPackages ++ [
+            "/run/wrappers" # setuid shadow
+            config.systemd.package # To allow systemd-based container healthchecks
+          ] ++ lib.optional (config.boot.supportedFilesystems.zfs or false) config.boot.zfs.package;
+        extraRuntimes = [ pkgs.runc ]
+          ++ lib.optionals (config.virtualisation.containers.containersConf.settings.network.default_rootless_network_cmd or "" == "slirp4netns") (with pkgs; [
+          slirp4netns
+        ]);
+      };
     };
 
     defaultNetwork.settings = lib.mkOption {

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   installShellFiles,
   buildGoModule,
@@ -91,6 +92,15 @@ buildGoModule rec {
 
     # we intentionally don't build and install the helper so we shouldn't display messages to users about it
     ./rm-podman-mac-helper-msg.patch
+
+    # backport of fix for https://github.com/containers/storage/issues/2184
+    # https://github.com/containers/storage/pull/2185
+    (fetchpatch2 {
+      url = "https://github.com/containers/storage/commit/99b0d2d423c8093807d8a1464437152cd04d7d95.diff?full_index=1";
+      hash = "sha256-aahYXnDf3qCOlb6MfVDqFKCcQG257r5sbh5qnL0T40I=";
+      stripLen = 1;
+      extraPrefix = "vendor/github.com/containers/storage/";
+    })
   ];
 
   vendorHash = null;


### PR DESCRIPTION
If there are some incomplete layers, `podman` will try to remove them leading to a `SIGSEGV` due to https://github.com/containers/storage/issues/2184. This means the incomplete layers will remain and `podman` will keep failing with `SIGSEGV`.

According to https://github.com/containers/storage/issues/2184#issuecomment-2514940928, this fix won't be included in a release for another couple months which is not ideal for users who have a corrupted store

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
