### PR TITLE
python312Packages.flask-security: fix test

### DIFF
--- a/pkgs/development/python-modules/flask-security/default.nix
+++ b/pkgs/development/python-modules/flask-security/default.nix
@@ -64,6 +64,11 @@ buildPythonPackage rec {
     hash = "sha256-RGRwgrDFe+0v8NYyajMikdoi1DQf1I+B5y8KJyF+cZs=";
   };
 
+  patches = [
+    # https://github.com/pallets-eco/flask-security/pull/1040
+    ./fix_test_basic.patch
+  ];
+
   build-system = [ flit-core ];
 
   # flask-login>=0.6.2 not satisfied by version 0.7.0.dev0

--- a/pkgs/development/python-modules/flask-security/fix_test_basic.patch
+++ b/pkgs/development/python-modules/flask-security/fix_test_basic.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_basic.py b/tests/test_basic.py
+index d52be429..09dfa8e4 100644
+--- a/tests/test_basic.py
++++ b/tests/test_basic.py
+@@ -157,6 +157,8 @@ def test_authenticate_with_subdomain_next(app, client, get_message):
+ 
+ @pytest.mark.settings(subdomain="auth")
+ def test_authenticate_with_root_domain_next(app, client, get_message):
++    # As of Flask 3.1 this must be explicitly set.
++    app.subdomain_matching = True
+     app.config["SERVER_NAME"] = "lp.com"
+     app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
+     data = dict(email="matt@lp.com", password="password")


### PR DESCRIPTION
Currently, `flask-security` fails on master. This has been fixed upstream and was due to an update of flask to 3.1

see https://github.com/pallets-eco/flask-security/pull/1040

Log was:
```
flask-security> =================================== FAILURES ===================================
flask-security> ___________________ test_authenticate_with_root_domain_next ____________________
flask-security>
flask-security> app = <SecurityFixture 'tests.conftest'>
flask-security> client = <FlaskClient <SecurityFixture 'tests.conftest'>>
flask-security> get_message = <function get_message.<locals>.fn at 0x7ffff146dee0>
flask-security>
flask-security>     @pytest.mark.settings(subdomain="auth")
flask-security>     def test_authenticate_with_root_domain_next(app, client, get_message):
flask-security>         app.config["SERVER_NAME"] = "lp.com"
flask-security>         app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
flask-security>         data = dict(email="matt@lp.com", password="password")
flask-security>         response = client.post("http://auth.lp.com/login?next=http://lp.com", data=data)
flask-security> >       assert response.status_code == 302
flask-security> E       assert 404 == 302
flask-security> E        +  where 404 = <WrapperTestResponse streamed [404 NOT FOUND]>.status_code
flask-security>
flask-security> tests/test_basic.py:164: AssertionError
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
