### PR TITLE
miniforge: added default.nix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18567,12 +18567,6 @@
     githubId = 40905037;
     name = "qwqawawow";
   };
-  qxrein = {
-    email = "manavrj.07@gmail.com";
-    github = "qxrein";
-    githubId = 101001298;
-    name = "qxrein";
-  };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18567,6 +18567,12 @@
     githubId = 40905037;
     name = "qwqawawow";
   };
+  qxrein = {
+    email = "manavrj.07@gmail.com.com";
+    github = "qxrein";
+    githubId = 101001298;
+    name = "qxrein";
+  };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18568,7 +18568,7 @@
     name = "qwqawawow";
   };
   qxrein = {
-    email = "manavrj.07@gmail.com.com";
+    email = "manavrj.07@gmail.com";
     github = "qxrein";
     githubId = 101001298;
     name = "qxrein";

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = [ "qxrein" ];
+    maintainers = with maintainers; [ "qxrein" ];
   };
 }

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ "qxrein" ];
+    maintainers = with maintainers; [ qxrein ];
   };
 }

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -1,9 +1,4 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, python3
-, conda
-}:
+{ lib, stdenv, fetchFromGitHub, python3, conda }:
 
 stdenv.mkDerivation rec {
   pname = "miniforge";
@@ -13,13 +8,11 @@ stdenv.mkDerivation rec {
     owner = "conda-forge";
     repo = "miniforge";
     rev = version;
-    sha256 = "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ=";  # Will be provided by nix-build error
+    sha256 =
+      "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ="; 
   };
 
-  buildInputs = [
-    python3
-    conda
-  ];
+  buildInputs = [ python3 conda ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -32,6 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ];  # Add your maintainer handle after PR to nixpkgs-maintainers
+    maintainers = with maintainers;
+      [ ]; 
   };
 }

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildPythonPackage, stdenv, fetchFromGitHub, python3, conda }:
+{
+  lib,
+  buildPythonPackage,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  conda,
+}:
 
 stdenv.mkDerivation rec {
   pname = "miniforge";
@@ -8,10 +15,13 @@ stdenv.mkDerivation rec {
     owner = "conda-forge";
     repo = "miniforge";
     rev = version;
-    hash = "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ="; 
+    hash = "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ=";
   };
 
-  buildInputs = [ python3 conda ];
+  buildInputs = [
+    python3
+    conda
+  ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -24,7 +34,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers;
-      [ qxrein ]; 
+    maintainers = with maintainers; [ qxrein ];
   };
 }

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A conda-forge distribution with mamba 1.5.11";
+    description = "Conda-forge distribution with mamba";
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Conda-forge distribution with mamba";
     homepage = "https://github.com/conda-forge/miniforge";
-    license =  with licenses; [ bsd3 ];
+    license = with licenses; [ bsd3 ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ qxrein ];
   };

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -8,8 +8,7 @@ stdenv.mkDerivation rec {
     owner = "conda-forge";
     repo = "miniforge";
     rev = version;
-    sha256 =
-      "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ="; 
+    hash = "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ="; 
   };
 
   buildInputs = [ python3 conda ];

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Conda-forge distribution with mamba";
     homepage = "https://github.com/conda-forge/miniforge";
-    license = licenses.bsd3;
+    license =  with licenses; [ bsd3 ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ qxrein ];
   };

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, conda
+}:
+
+stdenv.mkDerivation rec {
+  pname = "miniforge";
+  version = "24.11.0-0";
+
+  src = fetchFromGitHub {
+    owner = "conda-forge";
+    repo = "miniforge";
+    rev = version;
+    sha256 = "sha256-Mtw0TI5LWv7aC2kCx7EStYXEUa9J3xTwUPpN/z9GvAQ=";  # Will be provided by nix-build error
+  };
+
+  buildInputs = [
+    python3
+    conda
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/
+    ln -s $out/miniforge3/bin/conda $out/bin/miniforge-conda
+  '';
+
+  meta = with lib; {
+    description = "A conda-forge distribution with mamba 1.5.11";
+    homepage = "https://github.com/conda-forge/miniforge";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ];  # Add your maintainer handle after PR to nixpkgs-maintainers
+  };
+}

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  buildPythonPackage,
   stdenv,
   fetchFromGitHub,
   python3,
@@ -25,15 +24,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -r * $out/
-    ln -s $out/miniforge3/bin/conda $out/bin/miniforge-conda
+    cp -r Miniforge3/* $out/
+    ln -s ${conda}/bin/conda $out/bin/miniforge-conda
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Conda-forge distribution with mamba";
     homepage = "https://github.com/conda-forge/miniforge";
-    license = with licenses; [ bsd3 ];
+    license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ qxrein ];
+    maintainers = [ "qxrein" ];
   };
 }

--- a/pkgs/development/python-modules/miniforge/default.nix
+++ b/pkgs/development/python-modules/miniforge/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, conda }:
+{ lib, buildPythonPackage, stdenv, fetchFromGitHub, python3, conda }:
 
 stdenv.mkDerivation rec {
   pname = "miniforge";
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
     ln -s $out/miniforge3/bin/conda $out/bin/miniforge-conda
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Conda-forge distribution with mamba";
     homepage = "https://github.com/conda-forge/miniforge";
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = with maintainers;
-      [ ]; 
+      [ qxrein ]; 
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8185,6 +8185,8 @@ self: super: with self; {
 
   minidump = callPackage ../development/python-modules/minidump { };
 
+  miniforge = callPackage ../development/python-modules/miniforge { };
+
   miniful = callPackage ../development/python-modules/miniful { };
 
   minikanren = callPackage ../development/python-modules/minikanren { };


### PR DESCRIPTION
63d2c3f5237217bf684ae3b849281d4a0b87cb40

python-modules/miniforge: init at 24.11.0-0

Add miniforge package, a conda-forge distribution that includes mamba 1.5.11.

Features:

Based on the latest 24.11.0-0 release
Supports x86_64, aarch64 platforms
Includes Python 3 and conda package manager
Testing:

Builds successfully on NixOS
Package installs and conda command works
Closes #368355
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
