### PR TITLE
elixir: add maximumOTPVersion assertion

### DIFF
--- a/pkgs/development/interpreters/elixir/1.14.nix
+++ b/pkgs/development/interpreters/elixir/1.14.nix
@@ -5,4 +5,5 @@ mkDerivation {
   sha256 = "sha256-bCCTjFT+FG1hz+0H6k/izbCmi0JgO3Kkqc3LWWCs5Po=";
   # https://hexdocs.pm/elixir/1.14.5/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
   minimumOTPVersion = "23";
+  maximumOTPVersion = "26";
 }

--- a/pkgs/development/interpreters/elixir/1.15.nix
+++ b/pkgs/development/interpreters/elixir/1.15.nix
@@ -4,5 +4,6 @@ mkDerivation {
   sha256 = "sha256-6GfZycylh+sHIuiQk/GQr1pRQRY1uBycSQdsVJ0J13k=";
   # https://hexdocs.pm/elixir/1.15.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
   minimumOTPVersion = "24";
+  maximumOTPVersion = "26";
   escriptPath = "lib/elixir/scripts/generate_app.escript";
 }

--- a/pkgs/development/interpreters/elixir/1.16.nix
+++ b/pkgs/development/interpreters/elixir/1.16.nix
@@ -4,5 +4,6 @@ mkDerivation {
   sha256 = "sha256-WUBqoz3aQvBlSG3pTxGBpWySY7I0NUcDajQBgq5xYTU=";
   # https://hexdocs.pm/elixir/1.16.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
   minimumOTPVersion = "24";
+  maximumOTPVersion = "26";
   escriptPath = "lib/elixir/scripts/generate_app.escript";
 }

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -16,6 +16,7 @@
   version,
   erlang ? inputs.erlang,
   minimumOTPVersion,
+  maximumOTPVersion ? null,
   sha256 ? null,
   rev ? "v${version}",
   src ? fetchFromGitHub {
@@ -28,14 +29,37 @@
 
 let
   inherit (lib)
-    getVersion
-    versionAtLeast
-    optional
+    assertMsg
     concatStringsSep
+    getVersion
+    optional
+    optionalString
+    toInt
+    versions
+    versionAtLeast
+    versionOlder
     ;
 
+  compatibilityMsg = ''
+    Unsupported elixir and erlang OTP combination.
+
+    elixir ${version}
+    erlang OTP ${getVersion erlang} is not >= ${minimumOTPVersion} ${
+      optionalString (maximumOTPVersion != null) "and <= ${maximumOTPVersion}"
+    }
+
+    See https://hexdocs.pm/elixir/${version}/compatibility-and-deprecations.html
+  '';
+
+  maxShiftMajor = builtins.toString ((toInt (versions.major maximumOTPVersion)) + 1);
+  maxAssert =
+    if (maximumOTPVersion == null) then
+      true
+    else
+      versionOlder (versions.major (getVersion erlang)) maxShiftMajor;
 in
-assert versionAtLeast (getVersion erlang) minimumOTPVersion;
+assert assertMsg (versionAtLeast (getVersion erlang) minimumOTPVersion) compatibilityMsg;
+assert assertMsg maxAssert compatibilityMsg;
 
 stdenv.mkDerivation ({
   pname = "${baseName}";


### PR DESCRIPTION
Add an assertion to provide an upper bounds for elixir+OTP compatibility, matching upstream's documentation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
