### PR TITLE
[backport staging-24.11] libuv and Node.js changes

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -24,14 +24,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.48.0";
+  version = "1.49.2";
   pname = "libuv";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-U68BmIQNpmIy3prS7LkYl+wvDJQNikoeFiKh50yQFoA=";
+    hash = "sha256-hNXW3cQVW8VGMQrHFkezRI2OqYF7Qf1riD8sHy66qxg=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tcp_ref3"
           "tcp_ref4"
           "tcp_bind6_error_inval"
-          "tcp_bind6_error_addrinuse"
           "tcp_read_stop"
           "tcp_unexpected_read"
           "tcp_write_to_half_open_connection"
@@ -98,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tcp_open"
           "tcp_write_queue_order"
           "tcp_try_write"
-          "tcp_writealot"
           "multiple_listen"
           "delayed_accept"
           "udp_recv_in_a_row"
@@ -109,7 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
           "tty_pty"
           "condvar_5"
           "hrtime"
-          "udp_multicast_join"
           # Tests that fail when sandboxing is enabled.
           "fs_event_close_in_callback"
           "fs_event_watch_dir"

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -122,6 +122,11 @@ stdenv.mkDerivation (finalAttrs: {
           "udp_create_early_bad_bind"
           "fs_event_watch_delete_dir"
         ]
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionOlder finalAttrs.version "1.49.3") [
+          # https://github.com/libuv/libuv/issues/4650
+          # can enable on upgrade from 1.49.2
+          "udp_mmsg"
+        ]
         ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
           # fail on macos < 10.15 (starting in libuv 1.47.0)
           "fs_write_alotof_bufs_with_offset"

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, python, zlib, libuv, http-parser, icu, bash
+{ lib, stdenv, fetchurl, openssl, python, zlib, libuv, sqlite, http-parser, icu, bash
 , ninja, pkgconf, unixtools, runCommand, buildPackages
 , testers
 # for `.pkgs` attribute
@@ -97,8 +97,15 @@ let
   # TODO: also handle MIPS flags (mips_arch, mips_fpu, mips_float_abi).
 
   useSharedHttpParser = !stdenv.hostPlatform.isDarwin && lib.versionOlder "${majorVersion}.${minorVersion}" "11.4";
+  useSharedSQLite = lib.versionAtLeast version "22.5";
 
-  sharedLibDeps = { inherit openssl zlib libuv; } // (lib.optionalAttrs useSharedHttpParser { inherit http-parser; });
+  sharedLibDeps = {
+    inherit openssl zlib libuv;
+  } // (lib.optionalAttrs useSharedHttpParser {
+    inherit http-parser;
+  }) // (lib.optionalAttrs useSharedSQLite {
+    inherit sqlite;
+  });
 
   copyLibHeaders =
     map
@@ -151,7 +158,8 @@ let
     # wrappers over the corresponding JS scripts. There are some packages though
     # that use bash wrappers, e.g. polaris-web.
     buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ApplicationServices ]
-      ++ [ zlib libuv openssl http-parser icu bash ];
+      ++ [ zlib libuv openssl http-parser icu bash ]
+      ++ lib.optionals useSharedSQLite [ sqlite ];
 
     nativeBuildInputs =
       [

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -19,34 +19,6 @@ buildNodejs {
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
 
-    # Those reverts are due to a mismatch with the libuv version used upstream
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/84fe809535b0954bbfed8658d3ede8a2f0e030db.patch?full_index=1";
-      hash = "sha256-C1xG2K9Ejofqkl/vKWLBz3vE0mIPBjCdfA5GX2wlS0I=";
-      revert = true;
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/dcbc5fbe65b068a90c3d0970155d3a68774caa38.patch?full_index=1";
-      hash = "sha256-Q7YrooolMjsGflTQEj5ra6hRVGhMP6APaydf1MGH54Q=";
-      revert = true;
-      excludes = [ "doc/*" ];
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/ec867ac7ce4e4913a8415eda48a7af9fc226097d.patch?full_index=1";
-      hash = "sha256-zfnHxC7ZMZAiu0/6PsX7RFasTevHMETv+azhTZnKI64=";
-      revert = true;
-      excludes = [ "doc/*" ];
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/f97865fab436fba24b46dad14435ec4b482243a2.patch?full_index=1";
-      hash = "sha256-o5aPQqUXubtJKMX28jn8LdjZHw37/BqENkYt6RAR3kY=";
-      revert = true;
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/54d55f2337ebe04451da770935ad453accb147f9.patch?full_index=1";
-      hash = "sha256-gmIyiSyNzC3pClL1SM2YicckWM+/2tsbV1xv2S3d5G0=";
-      revert = true;
-    })
     # Fix for https://github.com/NixOS/nixpkgs/issues/355919
     # FIXME: remove after a minor point release
     (fetchpatch2 {

--- a/pkgs/development/web/nodejs/v23.nix
+++ b/pkgs/development/web/nodejs/v23.nix
@@ -25,34 +25,6 @@ buildNodejs {
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
 
-    # Those reverts are due to a mismatch with the libuv version used upstream
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/84fe809535b0954bbfed8658d3ede8a2f0e030db.patch?full_index=1";
-      hash = "sha256-C1xG2K9Ejofqkl/vKWLBz3vE0mIPBjCdfA5GX2wlS0I=";
-      revert = true;
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/dcbc5fbe65b068a90c3d0970155d3a68774caa38.patch?full_index=1";
-      hash = "sha256-Q7YrooolMjsGflTQEj5ra6hRVGhMP6APaydf1MGH54Q=";
-      revert = true;
-      excludes = [ "doc/*" ];
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/ec867ac7ce4e4913a8415eda48a7af9fc226097d.patch?full_index=1";
-      hash = "sha256-zfnHxC7ZMZAiu0/6PsX7RFasTevHMETv+azhTZnKI64=";
-      revert = true;
-      excludes = [ "doc/*" ];
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/f97865fab436fba24b46dad14435ec4b482243a2.patch?full_index=1";
-      hash = "sha256-o5aPQqUXubtJKMX28jn8LdjZHw37/BqENkYt6RAR3kY=";
-      revert = true;
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/54d55f2337ebe04451da770935ad453accb147f9.patch?full_index=1";
-      hash = "sha256-gmIyiSyNzC3pClL1SM2YicckWM+/2tsbV1xv2S3d5G0=";
-      revert = true;
-    })
     # FIXME: remove after a minor point release
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/49acdc8748fe9fe83bc1b444e24c456dff00ecc5.patch?full_index=1";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
