### PR TITLE
nixos/powertop: add hooks to fix incorrect configurations

### DIFF
--- a/nixos/modules/tasks/powertop.nix
+++ b/nixos/modules/tasks/powertop.nix
@@ -13,7 +13,38 @@ in
 {
   ###### interface
 
-  options.powerManagement.powertop.enable = mkEnableOption "powertop auto tuning on startup";
+  options.powerManagement.powertop = {
+    enable = mkEnableOption "powertop auto tuning on startup";
+
+    preStart = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Shell commands executed before `powertop` is started.
+      '';
+    };
+
+    postStart = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        ''${lib.getExe' config.systemd.package "udevadm"} trigger -c bind -s usb -a idVendor=046d -a idProduct=c08c
+      '';
+      description = ''
+        Shell commands executed after `powertop` is started.
+
+        This can be used to workaround problematic configurations. For example,
+        you can retrigger an `udev` rule to disable power saving on unsupported
+        USB devices:
+        ```
+        services.udev.extraRules = ''''
+          # disable USB auto suspend for Logitech, Inc. G PRO Gaming Mouse
+          ACTION=="bind", SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c08c", TEST=="power/control", ATTR{power/control}="on"
+        '''';
+        ```
+      '';
+    };
+  };
 
   ###### implementation
 
@@ -24,6 +55,8 @@ in
         after = [ "multi-user.target" ];
         description = "Powertop tunings";
         path = [ pkgs.kmod ];
+        preStart = cfg.preStart;
+        postStart = cfg.postStart;
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = "yes";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`powertop` will set USB auto suspend for all connected devices to `auto`. This can be checked with `head /sys/bus/usb/devices/*/power/control`.

However, the reason this is not `auto` by default is because [some devices does not support this properly](https://www.kernel.org/doc/html/latest/driver-api/usb/power-management.html#warnings). I'm getting the same issue as described [here](https://bbs.archlinux.org/viewtopic.php?id=185799) on my Logitech mouse, and I have confirmed that the workaround there works.

As such, let's expose `postStart` to allow arbitrary fixup script, since there might be other types of buggy hardware. I included an `udev` based example, since this is more declarative (locate device by VID and PID) than some custom bash scripts to iterate all `/sys/bus/usb/devices` nodes.

While we are on it, let's also expose `preStart`. Though I can't think of any obvious usage right now. Maybe `rmmod` some drivers so they won't be affected by power setting changes, and re-enable them in `postStart`? It is more about the completeness at this point.

As usual, I'm [dogfooding this PR](https://github.com/MakiseKurisu/nixos-config/commit/32000d5ba09fbd198b2ddc1d3bc30d484a6a06b2#diff-01ce112b99217c9566778d6f18cba6e0d00dc9ef4990d7eb2c5c5ea9b1e348d5).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
