### PR TITLE
upcloud-cli: init at 3.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13248,6 +13248,12 @@
     githubId = 37505890;
     name = "Luis Wirth";
   };
+  lu1a = {
+    email = "lu5a@proton.me";
+    github = "lu1a";
+    githubId = 83420438;
+    name = "Lewis";
+  };
   LucaGuerra = {
     email = "luca@guerra.sh";
     github = "LucaGuerra";

--- a/pkgs/by-name/up/upcloud-cli/package.nix
+++ b/pkgs/by-name/up/upcloud-cli/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "upcloud-cli";
+  version = "3.14.0";
+
+  src = fetchFromGitHub {
+    owner = "UpCloudLtd";
+    repo = "upcloud-cli";
+    tag = "v${version}";
+    hash = "sha256-zKPoJFfgqi6ZIeZKJy7YeYuqHWVPH0LXvWpOYCEM7dE=";
+  };
+
+  vendorHash = "sha256-76bLk4zten9SGXbt/M8VKPSylCwQqclyscSVQQaAtbA=";
+
+  ldflags = [
+    "-s -w -X github.com/UpCloudLtd/upcloud-cli/v3/internal/config.Version=${version}"
+  ];
+
+  subPackages = [
+    "cmd/upctl"
+    "internal/*"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/upctl";
+  versionCheckProgramArg = [ "version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = lib.nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/UpCloudLtd/upcloud-cli/blob/refs/tags/v${version}/CHANGELOG.md";
+    description = "Command-line tool for managing UpCloud services";
+    homepage = "https://github.com/UpCloudLtd/upcloud-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lu1a ];
+    mainProgram = "upctl";
+  };
+}


### PR DESCRIPTION
Introducing upcloud-cli as a nix pkg.
upcloud-cli is a command-line tool for managing UpCloud services.
Source: [https://github.com/UpCloudLtd/upcloud-cli](https://github.com/UpCloudLtd/upcloud-cli)

I also added myself as a maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
