### PR TITLE
cups-brother-dcpl3550cdw: init at 1.0.2-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22307,6 +22307,13 @@
     githubId = 159372832;
     keys = [ { fingerprint = "6F54 C08C 37C8 EC78 15FA  0D01 A721 8CBA 2D80 15C3"; } ];
   };
+  Tert0 = {
+    name = "Tert0";
+    github = "Tert0";
+    githubId = 62036464;
+    email = "tert0byte@gmail.com";
+    keys = [ { fingerprint = "F899 D3B5 00BF 98AE 9097  F616 7069 D89F 9E5C 97ED"; } ];
+  };
   tesq0 = {
     email = "mikolaj.galkowski@gmail.com";
     github = "tesq0";

--- a/pkgs/by-name/cu/cups-brother-dcpl3550cdw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpl3550cdw/package.nix
@@ -1,0 +1,109 @@
+{
+  pkgsi686Linux,
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  ghostscript,
+  file,
+  gnused,
+  gnugrep,
+  coreutils,
+  which,
+  perl,
+}:
+let
+  version = "1.0.2-0";
+  model = "dcpl3550cdw";
+  interpreter = "${pkgsi686Linux.stdenv.cc.libc}/lib/ld-linux.so.2";
+in
+stdenv.mkDerivation {
+  pname = "cups-brother-${model}";
+  inherit version;
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103919/dcpl3550cdwpdrv-${version}.i386.deb";
+    hash = "sha256-FbtqISK3f1q1+JXJ+RP5O/8G0ZW9gcCS7OI0YRljwyY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x $src $out
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter_${model} \
+      --replace-fail /usr/bin/perl ${lib.getExe perl} \
+      --replace-fail "PRINTER =~" "PRINTER = \"${model}\"; #" \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/${model}/\"; #"
+
+    substituteInPlace $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} \
+      --replace-fail /usr/bin/perl ${lib.getExe perl} \
+      --replace-fail "basedir =~ " "basedir = \"$out/opt/brother/Printers/${model}/\"; #" \
+      --replace-fail "PRINTER =~ " "PRINTER = \"${model}\"; #" \
+      --replace-fail "LPDCONFIGEXE=" "LPDCONFIGEXE=\"$out/usr/bin/brprintconf_\"; #"
+
+    patchelf --set-interpreter ${interpreter} $out/opt/brother/Printers/${model}/lpd/br${model}filter
+    patchelf --set-interpreter ${interpreter} $out/usr/bin/brprintconf_${model}
+
+    mkdir -p $out/lib/cups/filter $out/share/cups/model
+    ln -s $out/opt/brother/Printers/${model}/lpd/filter_${model} $out/lib/cups/filter/brlpdwrapper${model}
+    ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} $out/lib/cups/filter/brother_lpdwrapper_${model}
+    ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/brother_${model}_printer_en.ppd
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/opt/brother/Printers/${model}/lpd/filter_${model} \
+        --prefix PATH ":" ${
+          lib.makeBinPath [
+            ghostscript
+            file
+            gnused
+            gnugrep
+            coreutils
+            which
+          ]
+        }
+    wrapProgram $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gnugrep
+          coreutils
+        ]
+      }
+    wrapProgram $out/usr/bin/brprintconf_${model} \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+    wrapProgram $out/opt/brother/Printers/${model}/lpd/br${model}filter \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+  '';
+
+  meta = {
+    homepage = "https://www.brother.com/";
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=${model}_eu&os=128";
+    description = "Brother DCP-L3550CDW printer driver";
+    license = with lib.licenses; [
+      unfreeRedistributable
+      gpl2Only
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    maintainers = with lib.maintainers; [ Tert0 ];
+  };
+}


### PR DESCRIPTION
This package provides a cups driver for Brother DCP-L3550CDW Printers: [Download Page](https://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=dcpl3550cdw_eu&os=128#nolang)


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] ~~Tested, as applicable:~~
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
	- [x] Tested indirectly via cups (`services.printing.drivers = [pkgs.cups-brother-dcpl3550cdw];`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
