### PR TITLE
python3Packages.color-manager: init at 0-unstable-2024-11-15

### DIFF
--- a/pkgs/development/python-modules/basic-colormath/default.nix
+++ b/pkgs/development/python-modules/basic-colormath/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  setuptools-scm,
+  pillow,
+  nix-update-script,
+  numpy,
+  colormath,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "basic-colormath";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "basic_colormath";
+    hash = "sha256-p/uNuNg5kqKIkeMmX5sWY8umGAg0E4/otgQxhzIuo0E=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [ pillow ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeCheckInputs = [
+    numpy
+    colormath
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Simple color conversion and perceptual (DeltaE CIE 2000) difference";
+    homepage = "https://github.com/ShayHill/basic_colormath";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anomalocaris ];
+  };
+}

--- a/pkgs/development/python-modules/color-manager/default.nix
+++ b/pkgs/development/python-modules/color-manager/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  tqdm,
+  basic-colormath,
+  unstableGitUpdater,
+  setuptools,
+}:
+buildPythonPackage {
+  pname = "color-manager";
+  version = "0-unstable-2024-11-15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NicklasVraa";
+    repo = "Color-manager";
+    rev = "9e55e0971ecd0e3141ed5d7d9a8377f7052cef96";
+    hash = "sha256-kXRjp1sFgSiIQC9+fUQcNRK990Hd5nZwJpRGB7qRYrY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    tqdm
+    basic-colormath
+  ];
+
+  doCheck = false;
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "Recolor icon packs, themes, wallpapers and assets with a few clicks or lines of code";
+    homepage = "https://github.com/NicklasVraa/Color-manager";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ anomalocaris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1703,6 +1703,8 @@ self: super: with self; {
 
   bashlex = callPackage ../development/python-modules/bashlex { };
 
+  basic-colormath = callPackage ../development/python-modules/basic-colormath { };
+
   basiciw = callPackage ../development/python-modules/basiciw { };
 
   basswood-av = callPackage ../development/python-modules/basswood-av { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2777,6 +2777,8 @@ self: super: with self; {
 
   collidoscope = callPackage ../development/python-modules/collidoscope { };
 
+  color-manager = callPackage ../development/python-modules/color-manager { };
+
   color-operations = callPackage ../development/python-modules/color-operations { };
 
   color-parser-py = callPackage ../development/python-modules/color-parser-py { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Color Manager](https://github.com/NicklasVraa/Color-manager), a Python library for recoloring icons, css stylesheets, and images. It also provides a Python script that launches a GUI program, but I cannot figure out how to expose it as an executable.

I also added [`basic_colormath`](https://github.com/ShayHill/basic_colormath), a simpler and more performant version of `python-colormath` because it is a required dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
