### PR TITLE
antora-ui-default: 0-unstable-2024-09-20 -> 0-unstable-2024-12-26

### DIFF
--- a/pkgs/by-name/an/antora-ui-default/package.nix
+++ b/pkgs/by-name/an/antora-ui-default/package.nix
@@ -8,12 +8,12 @@ let
     hash = "sha256-q2FwkwzjanxTIxjMpCyMpzPt782uYZiWVdZ7Eev79oM=";
     owner = "trueNAHO";
     repo = "antora-ui-default";
-    rev = "83bf9bf5f22a6dee397f8b089eb0315c14a278b5";
+    rev = "11f563294248e9b64124b9289d639e349f2e9f5f";
   };
 in
 stdenvNoCC.mkDerivation {
   pname = "antora-ui-default";
-  version = "0-unstable-2024-09-20";
+  version = "0-unstable-2024-12-26";
 
   # The UI bundle is fetched from lib.maintainers.naho's antora-ui-default fork
   # for the following reasons:
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation {
   #
   # For reference, the UI bundle from [3] is 300K large.
   #
-  # [3]: https://gitlab.com/trueNAHO/antora-ui-default/-/commit/83bf9bf5f22a6dee397f8b089eb0315c14a278b5
+  # [3]: https://gitlab.com/trueNAHO/antora-ui-default/-/commit/11f563294248e9b64124b9289d639e349f2e9f5f
   src = fetchFromGitLab srcFetchFromGitLab;
 
   phases = [ "installPhase" ];

--- a/pkgs/by-name/an/antora-ui-default/package.nix
+++ b/pkgs/by-name/an/antora-ui-default/package.nix
@@ -13,7 +13,7 @@ let
 in
 stdenvNoCC.mkDerivation {
   pname = "antora-ui-default";
-  version = "0";
+  version = "0-unstable-2024-09-20";
 
   # The UI bundle is fetched from lib.maintainers.naho's antora-ui-default fork
   # for the following reasons:


### PR DESCRIPTION
```
NAHO (2):
  antora-ui-default: use correct version naming convention
  antora-ui-default: 0-unstable-2024-09-20 -> 0-unstable-2024-12-26

 pkgs/by-name/an/antora-ui-default/package.nix | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

I have successfully tested this patchset on my documentation that relies on this package.

Cc: @ehllie

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
