### PR TITLE
Influxdb{2}: fix build with Rust1.83 compat

### DIFF
--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -34,7 +34,14 @@ let
         hash = "sha256-6LOTgbOCfETNTmshyXgtDZf9y4t/2iqRuVPkz9dYPHc=";
       })
       ../influxdb2/fix-unsigned-char.patch
+      # https://github.com/influxdata/flux/pull/5516
+      ../influxdb2/rust_lifetime.patch
     ];
+    # Don't fail on missing code documentation
+    postPatch = ''
+      substituteInPlace flux-core/src/lib.rs \
+        --replace-fail "deny(warnings, missing_docs))]" "deny(warnings))]"
+    '';
     sourceRoot = "${src.name}/libflux";
     cargoHash = "sha256-O+t4f4P5291BuyARH6Xf3LejMFEQEBv+qKtyjHRhclA=";
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
@@ -95,7 +102,9 @@ buildGoModule rec {
 
   excludedPackages = "test";
 
-  passthru.tests = { inherit (nixosTests) influxdb; };
+  passthru.tests = {
+    inherit (nixosTests) influxdb;
+  };
 
   meta = with lib; {
     description = "Open-source distributed time series database";

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -50,7 +50,14 @@ let
         hash = "sha256-6LOTgbOCfETNTmshyXgtDZf9y4t/2iqRuVPkz9dYPHc=";
       })
       ./fix-unsigned-char.patch
+      # https://github.com/influxdata/flux/pull/5516
+      ./rust_lifetime.patch
     ];
+    # Don't fail on missing code documentation
+    postPatch = ''
+      substituteInPlace flux-core/src/lib.rs \
+        --replace-fail "deny(warnings, missing_docs))]" "deny(warnings))]"
+    '';
     sourceRoot = "${src.name}/libflux";
     cargoHash = "sha256-O+t4f4P5291BuyARH6Xf3LejMFEQEBv+qKtyjHRhclA=";
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
@@ -74,7 +81,6 @@ let
         install_name_tool -id $out/lib/libflux.dylib $out/lib/libflux.dylib
       '';
   };
-
 in
 buildGoModule {
   pname = "influxdb";
@@ -132,7 +138,9 @@ buildGoModule {
     "-X main.version=${version}"
   ];
 
-  passthru.tests = { inherit (nixosTests) influxdb2; };
+  passthru.tests = {
+    inherit (nixosTests) influxdb2;
+  };
 
   meta = with lib; {
     description = "Open-source distributed time series database";

--- a/pkgs/servers/nosql/influxdb2/rust_lifetime.patch
+++ b/pkgs/servers/nosql/influxdb2/rust_lifetime.patch
@@ -1,0 +1,26 @@
+diff --git a/flux-core/src/ast/walk/mod.rs b/flux-core/src/ast/walk/mod.rs
+index 90f70ba6f7..a6966827e8 100644
+--- a/flux-core/src/ast/walk/mod.rs
++++ b/flux-core/src/ast/walk/mod.rs
+@@ -180,7 +180,7 @@ impl<'a> Node<'a> {
+ 
+ impl<'a> Node<'a> {
+     #[allow(missing_docs)]
+-    pub fn from_expr(expr: &'a Expression) -> Node {
++    pub fn from_expr(expr: &'a Expression) -> Node<'a> {
+         match expr {
+             Expression::Identifier(e) => Node::Identifier(e),
+             Expression::Array(e) => Node::ArrayExpr(e),
+diff --git a/flux-core/src/parser/mod.rs b/flux-core/src/parser/mod.rs
+index ac7d4b9a72..561c3a0ff6 100644
+--- a/flux-core/src/parser/mod.rs
++++ b/flux-core/src/parser/mod.rs
+@@ -41,7 +41,7 @@ pub struct Parser<'input> {
+ 
+ impl<'input> Parser<'input> {
+     /// Instantiates a new parser with the given string as input.
+-    pub fn new(src: &'input str) -> Parser {
++    pub fn new(src: &'input str) -> Parser<'input> {
+         let s = Scanner::new(src);
+         Parser {
+             s,


### PR DESCRIPTION
Fix current build issue (https://hydra.nixos.org/build/281927328/nixlog/3):

```
   Compiling flux-core v0.154.0 (/build/source/libflux/flux-core)
error: elided lifetime has a name
   --> flux-core/src/ast/walk/mod.rs:183:47
    |
181 | impl<'a> Node<'a> {
    |      -- lifetime `'a` declared here
182 |     #[allow(missing_docs)]
183 |     pub fn from_expr(expr: &'a Expression) -> Node {
    |                                               ^^^^ this elided lifetime gets resolved as `'a`
    |
note: the lint level is defined here
   --> flux-core/src/lib.rs:1:38
    |
1   | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
    |                                      ^^^^^^^^
    = note: `#[deny(elided_named_lifetimes)]` implied by `#[deny(warnings)]`

error: elided lifetime has a name
  --> flux-core/src/parser/mod.rs:44:37
   |
42 | impl<'input> Parser<'input> {
   |      ------ lifetime `'input` declared here
43 |     /// Instantiates a new parser with the given string as input.
44 |     pub fn new(src: &'input str) -> Parser {
   |                                     ^^^^^^ this elided lifetime gets resolved as `'input`

error: could not compile `flux-core` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `flux-core` (lib) due to 2 previous errors
```

fix from https://github.com/influxdata/flux/pull/5516

Also need to disable errors on missing docs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
