### PR TITLE
nixos/opensnitch: fix eval for `services.opensnitch.settings.ProcMonitorMethod` different than default (`ebpf`)

### DIFF
--- a/nixos/tests/opensnitch.nix
+++ b/nixos/tests/opensnitch.nix
@@ -1,5 +1,13 @@
 import ./make-test-python.nix (
-  { pkgs, ... }:
+  { pkgs, lib, ... }:
+  let
+    monitorMethods = [
+      "ebpf"
+      "proc"
+      "ftrace"
+      "audit"
+    ];
+  in
   {
     name = "opensnitch";
 
@@ -7,10 +15,9 @@ import ./make-test-python.nix (
       maintainers = [ onny ];
     };
 
-    nodes = {
-      server =
-        { ... }:
-        {
+    nodes =
+      {
+        server = {
           networking.firewall.allowedTCPPorts = [ 80 ];
           services.caddy = {
             enable = true;
@@ -19,50 +26,60 @@ import ./make-test-python.nix (
             '';
           };
         };
-
-      clientBlocked =
-        { ... }:
-        {
-          services.opensnitch = {
-            enable = true;
-            settings.DefaultAction = "deny";
-          };
-        };
-
-      clientAllowed =
-        { ... }:
-        {
-          services.opensnitch = {
-            enable = true;
-            settings.DefaultAction = "deny";
-            rules = {
-              curl = {
-                name = "curl";
-                enabled = true;
-                action = "allow";
-                duration = "always";
-                operator = {
-                  type = "simple";
-                  sensitive = false;
-                  operand = "process.path";
-                  data = "${pkgs.curl}/bin/curl";
+      }
+      // (lib.listToAttrs (
+        map (
+          m:
+          lib.nameValuePair "client_blocked_${m}" {
+            services.opensnitch = {
+              enable = true;
+              settings.DefaultAction = "deny";
+              settings.ProcMonitorMethod = m;
+            };
+          }
+        ) monitorMethods
+      ))
+      // (lib.listToAttrs (
+        map (
+          m:
+          lib.nameValuePair "client_allowed_${m}" {
+            services.opensnitch = {
+              enable = true;
+              settings.DefaultAction = "deny";
+              settings.ProcMonitorMethod = m;
+              rules = {
+                curl = {
+                  name = "curl";
+                  enabled = true;
+                  action = "allow";
+                  duration = "always";
+                  operator = {
+                    type = "simple";
+                    sensitive = false;
+                    operand = "process.path";
+                    data = "${pkgs.curl}/bin/curl";
+                  };
                 };
               };
             };
-          };
-        };
-    };
+          }
+        ) monitorMethods
+      ));
 
-    testScript = ''
-      start_all()
-      server.wait_for_unit("caddy.service")
-      server.wait_for_open_port(80)
+    testScript =
+      ''
+        start_all()
+        server.wait_for_unit("caddy.service")
+        server.wait_for_open_port(80)
+      ''
+      + lib.concatLines (
+        map (m: ''
+          client_blocked_${m}.wait_for_unit("opensnitchd.service")
+          client_blocked_${m}.fail("curl http://server")
 
-      clientBlocked.wait_for_unit("opensnitchd.service")
-      clientBlocked.fail("curl http://server")
-
-      clientAllowed.wait_for_unit("opensnitchd.service")
-      clientAllowed.succeed("curl http://server")
-    '';
+          client_allowed_${m}.wait_for_unit("opensnitchd.service")
+          client_allowed_${m}.succeed("curl http://server")
+        '') monitorMethods
+      );
   }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/368315

Previously, any ProcMonitorMethod that was not `ebpf` would fail to evaluate, as the default would define a null for a path-type config option. This in itself is a trivial fix.
Additionally, ebpf-specific config will now be removed from the config file written to the systemd unit if ebpf is not the monitoring method.

To validate these changes, i adapted the nixos test for opensnitch to test all the different monitor methods. This makes the test quite slow, as the deny timeout has to pass for each of the failing connections. But i did test this successfully, and this does improve coverage.

cc @onny (for real this time, now that i actually managed to fix the issue)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
