### PR TITLE
gitstatus: fix build with GCC14 and on darwin

### DIFF
--- a/pkgs/by-name/gi/gitstatus/package.nix
+++ b/pkgs/by-name/gi/gitstatus/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   git,
   zsh,
+  zlib,
   runtimeShell,
 }:
 stdenv.mkDerivation rec {
@@ -18,11 +19,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-b+9bwJ87VV6rbOPobkwMkDXGH34STjYPlt8wCRR5tEc=";
   };
 
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_LDFLAGS = "-liconv";
-  };
+  env.NIX_LDFLAGS = toString (
+    [
+      # required by libgit2.a
+      "-lz"
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin "-liconv"
+  );
 
-  buildInputs = [ (callPackage ./romkatv_libgit2.nix { }) ];
+  buildInputs = [
+    zlib
+    (callPackage ./romkatv_libgit2.nix { })
+  ];
 
   postPatch = ''
     sed -i '1i GITSTATUS_AUTO_INSTALL=''${GITSTATUS_AUTO_INSTALL-0}' gitstatus.plugin.sh

--- a/pkgs/by-name/gi/gitstatus/package.nix
+++ b/pkgs/by-name/gi/gitstatus/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
     # run zsh as a full-fledged independent process and then wait for it to
     # exit. (The "exit" statements in the zshrc ensure that zsh will exit
     # almost immediately after starting.)
-    ZDOTDIR=. zsh -i &
+    ZDOTDIR=. zsh -d -i &
     wait $!
   '';
 

--- a/pkgs/by-name/gi/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/by-name/gi/gitstatus/romkatv_libgit2.nix
@@ -5,7 +5,6 @@ libgit2.overrideAttrs (oldAttrs: {
     "-DBUILD_CLAR=OFF"
     "-DBUILD_SHARED_LIBS=OFF"
     "-DREGEX_BACKEND=builtin"
-    "-DUSE_BUNDLED_ZLIB=ON"
     "-DUSE_GSSAPI=OFF"
     "-DUSE_HTTPS=OFF"
     "-DUSE_HTTP_PARSER=builtin" # overwritten from libgit2


### PR DESCRIPTION
from original PR #368052

fixes https://github.com/NixOS/nixpkgs/issues/367930

The issue described [here](https://github.com/NixOS/nixpkgs/pull/368052#issuecomment-2561982284) is also fixed and is due to `zsh` complaining in the `installCheckPhase` about insecure directories.

CC @SuperSandro2000 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
