### PR TITLE
workflows/periodic-merge: merge merge-base into haskell-updates

### DIFF
--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -33,8 +33,6 @@ jobs:
       max-parallel: 1
       matrix:
         pairs:
-          - from: master
-            into: haskell-updates
           - from: release-24.11
             into: staging-next-24.11
           - from: staging-next-24.11

--- a/.github/workflows/periodic-merge-haskell-updates.yml
+++ b/.github/workflows/periodic-merge-haskell-updates.yml
@@ -1,0 +1,59 @@
+# This action periodically merges a merge base of master and staging into haskell-updates.
+#
+# haskell-updates is based on master (so there are little unrelated failures and the cache
+# is already prepopulated), but needs to target staging due to the high amount of rebuilds
+# it typically causes. To prevent unrelated commits clattering the GitHub UI, we need to
+# take care to only merge the merge-base of master and staging into haskell-updates.
+#
+# See also https://github.com/NixOS/nixpkgs/issues/361143.
+
+name: "Periodic Merges (haskell-updates)"
+
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Merge every 24 hours
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  periodic-merge:
+    permissions:
+      contents: write  # for devmasx/merge-branch to merge branches
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
+    if: github.repository_owner == 'NixOS'
+    runs-on: ubuntu-latest
+    name: git merge-base master staging → haskell-updates
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      # Note: If we want to do something similar for more branches, we can move this into a
+      # separate job, so we can use the matrix strategy again.
+      - name: Find merge base of master and staging
+        id: find_merge_base_step
+        run: |
+          merge_base="$(git merge-base refs/remotes/origin/master refs/remotes/origin/staging)"
+          echo "Found merge base: $merge_base" >&2
+          echo "merge_base=$merge_base" >> "$GITHUB_OUTPUT"
+
+      - name: git merge-base master staging → haskell-updates
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # 1.4.0
+        with:
+          type: now
+          head_to_merge: ${{ steps.find_merge_base_step.outputs.merge_base }}
+          target_branch: haskell-updates
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: ${{ failure() }}
+        with:
+          issue-number: 367709
+          body: |
+            Periodic merge from `${{ steps.find_merge_base_step.outputs.merge_base }}` into `haskell-updates` has [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
Since haskell-updates is based on master, but merges into staging, we need to merge in a merge-base of staging and master. See #361143.

I'm a bit worried that the information GitHub uses for displaying Pull-Requests becomes stale and this will “add” commits to the PR compared to the base anyways. We'll find out, I suppose.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
