### PR TITLE
nixos/borgmatic: automatically add binaries required for database dumping

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -16,11 +16,17 @@ let
     // {
       postgresql_databases = map (
         d:
+        let
+          as_user = if d ? username then "${pkgs.sudo}/bin/sudo -u ${d.username} " else "";
+        in
         {
           pg_dump_command =
-            if d.name == "all" then "${postgresql}/bin/pg_dumpall" else "${postgresql}/bin/pg_dump";
-          pg_restore_command = "${postgresql}/bin/pg_restore";
-          psql_command = "${postgresql}/bin/psql";
+            if d.name == "all" then
+              "${as_user}${postgresql}/bin/pg_dumpall"
+            else
+              "${as_user}${postgresql}/bin/pg_dump";
+          pg_restore_command = "${as_user}${postgresql}/bin/pg_restore";
+          psql_command = "${as_user}${postgresql}/bin/psql";
         }
         // d
       ) (s.postgresql_databases or [ ]);

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -166,6 +166,7 @@ in
       environment.etc = configFiles;
 
       systemd.packages = [ pkgs.borgmatic ];
+      systemd.services.borgmatic.path = [ pkgs.coreutils ];
 
       # Workaround: https://github.com/NixOS/nixpkgs/issues/81138
       systemd.timers.borgmatic.wantedBy = [ "timers.target" ];


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/329602 .

Coreutils does seem to be a reasonable addition to the systemd unit closure; the others are added only conditional on the relevant configuration parameter being set, and stay override-able.

I also included `sudo -u ${username}` when applicable by default because postgresql defaults to peer authentication; it still stays override-able for anyone who'd have a non-default setup.

## Things done

Basically nothing, only added the lines suggested in #329602 (with the sudo) on my machine, and checked that postgresql backups now work fine.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
