### PR TITLE
fishPlugins.exercism-cli-fish-wrapper: init at 0-unstable-2024-11-29

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -21,6 +21,8 @@ lib.makeScope newScope (self: with self; {
 
   done = callPackage ./done.nix { };
 
+  exercism-cli-fish-wrapper = callPackage ./exercism-cli-fish-wrapper.nix { };
+
   fifc = callPackage ./fifc.nix { };
 
   fish-bd = callPackage ./fish-bd.nix { };

--- a/pkgs/shells/fish/plugins/exercism-cli-fish-wrapper.nix
+++ b/pkgs/shells/fish/plugins/exercism-cli-fish-wrapper.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+buildFishPlugin {
+  pname = "exercism-cli-fish-wrapper";
+  version = "0-unstable-2024-11-29";
+
+  src = fetchFromGitHub {
+    owner = "glennj";
+    repo = "exercism-cli-fish-wrapper";
+    rev = "f25f76dcc9bf164c30a9292a16a2159c9350a146";
+    hash = "sha256-R9Vf8tlLytqvMlJdWGyTy1g0TUhOcp7tifz0Bxb4Gts=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Fish wrapper for the Exercism CLI";
+    homepage = "https://github.com/glennj/exercism-cli-fish-wrapper";
+    license = lib.licenses.unfree; # No upstream license
+    maintainers = with lib.maintainers; [ anomalocaris ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [`exercism-cli-fish-wrapper`](https://github.com/glennj/exercism-cli-fish-wrapper), a fish plugin that adds new functionality to the `exercism` cli client.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
