### PR TITLE
z3_4_{8_5,8,11,12}: fix clang-19 build

### DIFF
--- a/pkgs/applications/science/logic/z3/4-8-5-typos.diff
+++ b/pkgs/applications/science/logic/z3/4-8-5-typos.diff
@@ -1,0 +1,26 @@
+diff --git a/src/util/lp/lp_core_solver_base.h b/src/util/lp/lp_core_solver_base.h
+index 4c17df2..4c3c311 100644
+--- a/src/util/lp/lp_core_solver_base.h
++++ b/src/util/lp/lp_core_solver_base.h
+@@ -600,8 +600,6 @@ public:
+            out << " \n";
+     }
+ 
+-    bool column_is_free(unsigned j) const { return this->m_column_type[j] == free; }
+-
+     bool column_has_upper_bound(unsigned j) const {
+         switch(m_column_types[j]) {
+         case column_type::free_column:
+diff --git a/src/util/lp/static_matrix_def.h b/src/util/lp/static_matrix_def.h
+index 7949573..2f1cb42 100644
+--- a/src/util/lp/static_matrix_def.h
++++ b/src/util/lp/static_matrix_def.h
+@@ -86,7 +86,7 @@ static_matrix<T, X>::static_matrix(static_matrix const &A, unsigned * /* basis *
+     init_row_columns(m, m);
+     while (m--) {
+         for (auto & col : A.m_columns[m]){
+-            set(col.var(), m, A.get_value_of_column_cell(col));
++            set(col.var(), m, A.get_column_cell(col));
+         }
+     }
+ }

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , python
 , fixDarwinDylibNames
 , javaBindings ? false
@@ -11,6 +12,7 @@
 , findlib ? null
 , zarith ? null
 , writeScript
+, replaceVars
 }:
 
 assert javaBindings -> jdk != null;
@@ -85,23 +87,71 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
       maintainers = with maintainers; [ thoughtpolice ttuegel ];
     };
   };
+
+  static-matrix-def-patch = fetchpatch {
+    # clang / gcc fixes. fixes typos in some member names
+    name = "gcc-15-fixes.patch";
+    url = "https://github.com/Z3Prover/z3/commit/2ce89e5f491fa817d02d8fdce8c62798beab258b.patch";
+    includes = [ "src/math/lp/static_matrix_def.h" ];
+    hash = "sha256-rEH+UzylzyhBdtx65uf8QYj5xwuXOyG6bV/4jgKkXGo=";
+  };
+
+  static-matrix-patch = fetchpatch {
+    # clang / gcc fixes. fixes typos in some member names
+    name = "gcc-15-fixes.patch";
+    url = "https://github.com/Z3Prover/z3/commit/2ce89e5f491fa817d02d8fdce8c62798beab258b.patch";
+    includes = [ "src/@dir@/lp/static_matrix.h" ];
+    stripLen = 3;
+    extraPrefix = "src/@dir@/";
+    hash = "sha256-+H1/VJPyI0yq4M/61ay8SRCa6OaoJ/5i+I3zVTAPUVo=";
+  };
+
+  # replace @dir@ in the path of the given list of patches
+  fixupPatches = dir: map (patch: replaceVars patch { dir = dir; });
 in
 {
   z3_4_12 = common {
     version = "4.12.5";
     sha256 = "sha256-Qj9w5s02OSMQ2qA7HG7xNqQGaUacA1d4zbOHynq5k+A=";
+    patches = fixupPatches "math" [
+      ./lower-bound-typo.diff
+      static-matrix-patch
+    ] ++ [
+      static-matrix-def-patch
+    ];
   };
   z3_4_11 = common {
     version = "4.11.2";
     sha256 = "sha256-OO0wtCvSKwGxnKvu+AfXe4mEzv4nofa7A00BjX+KVjc=";
+    patches = fixupPatches "math" [
+      ./lower-bound-typo.diff
+      static-matrix-patch
+      ./tail-matrix.diff
+    ] ++ [
+      static-matrix-def-patch
+    ];
   };
   z3_4_8 = common {
     version = "4.8.17";
     sha256 = "sha256-BSwjgOU9EgCcm18Zx0P9mnoPc9ZeYsJwEu0ffnACa+8=";
+    patches = fixupPatches "math" [
+      ./lower-bound-typo.diff
+      static-matrix-patch
+      ./tail-matrix.diff
+    ] ++ [
+      static-matrix-def-patch
+    ];
   };
   z3_4_8_5 = common {
     tag = "Z3";
     version = "4.8.5";
     sha256 = "sha256-ytG5O9HczbIVJAiIGZfUXC/MuYH7d7yLApaeTRlKXoc=";
+    patches = fixupPatches "util" [
+      ./lower-bound-typo.diff
+      static-matrix-patch
+      ./tail-matrix.diff
+    ] ++ [
+      ./4-8-5-typos.diff
+    ];
   };
 }

--- a/pkgs/applications/science/logic/z3/lower-bound-typo.diff
+++ b/pkgs/applications/science/logic/z3/lower-bound-typo.diff
@@ -1,0 +1,13 @@
+diff --git a/src/@dir@/lp/column_info.h b/src/@dir@/lp/column_info.h
+index 1dc0c60..9cbeea6 100644
+--- a/src/@dir@/lp/column_info.h
++++ b/src/@dir@/lp/column_info.h
+@@ -47,7 +47,7 @@ public:
+             m_lower_bound_is_strict == c.m_lower_bound_is_strict &&
+             m_upper_bound_is_set == c.m_upper_bound_is_set&&
+             m_upper_bound_is_strict == c.m_upper_bound_is_strict&&
+-            (!m_lower_bound_is_set || m_lower_bound == c.m_low_bound) &&
++            (!m_lower_bound_is_set || m_lower_bound == c.m_lower_bound) &&
+             (!m_upper_bound_is_set || m_upper_bound == c.m_upper_bound) &&
+             m_cost == c.m_cost &&
+             m_is_fixed == c.m_is_fixed &&

--- a/pkgs/applications/science/logic/z3/tail-matrix.diff
+++ b/pkgs/applications/science/logic/z3/tail-matrix.diff
@@ -1,0 +1,12 @@
+diff --git a/src/@dir@/lp/tail_matrix.h b/src/@dir@/lp/tail_matrix.h
+index 2047e8c..c84340e 100644
+--- a/src/@dir@/lp/tail_matrix.h
++++ b/src/@dir@/lp/tail_matrix.h
+@@ -43,7 +43,6 @@ public:
+         const tail_matrix & m_A;
+         unsigned m_row;
+         ref_row(const tail_matrix& m, unsigned row): m_A(m), m_row(row) {}
+-        T operator[](unsigned j) const { return m_A.get_elem(m_row, j);}
+     };
+     ref_row operator[](unsigned i) const { return ref_row(*this, i);}
+ };


### PR DESCRIPTION
z3 contains a bunch of typos in never used functions. The update to clang-19 now reports the typos -- wrong member function / variable names.  There is an upstream patch which fixes some of these:

https://github.com/Z3Prover/z3/commit/2ce89e5f491fa817d02d8fdce8c62798beab258b

And the others we patch or remove as the upstream code has since been modified.

https://hydra.nixos.org/build/281894894
https://hydra.nixos.org/build/281915487
https://hydra.nixos.org/build/282836452
https://hydra.nixos.org/build/282910819



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
