### PR TITLE
pkgs/stdenv/generic/make-derivation.nix: format with nixfmt-rfc-style

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -38,7 +38,7 @@ let
     subtractLists
     unique
     zipAttrsWith
-  ;
+    ;
 
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
   inherit (import ../../build-support/lib/meson.nix { inherit lib stdenv; }) makeMesonFlags;
@@ -63,9 +63,10 @@ let
   */
   mkDerivation =
     fnOrAttrs:
-      if builtins.isFunction fnOrAttrs
-      then makeDerivationExtensible fnOrAttrs
-      else makeDerivationExtensibleConst fnOrAttrs;
+    if builtins.isFunction fnOrAttrs then
+      makeDerivationExtensible fnOrAttrs
+    else
+      makeDerivationExtensibleConst fnOrAttrs;
 
   checkMeta = import ./check-meta.nix {
     inherit lib config;
@@ -75,7 +76,8 @@ let
   };
 
   # Based off lib.makeExtensible, with modifications:
-  makeDerivationExtensible = rattrs:
+  makeDerivationExtensible =
+    rattrs:
     let
       # NOTE: The following is a hint that will be printed by the Nix cli when
       # encountering an infinite recursion. It must not be formatted into
@@ -85,31 +87,31 @@ let
       args = rattrs (args // { inherit finalPackage overrideAttrs; });
       #              ^^^^
 
-      overrideAttrs = f0:
-        makeDerivationExtensible
-          (lib.extends (lib.toExtension f0) rattrs);
+      overrideAttrs = f0: makeDerivationExtensible (lib.extends (lib.toExtension f0) rattrs);
 
-      finalPackage =
-        mkDerivationSimple overrideAttrs args;
+      finalPackage = mkDerivationSimple overrideAttrs args;
 
-    in finalPackage;
+    in
+    finalPackage;
 
   #makeDerivationExtensibleConst = attrs: makeDerivationExtensible (_: attrs);
   # but pre-evaluated for a slight improvement in performance.
-  makeDerivationExtensibleConst = attrs:
-    mkDerivationSimple
-      (f0:
-        let
-          f = self: super:
-            let x = f0 super;
-            in
-              if builtins.isFunction x
-              then
-                f0 self super
-              else x;
-        in
-          makeDerivationExtensible (self: attrs // (if builtins.isFunction f0 || f0?__functor then f self attrs else f0)))
-      attrs;
+  makeDerivationExtensibleConst =
+    attrs:
+    mkDerivationSimple (
+      f0:
+      let
+        f =
+          self: super:
+          let
+            x = f0 super;
+          in
+          if builtins.isFunction x then f0 self super else x;
+      in
+      makeDerivationExtensible (
+        self: attrs // (if builtins.isFunction f0 || f0 ? __functor then f self attrs else f0)
+      )
+    ) attrs;
 
   knownHardeningFlags = [
     "bindnow"
@@ -129,24 +131,33 @@ let
   ];
 
   removedOrReplacedAttrNames = [
-    "checkInputs" "installCheckInputs"
-    "nativeCheckInputs" "nativeInstallCheckInputs"
+    "checkInputs"
+    "installCheckInputs"
+    "nativeCheckInputs"
+    "nativeInstallCheckInputs"
     "__contentAddressed"
     "__darwinAllowLocalNetworking"
-    "__impureHostDeps" "__propagatedImpureHostDeps"
-    "sandboxProfile" "propagatedSandboxProfile"
-    "disallowedReferences" "disallowedRequisites"
-    "allowedReferences" "allowedRequisites"
+    "__impureHostDeps"
+    "__propagatedImpureHostDeps"
+    "sandboxProfile"
+    "propagatedSandboxProfile"
+    "disallowedReferences"
+    "disallowedRequisites"
+    "allowedReferences"
+    "allowedRequisites"
   ];
 
   # Turn a derivation into its outPath without a string context attached.
   # See the comment at the usage site.
-  unsafeDerivationToUntrackedOutpath = drv:
-    if isDerivation drv && (!drv.__contentAddressed or false)
-    then builtins.unsafeDiscardStringContext drv.outPath
-    else drv;
+  unsafeDerivationToUntrackedOutpath =
+    drv:
+    if isDerivation drv && (!drv.__contentAddressed or false) then
+      builtins.unsafeDiscardStringContext drv.outPath
+    else
+      drv;
 
-  makeOutputChecks = attrs:
+  makeOutputChecks =
+    attrs:
     # If we use derivations directly here, they end up as build-time dependencies.
     # This is especially problematic in the case of disallowed*, since the disallowed
     # derivations will be built by nix as build-time dependencies, while those
@@ -166,502 +177,620 @@ let
     # having to wait while nix builds a derivation that might not be used.
     # See also https://github.com/NixOS/nix/issues/4629
     optionalAttrs (attrs ? disallowedReferences) {
-      disallowedReferences =
-        map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
-    } //
-    optionalAttrs (attrs ? disallowedRequisites) {
-      disallowedRequisites =
-        map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
-    } //
-    optionalAttrs (attrs ? allowedReferences) {
-      allowedReferences =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
-    } //
-    optionalAttrs (attrs ? allowedRequisites) {
-      allowedRequisites =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+      disallowedReferences = map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
+    }
+    // optionalAttrs (attrs ? disallowedRequisites) {
+      disallowedRequisites = map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
+    }
+    // optionalAttrs (attrs ? allowedReferences) {
+      allowedReferences = mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+    }
+    // optionalAttrs (attrs ? allowedRequisites) {
+      allowedRequisites = mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
     };
 
   makeDerivationArgument =
 
+    # `makeDerivationArgument` is responsible for the `mkDerivation` arguments that
+    # affect the actual derivation, excluding a few behaviors that are not
+    # essential, and specific to `mkDerivation`: `env`, `cmakeFlags`, `mesonFlags`.
+    #
+    # See also:
+    #
+    # * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
+    #   Details on how to use this mkDerivation function
+    #
+    # * https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations
+    #   Explanation about derivations in general
+    {
 
-# `makeDerivationArgument` is responsible for the `mkDerivation` arguments that
-# affect the actual derivation, excluding a few behaviors that are not
-# essential, and specific to `mkDerivation`: `env`, `cmakeFlags`, `mesonFlags`.
-#
-# See also:
-#
-# * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
-#   Details on how to use this mkDerivation function
-#
-# * https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations
-#   Explanation about derivations in general
-{
+      # These types of dependencies are all exhaustively documented in
+      # the "Specifying Dependencies" section of the "Standard
+      # Environment" chapter of the Nixpkgs manual.
 
-# These types of dependencies are all exhaustively documented in
-# the "Specifying Dependencies" section of the "Standard
-# Environment" chapter of the Nixpkgs manual.
+      # TODO(@Ericson2314): Stop using legacy dep attribute names
 
-# TODO(@Ericson2314): Stop using legacy dep attribute names
+      #                                 host offset -> target offset
+      depsBuildBuild ? [ ], # -1 -> -1
+      depsBuildBuildPropagated ? [ ], # -1 -> -1
+      nativeBuildInputs ? [ ], # -1 ->  0  N.B. Legacy name
+      propagatedNativeBuildInputs ? [ ], # -1 ->  0  N.B. Legacy name
+      depsBuildTarget ? [ ], # -1 ->  1
+      depsBuildTargetPropagated ? [ ], # -1 ->  1
 
-#                                 host offset -> target offset
-  depsBuildBuild                    ? [] # -1 -> -1
-, depsBuildBuildPropagated          ? [] # -1 -> -1
-, nativeBuildInputs                 ? [] # -1 ->  0  N.B. Legacy name
-, propagatedNativeBuildInputs       ? [] # -1 ->  0  N.B. Legacy name
-, depsBuildTarget                   ? [] # -1 ->  1
-, depsBuildTargetPropagated         ? [] # -1 ->  1
+      depsHostHost ? [ ], # 0 ->  0
+      depsHostHostPropagated ? [ ], # 0 ->  0
+      buildInputs ? [ ], # 0 ->  1  N.B. Legacy name
+      propagatedBuildInputs ? [ ], # 0 ->  1  N.B. Legacy name
 
-, depsHostHost                      ? [] #  0 ->  0
-, depsHostHostPropagated            ? [] #  0 ->  0
-, buildInputs                       ? [] #  0 ->  1  N.B. Legacy name
-, propagatedBuildInputs             ? [] #  0 ->  1  N.B. Legacy name
+      depsTargetTarget ? [ ], # 1 ->  1
+      depsTargetTargetPropagated ? [ ], # 1 ->  1
 
-, depsTargetTarget                  ? [] #  1 ->  1
-, depsTargetTargetPropagated        ? [] #  1 ->  1
+      checkInputs ? [ ],
+      installCheckInputs ? [ ],
+      nativeCheckInputs ? [ ],
+      nativeInstallCheckInputs ? [ ],
 
-, checkInputs                       ? []
-, installCheckInputs                ? []
-, nativeCheckInputs                 ? []
-, nativeInstallCheckInputs          ? []
+      # Configure Phase
+      configureFlags ? [ ],
+      # Target is not included by default because most programs don't care.
+      # Including it then would cause needless mass rebuilds.
+      #
+      # TODO(@Ericson2314): Make [ "build" "host" ] always the default / resolve #87909
+      configurePlatforms ?
+        optionals (stdenv.hostPlatform != stdenv.buildPlatform || config.configurePlatformsByDefault)
+          [
+            "build"
+            "host"
+          ],
 
-# Configure Phase
-, configureFlags ? []
-, # Target is not included by default because most programs don't care.
-  # Including it then would cause needless mass rebuilds.
-  #
-  # TODO(@Ericson2314): Make [ "build" "host" ] always the default / resolve #87909
-  configurePlatforms ? optionals
-    (stdenv.hostPlatform != stdenv.buildPlatform || config.configurePlatformsByDefault)
-    [ "build" "host" ]
+      # TODO(@Ericson2314): Make unconditional / resolve #33599
+      # Check phase
+      doCheck ? config.doCheckByDefault or false,
 
-# TODO(@Ericson2314): Make unconditional / resolve #33599
-# Check phase
-, doCheck ? config.doCheckByDefault or false
+      # TODO(@Ericson2314): Make unconditional / resolve #33599
+      # InstallCheck phase
+      doInstallCheck ? config.doCheckByDefault or false,
 
-# TODO(@Ericson2314): Make unconditional / resolve #33599
-# InstallCheck phase
-, doInstallCheck ? config.doCheckByDefault or false
+      # TODO(@Ericson2314): Make always true and remove / resolve #178468
+      strictDeps ?
+        if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform,
 
-, # TODO(@Ericson2314): Make always true and remove / resolve #178468
-  strictDeps ? if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform
+      enableParallelBuilding ? config.enableParallelBuildingByDefault,
 
-, enableParallelBuilding ? config.enableParallelBuildingByDefault
+      separateDebugInfo ? false,
+      outputs ? [ "out" ],
+      __darwinAllowLocalNetworking ? false,
+      __impureHostDeps ? [ ],
+      __propagatedImpureHostDeps ? [ ],
+      sandboxProfile ? "",
+      propagatedSandboxProfile ? "",
 
-, separateDebugInfo ? false
-, outputs ? [ "out" ]
-, __darwinAllowLocalNetworking ? false
-, __impureHostDeps ? []
-, __propagatedImpureHostDeps ? []
-, sandboxProfile ? ""
-, propagatedSandboxProfile ? ""
+      hardeningEnable ? [ ],
+      hardeningDisable ? [ ],
 
-, hardeningEnable ? []
-, hardeningDisable ? []
+      patches ? [ ],
 
-, patches ? []
+      __contentAddressed ?
+        (!attrs ? outputHash) # Fixed-output drvs can't be content addressed too
+        && config.contentAddressedByDefault,
 
-, __contentAddressed ?
-  (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
-  && config.contentAddressedByDefault
+      # Experimental.  For simple packages mostly just works,
+      # but for anything complex, be prepared to debug if enabling.
+      __structuredAttrs ? config.structuredAttrsByDefault or false,
 
-# Experimental.  For simple packages mostly just works,
-# but for anything complex, be prepared to debug if enabling.
-, __structuredAttrs ? config.structuredAttrsByDefault or false
+      ...
+    }@attrs:
 
-, ... } @ attrs:
-
-# Policy on acceptable hash types in nixpkgs
-assert attrs ? outputHash -> (
-  let algo =
-    attrs.outputHashAlgo or (head (splitString "-" attrs.outputHash));
-  in
-  if algo == "md5" then
-    throw "Rejected insecure ${algo} hash '${attrs.outputHash}'"
-  else
-    true
-);
-
-let
-  # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
-  # no package has `doCheck = true`.
-  doCheck' = doCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-  doInstallCheck' = doInstallCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
-  separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux;
-  outputs' = outputs ++ optional separateDebugInfo' "debug";
-
-  noNonNativeDeps = builtins.length (depsBuildTarget ++ depsBuildTargetPropagated
-                                  ++ depsHostHost ++ depsHostHostPropagated
-                                  ++ buildInputs ++ propagatedBuildInputs
-                                  ++ depsTargetTarget ++ depsTargetTargetPropagated) == 0;
-  dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenv.hasCC;
-
-  hardeningDisable' = if any (x: x == "fortify") hardeningDisable
-    # disabling fortify implies fortify3 should also be disabled
-    then unique (hardeningDisable ++ [ "fortify3" ])
-    else hardeningDisable;
-  defaultHardeningFlags =
-    (if stdenv.hasCC then stdenv.cc else {}).defaultHardeningFlags or
-      # fallback safe-ish set of flags
-      (if with stdenv.hostPlatform; isOpenBSD && isStatic
-       then knownHardeningFlags # Need pie, in fact
-       else remove "pie" knownHardeningFlags);
-  enabledHardeningOptions =
-    if builtins.elem "all" hardeningDisable'
-    then []
-    else subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
-  # hardeningDisable additionally supports "all".
-  erroneousHardeningFlags = subtractLists knownHardeningFlags (hardeningEnable ++ remove "all" hardeningDisable);
-
-  checkDependencyList = checkDependencyList' [];
-  checkDependencyList' = positions: name: deps:
-    imap1
-      (index: dep:
-        if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
-        else if isList dep then checkDependencyList' ([index] ++ positions) name dep
-        else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}")
-      deps;
-in if builtins.length erroneousHardeningFlags != 0
-then abort ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {
-  inherit erroneousHardeningFlags hardeningDisable hardeningEnable knownHardeningFlags;
-})
-else let
-  doCheck = doCheck';
-  doInstallCheck = doInstallCheck';
-  buildInputs' = buildInputs
-         ++ optionals doCheck checkInputs
-         ++ optionals doInstallCheck installCheckInputs;
-  nativeBuildInputs' = nativeBuildInputs
-         ++ optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh
-         ++ optional stdenv.hostPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh
-         ++ optionals doCheck nativeCheckInputs
-         ++ optionals doInstallCheck nativeInstallCheckInputs;
-
-  outputs = outputs';
-
-  dependencies = [
-    [
-      (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
-      (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
-      (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
-    ]
-    [
-      (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-      (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
-    ]
-    [
-      (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
-    ]
-  ];
-  propagatedDependencies = [
-    [
-      (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
-      (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
-      (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
-    ]
-    [
-      (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
-      (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
-    ]
-    [
-      (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
-    ]
-  ];
-
-  derivationArg =
-    removeAttrs attrs removedOrReplacedAttrNames
-    // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
-      name =
+    # Policy on acceptable hash types in nixpkgs
+    assert
+      attrs ? outputHash
+      -> (
         let
-          # Indicate the host platform of the derivation if cross compiling.
-          # Fixed-output derivations like source tarballs shouldn't get a host
-          # suffix. But we have some weird ones with run-time deps that are
-          # just used for their side-affects. Those might as well since the
-          # hash can't be the same. See #32986.
-          hostSuffix = optionalString
-            (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)
-            "-${stdenv.hostPlatform.config}";
-
-          # Disambiguate statically built packages. This was originally
-          # introduce as a means to prevent nix-env to get confused between
-          # nix and nixStatic. This should be also achieved by moving the
-          # hostSuffix before the version, so we could contemplate removing
-          # it again.
-          staticMarker = optionalString stdenv.hostPlatform.isStatic "-static";
+          algo = attrs.outputHashAlgo or (head (splitString "-" attrs.outputHash));
         in
-        lib.strings.sanitizeDerivationName (
-          if attrs ? name
-          then attrs.name + hostSuffix
-          else
-            # we cannot coerce null to a string below
-            assert assertMsg (attrs ? version && attrs.version != null) "The `version` attribute cannot be null.";
-            "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
-        );
-    }) // {
-      builder = attrs.realBuilder or stdenv.shell;
-      args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
-      inherit stdenv;
+        if algo == "md5" then throw "Rejected insecure ${algo} hash '${attrs.outputHash}'" else true
+      );
 
-      # The `system` attribute of a derivation has special meaning to Nix.
-      # Derivations set it to choose what sort of machine could be used to
-      # execute the build, The build platform entirely determines this,
-      # indeed more finely than Nix knows or cares about. The `system`
-      # attribute of `buildPlatfom` matches Nix's degree of specificity.
-      # exactly.
-      inherit (stdenv.buildPlatform) system;
-
-      userHook = config.stdenv.userHook or null;
-      __ignoreNulls = true;
-      inherit __structuredAttrs strictDeps;
-
-      depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
-      nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
-      depsBuildTarget             = elemAt (elemAt dependencies 0) 2;
-      depsHostHost                = elemAt (elemAt dependencies 1) 0;
-      buildInputs                 = elemAt (elemAt dependencies 1) 1;
-      depsTargetTarget            = elemAt (elemAt dependencies 2) 0;
-
-      depsBuildBuildPropagated    = elemAt (elemAt propagatedDependencies 0) 0;
-      propagatedNativeBuildInputs = elemAt (elemAt propagatedDependencies 0) 1;
-      depsBuildTargetPropagated   = elemAt (elemAt propagatedDependencies 0) 2;
-      depsHostHostPropagated      = elemAt (elemAt propagatedDependencies 1) 0;
-      propagatedBuildInputs       = elemAt (elemAt propagatedDependencies 1) 1;
-      depsTargetTargetPropagated  = elemAt (elemAt propagatedDependencies 2) 0;
-
-      # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
-      configureFlags =
-        configureFlags
-        ++ optional (elem "build"  configurePlatforms) "--build=${stdenv.buildPlatform.config}"
-        ++ optional (elem "host"   configurePlatforms) "--host=${stdenv.hostPlatform.config}"
-        ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";
-
-      inherit patches;
-
-      inherit doCheck doInstallCheck;
-
-      inherit outputs;
-    } // optionalAttrs (__contentAddressed) {
-      inherit __contentAddressed;
-      # Provide default values for outputHashMode and outputHashAlgo because
-      # most people won't care about these anyways
-      outputHashAlgo = attrs.outputHashAlgo or "sha256";
-      outputHashMode = attrs.outputHashMode or "recursive";
-    } // optionalAttrs (enableParallelBuilding) {
-      inherit enableParallelBuilding;
-      enableParallelChecking = attrs.enableParallelChecking or true;
-      enableParallelInstalling = attrs.enableParallelInstalling or true;
-    } // optionalAttrs (hardeningDisable != [] || hardeningEnable != [] || stdenv.hostPlatform.isMusl) {
-      NIX_HARDENING_ENABLE = builtins.concatStringsSep " " enabledHardeningOptions;
-    } // optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch) {
-      requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.gcc.arch}" ];
-    } // optionalAttrs (stdenv.buildPlatform.isDarwin) (
-      let
-        allDependencies = concatLists (concatLists dependencies);
-        allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
-
-        computedSandboxProfile =
-          concatMap (input: input.__propagatedSandboxProfile or [])
-            (stdenv.extraNativeBuildInputs
-            ++ stdenv.extraBuildInputs
-            ++ allDependencies);
-
-        computedPropagatedSandboxProfile =
-          concatMap (input: input.__propagatedSandboxProfile or [])
-            allPropagatedDependencies;
-
-        computedImpureHostDeps =
-          unique (concatMap (input: input.__propagatedImpureHostDeps or [])
-            (stdenv.extraNativeBuildInputs
-            ++ stdenv.extraBuildInputs
-            ++ allDependencies));
-
-        computedPropagatedImpureHostDeps =
-          unique (concatMap (input: input.__propagatedImpureHostDeps or [])
-            allPropagatedDependencies);
-    in {
-      inherit __darwinAllowLocalNetworking;
-      # TODO: remove `unique` once nix has a list canonicalization primitive
-      __sandboxProfile =
-      let profiles = [ stdenv.extraSandboxProfile ] ++ computedSandboxProfile ++ computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile sandboxProfile ];
-          final = concatStringsSep "\n" (filter (x: x != "") (unique profiles));
-      in final;
-      __propagatedSandboxProfile = unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
-      __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ stdenv.__extraImpureHostDeps ++ [
-        "/dev/zero"
-        "/dev/random"
-        "/dev/urandom"
-        "/bin/sh"
-      ];
-      __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-    }) // (if !__structuredAttrs then makeOutputChecks attrs else {
-      outputChecks = builtins.listToAttrs (map (name: {
-        inherit name;
-        value = zipAttrsWith (_: builtins.concatLists) [
-          (makeOutputChecks attrs)
-          (makeOutputChecks attrs.outputChecks.${name} or {})
-        ];
-      }) outputs);
-    });
-
-in
-  derivationArg;
-
-mkDerivationSimple = overrideAttrs:
-
-# `mkDerivation` wraps the builtin `derivation` function to
-# produce derivations that use this stdenv and its shell.
-#
-# Internally, it delegates most of its behavior to `makeDerivationArgument`,
-# except for the `env`, `cmakeFlags`, and `mesonFlags` attributes, as well
-# as the attributes `meta` and `passthru` that affect [package attributes],
-# and not the derivation itself.
-#
-# See also:
-#
-# * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
-#   Details on how to use this mkDerivation function
-#
-# * https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations
-#   Explanation about derivations in general
-#
-# * [package attributes]: https://nixos.org/manual/nix/stable/glossary#package-attribute-set
-{
-
-# Configure Phase
-  cmakeFlags ? []
-, mesonFlags ? []
-
-, meta ? {}
-, passthru ? {}
-, pos ? # position used in error messages and for meta.position
-    (if attrs.meta.description or null != null
-      then builtins.unsafeGetAttrPos "description" attrs.meta
-      else if attrs.version or null != null
-      then builtins.unsafeGetAttrPos "version" attrs
-      else builtins.unsafeGetAttrPos "name" attrs)
-
-# Experimental.  For simple packages mostly just works,
-# but for anything complex, be prepared to debug if enabling.
-, __structuredAttrs ? config.structuredAttrsByDefault or false
-
-, env ? { }
-
-, ... } @ attrs:
-
-# Policy on acceptable hash types in nixpkgs
-assert attrs ? outputHash -> (
-  let algo =
-    attrs.outputHashAlgo or (head (splitString "-" attrs.outputHash));
-  in
-  if algo == "md5" then
-    throw "Rejected insecure ${algo} hash '${attrs.outputHash}'"
-  else
-    true
-);
-
-let
-  envIsExportable = isAttrs env && !isDerivation env;
-
-  derivationArg = makeDerivationArgument
-    (removeAttrs
-      attrs
-        (["meta" "passthru" "pos"]
-        ++ optional (__structuredAttrs || envIsExportable) "env"
-        )
-    // optionalAttrs __structuredAttrs { env = checkedEnv; }
-    // {
-      cmakeFlags = makeCMakeFlags attrs;
-      mesonFlags = makeMesonFlags attrs;
-    });
-
-  meta = checkMeta.commonMeta {
-    inherit validity attrs pos;
-    references = attrs.nativeBuildInputs or [] ++ attrs.buildInputs or []
-              ++ attrs.propagatedNativeBuildInputs or [] ++ attrs.propagatedBuildInputs or [];
-  };
-  validity = checkMeta.assertValidity { inherit meta attrs; };
-
-  checkedEnv =
     let
-      overlappingNames = attrNames (builtins.intersectAttrs env derivationArg);
-      prettyPrint = lib.generators.toPretty {};
-      makeError = name: "  - ${name}: in `env`: ${prettyPrint env.${name}}; in derivation arguments: ${prettyPrint derivationArg.${name}}";
-      errors = lib.concatMapStringsSep "\n" makeError overlappingNames;
+      # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
+      # no package has `doCheck = true`.
+      doCheck' = doCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+      doInstallCheck' = doInstallCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+      separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux;
+      outputs' = outputs ++ optional separateDebugInfo' "debug";
+
+      noNonNativeDeps =
+        builtins.length (
+          depsBuildTarget
+          ++ depsBuildTargetPropagated
+          ++ depsHostHost
+          ++ depsHostHostPropagated
+          ++ buildInputs
+          ++ propagatedBuildInputs
+          ++ depsTargetTarget
+          ++ depsTargetTargetPropagated
+        ) == 0;
+      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenv.hasCC;
+
+      hardeningDisable' =
+        if
+          any (x: x == "fortify") hardeningDisable
+        # disabling fortify implies fortify3 should also be disabled
+        then
+          unique (hardeningDisable ++ [ "fortify3" ])
+        else
+          hardeningDisable;
+      defaultHardeningFlags =
+        (if stdenv.hasCC then stdenv.cc else { }).defaultHardeningFlags or
+        # fallback safe-ish set of flags
+        (
+          if with stdenv.hostPlatform; isOpenBSD && isStatic then
+            knownHardeningFlags # Need pie, in fact
+          else
+            remove "pie" knownHardeningFlags
+        );
+      enabledHardeningOptions =
+        if builtins.elem "all" hardeningDisable' then
+          [ ]
+        else
+          subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
+      # hardeningDisable additionally supports "all".
+      erroneousHardeningFlags = subtractLists knownHardeningFlags (
+        hardeningEnable ++ remove "all" hardeningDisable
+      );
+
+      checkDependencyList = checkDependencyList' [ ];
+      checkDependencyList' =
+        positions: name: deps:
+        imap1 (
+          index: dep:
+          if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then
+            dep
+          else if isList dep then
+            checkDependencyList' ([ index ] ++ positions) name dep
+          else
+            throw "Dependency is not of a valid type: ${
+              concatMapStrings (ix: "element ${toString ix} of ") ([ index ] ++ positions)
+            }${name} for ${attrs.name or attrs.pname}"
+        ) deps;
     in
-    assert assertMsg envIsExportable
-      "When using structured attributes, `env` must be an attribute set of environment variables.";
-    assert assertMsg (overlappingNames == [ ])
-      "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
-    mapAttrs
-      (n: v: assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
-        "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}."; v)
-      env;
+    if builtins.length erroneousHardeningFlags != 0 then
+      abort (
+        "mkDerivation was called with unsupported hardening flags: "
+        + lib.generators.toPretty { } {
+          inherit
+            erroneousHardeningFlags
+            hardeningDisable
+            hardeningEnable
+            knownHardeningFlags
+            ;
+        }
+      )
+    else
+      let
+        doCheck = doCheck';
+        doInstallCheck = doInstallCheck';
+        buildInputs' =
+          buildInputs ++ optionals doCheck checkInputs ++ optionals doInstallCheck installCheckInputs;
+        nativeBuildInputs' =
+          nativeBuildInputs
+          ++ optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh
+          ++ optional stdenv.hostPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh
+          ++ optionals doCheck nativeCheckInputs
+          ++ optionals doInstallCheck nativeInstallCheckInputs;
 
-  # Fixed-output derivations may not reference other paths, which means that
-  # for a fixed-output derivation, the corresponding inputDerivation should
-  # *not* be fixed-output. To achieve this we simply delete the attributes that
-  # would make it fixed-output.
-  deleteFixedOutputRelatedAttrs = lib.flip builtins.removeAttrs [ "outputHashAlgo" "outputHash" "outputHashMode" ];
+        outputs = outputs';
 
-in
+        dependencies = [
+          [
+            (map (drv: getDev drv.__spliced.buildBuild or drv) (
+              checkDependencyList "depsBuildBuild" depsBuildBuild
+            ))
+            (map (drv: getDev drv.__spliced.buildHost or drv) (
+              checkDependencyList "nativeBuildInputs" nativeBuildInputs'
+            ))
+            (map (drv: getDev drv.__spliced.buildTarget or drv) (
+              checkDependencyList "depsBuildTarget" depsBuildTarget
+            ))
+          ]
+          [
+            (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
+            (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
+          ]
+          [
+            (map (drv: getDev drv.__spliced.targetTarget or drv) (
+              checkDependencyList "depsTargetTarget" depsTargetTarget
+            ))
+          ]
+        ];
+        propagatedDependencies = [
+          [
+            (map (drv: getDev drv.__spliced.buildBuild or drv) (
+              checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
+            ))
+            (map (drv: getDev drv.__spliced.buildHost or drv) (
+              checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
+            ))
+            (map (drv: getDev drv.__spliced.buildTarget or drv) (
+              checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
+            ))
+          ]
+          [
+            (map (drv: getDev drv.__spliced.hostHost or drv) (
+              checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
+            ))
+            (map (drv: getDev drv.__spliced.hostTarget or drv) (
+              checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
+            ))
+          ]
+          [
+            (map (drv: getDev drv.__spliced.targetTarget or drv) (
+              checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
+            ))
+          ]
+        ];
 
-extendDerivation
-  validity.handled
-  ({
-     # A derivation that always builds successfully and whose runtime
-     # dependencies are the original derivations build time dependencies
-     # This allows easy building and distributing of all derivations
-     # needed to enter a nix-shell with
-     #   nix-build shell.nix -A inputDerivation
-     inputDerivation = derivation (deleteFixedOutputRelatedAttrs derivationArg // {
-       # Add a name in case the original drv didn't have one
-       name = derivationArg.name or "inputDerivation";
-       # This always only has one output
-       outputs = [ "out" ];
+        derivationArg =
+          removeAttrs attrs removedOrReplacedAttrNames
+          // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
+            name =
+              let
+                # Indicate the host platform of the derivation if cross compiling.
+                # Fixed-output derivations like source tarballs shouldn't get a host
+                # suffix. But we have some weird ones with run-time deps that are
+                # just used for their side-affects. Those might as well since the
+                # hash can't be the same. See #32986.
+                hostSuffix = optionalString (
+                  stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix
+                ) "-${stdenv.hostPlatform.config}";
 
-       # Propagate the original builder and arguments, since we override
-       # them and they might contain references to build inputs
-       _derivation_original_builder = derivationArg.builder;
-       _derivation_original_args = derivationArg.args;
+                # Disambiguate statically built packages. This was originally
+                # introduce as a means to prevent nix-env to get confused between
+                # nix and nixStatic. This should be also achieved by moving the
+                # hostSuffix before the version, so we could contemplate removing
+                # it again.
+                staticMarker = optionalString stdenv.hostPlatform.isStatic "-static";
+              in
+              lib.strings.sanitizeDerivationName (
+                if attrs ? name then
+                  attrs.name + hostSuffix
+                else
+                  # we cannot coerce null to a string below
+                  assert assertMsg (
+                    attrs ? version && attrs.version != null
+                  ) "The `version` attribute cannot be null.";
+                  "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
+              );
+          })
+          // {
+            builder = attrs.realBuilder or stdenv.shell;
+            args =
+              attrs.args or [
+                "-e"
+                (attrs.builder or ./default-builder.sh)
+              ];
+            inherit stdenv;
 
-       builder = stdenv.shell;
-       # The builtin `declare -p` dumps all bash and environment variables,
-       # which is where all build input references end up (e.g. $PATH for
-       # binaries). By writing this to $out, Nix can find and register
-       # them as runtime dependencies (since Nix greps for store paths
-       # through $out to find them). Using placeholder for $out works with
-       # and without structuredAttrs.
-       # This build script does not use setup.sh or stdenv, to keep
-       # the env most pristine. This gives us a very bare bones env,
-       # hence the extra/duplicated compatibility logic and "pure bash" style.
-       args = [ "-c" ''
-         out="${placeholder "out"}"
-         if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
-         declare -p > $out
-         for var in $passAsFile; do
-             pathVar="''${var}Path"
-             printf "%s" "$(< "''${!pathVar}")" >> $out
-         done
-       '' ];
+            # The `system` attribute of a derivation has special meaning to Nix.
+            # Derivations set it to choose what sort of machine could be used to
+            # execute the build, The build platform entirely determines this,
+            # indeed more finely than Nix knows or cares about. The `system`
+            # attribute of `buildPlatfom` matches Nix's degree of specificity.
+            # exactly.
+            inherit (stdenv.buildPlatform) system;
 
-       # inputDerivation produces the inputs; not the outputs, so any
-       # restrictions on what used to be the outputs don't serve a purpose
-       # anymore.
-       allowedReferences = null;
-       allowedRequisites = null;
-       disallowedReferences = [ ];
-       disallowedRequisites = [ ];
-     });
+            userHook = config.stdenv.userHook or null;
+            __ignoreNulls = true;
+            inherit __structuredAttrs strictDeps;
 
-     inherit passthru overrideAttrs;
-     inherit meta;
-   } //
-   # Pass through extra attributes that are not inputs, but
-   # should be made available to Nix expressions using the
-   # derivation (e.g., in assertions).
-   passthru)
-  (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
+            depsBuildBuild = elemAt (elemAt dependencies 0) 0;
+            nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
+            depsBuildTarget = elemAt (elemAt dependencies 0) 2;
+            depsHostHost = elemAt (elemAt dependencies 1) 0;
+            buildInputs = elemAt (elemAt dependencies 1) 1;
+            depsTargetTarget = elemAt (elemAt dependencies 2) 0;
+
+            depsBuildBuildPropagated = elemAt (elemAt propagatedDependencies 0) 0;
+            propagatedNativeBuildInputs = elemAt (elemAt propagatedDependencies 0) 1;
+            depsBuildTargetPropagated = elemAt (elemAt propagatedDependencies 0) 2;
+            depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
+            propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
+            depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;
+
+            # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
+            configureFlags =
+              configureFlags
+              ++ optional (elem "build" configurePlatforms) "--build=${stdenv.buildPlatform.config}"
+              ++ optional (elem "host" configurePlatforms) "--host=${stdenv.hostPlatform.config}"
+              ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";
+
+            inherit patches;
+
+            inherit doCheck doInstallCheck;
+
+            inherit outputs;
+          }
+          // optionalAttrs (__contentAddressed) {
+            inherit __contentAddressed;
+            # Provide default values for outputHashMode and outputHashAlgo because
+            # most people won't care about these anyways
+            outputHashAlgo = attrs.outputHashAlgo or "sha256";
+            outputHashMode = attrs.outputHashMode or "recursive";
+          }
+          // optionalAttrs (enableParallelBuilding) {
+            inherit enableParallelBuilding;
+            enableParallelChecking = attrs.enableParallelChecking or true;
+            enableParallelInstalling = attrs.enableParallelInstalling or true;
+          }
+          // optionalAttrs (hardeningDisable != [ ] || hardeningEnable != [ ] || stdenv.hostPlatform.isMusl) {
+            NIX_HARDENING_ENABLE = builtins.concatStringsSep " " enabledHardeningOptions;
+          }
+          // optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch) {
+            requiredSystemFeatures = attrs.requiredSystemFeatures or [ ] ++ [
+              "gccarch-${stdenv.hostPlatform.gcc.arch}"
+            ];
+          }
+          // optionalAttrs (stdenv.buildPlatform.isDarwin) (
+            let
+              allDependencies = concatLists (concatLists dependencies);
+              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
+
+              computedSandboxProfile = concatMap (input: input.__propagatedSandboxProfile or [ ]) (
+                stdenv.extraNativeBuildInputs ++ stdenv.extraBuildInputs ++ allDependencies
+              );
+
+              computedPropagatedSandboxProfile = concatMap (
+                input: input.__propagatedSandboxProfile or [ ]
+              ) allPropagatedDependencies;
+
+              computedImpureHostDeps = unique (
+                concatMap (input: input.__propagatedImpureHostDeps or [ ]) (
+                  stdenv.extraNativeBuildInputs ++ stdenv.extraBuildInputs ++ allDependencies
+                )
+              );
+
+              computedPropagatedImpureHostDeps = unique (
+                concatMap (input: input.__propagatedImpureHostDeps or [ ]) allPropagatedDependencies
+              );
+            in
+            {
+              inherit __darwinAllowLocalNetworking;
+              # TODO: remove `unique` once nix has a list canonicalization primitive
+              __sandboxProfile =
+                let
+                  profiles =
+                    [ stdenv.extraSandboxProfile ]
+                    ++ computedSandboxProfile
+                    ++ computedPropagatedSandboxProfile
+                    ++ [
+                      propagatedSandboxProfile
+                      sandboxProfile
+                    ];
+                  final = concatStringsSep "\n" (filter (x: x != "") (unique profiles));
+                in
+                final;
+              __propagatedSandboxProfile = unique (
+                computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]
+              );
+              __impureHostDeps =
+                computedImpureHostDeps
+                ++ computedPropagatedImpureHostDeps
+                ++ __propagatedImpureHostDeps
+                ++ __impureHostDeps
+                ++ stdenv.__extraImpureHostDeps
+                ++ [
+                  "/dev/zero"
+                  "/dev/random"
+                  "/dev/urandom"
+                  "/bin/sh"
+                ];
+              __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
+            }
+          )
+          // (
+            if !__structuredAttrs then
+              makeOutputChecks attrs
+            else
+              {
+                outputChecks = builtins.listToAttrs (
+                  map (name: {
+                    inherit name;
+                    value = zipAttrsWith (_: builtins.concatLists) [
+                      (makeOutputChecks attrs)
+                      (makeOutputChecks attrs.outputChecks.${name} or { })
+                    ];
+                  }) outputs
+                );
+              }
+          );
+
+      in
+      derivationArg;
+
+  mkDerivationSimple =
+    overrideAttrs:
+
+    # `mkDerivation` wraps the builtin `derivation` function to
+    # produce derivations that use this stdenv and its shell.
+    #
+    # Internally, it delegates most of its behavior to `makeDerivationArgument`,
+    # except for the `env`, `cmakeFlags`, and `mesonFlags` attributes, as well
+    # as the attributes `meta` and `passthru` that affect [package attributes],
+    # and not the derivation itself.
+    #
+    # See also:
+    #
+    # * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
+    #   Details on how to use this mkDerivation function
+    #
+    # * https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations
+    #   Explanation about derivations in general
+    #
+    # * [package attributes]: https://nixos.org/manual/nix/stable/glossary#package-attribute-set
+    {
+
+      # Configure Phase
+      cmakeFlags ? [ ],
+      mesonFlags ? [ ],
+
+      meta ? { },
+      passthru ? { },
+      pos ? # position used in error messages and for meta.position
+        (
+          if attrs.meta.description or null != null then
+            builtins.unsafeGetAttrPos "description" attrs.meta
+          else if attrs.version or null != null then
+            builtins.unsafeGetAttrPos "version" attrs
+          else
+            builtins.unsafeGetAttrPos "name" attrs
+        ),
+
+      # Experimental.  For simple packages mostly just works,
+      # but for anything complex, be prepared to debug if enabling.
+      __structuredAttrs ? config.structuredAttrsByDefault or false,
+
+      env ? { },
+
+      ...
+    }@attrs:
+
+    # Policy on acceptable hash types in nixpkgs
+    assert
+      attrs ? outputHash
+      -> (
+        let
+          algo = attrs.outputHashAlgo or (head (splitString "-" attrs.outputHash));
+        in
+        if algo == "md5" then throw "Rejected insecure ${algo} hash '${attrs.outputHash}'" else true
+      );
+
+    let
+      envIsExportable = isAttrs env && !isDerivation env;
+
+      derivationArg = makeDerivationArgument (
+        removeAttrs attrs (
+          [
+            "meta"
+            "passthru"
+            "pos"
+          ]
+          ++ optional (__structuredAttrs || envIsExportable) "env"
+        )
+        // optionalAttrs __structuredAttrs { env = checkedEnv; }
+        // {
+          cmakeFlags = makeCMakeFlags attrs;
+          mesonFlags = makeMesonFlags attrs;
+        }
+      );
+
+      meta = checkMeta.commonMeta {
+        inherit validity attrs pos;
+        references =
+          attrs.nativeBuildInputs or [ ]
+          ++ attrs.buildInputs or [ ]
+          ++ attrs.propagatedNativeBuildInputs or [ ]
+          ++ attrs.propagatedBuildInputs or [ ];
+      };
+      validity = checkMeta.assertValidity { inherit meta attrs; };
+
+      checkedEnv =
+        let
+          overlappingNames = attrNames (builtins.intersectAttrs env derivationArg);
+          prettyPrint = lib.generators.toPretty { };
+          makeError =
+            name:
+            "  - ${name}: in `env`: ${prettyPrint env.${name}}; in derivation arguments: ${
+                prettyPrint derivationArg.${name}
+              }";
+          errors = lib.concatMapStringsSep "\n" makeError overlappingNames;
+        in
+        assert assertMsg envIsExportable
+          "When using structured attributes, `env` must be an attribute set of environment variables.";
+        assert assertMsg (overlappingNames == [ ])
+          "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
+        mapAttrs (
+          n: v:
+          assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
+            "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
+          v
+        ) env;
+
+      # Fixed-output derivations may not reference other paths, which means that
+      # for a fixed-output derivation, the corresponding inputDerivation should
+      # *not* be fixed-output. To achieve this we simply delete the attributes that
+      # would make it fixed-output.
+      deleteFixedOutputRelatedAttrs = lib.flip builtins.removeAttrs [
+        "outputHashAlgo"
+        "outputHash"
+        "outputHashMode"
+      ];
+
+    in
+
+    extendDerivation validity.handled (
+      {
+        # A derivation that always builds successfully and whose runtime
+        # dependencies are the original derivations build time dependencies
+        # This allows easy building and distributing of all derivations
+        # needed to enter a nix-shell with
+        #   nix-build shell.nix -A inputDerivation
+        inputDerivation = derivation (
+          deleteFixedOutputRelatedAttrs derivationArg
+          // {
+            # Add a name in case the original drv didn't have one
+            name = derivationArg.name or "inputDerivation";
+            # This always only has one output
+            outputs = [ "out" ];
+
+            # Propagate the original builder and arguments, since we override
+            # them and they might contain references to build inputs
+            _derivation_original_builder = derivationArg.builder;
+            _derivation_original_args = derivationArg.args;
+
+            builder = stdenv.shell;
+            # The builtin `declare -p` dumps all bash and environment variables,
+            # which is where all build input references end up (e.g. $PATH for
+            # binaries). By writing this to $out, Nix can find and register
+            # them as runtime dependencies (since Nix greps for store paths
+            # through $out to find them). Using placeholder for $out works with
+            # and without structuredAttrs.
+            # This build script does not use setup.sh or stdenv, to keep
+            # the env most pristine. This gives us a very bare bones env,
+            # hence the extra/duplicated compatibility logic and "pure bash" style.
+            args = [
+              "-c"
+              ''
+                out="${placeholder "out"}"
+                if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+                declare -p > $out
+                for var in $passAsFile; do
+                    pathVar="''${var}Path"
+                    printf "%s" "$(< "''${!pathVar}")" >> $out
+                done
+              ''
+            ];
+
+            # inputDerivation produces the inputs; not the outputs, so any
+            # restrictions on what used to be the outputs don't serve a purpose
+            # anymore.
+            allowedReferences = null;
+            allowedRequisites = null;
+            disallowedReferences = [ ];
+            disallowedRequisites = [ ];
+          }
+        );
+
+        inherit passthru overrideAttrs;
+        inherit meta;
+      }
+      //
+        # Pass through extra attributes that are not inputs, but
+        # should be made available to Nix expressions using the
+        # derivation (e.g., in assertions).
+        passthru
+    ) (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
 
 in
 {


### PR DESCRIPTION
This PR formats `pkgs/stdenv/generic/make-derivation` with the pinned `nixfmt-rfc-style` in the project root Nix shell.

Command: `nix develop -c nixfmt pkgs/stdenv/generic/make-derivation.nix`

This fixes all the style inconsistencies, including some three-space-indented blocks.

The comments for recursion error messages work as expected.

```nix-repl
nixpkgs_factor-lang on  stdenv-mkderivation-format:master [$⇡] took 3s 
❯ nix repl
Nix 2.24.10
Type :? for help.
nix-repl> lib = import ./lib                                           

nix-repl> pkgs = import ./. { config = { allowAliases = false; checkMeta = true; }; }                                 

nix-repl> pkgs.stdenv.mkDerivation (finalAttrs: finalAttrs)            
error:
       … from call site
         at /home/shamrock/Projects/NixOS/nixpkgs_factor-lang/pkgs/stdenv/generic/make-derivation.nix:92:22:
           91|
           92|       finalPackage = mkDerivationSimple overrideAttrs args;
             |                      ^
           93|

       … in the left operand of the update (//) operator
         at /home/shamrock/Projects/NixOS/nixpkgs_factor-lang/pkgs/stdenv/generic/make-derivation.nix:87:27:
           86|       # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
           87|       args = rattrs (args // { inherit finalPackage overrideAttrs; });
             |                           ^
           88|       #              ^^^^

       error: infinite recursion encountered
       at /home/shamrock/Projects/NixOS/nixpkgs_factor-lang/pkgs/stdenv/generic/make-derivation.nix:87:22:
           86|       # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
           87|       args = rattrs (args // { inherit finalPackage overrideAttrs; });
             |                      ^
           88|       #              ^^^^

nix-repl> 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
