### PR TITLE
tt-rss : Cleanup, better tests, mark plugins as broken

### DIFF
--- a/nixos/tests/web-apps/tt-rss.nix
+++ b/nixos/tests/web-apps/tt-rss.nix
@@ -10,13 +10,32 @@ import ../make-test-python.nix (
           enable = true;
           virtualHost = "localhost";
           selfUrlPath = "http://localhost/";
+          pluginPackages = with pkgs; [
+            tt-rss-plugin-auth-ldap
+          ];
           singleUserMode = true;
+          themePackages = with pkgs; [ tt-rss-theme-feedly ];
         };
       };
 
     testScript = ''
+      import json
+      import re
       machine.wait_for_unit("tt-rss.service")
-      machine.succeed("curl -sSfL http://localhost/ | grep 'Tiny Tiny RSS'")
+
+      matches = re.search('__csrf_token = "([^"]*)"', machine.succeed("curl -sSfL --cookie cjar --cookie-jar cjar -sSfL http://localhost/"))
+      if matches is None:
+        assert False, "CSRF token not found"
+      csrf_token = matches.group(1)
+
+      # Ensure themes are loaded. No API found for these, so it's a crude check.
+      preference_page = machine.succeed("curl -sSfL --cookie cjar --cookie-jar cjar http://localhost/backend.php?op=Pref_Prefs")
+      assert "feedly" in preference_page
+
+      plugins = json.loads(machine.succeed(f"curl -sSfL --cookie cjar --cookie-jar cjar 'http://localhost/backend.php' -X POST --data-raw 'op=Pref_Prefs&method=getPluginsList&csrf_token={csrf_token}'"))["plugins"]
+      expected_plugins = ["auth_ldap"];
+      found_plugins = [p["name"] for p in plugins if p["name"] in expected_plugins]
+      assert len(found_plugins) == len(expected_plugins), f"Expected plugins {expected_plugins}, found {found_plugins}"
     '';
   }
 )

--- a/nixos/tests/web-apps/tt-rss.nix
+++ b/nixos/tests/web-apps/tt-rss.nix
@@ -12,6 +12,12 @@ import ../make-test-python.nix (
           selfUrlPath = "http://localhost/";
           pluginPackages = with pkgs; [
             tt-rss-plugin-auth-ldap
+            tt-rss-plugin-feediron
+          ];
+          plugins = [
+            "auth_internal"
+            "feediron"
+            "note"
           ];
           singleUserMode = true;
           themePackages = with pkgs; [ tt-rss-theme-feedly ];
@@ -33,7 +39,7 @@ import ../make-test-python.nix (
       assert "feedly" in preference_page
 
       plugins = json.loads(machine.succeed(f"curl -sSfL --cookie cjar --cookie-jar cjar 'http://localhost/backend.php' -X POST --data-raw 'op=Pref_Prefs&method=getPluginsList&csrf_token={csrf_token}'"))["plugins"]
-      expected_plugins = ["auth_ldap"];
+      expected_plugins = ["auth_internal", "auth_ldap", "feediron", "note"];
       found_plugins = [p["name"] for p in plugins if p["name"] in expected_plugins]
       assert len(found_plugins) == len(expected_plugins), f"Expected plugins {expected_plugins}, found {found_plugins}"
     '';

--- a/pkgs/by-name/tt/tt-rss-plugin-auth-ldap/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-auth-ldap/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosTests,
   stdenv,
   fetchFromGitHub,
 }:
@@ -18,6 +19,10 @@ stdenv.mkDerivation {
   installPhase = ''
     install -D plugins/auth_ldap/init.php $out/auth_ldap/init.php
   '';
+
+  passthru = {
+    tests = { inherit (nixosTests) tt-rss; };
+  };
 
   meta = with lib; {
     description = "Plugin for TT-RSS to authenticate users via ldap";

--- a/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    broken = true; # Plugin code does not conform to plugin API changes. See https://github.com/wltb/ff_instagram/issues/13
     description = "Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites";
     longDescription = ''
       Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites.

--- a/pkgs/by-name/tt/tt-rss-theme-feedly/package.nix
+++ b/pkgs/by-name/tt/tt-rss-theme-feedly/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosTests,
   stdenv,
   fetchFromGitHub,
 }:
@@ -22,6 +23,10 @@ stdenv.mkDerivation rec {
 
     cp -ra feedly *.css $out
   '';
+
+  passthru = {
+    tests = { inherit (nixosTests) tt-rss; };
+  };
 
   meta = with lib; {
     description = "Feedly theme for Tiny Tiny RSS";

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Web-based news feed (RSS/Atom) aggregator";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl3Plus;
     homepage = "https://tt-rss.org";
     maintainers = with maintainers; [
       gileri

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit (nixosTests) tt-rss;
+    tests = { inherit (nixosTests) tt-rss; };
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };
 

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -1,3 +1,4 @@
+# nixpkgs-update: no auto update
 {
   lib,
   stdenv,


### PR DESCRIPTION
<!--

* Move tt-rss to by-name hierarchy
* Mark tt-rss-plugin-ff-instagram, tt-rss-plugin-feediron as broken (incompatible plugin API changes)
* More comprehensive test, which check for theme and plugin loading
*  Fix license for tt-rss

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
