### PR TITLE
vesktop: fix crashing when settings.json or state.json are read-only

### DIFF
--- a/pkgs/by-name/ve/vesktop/fix_read_only_settings.patch
+++ b/pkgs/by-name/ve/vesktop/fix_read_only_settings.patch
@@ -1,0 +1,19 @@
+diff --git a/src/main/settings.ts b/src/main/settings.ts
+index 6fad97f..dfc64e3 100644
+--- a/src/main/settings.ts
++++ b/src/main/settings.ts
+@@ -26,8 +26,12 @@ function loadSettings<T extends object = any>(file: string, name: string) {
+ 
+     const store = new SettingsStore(settings);
+     store.addGlobalChangeListener(o => {
+-        mkdirSync(dirname(file), { recursive: true });
+-        writeFileSync(file, JSON.stringify(o, null, 4));
++        try {
++            mkdirSync(dirname(file), { recursive: true });
++            writeFileSync(file, JSON.stringify(o, null, 4));
++        } catch (e) {
++            console.error("Nix: Failed to write settings.", e);
++        }
+     });
+ 
+     return store;

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -69,7 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches =
-    [ ./disable_update_checking.patch ]
+    [
+      ./disable_update_checking.patch
+      ./fix_read_only_settings.patch
+    ]
     ++ lib.optional withSystemVencord (
       replaceVars ./use_system_vencord.patch {
         inherit vencord;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Patches Vesktop to not crash when `~/.config/settings.json` or `~/.config/state.json` are read-only so that they can be declaratively configured.

Unfortunately, from the discussion in Vencord/Vesktop/issues/220, the developer does not seem particularly likely to fix it upstream.

Also, the patch comes from that same issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
