### PR TITLE
x32edit,m32edit: 4.1 -> 4.3

### DIFF
--- a/pkgs/applications/audio/midas/deps.nix
+++ b/pkgs/applications/audio/midas/deps.nix
@@ -1,0 +1,496 @@
+# This is a generated file.  Do not modify!
+# Following are the Debian packages constituting the closure of: libstdc++6 libcurl3-gnutls libfreetype6 libasound2 libx11-6 libxext6
+
+{ fetchurl }:
+
+[
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb";
+      sha256 = "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb";
+      sha256 = "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf";
+    })
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb";
+      sha256 = "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef";
+    })
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/glibc/libc6_2.31-13+deb11u6_amd64.deb";
+      sha256 = "cb8771d39b068834197b2b75c6b06433685b6e6a23a315064fb7cb5ab80cc235";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb";
+      sha256 = "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb";
+      sha256 = "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb";
+      sha256 = "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb";
+      sha256 = "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb";
+      sha256 = "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb";
+      sha256 = "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb";
+      sha256 = "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb";
+      sha256 = "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb";
+      sha256 = "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb";
+      sha256 = "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u3_amd64.deb";
+      sha256 = "d7d504ff9d45a292a4af549014c9471b526a0dbc898ff9a606fe24e0319a2d8e";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb";
+      sha256 = "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb";
+      sha256 = "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb";
+      sha256 = "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb";
+      sha256 = "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb";
+      sha256 = "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb";
+      sha256 = "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb";
+      sha256 = "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/t/tar/tar_1.34+dfsg-1_amd64.deb";
+      sha256 = "bd8e963c6edcf1c806df97cd73560794c347aa94b9aaaf3b88eea585bb2d2f3c";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb";
+      sha256 = "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb";
+      sha256 = "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435";
+      name = "liblzma5_5.2.5-2.1deb11u1_amd64.deb";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb";
+      sha256 = "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb";
+      sha256 = "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u2_amd64.deb";
+      sha256 = "018a3e48e58cbc478d3a4365090fb1daa151769f90f9b45984ec9d056ef96adc";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/debconf/debconf_1.5.77_all.deb";
+      sha256 = "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb";
+      sha256 = "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb";
+      sha256 = "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb";
+      sha256 = "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb";
+      sha256 = "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.27+dfsg-2.1+deb11u1_amd64.deb";
+      sha256 = "122bf3de4ca0ec873bc35bdde1f21ec9d91ace4f5245c3b1240e077f866e1ae9";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.27+dfsg-2.1+deb11u1_amd64.deb";
+      sha256 = "2e86ab7a3329aad4b7350a9b067fe8f80b680302f2f82d94f73f9bf075404460";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openldap/libldap-2.4-2_2.4.57+dfsg-3+deb11u1_amd64.deb";
+      sha256 = "3d79ee84c42c1d1b58a6e0d7debc7e3c8444147b84412b8248a7789809bc3163";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nghttp2/libnghttp2-14_1.43.0-1_amd64.deb";
+      sha256 = "a1a8aae24ced43025c94a9cb0c0eabfb3fc070785de9ee51c9a3a4fe86f0d11e";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb";
+      sha256 = "d716f5b4346ec85bb728f4530abeb1da4a79f696c72d7f774c59ba127c202fa7";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b2_amd64.deb";
+      sha256 = "e1f69020dc2c466e421ec6a58406b643be8b5c382abf0f8989011c1d3df91c87";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb";
+      sha256 = "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb";
+      sha256 = "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libs/libssh2/libssh2-1_1.9.0-2_amd64.deb";
+      sha256 = "f730fe45716a206003597819ececeeffe0fff754bdbbd0105425a177aa20a2de";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+deb11u9_amd64.deb";
+      sha256 = "bfaffacec95713a1486b20f24219952a0d56db041d43ece1768b732d859be885";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb";
+      sha256 = "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb";
+      sha256 = "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2-data_1.2.4-1.1_all.deb";
+      sha256 = "76211f5f201ad1069b95d047863e0c1b51d8400c874b59e00f24f31f972b4036";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2_1.2.4-1.1_amd64.deb";
+      sha256 = "d8c9b5182768db2a7c5c73f1eed0b1be1431ae4f41084d502b325d06d5b0f648";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb";
+      sha256 = "679db1c4579ec7c61079adeaae8528adeb2e4bf5465baa6c56233b995d714750";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb";
+      sha256 = "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb";
+      sha256 = "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb";
+      sha256 = "ecb8536f5fb34543b55bb9dc5f5b14c9dbb4150a7bddb3f2287b7cab6e9d25ef";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb";
+      sha256 = "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-data_1.7.2-1+deb11u1_all.deb";
+      sha256 = "457db358e1d77cfe4f8af5e6efa7a1b262848b65192589932c38a589a4b6976b";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-6_1.7.2-1+deb11u1_amd64.deb";
+      sha256 = "23385ffd6d2e3e507a7532fb24dc48176dada9c861e5d43853e18179a08bf861";
+    })
+
+  ]
+
+  [
+
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxext/libxext6_1.3.3-1.1_amd64.deb";
+      sha256 = "dc1ff8a2b60c7dd3c8917ffb9aa65ee6cda52648d9150608683c47319d1c0c8c";
+    })
+
+  ]
+
+]

--- a/pkgs/applications/audio/midas/gen-deps
+++ b/pkgs/applications/audio/midas/gen-deps
@@ -1,0 +1,4 @@
+#!/bin/sh -eu
+cd "$(dirname "$0")"
+deps=$(nix-build --no-link -A x32edit.deps ../../../..)
+cat "$deps" > deps.nix

--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -2,25 +2,36 @@
   stdenv,
   fetchurl,
   lib,
-  libX11,
-  libXext,
-  alsa-lib,
-  freetype,
   brand,
   type,
   version,
   homepage,
   url,
-  sha256,
+  hash,
+  runCommand,
+  dpkg,
+  vmTools,
+  runtimeShell,
+  bubblewrap,
   ...
 }:
+let
+  debian =
+    let
+      debs = lib.flatten (import ./deps.nix { inherit fetchurl; });
+    in
+    runCommand "x32edit-debian" { nativeBuildInputs = [ dpkg ]; } (
+      lib.concatMapStringsSep "\n" (deb: ''
+        dpkg-deb -x ${deb} $out
+      '') debs
+    );
+in
 stdenv.mkDerivation rec {
   pname = "${lib.toLower type}-edit";
   inherit version;
 
   src = fetchurl {
-    inherit url;
-    inherit sha256;
+    inherit url hash;
   };
 
   sourceRoot = ".";
@@ -29,25 +40,38 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ${type}-Edit $out/bin/${pname}
+    cp ${type}-Edit $out/bin/.${pname}
+
+    cat >$out/bin/${pname} <<EOF
+    #!${runtimeShell} -eu
+    exec ${lib.getExe bubblewrap} \
+      --dev-bind / / \
+      --ro-bind "${debian}/lib" /lib \
+      --ro-bind "${debian}/lib64" /lib64 \
+      --tmpfs /usr \
+      --ro-bind "${debian}/usr/lib" /usr/lib \
+      $out/bin/.${pname}
+    EOF
+    chmod 755 $out/bin/${pname}
   '';
-  preFixup =
+
+  passthru.deps =
     let
-      # we prepare our library path in the let clause to avoid it become part of the input of mkDerivation
-      libPath = lib.makeLibraryPath [
-        libX11 # libX11.so.6
-        libXext # libXext.so.6
-        alsa-lib # libasound.so.2
-        freetype # libfreetype.so.6
-        (lib.getLib stdenv.cc.cc) # libstdc++.so.6
-      ];
+      distro = vmTools.debDistros.debian11x86_64;
     in
-    ''
-      patchelf \
-        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${libPath}" \
-        $out/bin/${pname}
-    '';
+    vmTools.debClosureGenerator {
+      name = "x32edit-dependencies";
+      inherit (distro) urlPrefix;
+      packagesLists = [ distro.packagesList ];
+      packages = [
+        "libstdc++6"
+        "libcurl3-gnutls"
+        "libfreetype6"
+        "libasound2"
+        "libx11-6"
+        "libxext6"
+      ];
+    };
 
   meta = with lib; {
     inherit homepage;

--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -5,9 +5,9 @@ callPackage ./generic.nix (
   // rec {
     brand = "Midas";
     type = "M32";
-    version = "4.1";
+    version = "4.3";
     url = "https://mediadl.musictribe.com/download/software/midas_${type}/${type}-Edit_LINUX_${version}.tar.gz";
-    sha256 = "0aqhdrxqa49liyvbbw5x32kwk0h1spzvmizmdxklrfs64vvr9bvh";
+    hash = "sha256-1+7xGmSqIPn5NGOnk2VvPJxkI2y1em/kjeldXU0M35w=";
     homepage = "https://midasconsoles.com/midas/product?modelCode=P0B3I";
   }
 )

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -5,9 +5,9 @@ callPackage ./generic.nix (
   // rec {
     brand = "Behringer";
     type = "X32";
-    version = "4.1";
+    version = "4.3";
     url = "https://mediadl.musictribe.com/download/software/behringer/${type}/${type}-Edit_LINUX_${version}.tar.gz";
-    sha256 = "0zsw7qfmcci87skkpq8vx5zxk35phn8y4byispvki9ascifnnb33";
+    hash = "sha256-iVBBW6qVtEGlNXqKRZxObB9WfbOEjXMA1Nsp1CTFOH4=";
     homepage = "https://www.behringer.com/behringer/product?modelCode=P0ASF";
   }
 )

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -726,7 +726,7 @@ rec {
     {name, packagesLists, urlPrefix, packages}:
 
     runCommand "${name}.nix"
-      { nativeBuildInputs = [ buildPackages.perl buildPackages.dpkg ]; } ''
+      { nativeBuildInputs = [ buildPackages.perl buildPackages.dpkg pkgs.nixfmt-rfc-style ]; } ''
       for i in ${toString packagesLists}; do
         echo "adding $i..."
         case $i in
@@ -744,6 +744,7 @@ rec {
 
       perl -w ${deb/deb-closure.pl} \
         ./Packages ${urlPrefix} ${toString packages} > $out
+      nixfmt $out
     '';
 
 


### PR DESCRIPTION
Update x32edit and m32edit to the latest version 4.3. The program starts, but please check if all functions work as expected.
Since version 4.3 (built 2021) the executable is linked against libcurl3-gnutls, which is not available in nixpkgs.
I had to link the original Debian package to the executable. The approach is novel, so please have a deeper look.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @Korny666  @markuskowa 