### PR TITLE
python312.opentelemetry-instrumentation: fix build

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -43,6 +43,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation" ];
 
+  disabledTests = [
+    # bootstrap: error: argument -a/--action: invalid choice: 'pipenv' (choose from install, requirements)
+    # RuntimeError: Patch is already started
+    "test_run_cmd_install"
+    "test_run_cmd_print"
+    "test_run_unknown_cmd"
+  ];
+
   passthru.updateScript = opentelemetry-api.updateScript;
 
   meta = with lib; {


### PR DESCRIPTION
Without this PR, the build fails:

```
❯ nix-build -A python312Packages.opentelemetry-instrumentation
this derivation will be built:
  /nix/store/lv5flzl2bmxm67hxjlc475pkvhbhpdp3-python3.12-opentelemetry-instrumentation-0.48b0.drv
these 4 paths will be fetched (0.59 MiB download, 6.29 MiB unpacked):
  /nix/store/98yp1bjmaiv86hrygxsdww99jszvrqz0-python3.12-opentelemetry-sdk-1.27.0
  /nix/store/j2z0iapn1scsiq91izxpxfakryq9fcc1-python3.12-opentelemetry-semantic-conventions-0.48b0
  /nix/store/4ij0rnhg1kmi00nzfghnmpdlyhfm39ki-python3.12-opentelemetry-test-utils-0.48b0
  /nix/store/4f3zimfl4h3d8n5jl6ks4y7sfl809sd8-source
copying path '/nix/store/4f3zimfl4h3d8n5jl6ks4y7sfl809sd8-source' from 'https://cache.nixos.org'...
copying path '/nix/store/j2z0iapn1scsiq91izxpxfakryq9fcc1-python3.12-opentelemetry-semantic-conventions-0.48b0' from 'https://cache.nixos.org'...
copying path '/nix/store/98yp1bjmaiv86hrygxsdww99jszvrqz0-python3.12-opentelemetry-sdk-1.27.0' from 'https://cache.nixos.org'...
copying path '/nix/store/4ij0rnhg1kmi00nzfghnmpdlyhfm39ki-python3.12-opentelemetry-test-utils-0.48b0' from 'https://cache.nixos.org'...
building '/nix/store/lv5flzl2bmxm67hxjlc475pkvhbhpdp3-python3.12-opentelemetry-instrumentation-0.48b0.drv'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Running phase: unpackPhase
unpacking source archive /nix/store/4f3zimfl4h3d8n5jl6ks4y7sfl809sd8-source
source root is source/opentelemetry-instrumentation
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/opentelemetry-instrumentation/tests/test_utils.py
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built opentelemetry_instrumentation-0.48b0-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for opentelemetry_instrumentation-0.48b0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
Executing pypaInstallPhase
Successfully installed opentelemetry_instrumentation-0.48b0-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0
checking for references to /build/ in /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0...
patching script interpreter paths in /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0
stripping (with command strip and flags -S -p) in  /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/bin
shrinking RPATHs of ELF executables and libraries in /nix/store/lx4c7car1n112kpnlyknlv53sq49743c-python3.12-opentelemetry-instrumentation-0.48b0-dist
checking for references to /build/ in /nix/store/lx4c7car1n112kpnlyknlv53sq49743c-python3.12-opentelemetry-instrumentation-0.48b0-dist...
patching script interpreter paths in /nix/store/lx4c7car1n112kpnlyknlv53sq49743c-python3.12-opentelemetry-instrumentation-0.48b0-dist
Rewriting #!/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12 to #!/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8
wrapping `/nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/bin/opentelemetry-instrument'...
Rewriting #!/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12 to #!/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8
wrapping `/nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/bin/opentelemetry-bootstrap'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
Running phase: pythonRemoveBinBytecodePhase
Running phase: pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: opentelemetry.instrumentation
Running phase: pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.3, pluggy-1.5.0 -- /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12
cachedir: .pytest_cache
rootdir: /build/source
configfile: pytest.ini
collected 46 items                                                             

tests/auto_instrumentation/test_load.py::TestLoad::test_load_configurators 
-------------------------------- live log call ---------------------------------
WARNING  opentelemetry.instrumentation.auto_instrumentation._load:_load.py:116 Configuration of custom_configurator1 not loaded because custom_configurator2 is set by OTEL_PYTHON_CONFIGURATOR
WARNING  opentelemetry.instrumentation.auto_instrumentation._load:_load.py:102 Configuration of custom_configurator3 not loaded, custom_configurator2 already loaded
PASSED                                                                   [  2%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_configurators_error 
-------------------------------- live log call ---------------------------------
WARNING  opentelemetry.instrumentation.auto_instrumentation._load:_load.py:116 Configuration of custom_configurator1 not loaded because custom_configurator2 is set by OTEL_PYTHON_CONFIGURATOR
ERROR    opentelemetry.instrumentation.auto_instrumentation._load:_load.py:123 Configuration of custom_configurator2 failed
Traceback (most recent call last):
  File "/nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/_load.py", line 113, in _load_configurators
    entry_point.load()().configure(auto_instrumentation_version=__version__)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1139, in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1143, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1198, in _execute_mock_call
    raise effect
Exception
PASSED                                                                   [  4%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_configurators_no_ep PASSED [  6%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_distro PASSED [  8%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_distro_error 
-------------------------------- live log call ---------------------------------
ERROR    opentelemetry.instrumentation.auto_instrumentation._load:_load.py:52 Distribution custom_distro2 configuration failed
Traceback (most recent call last):
  File "/nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/_load.py", line 40, in _load_distro
    distro = entry_point.load()()
             ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1139, in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1143, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py", line 1198, in _execute_mock_call
    raise effect
Exception
PASSED                                                                   [ 10%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_distro_no_ep PASSED [ 13%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_distro_not_distro PASSED [ 15%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_instrumentors PASSED [ 17%]
tests/auto_instrumentation/test_load.py::TestLoad::test_load_instrumentors_dep_conflict PASSED [ 19%]
tests/auto_instrumentation/test_run.py::TestRun::test_after_path PASSED  [ 21%]
tests/auto_instrumentation/test_run.py::TestRun::test_empty PASSED       [ 23%]
tests/auto_instrumentation/test_run.py::TestRun::test_non_empty PASSED   [ 26%]
tests/auto_instrumentation/test_run.py::TestRun::test_single_path PASSED [ 28%]
tests/auto_instrumentation/test_run.py::TestExecl::test_execl PASSED     [ 30%]
tests/auto_instrumentation/test_run.py::TestArgs::test_exporter PASSED   [ 32%]
tests/test_bootstrap.py::TestBootstrap::test_run_cmd_install PASSED      [ 34%]
tests/test_bootstrap.py::TestBootstrap::test_run_cmd_print PASSED        [ 36%]
tests/test_bootstrap.py::TestBootstrap::test_run_unknown_cmd PASSED      [ 39%]
tests/test_bootstrap.py::TestBootstrap::test_run_unknown_cmd ERROR       [ 39%]
tests/test_dependencies.py::TestDependencyConflicts::test_get_dependency_conflicts_empty PASSED [ 41%]
tests/test_dependencies.py::TestDependencyConflicts::test_get_dependency_conflicts_mismatched_version PASSED [ 43%]
tests/test_dependencies.py::TestDependencyConflicts::test_get_dependency_conflicts_no_conflict PASSED [ 45%]
tests/test_dependencies.py::TestDependencyConflicts::test_get_dependency_conflicts_not_installed PASSED [ 47%]
tests/test_dependencies.py::TestDependencyConflicts::test_get_dist_dependency_conflicts PASSED [ 50%]
tests/test_distro.py::TestDistro::test_load_instrumentor PASSED          [ 52%]
tests/test_instrumentor.py::TestInstrumentor::test_protect PASSED        [ 54%]
tests/test_instrumentor.py::TestInstrumentor::test_singleton PASSED      [ 56%]
tests/test_propagators.py::TestGlobals::test_get_set PASSED              [ 58%]
tests/test_propagators.py::TestDictHeaderSetter::test_append PASSED      [ 60%]
tests/test_propagators.py::TestDictHeaderSetter::test_simple PASSED      [ 63%]
tests/test_propagators.py::TestTraceResponsePropagator::test_inject PASSED [ 65%]
tests/test_utils.py::TestUtils::test_add_sql_comments_with_semicolon PASSED [ 67%]
tests/test_utils.py::TestUtils::test_add_sql_comments_without_comments PASSED [ 69%]
tests/test_utils.py::TestUtils::test_add_sql_comments_without_semicolon PASSED [ 71%]
tests/test_utils.py::TestUtils::test_http_status_to_status_code PASSED   [ 73%]
tests/test_utils.py::TestUtils::test_http_status_to_status_code_none PASSED [ 76%]
tests/test_utils.py::TestUtils::test_http_status_to_status_code_redirect PASSED [ 78%]
tests/test_utils.py::TestUtils::test_http_status_to_status_code_server PASSED [ 80%]
tests/test_utils.py::TestUtils::test_is_instrumentation_enabled_by_default PASSED [ 82%]
tests/test_utils.py::TestUtils::test_remove_current_directory_from_python_path_linux PASSED [ 84%]
tests/test_utils.py::TestUtils::test_remove_current_directory_from_python_path_linux_only_path PASSED [ 86%]
tests/test_utils.py::TestUtils::test_remove_current_directory_from_python_path_windows PASSED [ 89%]
tests/test_utils.py::TestUtils::test_remove_current_directory_from_python_path_windows_only_path PASSED [ 91%]
tests/test_utils.py::TestUtils::test_suppress_http_instrumentation PASSED [ 93%]
tests/test_utils.py::TestUtils::test_suppress_http_instrumentation_key PASSED [ 95%]
tests/test_utils.py::TestUtils::test_suppress_instrumentation PASSED     [ 97%]
tests/test_utils.py::TestUtils::test_suppress_instrumentation_key PASSED [100%]

==================================== ERRORS ====================================
___________ ERROR at teardown of TestBootstrap.test_run_unknown_cmd ____________

cls = <class 'tests.test_bootstrap.TestBootstrap'>

    @classmethod
    def tearDownClass(cls):
>       cls.pip_check_patcher.start()

tests/test_bootstrap.py:65: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py:1624: in start
    result = self.__enter__()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <unittest.mock._patch object at 0x7ffff5608800>

    def __enter__(self):
        """Perform the patch."""
        if self.is_started:
>           raise RuntimeError("Patch is already started")
E           RuntimeError: Patch is already started

/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py:1446: RuntimeError
----------------------------- Captured stderr call -----------------------------
usage: bootstrap [-h] [--version] [-a {install,requirements}]
bootstrap: error: argument -a/--action: invalid choice: 'pipenv' (choose from install, requirements)
=============================== warnings summary ===============================
../../../nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/__init__.py:22
  /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/__init__.py:22: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import iter_entry_points

../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:475
  /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:475: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/build/source/pytest-cache-files-bowx2uhx'
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:429
  /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:429: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/lastfailed: [Errno 13] Permission denied: '/build/source/pytest-cache-files-pwn2hifq'
    config.cache.set("cache/lastfailed", self.lastfailed)

../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/stepwise.py:51
  /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/stepwise.py:51: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/stepwise: [Errno 13] Permission denied: '/build/source/pytest-cache-files-0xfxbexy'
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 46 passed, 4 warnings, 1 error in 0.47s ====================
error: builder for '/nix/store/lv5flzl2bmxm67hxjlc475pkvhbhpdp3-python3.12-opentelemetry-instrumentation-0.48b0.drv' failed with exit code 1;
       last 50 log lines:
       > tests/test_utils.py::TestUtils::test_suppress_http_instrumentation_key PASSED [ 95%]
       > tests/test_utils.py::TestUtils::test_suppress_instrumentation PASSED     [ 97%]
       > tests/test_utils.py::TestUtils::test_suppress_instrumentation_key PASSED [100%]
       >
       > ==================================== ERRORS ====================================
       > ___________ ERROR at teardown of TestBootstrap.test_run_unknown_cmd ____________
       >
       > cls = <class 'tests.test_bootstrap.TestBootstrap'>
       >
       >     @classmethod
       >     def tearDownClass(cls):
       > >       cls.pip_check_patcher.start()
       >
       > tests/test_bootstrap.py:65:
       > _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
       > /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py:1624: in start
       >     result = self.__enter__()
       > _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
       >
       > self = <unittest.mock._patch object at 0x7ffff5608800>
       >
       >     def __enter__(self):
       >         """Perform the patch."""
       >         if self.is_started:
       > >           raise RuntimeError("Patch is already started")
       > E           RuntimeError: Patch is already started
       >
       > /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/lib/python3.12/unittest/mock.py:1446: RuntimeError
       > ----------------------------- Captured stderr call -----------------------------
       > usage: bootstrap [-h] [--version] [-a {install,requirements}]
       > bootstrap: error: argument -a/--action: invalid choice: 'pipenv' (choose from install, requirements)
       > =============================== warnings summary ===============================
       > ../../../nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/__init__.py:22
       >   /nix/store/xkf10qbz2bgj3aln9hy13dxba9hp3i42-python3.12-opentelemetry-instrumentation-0.48b0/lib/python3.12/site-packages/opentelemetry/instrumentation/auto_instrumentation/__init__.py:22: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
       >     from pkg_resources import iter_entry_points
       >
       > ../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:475
       >   /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:475: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/build/source/pytest-cache-files-bowx2uhx'
       >     config.cache.set("cache/nodeids", sorted(self.cached_nodeids))
       >
       > ../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:429
       >   /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/cacheprovider.py:429: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/lastfailed: [Errno 13] Permission denied: '/build/source/pytest-cache-files-pwn2hifq'
       >     config.cache.set("cache/lastfailed", self.lastfailed)
       >
       > ../../../nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/stepwise.py:51
       >   /nix/store/zx6gfbpzcs60wnbd8d1fd2m7hnim3pvq-python3.12-pytest-8.3.3/lib/python3.12/site-packages/_pytest/stepwise.py:51: PytestCacheWarning: could not create cache path /build/source/.pytest_cache/v/cache/stepwise: [Errno 13] Permission denied: '/build/source/pytest-cache-files-0xfxbexy'
       >     session.config.cache.set(STEPWISE_CACHE_DIR, [])
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =================== 46 passed, 4 warnings, 1 error in 0.47s ====================
       For full logs, run 'nix log /nix/store/lv5flzl2bmxm67hxjlc475pkvhbhpdp3-python3.12-opentelemetry-instrumentation-0.48b0.drv'.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
