### PR TITLE
bespokesynth: Modernise, 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -76,8 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst-sdk}/VST2_SDK")
   ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [
-    python3
+    python3 # interpreter
     makeWrapper
     cmake
     pkg-config
@@ -85,7 +87,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [
+    [
+      python3 # library
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       # List obtained from https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml
       libX11
       libXrandr
@@ -160,6 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
       libXScrnSaver
     ])
   }";
+
   dontPatchELF = true; # needed or nix will try to optimize the binary by removing "useless" rpath
 
   meta = {

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -61,13 +61,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bespokesynth";
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "BespokeSynth";
     repo = "bespokesynth";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-vDvNm9sW9BfWloB0CA+JHTp/bfDWAP/T0hDXjoMZ3X4=";
+    hash = "sha256-ad8wdLos3jM0gRMpcfRKeaiUxJsPGqWd/7XeDz87ToQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -72,6 +72,14 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  # Linux builds are sandboxed properly, this always returns "localhost" there.
+  # Darwin builds doesn't have the same amount of sandboxing by default, and the builder's hostname is returned.
+  # In case this ever gets embedded into VersionInfoBld.cpp, hardcode it to the Linux value
+  postPatch = ''
+    substituteInPlace Source/cmake/versiontools.cmake \
+      --replace-fail 'cmake_host_system_information(RESULT BESPOKE_BUILD_FQDN QUERY FQDN)' 'set(BESPOKE_BUILD_FQDN "localhost")'
+  '';
+
   cmakeBuildType = "Release";
 
   cmakeFlags =

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchzip,
+  gitUpdater,
   cmake,
   pkg-config,
   ninja,
@@ -167,6 +168,10 @@ stdenv.mkDerivation (finalAttrs: {
   }";
 
   dontPatchELF = true; # needed or nix will try to optimize the binary by removing "useless" rpath
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = {
     description = "Software modular synth with controllers support, scripting and VST";

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -12,6 +12,7 @@
   alsa-lib,
   alsa-tools,
   freetype,
+  jsoncpp,
   libusb1,
   libX11,
   libXrandr,
@@ -73,9 +74,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeBuildType = "Release";
 
-  cmakeFlags = lib.optionals enableVST2 [
-    (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst-sdk}/VST2_SDK")
-  ];
+  cmakeFlags =
+    [
+      (lib.cmakeBool "BESPOKE_SYSTEM_PYBIND11" true)
+      (lib.cmakeBool "BESPOKE_SYSTEM_JSONCPP" true)
+    ]
+    ++ lib.optionals enableVST2 [
+      (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst-sdk}/VST2_SDK")
+    ];
 
   strictDeps = true;
 
@@ -89,7 +95,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
-      python3 # library
+      jsoncpp
+      # library & headers
+      (python3.withPackages (
+        ps: with ps; [
+          pybind11
+        ]
+      ))
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       # List obtained from https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml

--- a/pkgs/by-name/be/bespokesynth/2001-bespokesynth-fix-pipewire-jack.patch
+++ b/pkgs/by-name/be/bespokesynth/2001-bespokesynth-fix-pipewire-jack.patch
@@ -1,0 +1,30 @@
+diff --git a/libs/JUCE/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp b/libs/JUCE/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
+index 4cce7016f..25554a7cd 100644
+--- a/libs/JUCE/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
++++ b/libs/JUCE/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
+@@ -291,7 +291,6 @@ public:
+         juce::jack_on_info_shutdown (client, infoShutdownCallback, this);
+         juce::jack_set_xrun_callback (client, xrunCallback, this);
+         juce::jack_activate (client);
+-        deviceIsOpen = true;
+ 
+         if (! inputChannels.isZero())
+         {
+@@ -336,6 +335,7 @@ public:
+         }
+ 
+         updateActivePorts();
++        deviceIsOpen = true;
+ 
+         return lastError;
+     }
+@@ -525,7 +525,8 @@ private:
+     static void portConnectCallback (jack_port_id_t, jack_port_id_t, int, void* arg)
+     {
+         if (JackAudioIODevice* device = static_cast<JackAudioIODevice*> (arg))
+-            device->mainThreadDispatcher.updateActivePorts();
++            if (device->isOpen())
++                device->mainThreadDispatcher.updateActivePorts();
+     }
+ 
+     static void threadInitCallback (void* /* callbackArgument */)

--- a/pkgs/by-name/be/bespokesynth/package.nix
+++ b/pkgs/by-name/be/bespokesynth/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchzip,
   gitUpdater,
+  apple-sdk_11,
   cmake,
   pkg-config,
   ninja,
@@ -33,13 +34,6 @@
   pcre,
   mount,
   zenity,
-  Accelerate,
-  Cocoa,
-  WebKit,
-  CoreServices,
-  CoreAudioKit,
-  IOBluetooth,
-  MetalKit,
   # It is not allowed to distribute binaries with the VST2 SDK plugin without a license
   # (the author of Bespoke has such a licence but not Nix). VST3 should work out of the box.
   # Read more in https://github.com/NixOS/nixpkgs/issues/145607
@@ -138,19 +132,8 @@ stdenv.mkDerivation (finalAttrs: {
       mount
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      Accelerate
-      Cocoa
-      WebKit
-      CoreServices
-      CoreAudioKit
-      IOBluetooth
-      MetalKit
+      apple-sdk_11
     ];
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
-    # Fails to find fp.h on its own
-    "-isystem ${CoreServices}/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/CarbonCore.framework/Versions/Current/Headers/"
-  ]);
 
   postInstall =
     if stdenv.hostPlatform.isDarwin then

--- a/pkgs/by-name/be/bespokesynth/package.nix
+++ b/pkgs/by-name/be/bespokesynth/package.nix
@@ -66,6 +66,12 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix compatibility with pipewire's JACK emulation
+    # https://github.com/BespokeSynth/BespokeSynth/issues/1405#issuecomment-1721437868
+    ./2001-bespokesynth-fix-pipewire-jack.patch
+  ];
+
   # Linux builds are sandboxed properly, this always returns "localhost" there.
   # Darwin builds doesn't have the same amount of sandboxing by default, and the builder's hostname is returned.
   # In case this ever gets embedded into VersionInfoBld.cpp, hardcode it to the Linux value

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13213,10 +13213,6 @@ with pkgs;
 
   barrier = libsForQt5.callPackage ../applications/misc/barrier { };
 
-  bespokesynth = darwin.apple_sdk_11_0.callPackage ../applications/audio/bespokesynth {
-    inherit (darwin.apple_sdk_11_0.frameworks) Accelerate Cocoa WebKit CoreServices CoreAudioKit IOBluetooth MetalKit;
-  };
-
   bespokesynth-with-vst2 = bespokesynth.override {
     enableVST2 = true;
   };


### PR DESCRIPTION
Closes #367731

https://github.com/BespokeSynth/BespokeSynth/releases/tag/v1.3.0

- Modernise the derivation abit
- Add a `passthru.updateScript` for automatic / easier updates
- 1.2.1 -> 1.3.0
- Set flags to use less vendored dependencies
- Remove some build-time system inspection
- Migrate to by-name

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
