### PR TITLE
libqt5pas,lazarus-qt: 3.2-0 -> 3.6-0, init Qt6 variants

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -17,8 +17,7 @@
 , python3
 
 # Qt5
-, libqt5pas
-, qt5
+, libsForQt5
 
 , widgetset ? "qt5"
 # See https://github.com/Alexey-T/CudaText-lexers
@@ -59,13 +58,13 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ lazarus fpc ]
-    ++ lib.optional (widgetset == "qt5") qt5.wrapQtAppsHook;
+    ++ lib.optional (widgetset == "qt5") libsForQt5.wrapQtAppsHook;
 
   buildInputs = [ libX11 ]
     ++ lib.optionals (lib.hasPrefix "gtk" widgetset) [ pango cairo glib atk gdk-pixbuf ]
     ++ lib.optional (widgetset == "gtk2") gtk2
     ++ lib.optional (widgetset == "gtk3") gtk3
-    ++ lib.optional (widgetset == "qt5") libqt5pas;
+    ++ lib.optional (widgetset == "qt5") libsForQt5.libqtpas;
 
   NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
 

--- a/pkgs/by-name/do/doublecmd/package.nix
+++ b/pkgs/by-name/do/doublecmd/package.nix
@@ -8,7 +8,7 @@
   glib,
   lazarus,
   libX11,
-  libqt5pas,
+  libqtpas,
   wrapQtAppsHook,
 }:
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     glib
     libX11
-    libqt5pas
+    libqtpas
   ];
 
   env.NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath finalAttrs.buildInputs}";

--- a/pkgs/by-name/la/lazpaint/package.nix
+++ b/pkgs/by-name/la/lazpaint/package.nix
@@ -6,7 +6,6 @@
   fpc,
   autoPatchelfHook,
   libsForQt5,
-  libqt5pas,
   xorg,
   python3,
 }:
@@ -43,9 +42,9 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
   ];
 
-  buildInputs = [
-    libsForQt5.qtbase
-    libqt5pas
+  buildInputs = with libsForQt5; [
+    qtbase
+    libqtpas
   ];
 
   runtimeDependencies = [

--- a/pkgs/by-name/la/lazpaint/package.nix
+++ b/pkgs/by-name/la/lazpaint/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  lazarus-qt,
+  lazarus-qt5,
   fpc,
   autoPatchelfHook,
   libsForQt5,
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    lazarus-qt
+    lazarus-qt5
     fpc
     libsForQt5.wrapQtAppsHook
     autoPatchelfHook
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     cp -r --no-preserve=mode ${bgrabitmap} bgrabitmap
     cp -r --no-preserve=mode ${bgracontrols} bgracontrols
 
-    lazbuild --lazarusdir=${lazarus-qt}/share/lazarus \
+    lazbuild --lazarusdir=${lazarus-qt5}/share/lazarus \
       --build-mode=ReleaseQt5 \
       bgrabitmap/bgrabitmap/bgrabitmappack.lpk \
       bgracontrols/bgracontrols.lpk \

--- a/pkgs/by-name/pe/peazip/package.nix
+++ b/pkgs/by-name/pe/peazip/package.nix
@@ -6,7 +6,6 @@
   fpc,
   lazarus,
   xorg,
-  libqt5pas,
   runCommand,
   _7zz,
   archiver,
@@ -41,7 +40,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     xorg.libX11
-    libqt5pas
+    libsForQt5.libqtpas
   ];
 
   NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";

--- a/pkgs/by-name/ya/yandex-browser/package.nix
+++ b/pkgs/by-name/ya/yandex-browser/package.nix
@@ -46,7 +46,7 @@
 , systemd
 , at-spi2-atk
 , at-spi2-core
-, libqt5pas
+, libsForQt5
 , qt6
 , vivaldi-ffmpeg-codecs
 , edition ? "stable"
@@ -130,7 +130,7 @@ in stdenv.mkDerivation rec {
     nss
     pango
     (lib.getLib stdenv.cc.cc)
-    libqt5pas
+    libsForQt5.libqtpas
     qt6.qtbase
   ];
 

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -19,7 +19,7 @@
   binutils,
   withQt ? false,
   qtbase ? null,
-  libqt5pas ? null,
+  libqtpas ? null,
   wrapQtAppsHook ? null,
 }:
 
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
       gdk-pixbuf
     ]
     ++ lib.optionals withQt [
-      libqt5pas
+      libqtpas
       qtbase
     ];
 
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
       "-lpango-1.0"
     ]
     ++ lib.optionals withQt [
-      "-L${lib.getLib libqt5pas}/lib"
+      "-L${lib.getLib libqtpas}/lib"
       "-lQt5Pas"
     ]
   );

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -43,6 +43,7 @@ let
     )
   );
 
+  qtVersion = lib.versions.major qtbase.version;
 in
 stdenv.mkDerivation rec {
   pname = "lazarus-${LCL_PLATFORM}";
@@ -94,7 +95,7 @@ stdenv.mkDerivation rec {
     "bigide"
   ];
 
-  LCL_PLATFORM = if withQt then "qt5" else "gtk2";
+  LCL_PLATFORM = if withQt then "qt${qtVersion}" else "gtk2";
 
   NIX_LDFLAGS = lib.concatStringsSep " " (
     [
@@ -114,7 +115,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals withQt [
       "-L${lib.getLib libqtpas}/lib"
-      "-lQt5Pas"
+      "-lQt${qtVersion}Pas"
     ]
   );
 

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -27,7 +27,7 @@
 #  1. the build date is embedded in the binary through `$I %DATE%` - we should dump that
 
 let
-  version = "3.2-0";
+  version = "3.6-0";
 
   # as of 2.0.10 a suffix is being added. That may or may not disappear and then
   # come back, so just leave this here.
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${majorMinorPatch version}/lazarus-${version}.tar.gz";
-    sha256 = "69f43f0a10b9e09deea5f35094c73b84464b82d3f40d8a2fcfcb5a5ab03c6edf";
+    hash = "sha256-5luQNn9jvxfLe/NfW+acnvcEyklOkdjGfQcuM3P6sIU=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/fpc/libqt5pas.nix
+++ b/pkgs/development/compilers/fpc/libqt5pas.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation,
+  stdenv,
   lib,
   lazarus,
   qmake,
@@ -7,7 +7,7 @@
   qtx11extras,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "libqt5pas";
   inherit (lazarus) version src;
 
@@ -24,6 +24,8 @@ mkDerivation {
     qtbase
     qtx11extras
   ];
+
+  dontWrapQtApps = true;
 
   meta = with lib; {
     description = "Free Pascal Qt5 binding library";

--- a/pkgs/development/compilers/fpc/libqtpas.nix
+++ b/pkgs/development/compilers/fpc/libqtpas.nix
@@ -4,32 +4,41 @@
   lazarus,
   qmake,
   qtbase,
-  qtx11extras,
+  # Not in Qt6 anymore
+  qtx11extras ? null,
 }:
 
+let
+  qtVersion = lib.versions.major qtbase.version;
+in
 stdenv.mkDerivation {
   pname = "libqtpas";
   inherit (lazarus) version src;
 
-  sourceRoot = "lazarus/lcl/interfaces/qt5/cbindings";
+  sourceRoot = "lazarus/lcl/interfaces/qt${qtVersion}/cbindings";
 
   postPatch = ''
-    substituteInPlace Qt5Pas.pro \
+    substituteInPlace Qt${qtVersion}Pas.pro \
       --replace 'target.path = $$[QT_INSTALL_LIBS]' "target.path = $out/lib"
   '';
 
   nativeBuildInputs = [ qmake ];
 
-  buildInputs = [
-    qtbase
-    qtx11extras
-  ];
+  buildInputs =
+    [
+      qtbase
+    ]
+    ++ lib.optionals (qtVersion == "5") [
+      qtx11extras
+    ];
 
   dontWrapQtApps = true;
 
   meta = with lib; {
-    description = "Free Pascal Qt5 binding library";
-    homepage = "https://wiki.freepascal.org/Qt5_Interface#libqt5pas";
+    description = "Free Pascal Qt${qtVersion} binding library";
+    homepage =
+      "https://wiki.freepascal.org/Qt${qtVersion}_Interface"
+      + lib.optionalString (qtVersion == "5") "#libqt5pas";
     maintainers = with maintainers; [ sikmir ];
     inherit (lazarus.meta) license platforms;
   };

--- a/pkgs/development/compilers/fpc/libqtpas.nix
+++ b/pkgs/development/compilers/fpc/libqtpas.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "libqt5pas";
+  pname = "libqtpas";
   inherit (lazarus) version src;
 
   sourceRoot = "lazarus/lcl/interfaces/qt5/cbindings";

--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -10,7 +10,7 @@
   breeze-qt5,
   libGL,
   libGLU,
-  libqt5pas,
+  libqtpas,
   libX11,
   coreutils,
   git,
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     breeze-qt5
     libGL
     libGLU
-    libqt5pas
+    libqtpas
     libX11
   ];
 

--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -5,7 +5,7 @@
   stdenv,
   fetchFromGitHub,
   fpc,
-  lazarus-qt,
+  lazarus-qt5,
   wrapQtAppsHook,
   breeze-qt5,
   libGL,
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     fpc
-    lazarus-qt
+    lazarus-qt5
     wrapQtAppsHook
   ];
 
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-    HOME=$(mktemp -d) lazbuild --lazarusdir=${lazarus-qt}/share/lazarus -B goverlay.lpi
+    HOME=$(mktemp -d) lazbuild --lazarusdir=${lazarus-qt5}/share/lazarus -B goverlay.lpi
     runHook postBuild
   '';
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -664,6 +664,7 @@ mapAliases {
   liboop = throw "liboop has been removed as it is unmaintained upstream."; # Added 2024-08-14
   libpqxx_6 = throw "libpqxx_6 has been removed, please use libpqxx"; # Added 2024-10-02
   libpulseaudio-vanilla = libpulseaudio; # Added 2022-04-20
+  libqt5pas = libsForQt5.libqtpas; # Added 2024-12-25
   libquotient = libsForQt5.libquotient; # Added 2023-11-11
   librarian-puppet-go = throw "'librarian-puppet-go' has been removed, as it's upstream is unmaintained"; # Added 2024-06-10
   librdf = throw "'librdf' has been renamed to/replaced by 'lrdf'"; # Converted to throw 2024-10-17

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -633,6 +633,7 @@ mapAliases {
   LASzip2 = laszip_2; # Added 2024-06-12
   latencytop = throw "'latencytop' has been removed due to lack of maintenance upstream."; # Added 2024-12-04
   latinmodern-math = lmmath;
+  lazarus-qt = lazarus-qt5; # Added 2024-12-25
   leafpad = throw "'leafpad' has been removed due to lack of maintenance upstream. Consider using 'xfce.mousepad' instead"; # Added 2024-10-19
   ledger_agent = ledger-agent; # Added 2024-01-07
   lfs = dysk; # Added 2023-07-03

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6525,7 +6525,12 @@ with pkgs;
     fpc = fpc;
   };
 
-  lazarus-qt = libsForQt5.callPackage ../development/compilers/fpc/lazarus.nix {
+  lazarus-qt5 = libsForQt5.callPackage ../development/compilers/fpc/lazarus.nix {
+    fpc = fpc;
+    withQt = true;
+  };
+
+  lazarus-qt6 = qt6Packages.callPackage ../development/compilers/fpc/lazarus.nix {
     fpc = fpc;
     withQt = true;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1495,7 +1495,7 @@ with pkgs;
   ### APPLICATIONS/FILE-MANAGERS
 
   doublecmd = callPackage ../by-name/do/doublecmd/package.nix {
-    inherit (qt5) wrapQtAppsHook;
+    inherit (libsForQt5) libqtpas wrapQtAppsHook;
   };
 
   krusader = libsForQt5.callPackage ../applications/file-managers/krusader { };
@@ -3582,7 +3582,7 @@ with pkgs;
   gdown = with python3Packages; toPythonApplication gdown;
 
   goverlay = callPackage ../tools/graphics/goverlay {
-    inherit (qt5) wrapQtAppsHook;
+    inherit (libsForQt5) libqtpas wrapQtAppsHook;
     inherit (plasma5Packages) breeze-qt5;
   };
 
@@ -9913,8 +9913,6 @@ with pkgs;
   libpwquality = callPackage ../development/libraries/libpwquality {
     python = python3;
   };
-
-  libqt5pas = libsForQt5.callPackage ../development/compilers/fpc/libqt5pas.nix { };
 
   librsvg = callPackage ../development/libraries/librsvg {
     inherit (darwin) libobjc;

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -170,6 +170,8 @@ in (noExtraAttrs (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdP
 
   libqofono = callPackage ../development/libraries/libqofono { };
 
+  libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
+
   libquotient = callPackage ../development/libraries/libquotient { };
 
   libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -55,6 +55,9 @@ makeScopeWithSplicing' {
   futuresql = callPackage ../development/libraries/futuresql { };
   kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
   libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };
+
+  libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
+
   libquotient = callPackage ../development/libraries/libquotient { };
   mlt = pkgs.mlt.override {
     qt = qt6;


### PR DESCRIPTION
- `libqt5pas`,`lazarus-qt5`: 3.2-0 -> 3.6-0
  This is needed because the Qt6 code is broken in the currently-packaged version: https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/40901
- `libqt5pas`: `libsForQt5.mkDerivation` -> `stdenv.mkDerivation`
  In preparation for the next commit, don't depend on Qt5-isms anymore
- `libsForQt5.libqtpas`: Rename from `libqt5pas`
  So the Qt5 and the upcoming Qt6 versions have the same attribute name in reverse dependencies, just in different scopes (`libsForQt5` vs `qt6Packages`). Alias entry added, treewide switch to new name.
- `qt6Packages.libqtpas`: init at 3.6-0
- `lazarus-qt6`: init at 3.6-0
  `lazarus-qt` renamed to `lazarus-qt5`. Alias entry added, treewide switch to new name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
