### PR TITLE
nixos/opensnitch: remove services.opensnitch.settings.Ebpf option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -176,6 +176,8 @@
 
 - `gkraken` software and `hardware.gkraken.enable` option have been removed, use `coolercontrol` via `programs.coolercontrol.enable` option instead.
 
+- `services.opensnitch.settings.Ebpf` option has been removed. It was previously unused and did not affect anything.
+
 - To avoid delaying user logins unnecessarily the `multi-user.target` is no longer ordered after `network-online.target`.
   System services requiring a connection to start correctly must explicitly state so, i.e.
   ```nix

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -59,6 +59,10 @@ in
         type = types.submodule {
           freeformType = format.type;
 
+          imports = [
+            (mkRemovedOptionModule [ "Ebpf" ] "this option was unused")
+          ];
+
           options = {
             Server = {
 
@@ -150,24 +154,6 @@ in
                 '';
               };
 
-            };
-
-            Ebpf.ModulesPath = mkOption {
-              type = types.path;
-              default =
-                if cfg.settings.ProcMonitorMethod == "ebpf" then
-                  "${config.boot.kernelPackages.opensnitch-ebpf}/etc/opensnitchd"
-                else
-                  null;
-              defaultText = literalExpression ''
-                if cfg.settings.ProcMonitorMethod == "ebpf" then
-                  "\\$\\{config.boot.kernelPackages.opensnitch-ebpf\\}/etc/opensnitchd"
-                else null;
-              '';
-              description = ''
-                Configure eBPF modules path. Used when
-                `settings.ProcMonitorMethod` is set to `ebpf`.
-              '';
             };
 
             Rules.Path = mkOption {


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/368315
the option was previously entirely unused, but introduced weird failure mechanisms if the audit method was not ebpf.

No sensible person would ever define this option, as it simply did nothing. Because this did nothing, removing it will not break most existing opensnitch ebpf setups. Whether non-ebpf setups work after this PR is questionable, but at least the eval error goes away. This might potentially need a follow-up PR, i have to do more testing.

CC @onny 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
