### PR TITLE
mpvScripts.twitch-chat: init at 0-unstable-2024-06-23

### DIFF
--- a/pkgs/applications/video/mpv/scripts/twitch-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/twitch-chat.nix
@@ -1,0 +1,42 @@
+{
+  buildLua,
+  curl,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+buildLua (finalAttrs: {
+  pname = "twitch-chat";
+  version = "0-unstable-2024-06-23";
+
+  src = fetchFromGitHub {
+    owner = "CrendKing";
+    repo = "mpv-twitch-chat";
+    rev = "bb0c2e84675f4f1e0c221c8e1d3516b60242b985";
+    hash = "sha256-WyNPUiAs5U/vrjNbAgyqkfoxh9rabLmuZ1zG5uZYxaw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -D main.lua $out/share/mpv/scripts/twitch-chat.lua
+    runHook postInstall
+  '';
+
+  passthru.extraWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ curl ])
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Show Twitch chat messages as subtitles when watching Twitch VOD with mpv.";
+    homepage = "https://github.com/CrendKing/mpv-twitch-chat";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.naho ];
+  };
+})


### PR DESCRIPTION
This module is strongly inspired by [`mpvScripts.modernz`](https://github.com/NixOS/nixpkgs/blob/b5e12ffe521b8cb211e62e82011260b7421830ff/pkgs/applications/video/mpv/scripts/modernz.nix) and [`mpvScripts.youtube-chat`](https://github.com/NixOS/nixpkgs/blob/b5e12ffe521b8cb211e62e82011260b7421830ff/pkgs/applications/video/mpv/scripts/youtube-chat.nix).

For reference, I am using this patch as follows:

```patch
commit a58ebab2f53b8a1e343b4016ca6a4db0721b2380
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2024-12-26 19:17:45 +0100

    mpv: scripts: twitch-chat: init

diff --git a/flake.lock b/flake.lock
index 41d49c60..41adbbae 100644
--- a/flake.lock
+++ b/flake.lock
@@ -392,6 +392,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23": {
+      "locked": {
+        "lastModified": 1735251247,
+        "narHash": "sha256-kwFSGhuoWd+BgHslTB5exfrvJzELbpUlmuK2bVxOnNo=",
+        "owner": "trueNAHO",
+        "repo": "nixpkgs",
+        "rev": "732505cc8174deca56ff8c3547ddc1e76244b2ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trueNAHO",
+        "ref": "mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1731319897,
@@ -493,6 +509,7 @@
         "nix-alien": "nix-alien",
         "nix-index-database": "nix-index-database_2",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23": "nixpkgs-mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23",
         "nixvim": "nixvim",
         "os": "os",
         "stylix": "stylix",
diff --git a/flake.nix b/flake.nix
index 969d25d0..6c6a39d3 100644
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,11 @@
       url = "github:trueNAHO/nix-index-database/treewide-disable-programs-nix-index-enable-option-by-default";
     };

+    # TODO: Replace this fork with upstream once [1] is merged.
+    #
+    # [1]: https://github.com/NixOS/nixpkgs/pull/368422
+    nixpkgs-mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23.url = "github:trueNAHO/nixpkgs/mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23";
+
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

     nixvim = {
diff --git a/modules/inputs/home-manager/programs/mpv/default.nix b/modules/inputs/home-manager/programs/mpv/default.nix
index 6bea0dfe..ff7762fc 100644
--- a/modules/inputs/home-manager/programs/mpv/default.nix
+++ b/modules/inputs/home-manager/programs/mpv/default.nix
@@ -1,7 +1,9 @@
 {
   config,
+  inputs,
   lib,
   pkgs,
+  system,
   ...
 }: {
   options.dotfiles.inputs.home-manager.programs.mpv = {
@@ -35,6 +37,7 @@
     };

     scripts = {
+      mpv-twitch-chat = lib.dotfiles.mkEnableOption;
       playlistmanager = lib.dotfiles.mkEnableOption;
       thumbfast = lib.dotfiles.mkEnableOption;
       uosc = lib.dotfiles.mkEnableOption;
@@ -51,6 +54,7 @@
             bindings.anime4k = lib.mkDefault true;

             scripts = {
+              mpv-twitch-chat = lib.mkDefault true;
               playlistmanager = lib.mkDefault true;
               thumbfast = lib.mkDefault true;
               uosc = lib.mkDefault true;
@@ -263,6 +267,30 @@
           }
         )

+        (
+          lib.mkIf cfg.scripts.mpv-twitch-chat {
+            programs.mpv = {
+              profiles.twitch-chat = {
+                profile-cond = ''get("path", ""):find("^https://www.twitch.tv/") ~= nil'';
+                profile-restore = "copy-equal";
+                sub-align-x = "right";
+                sub-align-y = "top";
+                sub-font-size = 12;
+                sub-outline-size = 1;
+              };
+
+              scriptOpts.twitch_chat = {
+                duration_multiplier = 1000000;
+                fetch_aot = 11;
+                max_message_length = 0;
+                show_name = true;
+              };
+
+              scripts = [inputs.nixpkgs-mpv-script-mpv-twitch-chat-init-at-0-unstable-2024-06-23.legacyPackages.${system}.mpvScripts.twitch-chat];
+            };
+          }
+        )
+
         (
           lib.mkIf cfg.scripts.playlistmanager {
             programs.mpv = {
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
