### PR TITLE
python2Packages.pygtk: fix build with `-fpermissive`

### DIFF
--- a/pkgs/development/python2-modules/pygtk/default.nix
+++ b/pkgs/development/python2-modules/pygtk/default.nix
@@ -58,7 +58,8 @@ buildPythonPackage rec {
 
   env.NIX_CFLAGS_COMPILE =
     lib.optionalString stdenv.hostPlatform.isDarwin "-ObjC"
-    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) " -lpython2.7";
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) " -lpython2.7"
+    + " -fpermissive"; # downgrade code errors to warnings
 
   installPhase = "installPhase";
 
@@ -94,5 +95,6 @@ buildPythonPackage rec {
     homepage = "https://gitlab.gnome.org/Archive/pygtk";
     platforms = platforms.all;
     license = with licenses; [ lgpl21Plus ];
+    maintainers = with lib.maintainers; [ bryango ];
   };
 }


### PR DESCRIPTION
- fix build with `-fpermissive`, previously failing with [`-Wall`](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wall)
- adopt the package: add @bryango to maintainers.

<details><summary>P.S. build failure log</summary>

```
python2.7-pygtk> libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/nix/store/iml7d74jcxijq03k57pw9lcr4b4csrkb-python-2.7.18.8/include/python2.7 -I/nix/store/iml7d74jcxijq03k57pw9lcr4b4csrkb-python-2.7.18.8/include/python2.7 -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/y2f8mjbk85by3lak018g8aq71g52q91k-python2.7-pygobject-2.28.7/include/pygtk-2.0 -pthread -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I./gtk -I/nix/store/akxwqfa5h9n4giv2zp04m3v4ngabb18j-pango-1.54.0-dev/include/pango-1.0 -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/9w2ars9rx8k0y48pq9fbmqxypmmfga3q-harfbuzz-10.1.0-dev/include/harfbuzz -g -O2 -Wall -fno-strict-aliasing -std=c9x -c pango.c  -fPIC -DPIC -o .libs/pango_la-pango.o
python2.7-pygtk> In file included from pango.override:27:
python2.7-pygtk> /nix/store/y2f8mjbk85by3lak018g8aq71g52q91k-python2.7-pygobject-2.28.7/include/pygtk-2.0/pygobject.h:153:40: warning: ‘GParameter’ is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Wdeprecated-declarations8;;]
python2.7-pygtk>   153 |                                        GParameter  *params,
python2.7-pygtk>       |                                        ^~~~~~~~~~
python2.7-pygtk> In file included from /nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0/gobject/gobject.h:28,
python2.7-pygtk>                  from /nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0/gobject/gbinding.h:31,
python2.7-pygtk>                  from /nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0/glib-object.h:24,
python2.7-pygtk>                  from /nix/store/y2f8mjbk85by3lak018g8aq71g52q91k-python2.7-pygobject-2.28.7/include/pygtk-2.0/pygobject.h:8:
python2.7-pygtk> /nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0/gobject/gparam.h:278:8: note: declared here
python2.7-pygtk>   278 | struct _GParameter /* auxiliary structure for _setv() variants */
python2.7-pygtk>       |        ^~~~~~~~~~~
python2.7-pygtk> /nix/store/y2f8mjbk85by3lak018g8aq71g52q91k-python2.7-pygobject-2.28.7/include/pygtk-2.0/pygobject.h:187:40: warning: ‘GParameter’ is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Wdeprecated-declarations8;;]
python2.7-pygtk>   187 |                                        GParameter *parameters);
python2.7-pygtk>       |                                        ^~~~~~~~~~
python2.7-pygtk> /nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0/gobject/gparam.h:278:8: note: declared here
python2.7-pygtk>   278 | struct _GParameter /* auxiliary structure for _setv() variants */
python2.7-pygtk>       |        ^~~~~~~~~~~
python2.7-pygtk> pango.c: In function ‘_wrap_PangoFont__proxy_do_get_metrics’:
python2.7-pygtk> pango.c:3986:16: error: implicit declaration of function ‘pango_font_metrics_new’; did you mean ‘pango_font_metrics_ref’? [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
python2.7-pygtk>  3986 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk>       |                pango_font_metrics_ref
python2.7-pygtk> pango.c:3986:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  3986 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:4000:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  4000 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:4011:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  4011 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:4021:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  4021 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c: In function ‘_wrap_pango_font_map_get_shape_engine_type’:
python2.7-pygtk> pango.c:4710:11: error: implicit declaration of function ‘pango_font_map_get_shape_engine_type’; did you mean ‘_wrap_pango_font_map_get_shape_engine_type’? [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
python2.7-pygtk>  4710 |     ret = pango_font_map_get_shape_engine_type(PANGO_FONT_MAP(self->obj));
python2.7-pygtk>       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk>       |           _wrap_pango_font_map_get_shape_engine_type
python2.7-pygtk> pango.c:4710:9: error: assignment to ‘const gchar *’ {aka ‘const char *’} from ‘int’ makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  4710 |     ret = pango_font_map_get_shape_engine_type(PANGO_FONT_MAP(self->obj));
python2.7-pygtk>       |         ^
python2.7-pygtk> pango.c: In function ‘_wrap_PangoFontset__proxy_do_get_metrics’:
python2.7-pygtk> pango.c:5382:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  5382 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:5392:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  5392 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:5402:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  5402 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
python2.7-pygtk> pango.c:5411:16: error: returning ‘int’ from a function with return type ‘PangoFontMetrics *’ {aka ‘struct _PangoFontMetrics *’} makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-conversion-Wint-conversion8;;]
python2.7-pygtk>  5411 |         return pango_font_metrics_new();
python2.7-pygtk>       |                ^~~~~~~~~~~~~~~~~~~~~~~~
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
