### PR TITLE
prometheus-node-cert-exporter: init at 1.1.7

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -69,6 +69,8 @@
 
 - [nostr-rs-relay](https://git.sr.ht/~gheartsfield/nostr-rs-relay/), This is a nostr relay, written in Rust. Available as [services.nostr-rs-relay](options.html#opt-services.nostr-rs-relay.enable).
 
+- [Prometheus Node Cert Exporter](https://github.com/amimof/node-cert-exporter), a prometheus exporter to check for SSL cert expiry. Available under [services.prometheus.exporters.node-cert](#opt-services.prometheus.exporters.node-cert.enable).
+
 - [Actual Budget](https://actualbudget.org/), a local-first personal finance app. Available as [services.actual](#opt-services.actual.enable).
 
 - [mqtt-exporter](https://github.com/kpetremann/mqtt-exporter/), a Prometheus exporter for exposing messages from MQTT. Available as [services.prometheus.exporters.mqtt](#opt-services.prometheus.exporters.mqtt.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -66,6 +66,7 @@ let
     "nginx"
     "nginxlog"
     "node"
+    "node-cert"
     "nut"
     "nvidia-gpu"
     "pgbouncer"

--- a/nixos/modules/services/monitoring/prometheus/exporters/node-cert.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node-cert.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.node-cert;
+  inherit (lib) mkOption types concatStringsSep;
+in
+{
+  port = 9141;
+
+  extraOpts = {
+    paths = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        List of paths to search for SSL certificates.
+      '';
+    };
+
+    excludePaths = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        List of paths to exclute from searching for SSL certificates.
+      '';
+      default = [ ];
+    };
+
+    includeGlobs = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        List files matching a pattern to include. Uses Go blob pattern.
+      '';
+      default = [ ];
+    };
+
+    excludeGlobs = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        List files matching a pattern to include. Uses Go blob pattern.
+      '';
+      default = [ ];
+    };
+
+    user = mkOption {
+      type = types.str;
+      description = ''
+        User owning the certs.
+      '';
+      default = "acme";
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      User = cfg.user;
+      ExecStart = ''
+        ${lib.getExe pkgs.prometheus-node-cert-exporter} \
+          --listen ${toString cfg.listenAddress}:${toString cfg.port} \
+          --path ${concatStringsSep "," cfg.paths} \
+          --exclude-path "${concatStringsSep "," cfg.excludePaths}" \
+          --include-glob "${concatStringsSep "," cfg.includeGlobs}" \
+          --exclude-glob "${concatStringsSep "," cfg.excludeGlobs}" \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/gomod.patch
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/gomod.patch
@@ -1,0 +1,33 @@
+diff --git a/go.mod b/go.mod
+index 982eef4..bdb53ee 100644
+--- a/go.mod
++++ b/go.mod
+@@ -7,4 +7,15 @@ require (
+        github.com/spf13/pflag v1.0.3
+ )
+ 
+-go 1.16
++require (
++       github.com/beorn7/perks v1.0.1 // indirect
++       github.com/cespare/xxhash/v2 v2.1.1 // indirect
++       github.com/golang/protobuf v1.4.3 // indirect
++       github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
++       github.com/prometheus/client_model v0.2.0 // indirect
++       github.com/prometheus/procfs v0.6.0 // indirect
++       golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
++       google.golang.org/protobuf v1.26.0-rc.1 // indirect
++)
++
++go 1.18
+diff --git a/go.sum b/go.sum
+index 8bebbb3..75f756a 100644
+--- a/go.sum
++++ b/go.sum
+@@ -39,7 +39,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
+ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+ github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGo122Module,
+  fetchFromGitHub,
+  nixosTests,
+}:
+
+buildGo122Module {
+  pname = "node-cert-exporter";
+  version = "1.1.7-unstable-2024-12-26";
+
+  src = fetchFromGitHub {
+    owner = "amimof";
+    repo = "node-cert-exporter";
+    rev = "v1.1.7";
+    sha256 = "sha256-VYJPgNVsfEs/zh/SEdOrFn0FK6S+hNFGDhonj2syutQ=";
+  };
+
+  vendorHash = "sha256-31MHX3YntogvoJmbOytl0rXS6qtdBSBJe8ejKyu6gqM=";
+
+  # Required otherwise we get a few:
+  # vendor/github.com/golang/glog/internal/logsink/logsink.go:129:41:
+  # predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
+  patches = [ ./gomod.patch ];
+
+  meta = with lib; {
+    description = "Prometheus exporter for SSL certificate";
+    mainProgram = "node-cert-exporter";
+    homepage = "https://github.com/amimof/node-cert-exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ibizaman ];
+  };
+}


### PR DESCRIPTION
https://github.com/amimof/node-cert-exporter

For testing, apart from the included automated test I have been using it locally with acme generated certs with success.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
