### PR TITLE
[release-24.11] backport xz firmware compression

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -162,15 +162,9 @@ let
     '';
 
   compressFirmware = firmware:
-    let
-      inherit (config.boot.kernelPackages) kernelAtLeast;
-    in
-      if ! (firmware.compressFirmware or true) then
-        firmware
-      else
-        if kernelAtLeast "5.19" then pkgs.compressFirmwareZstd firmware
-        else if kernelAtLeast "5.3" then pkgs.compressFirmwareXz firmware
-        else firmware;
+    if config.hardware.firmwareCompression == "none" || (firmware.compressFirmware or false) == false then firmware
+    else if config.hardware.firmwareCompression == "zstd" then pkgs.compressFirmwareZstd firmware
+    else pkgs.compressFirmwareXz firmware;
 
   # Udev has a 512-character limit for ENV{PATH}, so create a symlink
   # tree to work around this.
@@ -279,6 +273,21 @@ in
       };
     };
 
+    hardware.firmwareCompression = lib.mkOption {
+      type = lib.types.enum [ "xz" "zstd" "none" ];
+      default = if config.boot.kernelPackages.kernelAtLeast "5.19" then "zstd"
+        else if config.boot.kernelPackages.kernelAtLeast "5.3" then "xz"
+        else "none";
+      defaultText = "auto";
+      description = ''
+        Whether to compress firmware files.
+        Defaults depend on the kernel version.
+        For kernels older than 5.3, firmware files are not compressed.
+        For kernels 5.3 and newer, firmware files are compressed with xz.
+        For kernels 5.19 and newer, firmware files are compressed with zstd.
+      '';
+    };
+
     networking.usePredictableInterfaceNames = lib.mkOption {
       default = true;
       type = lib.types.bool;
@@ -345,6 +354,23 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = config.hardware.firmwareCompression == "zstd" -> config.boot.kernelPackages.kernelAtLeast "5.19";
+        message = ''
+          The firmware compression method is set to zstd, but the kernel version is too old.
+          The kernel version must be at least 5.3 to use zstd compression.
+        '';
+      }
+      {
+        assertion = config.hardware.firmwareCompression == "xz" -> config.boot.kernelPackages.kernelAtLeast "5.3";
+        message = ''
+          The firmware compression method is set to xz, but the kernel version is too old.
+          The kernel version must be at least 5.3 to use xz compression.
+        '';
+      }
+    ];
 
     services.udev.extraRules = nixosRules;
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -162,7 +162,7 @@ let
     '';
 
   compressFirmware = firmware:
-    if config.hardware.firmwareCompression == "none" || (firmware.compressFirmware or false) == false then firmware
+    if config.hardware.firmwareCompression == "none" || (firmware.compressFirmware or true) == false then firmware
     else if config.hardware.firmwareCompression == "zstd" then pkgs.compressFirmwareZstd firmware
     else pkgs.compressFirmwareXz firmware;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is a backport of https://github.com/NixOS/nixpkgs/pull/364924 and https://github.com/NixOS/nixpkgs/pull/365532

It does not change the default behavior for compression. However it makes it configurable.
The reason is that we are currently depending on xz compression for nixos-anywhere to 
not crash on systems with 1GB of RAM.
With this patch we can rely on automatic updates again because we are currently manually bumping nixpkgs for the stable release.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
