### PR TITLE
oscar: update to 1.6.0, update source repo

### DIFF
--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -7,13 +7,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "oscar";
-  version = "1.5.3";
+  version = "1.6.0";
 
   src = fetchFromGitLab {
-    owner = "pholy";
+    owner = "CrimsonNape";
     repo = "OSCAR-code";
-    rev = "${version}";
-    hash = "sha256-ukd2pni4qEwWxG4lr8KUliZO/R2eziTTuSvDo8uigxQ=";
+    rev = "v${version}";
+    hash = "sha256-1rHgajjs+Vt9lcqkqKy92pWQLjvAHE10fPUTy8hurw4=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Updating Oscar to 1.6.0 

The repository changed owner. See this commit:

https://gitlab.com/pholy/OSCAR-code/-/commit/d16e40388d7b4dcbfc97afef85df43c520a03ccb

So now it's https://gitlab.com/CrimsonNape/OSCAR-code.git .  
Version is 1.6.0 on this one.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
