### PR TITLE
python3Packages.ray: re-add empty set fallback

### DIFF
--- a/pkgs/development/python-modules/ray/default.nix
+++ b/pkgs/development/python-modules/ray/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
       python = pyShortVersion;
       abi = pyShortVersion;
       platform = "manylinux2014_x86_64";
-      hash = binary-hashes.${pyShortVersion};
+      hash = binary-hashes.${pyShortVersion} or { };
     };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Now that nixpkgs recurses into python313 this has broken https://github.com/nix-community/nixpkgs-update-github-releases. It would be better to handle to try and handle these cases in nixpkgs-update-github-releases but for now I'd like to merge this to unblock package updates.

```
error:
        … while calling the 'listToAttrs' builtin
          at /nix/store/cpgc7nj9axliidxbqk9wm5kcxv1v4xc0-source/loadMetaFromPath.nix:42:3:
            41| in
            42|   pkgs.lib.listToAttrs filtered
              |   ^
            43|
        … while calling the 'filter' builtin
          at /nix/store/cpgc7nj9axliidxbqk9wm5kcxv1v4xc0-source/loadMetaFromPath.nix:40:14:
            39|     (pkgs.lib.splitString "\n" (pkgs.lib.fileContents universeFile));
            40|   filtered = pkgs.lib.filter (x: x != null) versions;
              |              ^
            41| in
        (stack trace truncated; use '--show-trace' to show the full, detailed trace)
        error: attribute 'cp313' missing
        at /nix/store/6jgvs97718i2c81f8dyldglpc3hf49xi-source/pkgs/development/python-modules/ray/default.nix:90:14:
            89|       platform = "manylinux2014_x86_64";
            90|       hash = binary-hashes.${pyShortVersion};
              |              ^
            91|     };
        Did you mean one of cp310, cp311 or cp312?
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
