### PR TITLE
jbig2enc: 0.29.0 -> 0.30.0

### DIFF
--- a/pkgs/by-name/jb/jbig2enc/package.nix
+++ b/pkgs/by-name/jb/jbig2enc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   leptonica,
   zlib,
   libwebp,
@@ -10,18 +9,19 @@
   libjpeg,
   libpng,
   libtiff,
+  python3,
   autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "jbig2enc";
-  version = "0.29";
+  version = "0.30";
 
   src = fetchFromGitHub {
     owner = "agl";
     repo = "jbig2enc";
     rev = version;
-    hash = "sha256-IAL4egXgaGmCilzcryjuvOoHhahyrfGWY68GBfXXgAM=";
+    hash = "sha256-B19l2NdMq+wWKQ5f/y5aoPiBtQnn6sqpaIoyIq+ugTg=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -34,20 +34,13 @@ stdenv.mkDerivation rec {
     libjpeg
     libpng
     libtiff
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "fix-build-leptonica-1.83.patch";
-      url = "https://github.com/agl/jbig2enc/commit/ea050190466f5336c69c6a11baa1cb686677fcab.patch";
-      hash = "sha256-+kScjFgDEU9F7VOUNAhm2XBjGm49fzAH8hYhmTm8xv8=";
-    })
+    python3
   ];
 
   # We don't want to install this Python 2 script
-  postInstall = ''
-    rm "$out/bin/pdf.py"
-  '';
+  #postInstall = ''
+  #  rm "$out/bin/pdf.py"
+  #'';
 
   # This is necessary, because the resulting library has
   # /tmp/nix-build-jbig2enc/src/.libs before /nix/store/jbig2enc/lib


### PR DESCRIPTION
https://github.com/agl/jbig2enc/releases/tag/0.30

Fixes CVE-2018-11230.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 368082`

---
### `aarch64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>python313Packages.ocrmypdf</li>
    <li>python313Packages.ocrmypdf.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>jbig2enc</li>
    <li>ocrmypdf (python312Packages.ocrmypdf)</li>
    <li>ocrmypdf.dist (python312Packages.ocrmypdf.dist)</li>
    <li>paperless-ngx</li>
  </ul>
</details>

Failure is unrelated to this change https://hydra.nixos.org/build/282862331

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
