### PR TITLE
python31{2,3}Packages.deal: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -71,6 +71,8 @@ buildPythonPackage rec {
     "test_doctest"
     "test_no_violations"
     "test_source_get_lambda_multiline_splitted_dec"
+    # assert basically correct but fails in string match due to '' removed
+    "test_unknown_command"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -12,6 +12,7 @@
   pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
+  pythonAtLeast,
   sphinx,
   typeguard,
   urllib3,
@@ -52,28 +53,34 @@ buildPythonPackage rec {
     vaa
   ];
 
-  disabledTests = [
-    # Tests need internet access
-    "test_smoke_has"
-    "test_pure_offline"
-    "test_raises_doesnt_override_another_contract"
-    "test_raises_doesnt_override_another_contract_async"
-    "test_raises_generator"
-    # AttributeError: module 'vaa' has no attribute 'Error'
-    "test_source_vaa_scheme"
-    "test_vaa_scheme_and_custom_exception"
-    "test_scheme_string_validation_args_correct"
-    "test_method_chain_decorator_with_scheme_is_fulfilled"
-    "test_scheme_contract_is_satisfied_when_setting_arg"
-    "test_scheme_contract_is_satisfied_within_chain"
-    "test_scheme_errors_rewrite_message"
-    # assert errors
-    "test_doctest"
-    "test_no_violations"
-    "test_source_get_lambda_multiline_splitted_dec"
-    # assert basically correct but fails in string match due to '' removed
-    "test_unknown_command"
-  ];
+  disabledTests =
+    [
+      # Tests need internet access
+      "test_smoke_has"
+      "test_pure_offline"
+      "test_raises_doesnt_override_another_contract"
+      "test_raises_doesnt_override_another_contract_async"
+      "test_raises_generator"
+      # AttributeError: module 'vaa' has no attribute 'Error'
+      "test_source_vaa_scheme"
+      "test_vaa_scheme_and_custom_exception"
+      "test_scheme_string_validation_args_correct"
+      "test_method_chain_decorator_with_scheme_is_fulfilled"
+      "test_scheme_contract_is_satisfied_when_setting_arg"
+      "test_scheme_contract_is_satisfied_within_chain"
+      "test_scheme_errors_rewrite_message"
+      # assert errors
+      "test_doctest"
+      "test_no_violations"
+      "test_source_get_lambda_multiline_splitted_dec"
+      # assert basically correct but fails in string match due to '' removed
+      "test_unknown_command"
+    ]
+    ++ lib.optional (pythonAtLeast "3.13") [
+      # assert basically correct but string match fails in due to
+      # ('pathlib._local', 'Path.write_text') != ('pathlib', 'Path.write_text')
+      "test_infer"
+    ];
 
   disabledTestPaths = [
     # Test needs internet access


### PR DESCRIPTION
test fails due to a bad string match as the single quotes disappeared:
"invalid choice: 'unknown' (choose from 'fake')" ->
"invalid choice: 'unknown' (choose from fake)"

and for python313:
('pathlib._local', 'Path.write_text') != ('pathlib', 'Path.write_text')

upstream doesn't support reporting issues so disable the test

https://hydra.nixos.org/build/282831225
https://hydra.nixos.org/build/282763317
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
