### PR TITLE
music-player: set broken on Darwin

### DIFF
--- a/pkgs/by-name/mu/music-player/package.nix
+++ b/pkgs/by-name/mu/music-player/package.nix
@@ -45,6 +45,9 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/tsirysndr/music-player/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.sigmasquadron ];
+    # A rust crate this project depends on is broken upstream on Darwin:
+    # https://github.com/RustAudio/coreaudio-sys/issues/25
+    badPlatforms = [ lib.systems.inspect.patterns.isDarwin ];
     mainProgram = "music-player";
   };
 }


### PR DESCRIPTION
The `coreaudio-sys` crate is a required build dependency for `music-player`, and that crate is broken on Darwin: https://github.com/RustAudio/coreaudio-sys/issues/25.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] No rebuilds.
- [x] No release notes: change is minor.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
