### PR TITLE
carl: init at 0.3.1

### DIFF
--- a/pkgs/by-name/ca/carl/package.nix
+++ b/pkgs/by-name/ca/carl/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "carl";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "b1rger";
+    repo = "carl";
+    rev = "v${version}";
+    hash = "sha256-+l11eP+1qKrWbZhyUJgQ8FgQ+2rncx778F5RPzCfvV4=";
+  };
+
+  doCheck = false;
+
+  cargoHash = "sha256-nBl34szwEQX26MibfT10E55czYXN3/9W3y2z936KqTc=";
+
+  meta = {
+    description = "cal(1) with more features and written in rust";
+    longDescription = ''
+      Carl is a calendar for the commandline. It tries to mimic the various cal(1)
+      implementations out there, but also adds enhanced features like colors and ical
+      support
+    '';
+    homepage = "https://github.com/b1rger/carl";
+    changelog = "https://github.com/b1rger/carl/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "carl";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Slightly slower than the util-linux version of `cal` and the tests fail, but it's an interesting project to keep an eye on

```
hyperfine --warmup 500 --shell=none /nix/store/6z0c5iiibq6j53ywp0i7ipc6cpdbkxcp-carl-0.3.1/bin/carl /nix/store/4wj2h8f0npnf7slsdgy1hy985pxpj4lx-util-linux-2.39.4-bin/bin/cal 2>/dev/null
Benchmark 1: /nix/store/6z0c5iiibq6j53ywp0i7ipc6cpdbkxcp-carl-0.3.1/bin/carl
  Time (mean ± σ):       1.4 ms ±   0.2 ms    [User: 0.2 ms, System: 1.2 ms]
  Range (min … max):     1.3 ms …   3.2 ms    1664 runs
 
Benchmark 2: /nix/store/4wj2h8f0npnf7slsdgy1hy985pxpj4lx-util-linux-2.39.4-bin/bin/cal
  Time (mean ± σ):       1.4 ms ±   0.2 ms    [User: 0.9 ms, System: 0.4 ms]
  Range (min … max):     1.3 ms …   3.0 ms    2205 runs
 
Summary
  /nix/store/4wj2h8f0npnf7slsdgy1hy985pxpj4lx-util-linux-2.39.4-bin/bin/cal ran
    1.04 ± 0.18 times faster than /nix/store/6z0c5iiibq6j53ywp0i7ipc6cpdbkxcp-carl-0.3.1/bin/carl
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
