### PR TITLE
lemminx: Update 0.27.0 -> 0.29.0 & Minor Refactor

### DIFF
--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -5,8 +5,12 @@
   jdk_headless,
   jre_minimal,
   maven,
-  writeScript,
-  lemminx,
+  writeShellApplication,
+  curl,
+  pcre,
+  common-updater-scripts,
+  jq,
+  gnused,
 }:
 
 let
@@ -79,26 +83,44 @@ maven.buildMavenPackage rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  passthru.updateScript = writeScript "update-lemminx" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl pcre common-updater-scripts jq gnused
-    set -eu -o pipefail
+  passthru = {
+    updateScript =
+      let
+        pkgFile = builtins.toString ./package.nix;
+      in
+      lib.getExe (writeShellApplication {
+        name = "update-${pname}";
+        runtimeInputs = [
+          curl
+          pcre
+          common-updater-scripts
+          jq
+          gnused
+        ];
+        text = ''
+          if [ -z "''${GITHUB_TOKEN:-}" ]; then
+              echo "no GITHUB_TOKEN provided - you could meet API request limiting" >&2
+          fi
 
-    LATEST_TAG=$(curl https://api.github.com/repos/eclipse/lemminx/tags | \
-      jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
-      map(tonumber)) | reverse | .[0].name')
-    update-source-version lemminx "$LATEST_TAG"
-    sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${lemminx}
+          LATEST_TAG=$(curl -H "Accept: application/vnd.github+json" \
+            ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
+            -Lsf https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
+            jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
+            map(tonumber)) | reverse | .[0].name')
+          update-source-version ${pname} "$LATEST_TAG"
+          sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${pkgFile}
 
-    echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
-    nix-build -A lemminx.fetchedMavenDeps 2> lemminx-stderr.log || true
+          echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
+          nix-build -A ${pname}.fetchedMavenDeps 2> ${pname}-stderr.log || true
 
-    NEW_MVN_HASH=$(cat lemminx-stderr.log | grep "got:" | awk '{print ''$2}')
-    rm lemminx-stderr.log
-    # escaping double quotes looks ugly but is needed for variable substitution
-    # use # instead of / as separator because the sha256 might contain the / character
-    sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${lemminx}
-  '';
+          NEW_MVN_HASH=$(grep "got:" ${pname}-stderr.log | awk '{print ''$2}')
+          rm ${pname}-stderr.log
+          # escaping double quotes looks ugly but is needed for variable substitution
+          # use # instead of / as separator because the sha256 might contain the / character
+          sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${pkgFile}
+        '';
+      });
+  };
 
   meta = with lib; {
     description = "XML Language Server";

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -42,21 +42,11 @@ maven.buildMavenPackage rec {
     '';
   };
 
-  manualMvnArtifacts = [
-    "org.apache.maven.surefire:surefire-junit-platform:3.1.2"
-    "org.junit.platform:junit-platform-launcher:1.10.0"
-  ];
-
   mvnJdk = jdk_headless;
-  mvnHash = "sha256-jIvYUATcNUZZmZcXbUMqyHGX4CYiXqL0jkji+zrCYJY=";
+  mvnHash = "sha256-Bl+fASYrSIzpmI0FQ3N7CUJb3a04wq3Vzc27JbD8qk8=";
 
-  buildOffline = true;
-
-  # disable gitcommitid plugin which needs a .git folder which we
-  # don't have
-  mvnDepsParameters = "-Dmaven.gitcommitid.skip=true";
-
-  # disable failing tests which either need internet access or are flaky
+  # Disable gitcommitid plugin which needs a .git folder which we don't have.
+  # Disable failing tests which either need internet access or are flaky.
   mvnParameters = lib.escapeShellArgs [
     "-Dmaven.gitcommitid.skip=true"
     "-Dtest=!XMLValidationCommandTest,
@@ -70,15 +60,16 @@ maven.buildMavenPackage rec {
     !MissingChildElementCodeActionTest,
     !XSDValidationExternalResourcesTest,
     !DocumentLifecycleParticipantTest,
-    !DTDValidationExternalResourcesTest"
+    !DTDValidationExternalResourcesTest,
+    !DTDHoverExtensionsTest,
+    !CacheResourcesManagerTest"
   ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin $out/share
-    install -Dm644 org.eclipse.lemminx/target/org.eclipse.lemminx-uber.jar \
-      $out/share
+    install -Dm644 org.eclipse.lemminx/target/org.eclipse.lemminx-uber.jar $out/share
 
     makeWrapper ${jre}/bin/java $out/bin/lemminx \
       --add-flags "-jar $out/share/org.eclipse.lemminx-uber.jar"

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -25,13 +25,13 @@ let
 in
 maven.buildMavenPackage rec {
   pname = "lemminx";
-  version = "0.27.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = "lemminx";
     rev = version;
-    hash = "sha256-VWYTkYlPziNRyxHdvIWVuDlABpKdzhC/F6BUBj/opks=";
+    hash = "sha256-joeaN0Q/XxEWa7UX/LVSWIAb8GGTfVUE+NudedbBLBI=";
     # Lemminx reads this git information at runtime from a git.properties
     # file on the classpath
     leaveDotGit = true;
@@ -47,7 +47,7 @@ maven.buildMavenPackage rec {
   };
 
   mvnJdk = jdk_headless;
-  mvnHash = "sha256-Bl+fASYrSIzpmI0FQ3N7CUJb3a04wq3Vzc27JbD8qk8=";
+  mvnHash = "sha256-7RLZSlmXnjl9vwvCf/Z+mc2906JtuUbjjkRGVMC1En8=";
 
   # Disable gitcommitid plugin which needs a .git folder which we don't have.
   # Disable failing tests which either need internet access or are flaky.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pr does the following:

- Updates 0.27.0 -> 0.29.0.
- Switches from offline build back to _normal_ online build so that it can be reliably updated with an update script.
- Fixes the update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
