### PR TITLE
lv: 4.51 -> 4.51-unstable-2020-08-03, fix gcc-14 build

### DIFF
--- a/pkgs/by-name/lv/lv/package.nix
+++ b/pkgs/by-name/lv/lv/package.nix
@@ -1,22 +1,30 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   ncurses,
+  unstableGitUpdater,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "lv";
-  version = "4.51";
+  version = "4.51-unstable-2020-08-03";
 
-  src = fetchurl {
-    url = "mirror://debian/pool/main/l/${pname}/${pname}_${version}.orig.tar.gz";
-    sha256 = "0yf3idz1qspyff1if41xjpqqcaqa8q8icslqlnz0p9dj36gmm5l3";
+  src = fetchFromGitHub {
+    owner = "ttdoda";
+    repo = "lv";
+    rev = "1fb214d4136334a1f6cd932b99f85c74609e1f23";
+    hash = "sha256-mUFiWzTTM6nAKQgXA0sYIUm1MwN7HBHD8LWBgzu3ZUk=";
   };
 
   makeFlags = [ "prefix=${placeholder "out"}" ];
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ncurses ];
+
+  preAutoreconf = "cd src";
+  postAutoreconf = "cd ..";
 
   configurePhase = ''
     mkdir -p build
@@ -28,9 +36,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
   '';
 
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
+
   meta = with lib; {
     description = "Powerful multi-lingual file viewer / grep";
-    homepage = "https://web.archive.org/web/20160310122517/www.ff.iij4u.or.jp/~nrt/lv/";
+    homepage = "https://github.com/ttdoda/lv";
     license = licenses.gpl2Plus;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ kayhide ];


### PR DESCRIPTION
Without the change the build fails against `gcc-14` due to outdated `./configure` script as
https://hydra.nixos.org/build/281834372/nixlog/3:

configure: error: installation or configuration problem: C compiler cannot create executables.

    configure:678:1: error: return type defaults to 'int' [-Wimplicit-int]
    configure: failed program was:

    main(){return(0);}

Fix the build by generating newer `./configure`.

While at it switched to the latest home page for `lv`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
