### PR TITLE
powerstation: init at 0.4.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -123,6 +123,8 @@
 
 - [InputPlumber](https://github.com/ShadowBlip/InputPlumber/), an open source input router and remapper daemon for Linux. Available as [services.inputplumber](#opt-services.inputplumber.enable).
 
+- [PowerStation](https://github.com/ShadowBlip/PowerStation/), an open source TDP control and performance daemon with DBus interface for Linux. Available as [services.powerstation](#opt-services.powerstation.enable).
+
 - [echoip](https://github.com/mpolden/echoip), a simple service for looking up your IP address. Available as [services.echoip](#opt-services.echoip.enable).
 
 - [Buffyboard](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/tree/master/buffyboard), a framebuffer on-screen keyboard. Available as [services.buffyboard](option.html#opt-services.buffyboard).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -631,6 +631,7 @@
   ./services/hardware/pcscd.nix
   ./services/hardware/pommed.nix
   ./services/hardware/power-profiles-daemon.nix
+  ./services/hardware/powerstation.nix
   ./services/hardware/rasdaemon.nix
   ./services/hardware/ratbagd.nix
   ./services/hardware/sane.nix

--- a/nixos/modules/services/hardware/powerstation.nix
+++ b/nixos/modules/services/hardware/powerstation.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.powerstation;
+in
+{
+  options.services.powerstation = {
+    enable = lib.mkEnableOption "PowerStation";
+    package = lib.mkPackageOption pkgs "powerstation" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.powerstation = {
+      description = "PowerStation Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "graphical-session.target" ];
+      environment = {
+        XDG_DATA_DIRS = "/run/current-system/sw/share";
+      };
+
+      serviceConfig = {
+        User = "root";
+        Group = "root";
+        ExecStart = lib.getExe cfg.package;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ shadowapex ];
+}

--- a/pkgs/by-name/po/powerstation/package.nix
+++ b/pkgs/by-name/po/powerstation/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  udev,
+  pciutils,
+  cmake,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "powerstation";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "ShadowBlip";
+    repo = "PowerStation";
+    tag = "v${version}";
+    hash = "sha256-R6p3zuYWggnOy60iGZ6G23ig1gzezweswAxVrCB+zvU=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3mOmDDDGW7AClG4tNuXti07lCNbK5bMnpWUnsxcxGPI=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    udev
+    pciutils
+  ];
+
+  postInstall = ''
+    cp -r rootfs/usr/* $out/
+  '';
+
+  meta = {
+    description = "Open source TDP control and performance daemon with DBus interface";
+    homepage = "https://github.com/ShadowBlip/PowerStation";
+    license = lib.licenses.gpl3Plus;
+    changelog = "https://github.com/ShadowBlip/PowerStation/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ shadowapex ];
+    mainProgram = "powerstation";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a derivation to run [PowerStation](https://github.com/ShadowBlip/PowerStation/) on NixOS.

PowerStation is an open source TDP (Thermal Design Power) control and performance daemon with DBus interface. It can allow a user to control the TDP of integrated GPUs (typically for handheld gaming PCs like the ROG Ally and Legion Go) and enable/disable CPU cores to greatly extend battery life at the cost of some gaming performance.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
