### PR TITLE
add podman slirp4netns change to rl-2411.section.md [documentation]

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -924,6 +924,8 @@
 
 - `buildNimSbom` was added as an alternative to `buildNimPackage`. `buildNimSbom` uses [SBOMs](https://cyclonedx.org/) to generate packages whereas `buildNimPackage` uses a custom JSON lockfile format.
 
+-  `podman` is no longer included with the optional network `slirp4netns` [313670](https://github.com/NixOS/nixpkgs/pull/313670). To use the podman `--network slirp4netns` parameter, you must add `slirp4netns` to the `environment.systemPackages`. Please note `slirp4netns` is deprecated and may be remove in futur version. If you use this driver to access the host from the container, there is a workaround in podman v5.2.3 that can be used until the [v5.3](https://linuxiac.com/podman-5-3-promises-an-enhanced-rootless-networking/). Include these parameters to the podman command `--network pasta:--map-guest-addr,169.254.1.2 --add-host host.containers.internal:169.254.1.2` and you host is reachable from `host.containers.internal`
+
 ## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}


### PR DESCRIPTION
podman is no longer default included with the optional network slirp4netns in Nixos 24.11
show workaround in the release notes