### PR TITLE
syslinux: fix GCC14 build issue

### DIFF
--- a/pkgs/by-name/sy/syslinux/gcc14.patch
+++ b/pkgs/by-name/sy/syslinux/gcc14.patch
@@ -1,0 +1,39 @@
+diff --git a/com32/chain/chain.c b/com32/chain/chain.c
+index 4e9e32d..b11b880 100644
+--- a/com32/chain/chain.c
++++ b/com32/chain/chain.c
+@@ -514,7 +514,7 @@ int main(int argc, char *argv[])
+     if (opt.file) {
+ 	fdat.base = (opt.fseg << 4) + opt.foff;
+
+-	if (loadfile(opt.file, &fdat.data, &fdat.size)) {
++	if (loadfile(opt.file, &fdat.data, (size_t*)&fdat.size)) {
+ 	    error("Couldn't read the boot file.");
+ 	    goto bail;
+ 	}
+diff --git a/com32/lib/syslinux/debug.c b/com32/lib/syslinux/debug.c
+index d9ab863..e8f53d5 100644
+--- a/com32/lib/syslinux/debug.c
++++ b/com32/lib/syslinux/debug.c
+@@ -1,6 +1,7 @@
+ #include <linux/list.h>
+ #include <string.h>
+ #include <stdbool.h>
++#include <stdio.h>
+
+ #ifdef DYNAMIC_DEBUG
+
+diff --git a/com32/libupload/tftp.h b/com32/libupload/tftp.h
+index 323dc16..09aa40b 100644
+--- a/com32/libupload/tftp.h
++++ b/com32/libupload/tftp.h
+@@ -19,4 +19,7 @@ TFTP_OK	= 11, /* Not in RFC */
+ };
+
+ extern const char *tftp_string_error_message[];
++
++extern int tftp_put(struct url_info *url, int flags, struct inode *inode,
++                               const char **redir, char *data, int data_length);
+ #endif
+--
+2.43.0

--- a/pkgs/by-name/sy/syslinux/package.nix
+++ b/pkgs/by-name/sy/syslinux/package.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation {
       ./import-efisetjmp.patch
       # Upstream patch: https://www.syslinux.org/archives/2024-February/026903.html
       ./define-wchar_t.patch
+      # https://lists.openembedded.org/g/openembedded-core/topic/patch_syslinux_fix_build/105858862
+      ./gcc14.patch
     ];
 
   postPatch = ''
@@ -115,7 +117,9 @@ stdenv.mkDerivation {
   # gcc-10. Otherwise build fails as:
   #   ld: acpi/xsdt.o:/build/syslinux-b404870/com32/gpllib/../gplinclude/memory.h:40: multiple definition of
   #     `e820_types'; memory.o:/build/syslinux-b404870/com32/gpllib/../gplinclude/memory.h:40: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  # Fix GCC 14 build.
+  # from incompatible pointer type [-Wincompatible-pointer-types]
+  env.NIX_CFLAGS_COMPILE = "-fcommon -Wno-error=incompatible-pointer-types";
 
   makeFlags =
     [


### PR DESCRIPTION
fixes #367703

based on a patch from Fedora 40 applied to OpenEmbedded Core (https://lists.openembedded.org/g/openembedded-core/topic/patch_syslinux_fix_build/105858862)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
