### PR TITLE
SDL_sound: fix cross build

### DIFF
--- a/pkgs/by-name/sd/SDL_sound/package.nix
+++ b/pkgs/by-name/sd/SDL_sound/package.nix
@@ -19,10 +19,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OZn9C7tIUomlK+FLL2i1ccuE44DMQzh+rfd49kx55t8=";
   };
 
-  nativeBuildInputs = [
-    SDL
-  ];
-
   buildInputs = [
     SDL
     flac
@@ -33,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     (lib.enableFeature enableSdltest "sdltest")
   ];
+
+  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
 
   strictDeps = true;
 


### PR DESCRIPTION
For some reason having SDL in nativeBuildInputs confused the build.
Instead we pass in sdl-config by environment variable.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).