### PR TITLE
elixir: modify Elixir license to Apache 2.0

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation ({
       with hot code upgrades.
     '';
 
-    license = licenses.epl10;
+    license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = teams.beam.members;
   };


### PR DESCRIPTION
The current license is Eclipse Public license (epl10) which is incorrect. I suspect this was intended to be Erlang Public License, which was the license for OTP versions up to OTP 18. Since the minimum OTP version for Elixir currently is 23, there should be no need to address per-version license in this case.

Elixir license [file](https://github.com/elixir-lang/elixir/blob/main/LICENSE). 
OTP [about page](https://www.erlang.org/about) with note about license change.