### PR TITLE
neovim-require-check-hook: include check inputs; vimPlugins: nativeCheckInputs -> checkInputs

### DIFF
--- a/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
@@ -51,7 +51,8 @@ run_require_checks() {
 
     export HOME="$TMPDIR"
     local deps="${dependencies[*]}"
-    local checks="${nativeBuildInputs[*]}"
+    local nativeCheckInputs="${nativeBuildInputs[*]}"
+    local checkInputs="${buildInputs[*]}"
     set +e
     for name in "${nvimRequireCheck[@]}"; do
         local skip=false
@@ -67,7 +68,8 @@ run_require_checks() {
             echo "Attempting to require module: $name"
             if @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
                 --cmd "set rtp+=$out,${deps// /,}" \
-                --cmd "set rtp+=$out,${checks// /,}" \
+                --cmd "set rtp+=$out,${nativeCheckInputs// /,}" \
+                --cmd "set rtp+=$out,${checkInputs// /,}" \
                 --cmd "lua require('$name')"; then
                 check_passed=true
                 successful_modules+=("$name")

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -347,55 +347,55 @@ in
     nvimRequireCheck = "cmd-parser";
   };
 
-  cmp-ai = super.cmp-ai.overrideAttrs (oa: {
+  cmp-ai = super.cmp-ai.overrideAttrs {
     # We dont want to bundle nvim-cmp anymore since blink.nvim can use these sources.
     # Add to check inputs though to validate plugin
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+    checkInputs = [ self.nvim-cmp ];
     dependencies = with self; [
       plenary-nvim
     ];
-  });
+  };
 
-  cmp-async-path = super.cmp-async-path.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-async-path = super.cmp-async-path.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-beancount = super.cmp-beancount.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-beancount = super.cmp-beancount.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-clippy = super.cmp-clippy.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-clippy = super.cmp-clippy.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = with self; [
       plenary-nvim
     ];
-  });
+  };
 
-  cmp-cmdline = super.cmp-cmdline.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-cmdline = super.cmp-cmdline.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-conjure = super.cmp-conjure.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-conjure = super.cmp-conjure.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.conjure ];
-  });
+  };
 
-  cmp-copilot = super.cmp-copilot.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-copilot = super.cmp-copilot.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.copilot-vim ];
-  });
+  };
 
-  cmp-ctags = super.cmp-ctags.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-ctags = super.cmp-ctags.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-dap = super.cmp-dap.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-dap = super.cmp-dap.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.nvim-dap ];
-  });
+  };
 
-  cmp-dictionary = super.cmp-dictionary.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-dictionary = super.cmp-dictionary.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     nvimSkipModule = [
       # Test files
       "cmp_dictionary.dict.external_spec"
@@ -403,137 +403,137 @@ in
       "cmp_dictionary.lib.trie_spec"
       "cmp_dictionary.lib.unknown_spec"
     ];
-  });
+  };
 
-  cmp-digraphs = super.cmp-digraphs.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-digraphs = super.cmp-digraphs.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-fish = super.cmp-fish.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-fish = super.cmp-fish.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.fuzzy-nvim ];
-  });
+  };
 
-  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.fuzzy-nvim ];
-  });
+  };
 
-  cmp-git = super.cmp-git.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-git = super.cmp-git.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  cmp-greek = super.cmp-greek.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-greek = super.cmp-greek.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-look = super.cmp-look.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-look = super.cmp-look.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp_luasnip = super.cmp_luasnip.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp_luasnip = super.cmp_luasnip.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.luasnip ];
-  });
+  };
 
-  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.neosnippet-vim ];
-  });
+  };
 
-  cmp-nixpkgs-maintainers = super.cmp-nixpkgs-maintainers.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-nixpkgs-maintainers = super.cmp-nixpkgs-maintainers.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-npm = super.cmp-npm.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-npm = super.cmp-npm.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.plenary-nvim ];
-  });
+  };
 
-  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-nvim-lua = super.cmp-nvim-lua.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-nvim-lua = super.cmp-nvim-lua.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-nvim-ultisnips = super.cmp-nvim-ultisnips.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-nvim-ultisnips = super.cmp-nvim-ultisnips.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.plenary-nvim ];
-  });
+  };
 
-  cmp-pandoc-references = super.cmp-pandoc-references.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-pandoc-references = super.cmp-pandoc-references.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-path = super.cmp-path.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-path = super.cmp-path.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-rg = super.cmp-rg.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-rg = super.cmp-rg.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-snippy = super.cmp-snippy.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-snippy = super.cmp-snippy.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.nvim-snippy ];
-  });
+  };
 
-  cmp-tabby = super.cmp-tabby.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-tabby = super.cmp-tabby.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-tabnine = super.cmp-tabnine.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-tabnine = super.cmp-tabnine.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     buildInputs = [ tabnine ];
 
     postFixup = ''
       mkdir -p $target/binaries/${tabnine.version}
       ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
-  });
+  };
 
-  cmp-tmux = super.cmp-tmux.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-tmux = super.cmp-tmux.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ tmux ];
-  });
+  };
 
-  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.vim-lsp ];
-  });
+  };
 
-  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.vimwiki ];
-  });
+  };
 
-  cmp-vsnip = super.cmp-vsnip.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-vsnip = super.cmp-vsnip.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-vimtex = super.cmp-vimtex.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
-  });
+  cmp-vimtex = super.cmp-vimtex.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
 
-  cmp-zsh = super.cmp-zsh.overrideAttrs (oa: {
-    nativeCheckInputs = oa.nativeCheckInputs ++ [ self.nvim-cmp ];
+  cmp-zsh = super.cmp-zsh.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
     dependencies = [ zsh ];
-  });
+  };
 
   cobalt2-nvim = super.cobalt2-nvim.overrideAttrs {
     dependencies = with self; [ colorbuddy-nvim ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Including checkInputs in the test and migrating current examples to use checkInputs over nativeCheckInputs because it's too easy to accidentally disable the check via trying to add inputs to fix a test case.

Since this is a full plugin set rebuild, going to see what other tweaks can be made to reduce amount of rebuilds we do.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
