### PR TITLE
sonarlint-ls:  Update 3.5.1.75119 -> 3.14.1.75775 & Minor Refactor

### DIFF
--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -86,17 +86,23 @@ maven.buildMavenPackage rec {
           gnused
         ];
         text = ''
-          LATEST_TAG=$(curl -L https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
+          if [ -z "''${GITHUB_TOKEN:-}" ]; then
+              echo "no GITHUB_TOKEN provided - you could meet API request limiting" >&2
+          fi
+
+          LATEST_TAG=$(curl -H "Accept: application/vnd.github+json" \
+            ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
+            -Lsf https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
             jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
             map(tonumber)) | reverse | .[0].name')
-          update-source-version sonarlint-ls "$LATEST_TAG"
+          update-source-version ${pname} "$LATEST_TAG"
           sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${pkgFile}
 
           echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
-          nix-build -A sonarlint-ls.fetchedMavenDeps 2> sonarlint-ls-stderr.log || true
+          nix-build -A ${pname}.fetchedMavenDeps 2> ${pname}-stderr.log || true
 
-          NEW_MVN_HASH=$(grep "got:" sonarlint-ls-stderr.log | awk '{print ''$2}')
-          rm sonarlint-ls-stderr.log
+          NEW_MVN_HASH=$(grep "got:" ${pname}-stderr.log | awk '{print ''$2}')
+          rm ${pname}-stderr.log
           # escaping double quotes looks ugly but is needed for variable substitution
           # use # instead of / as separator because the sha256 might contain the / character
           sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${pkgFile}

--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -27,18 +27,7 @@ maven.buildMavenPackage rec {
   };
 
   mvnJdk = jdk17;
-  manualMvnArtifacts = [
-    "org.apache.maven.surefire:surefire-junit-platform:3.1.2"
-    "org.junit.platform:junit-platform-launcher:1.8.2"
-  ];
-
-  mvnHash = "sha256-ZhAQtpi0wQP8+QPeYaor2MveY+DZ9RPENb3kITnuWd8=";
-
-  buildOffline = true;
-
-  # disable node and npm module installation because the need network access
-  # for the tests.
-  mvnDepsParameters = "-Dskip.installnodenpm=true -Dskip.npm package";
+  mvnHash = "sha256-SdRK2lI4cMG6Pp4xhz1pJ2r8bLzyWPueYwoa3M30RRg=";
 
   # disable failing tests which either need network access or are flaky
   mvnParameters = lib.escapeShellArgs [
@@ -48,20 +37,16 @@ maven.buildMavenPackage rec {
     !LanguageServerWithFoldersMediumTests,
     !NotebookMediumTests,
     !ConnectedModeMediumTests,
-    !JavaMediumTests"
+    !JavaMediumTests,
+    !OpenNotebooksCacheTests"
   ];
-
-  doCheck = false;
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/{bin,share/plugins}
-    install -Dm644 target/sonarlint-language-server-*.jar \
-      $out/share/sonarlint-ls.jar
-    install -Dm644 target/plugins/* \
-      $out/share/plugins
-
+    install -Dm644 target/sonarlint-language-server-*.jar $out/share/sonarlint-ls.jar
+    install -Dm644 target/plugins/* $out/share/plugins
 
     makeWrapper ${jre_headless}/bin/java $out/bin/sonarlint-ls \
       --add-flags "-jar $out/share/sonarlint-ls.jar" \
@@ -95,7 +80,7 @@ maven.buildMavenPackage rec {
           gnused
         ];
         text = ''
-          LATEST_TAG=$(curl https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
+          LATEST_TAG=$(curl -L https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
             jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
             map(tonumber)) | reverse | .[0].name')
           update-source-version sonarlint-ls "$LATEST_TAG"

--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -17,19 +17,25 @@
 
 maven.buildMavenPackage rec {
   pname = "sonarlint-ls";
-  version = "3.5.1.75119";
+  version = "3.14.1.75775";
 
   src = fetchFromGitHub {
     owner = "SonarSource";
     repo = "sonarlint-language-server";
     rev = version;
-    hash = "sha256-6tbuX0wUpqbTyM44e7PqZHL0/XjN8hTFCgfzV+qc1m0=";
+    hash = "sha256-QXBSdXpkhqcvfjihcWwy4oCjTMmbAJRZG1T66sa8T4U=";
   };
 
-  mvnJdk = jdk17;
-  mvnHash = "sha256-SdRK2lI4cMG6Pp4xhz1pJ2r8bLzyWPueYwoa3M30RRg=";
+  # Replaces unavailable versions with available ones in maven central. Can be
+  # removed again if
+  # https://github.com/SonarSource/sonarlint-language-server/pull/427 is
+  # merged.
+  patches = [ ./sonar-analyzers-versions.patch ];
 
-  # disable failing tests which either need network access or are flaky
+  mvnJdk = jdk17;
+  mvnHash = "sha256-SKkOf3f9Ze3Rm6i2uYbFkvSnnEySARvaoiAS1e2kFi0=";
+
+  # Disables failing tests which either need network access or are flaky.
   mvnParameters = lib.escapeShellArgs [
     "-Dskip.installnodenpm=true"
     "-Dskip.npm"

--- a/pkgs/by-name/so/sonarlint-ls/sonar-analyzers-versions.patch
+++ b/pkgs/by-name/so/sonarlint-ls/sonar-analyzers-versions.patch
@@ -1,0 +1,17 @@
+diff --git a/pom.xml b/pom.xml
+index c020fd1..fd4146b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -34,10 +34,10 @@
+     <sonar.python.version>4.17.0.14845</sonar.python.version>
+     <sonar.html.version>3.16.0.5274</sonar.html.version>
+     <sonar.xml.version>2.10.0.4108</sonar.xml.version>
+-    <sonar.text.version>2.18.0.4812</sonar.text.version>
++    <sonar.text.version>2.18.0.4866</sonar.text.version>
+     <sonar.go.version>1.15.0.4655</sonar.go.version>
+     <sonar.iac.version>1.27.0.9518</sonar.iac.version>
+-    <sonar.csharp.version>10.2.0.103721</sonar.csharp.version>
++    <sonar.csharp.version>10.2.0.105762</sonar.csharp.version>
+     <sonarlint.omnisharp.version>1.25.0.100242</sonarlint.omnisharp.version>
+     <gitRepositoryName>sonarlint-language-server</gitRepositoryName>
+     <!-- Release: enable publication to Bintray -->


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr does the following:

- Updates 3.5.1.75119 -> 3.14.1.75775.
- Switches from offline build back to _normal_ online build so that it can be reliably updated with an update script.
- Fixes the update script.
- Currently contains a patch to replace the analyzers versions with versions which are publicly available. After https://github.com/SonarSource/sonarlint-language-server/pull/428 has been merged it can be removed again with the next release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
