### PR TITLE
postgresql_14: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -146,29 +146,51 @@ let
         "lib"
         "man"
       ];
-      outputChecks.out = {
-        disallowedReferences = [
-          "dev"
-          "doc"
-          "man"
-        ];
-        disallowedRequisites = [
-          stdenv'.cc
-          llvmPackages.llvm.out
-        ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-      };
-      outputChecks.lib = {
-        disallowedReferences = [
-          "out"
-          "dev"
-          "doc"
-          "man"
-        ];
-        disallowedRequisites = [
-          stdenv'.cc
-          llvmPackages.llvm.out
-        ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-      };
+      outputChecks =
+        {
+          out = {
+            disallowedReferences = [
+              "dev"
+              "doc"
+              "man"
+            ];
+            disallowedRequisites = [
+              stdenv'.cc
+              llvmPackages.llvm.out
+            ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+          };
+
+          lib = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "doc"
+              "man"
+            ];
+            disallowedRequisites = [
+              stdenv'.cc
+              llvmPackages.llvm.out
+            ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+          };
+        }
+        // lib.optionalAttrs (atLeast "14" && olderThan "15") {
+          # TODO: Make this unconditional via staging because of number of rebuilds.
+          doc = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "man"
+            ];
+          };
+
+          man = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "doc"
+            ];
+          };
+        };
 
       strictDeps = true;
 


### PR DESCRIPTION
Building postgresql_14 currently fails with this on master:

```
error: derivation contains an illegal reference specifier 'man'
```

The odd thing is, that changing *anything* in the postInstall phase seems to fix this, including just adding a single character as a comment.

I have **no clue** what's happening here.

I don't have too much time the next couple of days to investigate this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
