### PR TITLE
zvbi: fix building for musl on x86_64

### DIFF
--- a/pkgs/by-name/zv/zvbi/musl-x86_64.patch
+++ b/pkgs/by-name/zv/zvbi/musl-x86_64.patch
@@ -1,0 +1,81 @@
+From ae143105863a9b8ecc9e46b91df011360e617f8f Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Fri, 20 Dec 2024 16:14:08 +0100
+Subject: [PATCH] Use standard va_copy(), not GNU __va_copy()
+
+va_copy() was standardized in C99.  My musl toolchain provides
+va_copy(), not __va_copy().  The Glibc documentation recommends
+using va_copy() if defined, and otherwise falling back to an
+assignment.
+
+Link: https://sourceware.org/glibc/manual/2.40/html_node/Argument-Macros.html#index-va_005fcopy-1
+---
+ src/export.c | 4 ++--
+ src/misc.c   | 4 ++--
+ src/misc.h   | 6 +++---
+ 3 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/export.c b/src/export.c
+index beb325f..26ae63a 100644
+--- a/src/export.c
++++ b/src/export.c
+@@ -1472,7 +1472,7 @@ vbi_export_vprintf		(vbi_export *		e,
+ 		return TRUE;
+ 	}
+ 
+-	__va_copy (ap2, ap);
++	va_copy (ap2, ap);
+ 
+ 	offset = e->buffer.offset;
+ 
+@@ -1509,7 +1509,7 @@ vbi_export_vprintf		(vbi_export *		e,
+ 		}
+ 
+ 		/* vsnprintf() may advance ap. */
+-		__va_copy (ap, ap2);
++		va_copy (ap, ap2);
+ 	}
+ 
+ 	_vbi_export_malloc_error (e);
+diff --git a/src/misc.c b/src/misc.c
+index 834cc89..288f83d 100644
+--- a/src/misc.c
++++ b/src/misc.c
+@@ -156,7 +156,7 @@ _vbi_vasprintf			(char **		dstp,
+ 	buf = NULL;
+ 	size = 64;
+ 
+-	__va_copy (ap2, ap);
++	va_copy (ap2, ap);
+ 
+ 	for (;;) {
+ 
+@@ -183,7 +183,7 @@ _vbi_vasprintf			(char **		dstp,
+ 		}
+ 
+ 		/* vsnprintf() may advance ap. */
+-		__va_copy (ap, ap2);
++		va_copy (ap, ap2);
+ 	}
+ 
+ 	vbi_free (buf);
+diff --git a/src/misc.h b/src/misc.h
+index 107a982..dbe91b8 100644
+--- a/src/misc.h
++++ b/src/misc.h
+@@ -423,9 +423,9 @@ _vbi_time_max			(void)
+ }
+ #endif
+ 
+-/* __va_copy is a GNU extension. */
+-#ifndef __va_copy
+-#  define __va_copy(ap1, ap2) do { ap1 = ap2; } while (0)
++/* va_copy is C99. */
++#ifndef va_copy
++#  define va_copy(ap1, ap2) do { ap1 = ap2; } while (0)
+ #endif
+ 
+ /* Use this instead of strncpy(). strlcpy() is a BSD extension. */
+-- 
+2.47.0
+

--- a/pkgs/by-name/zv/zvbi/package.nix
+++ b/pkgs/by-name/zv/zvbi/package.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Pj37lJSa1spjC/xrf+yu/ecFCuajb8ingszp6ib2WC8=";
   };
 
+  # https://github.com/zapping-vbi/zvbi/pull/54
+  patches = [ ./musl-x86_64.patch ];
+
   nativeBuildInputs = [
     autoreconfHook
     validatePkgConfig


### PR DESCRIPTION
I tested my last set of musl fixes on aarch64 — apparently one more change is required for x86_64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
