### PR TITLE
gltron: fix the build against gcc-14

### DIFF
--- a/pkgs/by-name/gl/gltron/package.nix
+++ b/pkgs/by-name/gl/gltron/package.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
     SDL_sound
   ];
 
+  enableParallelBuilding = true;
+
   meta = {
     homepage = "http://www.gltron.org/";
     description = "Game based on the movie Tron";

--- a/pkgs/by-name/gl/gltron/package.nix
+++ b/pkgs/by-name/gl/gltron/package.nix
@@ -20,7 +20,16 @@ stdenv.mkDerivation rec {
     sha256 = "e0c8ebb41a18a1f8d7302a9c2cb466f5b1dd63e9a9966c769075e6b6bdad8bb0";
   };
 
-  patches = [ ./gentoo-prototypes.patch ];
+  patches = [
+    ./gentoo-prototypes.patch
+
+    # gcc-14 build fix: https://sourceforge.net/p/gltron/patches/7/
+    (fetchurl {
+      name = "gcc-14.patch";
+      url = "https://sourceforge.net/p/gltron/patches/7/attachment/gcc-14.patch";
+      hash = "sha256-OJAUAM/OQVwxYnIacBkncNxMLn/HDCoysbi+Txe+DC8=";
+    })
+  ];
 
   postPatch = ''
     # Fix https://sourceforge.net/p/gltron/bugs/15


### PR DESCRIPTION
Without the change `gltron` fails to build as:

    ./src/gltron.c: In function 'main':
    ./src/gltron.c:13:30: error: passing argument 2 of 'initSubsystems' from incompatible pointer type [-Wincompatible-pointer-types]
       13 |         initSubsystems(argc, argv);
          |                              ^~~~
          |                              |
          |                              char **


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
