### PR TITLE
amnezia-vpn: init at 4.8.2.3; nixos/programs/amnezia-vpn: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -29,6 +29,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [AmneziaVPN](https://amnezia.org/en), an open-source VPN client, with a key feature that enables you to deploy your own VPN server on your server. Available as [programs.amnezia-vpn](#opt-programs.amnezia-vpn.enable).
+
 - [Bazecor](https://github.com/Dygmalab/Bazecor), the graphical configurator for Dygma Products.
 
 - [Bonsai](https://git.sr.ht/~stacyharper/bonsai), a general-purpose event mapper/state machine primarily used to create complex key shortcuts, and as part of the [SXMO](https://sxmo.org/) desktop environment. Available as [services.bonsaid](#opt-services.bonsaid.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -149,6 +149,7 @@
   ./programs/_1password.nix
   ./programs/adb.nix
   ./programs/alvr.nix
+  ./programs/amnezia-vpn.nix
   ./programs/appgate-sdp.nix
   ./programs/appimage.nix
   ./programs/arp-scan.nix

--- a/nixos/modules/programs/amnezia-vpn.nix
+++ b/nixos/modules/programs/amnezia-vpn.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.amnezia-vpn;
+in
+{
+  options.programs.amnezia-vpn = {
+    enable = lib.mkEnableOption "The AmneziaVPN client";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.amnezia-vpn ];
+    services.dbus.packages = [ pkgs.amnezia-vpn ];
+    services.resolved.enable = true;
+
+    systemd = {
+      packages = [ pkgs.amnezia-vpn ];
+      services."AmneziaVPN".wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ sund3RRR ];
+}

--- a/pkgs/by-name/am/amnezia-vpn/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn/package.nix
@@ -1,0 +1,157 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  kdePackages,
+  qt6,
+  libsecret,
+  xdg-utils,
+  amneziawg-go,
+  openvpn,
+  shadowsocks-rust,
+  cloak-pt,
+  wireguard-tools,
+  procps,
+  iproute2,
+  sudo,
+  libssh,
+  zlib,
+  tun2socks,
+  xray,
+}:
+let
+  amnezia-tun2socks = tun2socks.overrideAttrs (
+    finalAttrs: prevAttrs: {
+      pname = "amnezia-tun2socks";
+      version = "2.5.4";
+
+      src = fetchFromGitHub {
+        owner = "amnezia-vpn";
+        repo = "amnezia-tun2socks";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-lHo7WtcqccBSHly6neuksh1gC7RCKxbFNX9KSKNNeK8=";
+      };
+
+      vendorHash = "sha256-VvOaTJ6dBFlbGZGxnHy2sCtds1tyhu6VsPewYpsDBiM=";
+
+      ldflags = [
+        "-w"
+        "-s"
+        "-X github.com/amnezia-vpn/amnezia-tun2socks/v2/internal/version.Version=v${finalAttrs.version}"
+        "-X github.com/amnezia-vpn/amnezia-tun2socks/v2/internal/version.GitCommit=v${finalAttrs.version}"
+      ];
+    }
+  );
+
+  amnezia-xray = xray.overrideAttrs (
+    finalAttrs: prevAttrs: {
+      pname = "amnezia-xray";
+      version = "1.8.13";
+
+      src = fetchFromGitHub {
+        owner = "amnezia-vpn";
+        repo = "amnezia-xray-core";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-7XYdogoUEv3kTPTOQwRCohsPtfSDf+aRdI28IkTjvPk=";
+      };
+
+      vendorHash = "sha256-zArdGj5yeRxU0X4jNgT5YBI9SJUyrANDaqNPAPH3d5M=";
+    }
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amnezia-vpn";
+  version = "4.8.2.3";
+
+  src = fetchFromGitHub {
+    owner = "amnezia-vpn";
+    repo = "amnezia-client";
+    tag = finalAttrs.version;
+    hash = "sha256-bCWPyRW2xnnopcwfPHgQrdP85Ct0CDufJRQ1PvCAiDE=";
+    fetchSubmodules = true;
+  };
+
+  patches = [ ./router.patch ];
+
+  postPatch =
+    ''
+      substituteInPlace client/platforms/linux/daemon/wireguardutilslinux.cpp \
+        --replace-fail 'm_tunnel.start(appPath.filePath("../../client/bin/wireguard-go"), wgArgs);' 'm_tunnel.start("${amneziawg-go}/bin/amneziawg-go", wgArgs);'
+      substituteInPlace client/utilities.cpp \
+        --replace-fail 'return Utils::executable("../../client/bin/openvpn", true);' 'return Utils::executable("${openvpn}/bin/openvpn", false);' \
+        --replace-fail 'return Utils::executable("../../client/bin/tun2socks", true);' 'return Utils::executable("${amnezia-tun2socks}/bin/amnezia-tun2socks", false);' \
+        --replace-fail 'return Utils::usrExecutable("wg-quick");' 'return Utils::executable("${wireguard-tools}/bin/wg-quick", false);' \
+        --replace-fail 'QProcess::execute(QString("pkill %1").arg(name));' 'return QProcess::execute(QString("pkill -f %1").arg(name)) == 0;'
+      substituteInPlace client/protocols/xrayprotocol.cpp \
+        --replace-fail 'return Utils::executable(QString("xray"), true);' 'return Utils::executable(QString("${amnezia-xray}/bin/xray"), false);'
+      substituteInPlace client/protocols/openvpnovercloakprotocol.cpp \
+        --replace-fail 'return Utils::executable(QString("/ck-client"), true);' 'return Utils::executable(QString("${cloak-pt}/bin/ck-client"), false);'
+      substituteInPlace client/protocols/shadowsocksvpnprotocol.cpp \
+        --replace-fail 'return Utils::executable(QString("/ss-local"), true);' 'return Utils::executable(QString("${shadowsocks-rust}/bin/sslocal"), false);'
+      substituteInPlace client/configurators/openvpn_configurator.cpp \
+        --replace-fail ".arg(qApp->applicationDirPath());" ".arg(\"$out/local/bin\");"
+      substituteInPlace client/ui/qautostart.cpp \
+        --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/pixmaps/AmneziaVPN.png"
+      substituteInPlace deploy/installer/config/AmneziaVPN.desktop.in \
+        --replace-fail "#!/usr/bin/env xdg-open" "#!${xdg-utils}/bin/xdg-open" \
+        --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/pixmaps/AmneziaVPN.png"
+      substituteInPlace deploy/data/linux/AmneziaVPN.service \
+        --replace-fail "ExecStart=/opt/AmneziaVPN/service/AmneziaVPN-service.sh" "ExecStart=$out/bin/AmneziaVPN-service" \
+        --replace-fail "Environment=LD_LIBRARY_PATH=/opt/AmneziaVPN/client/lib" ""
+    ''
+    + (lib.optionalString (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) ''
+      substituteInPlace client/cmake/3rdparty.cmake \
+        --replace-fail 'set(LIBSSH_LIB_PATH "''${LIBSSH_ROOT_DIR}/linux/x86_64/libssh.a")' 'set(LIBSSH_LIB_PATH "${libssh}/lib/libssh.so")' \
+        --replace-fail 'set(ZLIB_LIB_PATH "''${LIBSSH_ROOT_DIR}/linux/x86_64/libz.a")' 'set(ZLIB_LIB_PATH "${zlib}/lib/libz.so")' \
+        --replace-fail 'set(OPENSSL_LIB_SSL_PATH "''${OPENSSL_ROOT_DIR}/linux/x86_64/libssl.a")' 'set(OPENSSL_LIB_SSL_PATH "''${OPENSSL_ROOT_DIR}/linux/arm64/libssl.a")' \
+        --replace-fail 'set(OPENSSL_LIB_CRYPTO_PATH "''${OPENSSL_ROOT_DIR}/linux/x86_64/libcrypto.a")' 'set(OPENSSL_LIB_CRYPTO_PATH "''${OPENSSL_ROOT_DIR}/linux/arm64/libcrypto.a")'
+    '');
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libsecret
+    qt6.qtbase
+    qt6.qttools
+    kdePackages.qtremoteobjects
+    kdePackages.qtsvg
+    kdePackages.qt5compat
+  ];
+
+  qtWrapperArgs = [
+    ''--prefix PATH : ${
+      lib.makeBinPath [
+        procps
+        iproute2
+        sudo
+      ]
+    }''
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin $out/local/bin $out/share/applications $out/share/pixmaps $out/lib/systemd/system
+    cp client/AmneziaVPN service/server/AmneziaVPN-service $out/bin/
+    cp ../deploy/data/linux/client/bin/update-resolv-conf.sh $out/local/bin/
+    cp ../AppDir/AmneziaVPN.desktop $out/share/applications/
+    cp ../deploy/data/linux/AmneziaVPN.png $out/share/pixmaps/
+    cp ../deploy/data/linux/AmneziaVPN.service $out/lib/systemd/system/
+  '';
+
+  meta = with lib; {
+    description = "Amnezia VPN Client";
+    downloadPage = "https://amnezia.org/en/downloads";
+    homepage = "https://amnezia.org/en";
+    license = licenses.gpl3;
+    mainProgram = "AmneziaVPN";
+    maintainers = with maintainers; [ sund3RRR ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/by-name/am/amnezia-vpn/router.patch
+++ b/pkgs/by-name/am/amnezia-vpn/router.patch
@@ -1,0 +1,54 @@
+--- a/service/server/router_linux.cpp   2025-01-01 11:36:27.615658613 +0300
++++ b/service/server/router_linux.cpp   2025-01-01 18:07:57.300178080 +0300
+@@ -19,9 +19,27 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <QFileInfo>
++#include <QStringList>
++#include <QString>
+ 
+ #include <core/networkUtilities.h>
+ 
++bool isServiceActive(const QString &serviceName) {
++    QProcess process;
++    process.start("systemctl", { "list-units", "--type=service", "--state=running", "--no-legend" });
++    process.waitForFinished();
++
++    QString output = process.readAllStandardOutput();
++    QStringList services = output.split('\n', Qt::SkipEmptyParts);
++
++    for (const QString &service : services) {
++        if (service.contains(serviceName)) {
++            return true;
++        }
++    }
++    return false;
++}
++
+ RouterLinux &RouterLinux::Instance()
+ {
+     static RouterLinux s;
+@@ -158,15 +176,14 @@
+     p.setProcessChannelMode(QProcess::MergedChannels);
+ 
+     //check what the dns manager use
+-    if (QFileInfo::exists("/usr/bin/nscd")
+-        || QFileInfo::exists("/usr/sbin/nscd")
+-        || QFileInfo::exists("/usr/lib/systemd/system/nscd.service"))
+-    {
+-        p.start("systemctl restart nscd");
+-    }
+-    else
+-    {
+-        p.start("systemctl restart systemd-resolved");
++    if (isServiceActive("nscd.service")) {
++        qDebug() << "Restarting nscd.service";
++        p.start("systemctl", { "restart", "nscd" });
++    } else if (isServiceActive("systemd-resolved.service")) {
++        qDebug() << "Restarting systemd-resolved.service";
++        p.start("systemctl", { "restart", "systemd-resolved" });
++    } else {
++        qDebug() << "No suitable DNS manager found.";
+     }
+ 
+     p.waitForFinished();


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/338380

[Amnezia](https://amnezia.org/) is an open-source VPN client, with a key feature that enables you to deploy your own VPN server on your server.

Road map:
- [x] Build
- [x] Module
- [x] Release note
- [x] Check AmneziaWG
- [x] Check Wireguard
- [x] Check OpenVPN
- [x] Check OpenVPN over Cloak
- [x] Check OpenVPN over SS
- [x] Check XRay
- [x] Check ssh
- [x] Check split tunneling is working
- [x] Fix segmentation violation due to [missing return](https://github.com/amnezia-vpn/amnezia-client/blob/4.8.2.3/client/utilities.cpp#L251) ([upstream PR](https://github.com/amnezia-vpn/amnezia-client/pull/1321))
- [ ] Fix segmentation violation on [Quit AmneziaVPN](https://github.com/amnezia-vpn/amnezia-client/issues/1050) (I don't know how to fix this)


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
