### PR TITLE
elixir: remove deprecated versions 1.10-1.13

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -296,7 +296,7 @@ Usually, we need to create a `shell.nix` file and do our development inside of t
 
 with pkgs;
 let
-  elixir = beam.packages.erlang_24.elixir_1_12;
+  elixir = beam.packages.erlang_24.elixir_1_18;
 in
 mkShell {
   buildInputs = [ elixir ];
@@ -311,18 +311,18 @@ If you need to use an overlay to change some attributes of a derivation, e.g. if
 
 ```nix
 let
-  elixir_1_13_1_overlay = (self: super: {
-      elixir_1_13 = super.elixir_1_13.override {
-        version = "1.13.1";
-        sha256 = "sha256-t0ic1LcC7EV3avWGdR7VbyX7pGDpnJSW1ZvwvQUPC3w=";
+  elixir_1_18_1_overlay = (self: super: {
+      elixir_1_18 = super.elixir_1_18.override {
+        version = "1.18.1";
+        sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
       };
     });
-  pkgs = import <nixpkgs> { overlays = [ elixir_1_13_1_overlay ]; };
+  pkgs = import <nixpkgs> { overlays = [ elixir_1_18_1_overlay ]; };
 in
 with pkgs;
 mkShell {
   buildInputs = [
-    elixir_1_13
+    elixir_1_18
   ];
 }
 ```
@@ -338,7 +338,7 @@ let
   # define packages to install
   basePackages = [
     git
-    # replace with beam.packages.erlang.elixir_1_13 if you need
+    # replace with beam.packages.erlang.elixir_1_18 if you need
     beam.packages.erlang.elixir
     nodejs
     postgresql_14

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -65,26 +65,6 @@ let
         debugInfo = true;
       };
 
-      elixir_1_13 = lib'.callElixir ../interpreters/elixir/1.13.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
-      elixir_1_12 = lib'.callElixir ../interpreters/elixir/1.12.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
-      elixir_1_11 = lib'.callElixir ../interpreters/elixir/1.11.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
-      elixir_1_10 = lib'.callElixir ../interpreters/elixir/1.10.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 

--- a/pkgs/development/interpreters/elixir/1.10.nix
+++ b/pkgs/development/interpreters/elixir/1.10.nix
@@ -1,9 +1,0 @@
-{ mkDerivation }:
-
-# How to obtain `sha256`:
-# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
-mkDerivation {
-  version = "1.10.4";
-  sha256 = "16j4rmm3ix088fvxhvyjqf1hnfg7wiwa87gml3b2mrwirdycbinv";
-  minimumOTPVersion = "21";
-}

--- a/pkgs/development/interpreters/elixir/1.11.nix
+++ b/pkgs/development/interpreters/elixir/1.11.nix
@@ -1,9 +1,0 @@
-{ mkDerivation }:
-
-# How to obtain `sha256`:
-# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
-mkDerivation {
-  version = "1.11.4";
-  sha256 = "sha256-qCX6hRWUbW+E5xaUhcYxRAnhnvncASUJck8lESlcDvk=";
-  minimumOTPVersion = "21";
-}

--- a/pkgs/development/interpreters/elixir/1.12.nix
+++ b/pkgs/development/interpreters/elixir/1.12.nix
@@ -1,9 +1,0 @@
-{ mkDerivation }:
-
-# How to obtain `sha256`:
-# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
-mkDerivation {
-  version = "1.12.3";
-  sha256 = "sha256-Jo9ZC5cSBVpjVnGZ8tEIUKOhW9uvJM/h84+VcnrT0R0=";
-  minimumOTPVersion = "22";
-}

--- a/pkgs/development/interpreters/elixir/1.13.nix
+++ b/pkgs/development/interpreters/elixir/1.13.nix
@@ -1,9 +1,0 @@
-{ mkDerivation }:
-
-# How to obtain `sha256`:
-# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
-mkDerivation {
-  version = "1.13.4";
-  sha256 = "sha256-xGKq62wzaIfgZN2j808fL3b8ykizQVPuePWzsy2HKfw=";
-  minimumOTPVersion = "22";
-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7177,7 +7177,7 @@ with pkgs;
 
   inherit (beam.interpreters)
     erlang erlang_27 erlang_26 erlang_25 erlang_24
-    elixir elixir_1_17 elixir_1_16 elixir_1_15 elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
+    elixir elixir_1_17 elixir_1_16 elixir_1_15 elixir_1_14
     elixir-ls;
 
   erlang_nox = beam_nox.interpreters.erlang;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -68,10 +68,6 @@ in
       elixir_1_16
       elixir_1_15
       elixir_1_14
-      elixir_1_13
-      elixir_1_12
-      elixir_1_11
-      elixir_1_10
       elixir-ls
       lfe
       lfe_2_1


### PR DESCRIPTION
These versions no longer receive security updates.

https://hexdocs.pm/elixir/1.18.0/compatibility-and-deprecations.html#between-elixir-and-erlang-otp

I'm inclined to also backport this to 24.11 since 1.10-1.12 have long been deprecated and should have been removed previously. 1.13 is only deprecated as of 1.18 but also is not receiving security updates.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
