### PR TITLE
spice-gtk: fix darwin build

### DIFF
--- a/pkgs/by-name/sp/spice-gtk/package.nix
+++ b/pkgs/by-name/sp/spice-gtk/package.nix
@@ -155,17 +155,24 @@ stdenv.mkDerivation rec {
       "-Dcoroutine=gthread" # Fixes "Function missing:makecontext"
     ];
 
-  postPatch = ''
-    # get rid of absolute path to helper in store so we can use a setuid wrapper
-    substituteInPlace src/usb-acl-helper.c \
-      --replace 'ACL_HELPER_PATH"/' '"'
-    # don't try to setcap/suid in a nix builder
-    substituteInPlace src/meson.build \
-      --replace "meson.add_install_script('../build-aux/setcap-or-suid'," \
-      "# meson.add_install_script('../build-aux/setcap-or-suid',"
+  postPatch =
+    ''
+      # get rid of absolute path to helper in store so we can use a setuid wrapper
+      substituteInPlace src/usb-acl-helper.c \
+        --replace-fail 'ACL_HELPER_PATH"/' '"'
+      # don't try to setcap/suid in a nix builder
+      substituteInPlace src/meson.build \
+        --replace-fail "meson.add_install_script('../build-aux/setcap-or-suid'," \
+        "# meson.add_install_script('../build-aux/setcap-or-suid',"
 
-    patchShebangs subprojects/keycodemapdb/tools/keymap-gen
-  '';
+      patchShebangs subprojects/keycodemapdb/tools/keymap-gen
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # don't use version script and don't export symbols
+      substituteInPlace src/meson.build \
+        --replace-fail "spice_gtk_version_script = [" "# spice_gtk_version_script = [" \
+        --replace-fail ",--version-script=@0@'.format(spice_client_glib_syms_path)" "'"
+    '';
 
   meta = with lib; {
     description = "GTK 3 SPICE widget";


### PR DESCRIPTION
fixes the error clang: error: unknown argument: '-export-symbols' and also unknown argument --version-script=[...]

See hydra https://hydra.nixos.org/build/282163292/nixlog/1

For some reason the meson check for the linker argument doesn't work on darwin and will fail with the unknown argument (first `--export-symbols` and then later with `--version-script=`)

This will patch out the arguments from the meson.build


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
