### PR TITLE
wol: fix build with GCC 14

### DIFF
--- a/pkgs/by-name/wo/wol/gcc-14.patch
+++ b/pkgs/by-name/wo/wol/gcc-14.patch
@@ -1,0 +1,68 @@
+diff -Naur wol-0.7.1-orig/configure.ac wol-0.7.1/configure.ac
+--- wol-0.7.1-orig/configure.ac	2024-12-25 13:52:38.209314369 +0900
++++ wol-0.7.1/configure.ac	2024-12-25 14:49:28.351829162 +0900
+@@ -60,6 +60,14 @@
+ dnl check data types
+ AC_CHECK_SIZEOF(unsigned char, 1)
+ 
++
++dnl config.h.in defines defaults
++AC_DEFINE([HAVE_STRUCT_ETHER_ADDR], 0, [struct ether_addr])
++AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_ETHER_ADDR_OCTET], 0, [struct ether_addr.ether_addr_octet])
++AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_OCTET], 0, [struct ether_addr.octet])
++AC_DEFINE([HAVE_ETHER_HOSTTON], 0, [ether_hostton])
++
++
+ ether_includes=""
+ AC_CHECK_TYPE([struct ether_addr], , , [#include <netinet/ether.h>]) dnl Linux
+ if test "$ac_cv_type_struct_ether_addr" = "yes"; then
+@@ -241,13 +249,6 @@
+ dnl fi
+ 
+ 
+-dnl config.h.in defines
+-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR], 0, [struct ether_addr])
+-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_ETHER_ADDR_OCTET], 0, [struct ether_addr.ether_addr_octet])
+-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_OCTET], 0, [struct ether_addr.octet])
+-AC_DEFINE([HAVE_ETHER_HOSTTON], 0, [ether_hostton])
+-
+-
+ dnl full featured warnings
+ CFLAGS="$CFLAGS -W -Wall -Wpointer-arith -Wimplicit-function-declaration"
+ 
+diff -Naur wol-0.7.1-orig/m4/getline.m4 wol-0.7.1/m4/getline.m4
+--- wol-0.7.1-orig/m4/getline.m4	2024-12-25 17:22:11.442627544 +0900
++++ wol-0.7.1/m4/getline.m4	2024-12-25 19:50:39.282552640 +0900
+@@ -27,7 +27,7 @@
+       if (!in)
+ 	return 1;
+       len = getline (&line, &siz, in);
+-      exit ((len == 4 && line && strcmp (line, "foo\n") == 0) ? 0 : 1);
++      return (len == 4 && line && strcmp (line, "foo\n") == 0) ? 0 : 1;
+     }
+     ], am_cv_func_working_getline=yes dnl The library version works.
+     , am_cv_func_working_getline=no dnl The library version does NOT work.
+diff -Naur wol-0.7.1-orig/m4/malloc.m4 wol-0.7.1/m4/malloc.m4
+--- wol-0.7.1-orig/m4/malloc.m4	2024-12-25 13:52:38.182314099 +0900
++++ wol-0.7.1/m4/malloc.m4	2024-12-25 14:31:34.627556193 +0900
+@@ -14,7 +14,7 @@
+ 
+  AC_CACHE_CHECK([for working malloc], jm_cv_func_working_malloc,
+   [AC_TRY_RUN([
+-    char *malloc ();
++    #include <stdlib.h>
+     int
+     main ()
+     {
+diff -Naur wol-0.7.1-orig/m4/realloc.m4 wol-0.7.1/m4/realloc.m4
+--- wol-0.7.1-orig/m4/realloc.m4	2024-12-25 13:52:38.185314129 +0900
++++ wol-0.7.1/m4/realloc.m4	2024-12-25 14:36:55.421560103 +0900
+@@ -14,7 +14,7 @@
+ 
+  AC_CACHE_CHECK([for working realloc], jm_cv_func_working_realloc,
+   [AC_TRY_RUN([
+-    char *realloc ();
++    #include <stdlib.h>
+     int
+     main ()
+     {

--- a/pkgs/by-name/wo/wol/package.nix
+++ b/pkgs/by-name/wo/wol/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  autoreconfHook,
   perl,
 }:
 
@@ -14,8 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "08i6l5lr14mh4n3qbmx6kyx7vjqvzdnh3j9yfvgjppqik2dnq270";
   };
 
-  # for pod2man in order to get a manpage
-  nativeBuildInputs = [ perl ];
+  patches = [ ./gcc-14.patch ];
+
+  nativeBuildInputs = [
+    perl # for pod2man in order to get a manpage
+    autoreconfHook # for the patch
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
GCC 14 (#356812) breaks this package due to various badly written autotools scripts:
* failed checks that shouldn't, e.g. `checking for working malloc... no`
* ignored checks that would otherwise have made wol correctly include headers (unconditinally setting to 0 after conditionally setting to 1)

(I wouldn't know how to upstream the patch to [sf](https://sourceforge.net/projects/wake-on-lan/) and the last commit is from 2004.)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>wol</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
