### PR TITLE
jcli: 0.0.44 → 0.0.46

### DIFF
--- a/pkgs/by-name/jc/jcli/package.nix
+++ b/pkgs/by-name/jc/jcli/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "jcli";
-  version = "0.0.44";
+  version = "0.0.46";
 
   src = fetchFromGitHub {
     owner = "jenkins-zh";
     repo = "jenkins-cli";
     tag = "v${version}";
-    hash = "sha256-lsYLUgjpHcURiMTA4we9g+a6dFimOupAYMw0TcmABk4=";
+    hash = "sha256-l0qpyrggDJSzaJMbhgJYVK2Y3A/R+xS0Qoy3afA/eGo=";
   };
 
-  vendorHash = "sha256-f2f/Qi6aav7LPpO9ERYkejygz0XiPQ8YrKLB63EpaoY=";
+  vendorHash = "sha256-0x0Cl6cqullGIvtQTlHTGnWz9dBCT7aMEIRSB/Cuy8k=";
 
   ldflags = [
     "-s"
@@ -36,6 +36,7 @@ buildGoModule rec {
     + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd jcli \
         --bash <($out/bin/jcli completion --type bash) \
+        --fish <($out/bin/jcli completion --type fish) \
         --zsh <($out/bin/jcli completion --type zsh)
     '';
 


### PR DESCRIPTION
https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.45
https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.46

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
