### PR TITLE
gltron: fix cross build

### DIFF
--- a/pkgs/by-name/gl/gltron/package.nix
+++ b/pkgs/by-name/gl/gltron/package.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
   # The build fails, unless we disable the default -Wall -Werror
   configureFlags = [ "--disable-warn" ];
 
+  makeFlags = [ "AR=${stdenv.cc.targetPrefix}ar" ];
+
+  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+
   buildInputs = [
     SDL
     libGLU
@@ -50,6 +54,7 @@ stdenv.mkDerivation rec {
     SDL_sound
   ];
 
+  strictDeps = true;
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
depends on #367712

## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).