### PR TITLE
rquickshare: build from source

### DIFF
--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -1,34 +1,123 @@
 {
-  appimageTools,
   lib,
-  fetchurl,
+  cargo-tauri,
+  cargo-tauri_1,
+  fetchFromGitHub,
+  glib-networking,
+  libayatana-appindicator,
+  libsoup_2_4,
+  libsoup_3,
+  nix-update,
+  nodejs,
+  openssl,
+  perl,
+  pkg-config,
+  pnpm,
+  protobuf,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_0,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+  writeShellScript,
+
+  # This package provides can be built using tauri v1 or v2.
+  # Try legacy (v1) version if main (v2) doesn't work.
+  app-type ? "main", # main or legacy
 }:
 let
-  pname = "rquickshare";
-  version = "0.11.2";
-  src = fetchurl {
-    url = "https://github.com/Martichou/rquickshare/releases/download/v${version}/r-quick-share-legacy_v${version}_glibc-2.31_amd64.AppImage";
-    hash = "sha256-VXYiYrTSedH8xFjuxbdplzVdfnO6s3ftY2I121Unlfw=";
-  };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  app-type-either =
+    arg1: arg2:
+    if app-type == "main" then
+      arg1
+    else if app-type == "legacy" then
+      arg2
+    else
+      throw "Wrong argument for app-type in rquickshare package";
+
+  proper-cargo-tauri = app-type-either cargo-tauri cargo-tauri_1;
 in
-appimageTools.wrapType2 {
-  inherit pname version src;
-  extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/r-quick-share.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/r-quick-share.desktop \
-      --replace-fail 'Exec=r-quick-share' 'Exec=r-quick-share %u'
-    cp -r ${appimageContents}/usr/share/icons $out/share
+rustPlatform.buildRustPackage rec {
+  pname = "rquickshare" + (app-type-either "" "-legacy");
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "Martichou";
+    repo = "rquickshare";
+    tag = "v${version}";
+    hash = "sha256-6gXt1UGcjOFInsCep56s3K5Zk/KIz2ZrFlmrgXP7/e8=";
+  };
+
+  # from https://github.com/NixOS/nixpkgs/blob/04e40bca2a68d7ca85f1c47f00598abb062a8b12/pkgs/by-name/ca/cargo-tauri/test-app.nix#L23-L26
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
+  pnpmRoot = "app/${app-type}";
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+
+    sourceRoot = "${src.name}/app/${app-type}";
+    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-sDHysaKMdNcbL1szww7/wg0bGHOnEKsKoySZJJCcPik=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoRoot = "app/${app-type}/src-tauri";
+  buildAndTestSubdir = cargoRoot;
+  cargoPatches = [ ./remove-duplicate-versions-of-sys-metrics.patch ];
+  cargoHash = app-type-either "sha256-R1RDBV8lcEuFdkh9vrNxFRSPSYVOWDvafPQAmQiJV2s=" "sha256-tgnSOICA/AFASIIlxnRoSjq5nx30Z7C6293bcvnWl0k=";
+
+  nativeBuildInputs = [
+    proper-cargo-tauri.hook
+
+    # Setup pnpm
+    nodejs
+    pnpm.configHook
+
+    # Make sure we can find our libraries
+    perl
+    pkg-config
+    protobuf
+    wrapGAppsHook4
+  ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      glib-networking
+      libayatana-appindicator
+    ]
+    ++ lib.optionals (app-type == "main") [
+      webkitgtk_4_1
+      libsoup_3
+    ]
+    ++ lib.optionals (app-type == "legacy") [
+      webkitgtk_4_0
+      libsoup_2_4
+    ];
+
+  passthru.updateScript =
+    let
+      updateScript = writeShellScript "update-rquickshare.sh" ''
+        ${lib.getExe nix-update} rquickshare
+        sed -i 's/version = "0.0.0";/' pkgs/by-name/rq/rquickshare/package.nix
+        ${lib.getExe nix-update} rquickshare-legacy
+      '';
+    in
+    # Don't set an update script for the legacy version
+    # so r-ryantm won't create two duplicate PRs
+    app-type-either updateScript null;
+
   meta = {
-    description = "Rust implementation of NearbyShare/QuickShare from Android for Linux";
+    description = "Rust implementation of NearbyShare/QuickShare from Android for Linux and macOS";
     homepage = "https://github.com/Martichou/rquickshare";
     changelog = "https://github.com/Martichou/rquickshare/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.luftmensch-luftmensch ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    mainProgram = "rquickshare";
+    mainProgram = app-type-either "rquickshare" "r-quick-share";
+    maintainers = with lib.maintainers; [
+      perchun
+      luftmensch-luftmensch
+    ];
   };
 }

--- a/pkgs/by-name/rq/rquickshare/remove-duplicate-versions-of-sys-metrics.patch
+++ b/pkgs/by-name/rq/rquickshare/remove-duplicate-versions-of-sys-metrics.patch
@@ -1,0 +1,116 @@
+diff --git a/app/legacy/src-tauri/Cargo.lock b/app/legacy/src-tauri/Cargo.lock
+index 109db68..c3a70c6 100644
+--- a/app/legacy/src-tauri/Cargo.lock
++++ b/app/legacy/src-tauri/Cargo.lock
+@@ -4138,7 +4138,7 @@ dependencies = [
+  "rand 0.8.5",
+  "serde",
+  "sha2",
+- "sys_metrics 0.2.7 (git+https://github.com/Martichou/sys_metrics)",
++ "sys_metrics",
+  "tokio",
+  "tokio-util",
+  "tracing-subscriber",
+@@ -4158,7 +4158,7 @@ dependencies = [
+  "rqs_lib",
+  "serde",
+  "serde_json",
+- "sys_metrics 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "sys_metrics",
+  "tauri",
+  "tauri-build",
+  "tauri-plugin-autostart",
+@@ -4759,22 +4759,7 @@ dependencies = [
+ [[package]]
+ name = "sys_metrics"
+ version = "0.2.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c9b266b80f59f86e2e1e0a4938e316e32c3730d94a749f236305152279f77484"
+-dependencies = [
+- "core-foundation-sys",
+- "glob",
+- "io-kit-sys",
+- "lazy_static",
+- "libc",
+- "mach",
+- "serde",
+-]
+-
+-[[package]]
+-name = "sys_metrics"
+-version = "0.2.7"
+-source = "git+https://github.com/Martichou/sys_metrics#c0f4ec7b9156d3ab83ee61276984c7fd4e632098"
++source = "git+https://github.com/Martichou/sys_metrics#e5b324a17d1724bd97923a173c3535cc06a44b0c"
+ dependencies = [
+  "core-foundation-sys",
+  "glob",
+diff --git a/app/legacy/src-tauri/Cargo.toml b/app/legacy/src-tauri/Cargo.toml
+index 5468707..68ed47b 100644
+--- a/app/legacy/src-tauri/Cargo.toml
++++ b/app/legacy/src-tauri/Cargo.toml
+@@ -20,7 +20,7 @@ notify-rust = "4.10"
+ rqs_lib = { path = "../../../core_lib", features = ["experimental"] }
+ serde = { version = "1.0", features = ["derive"] }
+ serde_json = "1.0"
+-sys_metrics = "0.2"
++sys_metrics = { git = "https://github.com/Martichou/sys_metrics" }
+ tauri = { version = "1.5", features = ["api-all", "reqwest-native-tls-vendored", "system-tray", "devtools"] }
+ tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+ tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+diff --git a/app/main/src-tauri/Cargo.lock b/app/main/src-tauri/Cargo.lock
+index c1f175c..7bf1450 100644
+--- a/app/main/src-tauri/Cargo.lock
++++ b/app/main/src-tauri/Cargo.lock
+@@ -4182,7 +4182,7 @@ dependencies = [
+  "rand 0.8.5",
+  "serde",
+  "sha2",
+- "sys_metrics 0.2.7 (git+https://github.com/Martichou/sys_metrics)",
++ "sys_metrics",
+  "tokio",
+  "tokio-util",
+  "tracing-subscriber",
+@@ -4202,7 +4202,7 @@ dependencies = [
+  "rqs_lib",
+  "serde",
+  "serde_json",
+- "sys_metrics 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "sys_metrics",
+  "tauri",
+  "tauri-build",
+  "tauri-plugin-autostart",
+@@ -4867,21 +4867,6 @@ dependencies = [
+  "syn 2.0.95",
+ ]
+ 
+-[[package]]
+-name = "sys_metrics"
+-version = "0.2.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c9b266b80f59f86e2e1e0a4938e316e32c3730d94a749f236305152279f77484"
+-dependencies = [
+- "core-foundation-sys",
+- "glob",
+- "io-kit-sys",
+- "lazy_static",
+- "libc",
+- "mach",
+- "serde",
+-]
+-
+ [[package]]
+ name = "sys_metrics"
+ version = "0.2.7"
+diff --git a/app/main/src-tauri/Cargo.toml b/app/main/src-tauri/Cargo.toml
+index 90dcc88..56abae2 100644
+--- a/app/main/src-tauri/Cargo.toml
++++ b/app/main/src-tauri/Cargo.toml
+@@ -20,7 +20,7 @@ notify-rust = "4.10"
+ rqs_lib = { path = "../../../core_lib", features = ["experimental"] }
+ serde = { version = "1.0", features = ["derive"] }
+ serde_json = "1.0"
+-sys_metrics = "0.2"
++sys_metrics = { git = "https://github.com/Martichou/sys_metrics" }
+ tauri = { version = "2.2", features = [ "devtools", "tray-icon", "native-tls-vendored"] }
+ tauri-plugin-autostart = "2.2"
+ tauri-plugin-process = "2.2"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14565,6 +14565,8 @@ with pkgs;
     x11Support = true;
   };
 
+  rquickshare-legacy = rquickshare.override { app-type = "legacy"; };
+
   seamly2d = libsForQt5.callPackage ../applications/graphics/seamly2d { };
 
   # a somewhat more maintained fork of ympd


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The main version didn't work for me (it couldn't see my device or accept connections), so I decided to try the legacy one (it didn't work too). Anyway, I added `rquickshare-legacy` so users can easily access legacy build.

Closes #357017
Fixes #350315
Supersedes #357673
Supersedes #367605

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
