### PR TITLE
torzu: init at unstable 12.15.24

### DIFF
--- a/pkgs/by-name/to/torzu/fix-debugger.patch
+++ b/pkgs/by-name/to/torzu/fix-debugger.patch
@@ -1,0 +1,53 @@
+diff --git a/src/core/debugger/debugger.cpp b/src/core/debugger/debugger.cpp
+index e86aae8460..a4dca23770 100644
+--- a/src/core/debugger/debugger.cpp
++++ b/src/core/debugger/debugger.cpp
+@@ -5,7 +5,13 @@
+ #include <mutex>
+ #include <thread>
+ 
+-#include <boost/asio.hpp>
++// Use basic asio functionality only
++#define BOOST_ASIO_STANDALONE
++#include <boost/asio/basic_io_object.hpp>
++#include <boost/asio/ip/tcp.hpp>
++#include <boost/asio/write.hpp>
++#include <boost/asio/read.hpp>
++
+ #include <boost/process/async_pipe.hpp>
+ 
+ #include "common/logging/log.h"
+@@ -21,17 +27,22 @@
+ 
+ template <typename Readable, typename Buffer, typename Callback>
+ static void AsyncReceiveInto(Readable& r, Buffer& buffer, Callback&& c) {
+-    static_assert(std::is_trivial_v<Buffer>);
+-    auto boost_buffer{boost::asio::buffer(&buffer, sizeof(Buffer))};
+-    r.async_read_some(
+-        boost_buffer, [&, c](const boost::system::error_code& error, size_t bytes_read) {
+-            if (!error.failed()) {
+-                const u8* buffer_start = reinterpret_cast<const u8*>(&buffer);
+-                std::span<const u8> received_data{buffer_start, buffer_start + bytes_read};
+-                c(received_data);
+-                AsyncReceiveInto(r, buffer, c);
+-            }
+-        });
++    try {
++            static_assert(std::is_trivial_v<Buffer>);
++            auto boost_buffer{boost::asio::buffer(&buffer, sizeof(Buffer))};
++            r.async_read_some(
++                boost_buffer,
++                [&, c](const boost::system::error_code& error, size_t bytes_read) {
++                    if (!error) {
++                        const u8* buffer_start = reinterpret_cast<const u8*>(&buffer);
++                        std::span<const u8> received_data{buffer_start, buffer_start + bytes_read};
++                        c(received_data);
++                        AsyncReceiveInto(r, buffer, c);
++                    }
++                });
++        } catch (const std::exception& e) {
++            LOG_ERROR(Debug_GDBStub, "AsyncReceiveInto error: {}", e.what());
++        }
+ }
+ 
+ template <typename Callback>

--- a/pkgs/by-name/to/torzu/fix-udp-client.patch
+++ b/pkgs/by-name/to/torzu/fix-udp-client.patch
@@ -1,0 +1,30 @@
+diff --git a/src/input_common/drivers/udp_client.cpp b/src/input_common/drivers/udp_client.cpp
+index 60821b31a6..8f9c047218 100644
+--- a/src/input_common/drivers/udp_client.cpp
++++ b/src/input_common/drivers/udp_client.cpp
+@@ -2,7 +2,15 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ 
+ #include <random>
+-#include <boost/asio.hpp>
++// Include only needed asio components
++#include <boost/asio/io_context.hpp>
++#include <boost/asio/ip/udp.hpp>
++#include <boost/asio/basic_waitable_timer.hpp>
++#include <boost/asio/write.hpp>
++#include <boost/asio/buffer.hpp>
++#include <boost/asio/basic_socket.hpp>
++#include <boost/asio/ip/address.hpp>
++#include <boost/asio/ip/address_v4.hpp>
+ #include <fmt/format.h>
+ 
+ #include "common/logging/log.h"
+@@ -113,7 +121,7 @@ private:
+     }
+ 
+     SocketCallback callback;
+-    boost::asio::io_service io_service;
++    boost::asio::io_context io_service;
+     boost::asio::basic_waitable_timer<clock> timer;
+     udp::socket socket;
+ 

--- a/pkgs/by-name/to/torzu/fix-udp-protocol.patch
+++ b/pkgs/by-name/to/torzu/fix-udp-protocol.patch
@@ -1,0 +1,13 @@
+diff --git a/src/input_common/helpers/udp_protocol.h b/src/input_common/helpers/udp_protocol.h
+index db08fc62c5..ea223ea937 100644
+--- a/src/input_common/helpers/udp_protocol.h
++++ b/src/input_common/helpers/udp_protocol.h
+@@ -69,7 +69,7 @@ Message<T> CreateMessage(const u32 magic, const T data, const u32 sender_id) {
+     };
+     Message<T> message{header, data};
+     crc.process_bytes(&message, sizeof(Message<T>));
+-    message.header.crc = crc.checksum();
++    message.header.crc = static_cast<u32_le>(crc.checksum());
+     return message;
+ }
+ 

--- a/pkgs/by-name/to/torzu/package.nix
+++ b/pkgs/by-name/to/torzu/package.nix
@@ -1,0 +1,244 @@
+{
+  lib,
+  stdenv,
+  SDL2,
+  autoconf,
+  boost,
+  catch2_3,
+  cmake,
+  fetchFromGitHub,
+  cpp-jwt,
+  cubeb,
+  discord-rpc,
+  enet,
+  fetchgit,
+  fetchurl,
+  ffmpeg-headless,
+  fmt,
+  glslang,
+  libopus,
+  libusb1,
+  libva,
+  lz4,
+  python3,
+  unzip,
+  nix-update-script,
+  nlohmann_json,
+  nv-codec-headers-12,
+  pkg-config,
+  qt6,
+  vulkan-headers,
+  vulkan-loader,
+  yasm,
+  simpleini,
+  zlib,
+  vulkan-memory-allocator,
+  zstd,
+}:
+
+let
+  inherit (qt6)
+    qtbase
+    qtmultimedia
+    qtwayland
+    wrapQtAppsHook
+    qttools
+    qtwebengine
+    ;
+
+  compat-list = stdenv.mkDerivation {
+    pname = "yuzu-compatibility-list";
+    version = "unstable-2024-02-26";
+
+    src = fetchFromGitHub {
+      owner = "flathub";
+      repo = "org.yuzu_emu.yuzu";
+      rev = "9c2032a3c7e64772a8112b77ed8b660242172068";
+      hash = "sha256-ITh/W4vfC9w9t+TJnPeTZwWifnhTNKX54JSSdpgaoBk=";
+    };
+
+    buildCommand = ''
+      cp $src/compatibility_list.json $out
+    '';
+  };
+
+  nx_tzdb = stdenv.mkDerivation rec {
+    pname = "nx_tzdb";
+    version = "221202";
+
+    src = fetchurl {
+      url = "https://github.com/lat9nq/tzdb_to_nx/releases/download/${version}/${version}.zip";
+      hash = "sha256-mRzW+iIwrU1zsxHmf+0RArU8BShAoEMvCz+McXFFK3c=";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    buildCommand = ''
+      unzip $src -d $out
+    '';
+
+  };
+
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "torzu";
+  version = "unstable-2024-12-15";
+
+  src = fetchgit {
+    url = "https://notabug.org/litucks/torzu";
+    rev = "02cfee3f184e6fdcc3b483ef399fb5d2bb1e8ec7";
+    hash = "sha256-hAWMFzTNJGFcrXov5LKMdW9YWhsu7wueATmiuS7EVkI=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Remove coroutines from debugger to fix boost::asio compatibility issues
+    ./fix-debugger.patch
+    # Add explicit cast for CRC checksum value
+    ./fix-udp-protocol.patch
+    # Use specific boost::asio includes and update to modern io_context
+    ./fix-udp-client.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    glslang
+    pkg-config
+    python3
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    # vulkan-headers must come first, so the older propagated versions
+    # don't get picked up by accident
+    vulkan-headers
+
+    boost
+    catch2_3
+    cpp-jwt
+    cubeb
+    discord-rpc
+    # intentionally omitted: dynarmic - prefer vendored version for compatibility
+    enet
+
+    # ffmpeg deps (also includes vendored)
+    # we do not use internal ffmpeg because cuda errors
+    autoconf
+    yasm
+    libva # for accelerated video decode on non-nvidia
+    nv-codec-headers-12 # for accelerated video decode on nvidia
+    ffmpeg-headless
+    # end ffmpeg deps
+
+    fmt
+    # intentionally omitted: gamemode - loaded dynamically at runtime
+    # intentionally omitted: httplib - upstream requires an older version than what we have
+    libopus
+    libusb1
+    # intentionally omitted: LLVM - heavy, only used for stack traces in the debugger
+    lz4
+    nlohmann_json
+    qtbase
+    qtmultimedia
+    qtwayland
+    qtwebengine
+    # intentionally omitted: renderdoc - heavy, developer only
+    SDL2
+    # intentionally omitted: stb - header only libraries, vendor uses git snapshot
+    vulkan-memory-allocator
+    # intentionally omitted: xbyak - prefer vendored version for compatibility
+    zlib
+    zstd
+  ];
+
+  # This changes `ir/opt` to `ir/var/empty` in `externals/dynarmic/src/dynarmic/CMakeLists.txt`
+  # making the build fail, as that path does not exist
+  dontFixCmake = true;
+
+  cmakeFlags = [
+    # actually has a noticeable performance impact
+    (lib.cmakeBool "YUZU_ENABLE_LTO" true)
+    (lib.cmakeBool "YUZU_TESTS" false)
+
+    (lib.cmakeBool "ENABLE_QT6" true)
+    (lib.cmakeBool "ENABLE_QT_TRANSLATION" true)
+
+    # use system libraries
+    # NB: "external" here means "from the externals/ directory in the source",
+    # so "off" means "use system"
+    (lib.cmakeBool "YUZU_USE_EXTERNAL_SDL2" false)
+    (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_HEADERS" true)
+    "-DVulkan_INCLUDE_DIRS=${vulkan-headers}/include"
+
+    # # don't use system ffmpeg, suyu uses internal APIs
+    # (lib.cmakeBool "YUZU_USE_BUNDLED_FFMPEG" true)
+
+    # don't check for missing submodules
+    (lib.cmakeBool "YUZU_CHECK_SUBMODULES" false)
+
+    # enable some optional features
+    (lib.cmakeBool "YUZU_USE_QT_WEB_ENGINE" true)
+    (lib.cmakeBool "YUZU_USE_QT_MULTIMEDIA" true)
+    (lib.cmakeBool "USE_DISCORD_PRESENCE" true)
+
+    # We dont want to bother upstream with potentially outdated compat reports
+    (lib.cmakeBool "YUZU_ENABLE_COMPATIBILITY_REPORTING" false)
+    (lib.cmakeBool "ENABLE_COMPATIBILITY_LIST_DOWNLOAD" false) # We provide this deterministically
+  ];
+
+  env = {
+    # Does some handrolled SIMD
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isx86_64 "-msse4.1";
+  };
+
+  qtWrapperArgs = [
+    # Fixes vulkan detection.
+    # FIXME: patchelf --add-rpath corrupts the binary for some reason, investigate
+    "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
+  ];
+
+  # Setting this through cmakeFlags does not work.
+  # https://github.com/NixOS/nixpkgs/issues/114044
+  preConfigure = lib.concatStringsSep "\n" [
+    ''
+      cmakeFlagsArray+=(
+        "-DTITLE_BAR_FORMAT_IDLE=${finalAttrs.pname} | ${finalAttrs.version} (nixpkgs) {}"
+        "-DTITLE_BAR_FORMAT_RUNNING=${finalAttrs.pname} | ${finalAttrs.version} (nixpkgs) | {}"
+      )
+    ''
+    # provide pre-downloaded tz data
+    ''
+      mkdir -p build/externals/nx_tzdb
+      ln -s ${nx_tzdb} build/externals/nx_tzdb/nx_tzdb
+    ''
+  ];
+
+  postConfigure = ''
+    ln -sf ${compat-list} ./dist/compatibility_list/compatibility_list.json
+  '';
+
+  postInstall = "
+    install -Dm444 $src/dist/72-yuzu-input.rules $out/lib/udev/rules.d/72-yuzu-input.rules
+  ";
+
+  meta = {
+    description = "Fork of yuzu, an open-source Nintendo Switch emulator";
+    homepage = "https://notabug.org/litucks/torzu";
+    mainProgram = "yuzu";
+    platforms = lib.platforms.linux;
+    badPlatforms = [
+      # Several conversion errors, probably caused by the update to GCC 14
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ liberodark ];
+    license = with lib.licenses; [
+      gpl3Plus
+      # Icons
+      asl20
+      mit
+      cc0
+    ];
+  };
+})


### PR DESCRIPTION
- Fix https://github.com/NixOS/nixpkgs/issues/300041

Torzu can be used by yuzu users without any change or configuration because is use same configuration. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
