### PR TITLE
wlcs,mir_2_15: Fix GCC 14 compat

### DIFF
--- a/pkgs/by-name/wl/wlcs/package.nix
+++ b/pkgs/by-name/wl/wlcs/package.nix
@@ -3,6 +3,7 @@
   lib,
   gitUpdater,
   fetchFromGitHub,
+  fetchpatch,
   testers,
   cmake,
   pkg-config,
@@ -23,6 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-BQPRymkbGu4YvTYXTaTMuyP5fHpqMWI4xPwjDRHZNEQ=";
   };
 
+  patches = [
+    # Remove when version > 1.7.0
+    (fetchpatch {
+      name = "0001-wlcs-Fix-GCC14-compat.patch";
+      url = "https://github.com/canonical/wlcs/commit/5c812e560052e2cbff4c6d26439935020ddee52f.patch";
+      hash = "sha256-8YrVKhgpTYZi8n4dZ4pRWJoAcZtr9eaFMv0NNV7/kWU=";
+    })
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [
@@ -37,6 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-scanner # needed by cmake
   ];
+
+  # GCC14-exclusive maybe-uninitialized error at higher optimisation levels that looks weird
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=maybe-uninitialized";
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/mir/1001-mir-2_15-Fix-ignored-return-value-of-std-lock_guard.patch
+++ b/pkgs/servers/mir/1001-mir-2_15-Fix-ignored-return-value-of-std-lock_guard.patch
@@ -1,0 +1,40 @@
+From d31d3abb36163b0f0a892898349d6a99aaf50e10 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 26 Dec 2024 23:12:39 +0100
+Subject: [PATCH] Fix ignored return value of std::lock_guard
+
+Upstream this seems to have been resolved as part of the big platform API change, so manually rewrote this change into a patch.
+---
+ src/platforms/wayland/displayclient.cpp         | 2 +-
+ src/server/frontend_xwayland/xcb_connection.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/platforms/wayland/displayclient.cpp b/src/platforms/wayland/displayclient.cpp
+index 27bdfe5..987be52 100644
+--- a/src/platforms/wayland/displayclient.cpp
++++ b/src/platforms/wayland/displayclient.cpp
+@@ -563,7 +563,7 @@ void mgw::DisplayClient::on_display_config_changed()
+ 
+ void mgw::DisplayClient::delete_outputs_to_be_deleted()
+ {
+-    std::lock_guard{outputs_mutex};
++    std::lock_guard lock{outputs_mutex};
+     outputs_to_be_deleted.clear();
+ }
+ 
+diff --git a/src/server/frontend_xwayland/xcb_connection.cpp b/src/server/frontend_xwayland/xcb_connection.cpp
+index 4f72b98..0be74b0 100644
+--- a/src/server/frontend_xwayland/xcb_connection.cpp
++++ b/src/server/frontend_xwayland/xcb_connection.cpp
+@@ -207,7 +207,7 @@ void mf::XCBConnection::verify_not_in_error_state() const
+ 
+ auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
+ {
+-    std::lock_guard{atom_name_cache_mutex};
++    std::lock_guard lock{atom_name_cache_mutex};
+     auto const iter = atom_name_cache.find(atom);
+ 
+     if (iter == atom_name_cache.end())
+-- 
+2.47.0
+

--- a/pkgs/servers/mir/1002-mir-2_15-Add-missing-includes-for-algorithm.patch
+++ b/pkgs/servers/mir/1002-mir-2_15-Add-missing-includes-for-algorithm.patch
@@ -1,0 +1,77 @@
+From ab00b6d09303c17ecc7a2131a95591716e9ad7a1 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@fedoraproject.org>
+Date: Thu, 26 Dec 2024 23:00:23 +0100
+Subject: [PATCH] Add missing includes for <algorithm>
+
+Co-authored-by: OPNA2608 <opna2608@protonmail.com>
+---
+ src/miral/external_client.cpp                                  | 1 +
+ src/miral/keymap.cpp                                           | 1 +
+ src/platform/graphics/linux_dmabuf.cpp                         | 1 +
+ src/server/scene/rendering_tracker.cpp                         | 1 +
+ tests/unit-tests/graphics/test_overlapping_output_grouping.cpp | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/src/miral/external_client.cpp b/src/miral/external_client.cpp
+index 0c3d176..792b962 100644
+--- a/src/miral/external_client.cpp
++++ b/src/miral/external_client.cpp
+@@ -22,6 +22,7 @@
+ #include <mir/options/option.h>
+ #include <mir/server.h>
+ 
++#include <algorithm>
+ #include <stdexcept>
+ 
+ namespace mo = mir::options;
+diff --git a/src/miral/keymap.cpp b/src/miral/keymap.cpp
+index e494a10..010cb75 100644
+--- a/src/miral/keymap.cpp
++++ b/src/miral/keymap.cpp
+@@ -30,6 +30,7 @@
+ #define MIR_LOG_COMPONENT "miral::Keymap"
+ #include <mir/log.h>
+ 
++#include <algorithm>
+ #include <mutex>
+ #include <string>
+ #include <vector>
+diff --git a/src/platform/graphics/linux_dmabuf.cpp b/src/platform/graphics/linux_dmabuf.cpp
+index f5a750f..840c3d0 100644
+--- a/src/platform/graphics/linux_dmabuf.cpp
++++ b/src/platform/graphics/linux_dmabuf.cpp
+@@ -41,6 +41,7 @@
+ #include <mutex>
+ #include <vector>
+ #include <optional>
++#include <algorithm>
+ #include <drm_fourcc.h>
+ #include <wayland-server.h>
+ 
+diff --git a/src/server/scene/rendering_tracker.cpp b/src/server/scene/rendering_tracker.cpp
+index fe4e05e..24393a3 100644
+--- a/src/server/scene/rendering_tracker.cpp
++++ b/src/server/scene/rendering_tracker.cpp
+@@ -17,6 +17,7 @@
+ #include "rendering_tracker.h"
+ #include "mir/scene/surface.h"
+ 
++#include <algorithm>
+ #include <stdexcept>
+ #include <boost/throw_exception.hpp>
+ 
+diff --git a/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp b/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp
+index 4478578..7167ad1 100644
+--- a/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp
++++ b/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp
+@@ -22,6 +22,7 @@
+ #include <gtest/gtest.h>
+ 
+ #include <vector>
++#include <algorithm>
+ 
+ namespace mg = mir::graphics;
+ namespace geom = mir::geometry;
+-- 
+2.47.0
+

--- a/pkgs/servers/mir/1003-mir-2_15-calloc-args-in-right-order.patch
+++ b/pkgs/servers/mir/1003-mir-2_15-calloc-args-in-right-order.patch
@@ -1,0 +1,35 @@
+From 2b3fa53f0115d73d1d515f8c839fc481ba5db46d Mon Sep 17 00:00:00 2001
+From: Alan Griffiths <alan@octopull.co.uk>
+Date: Thu, 26 Dec 2024 23:21:12 +0100
+Subject: [PATCH] calloc args in right order
+
+Co-authored-by: OPNA2608 <opna2608@protonmail.com>
+---
+ examples/client/wayland_client.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/examples/client/wayland_client.c b/examples/client/wayland_client.c
+index a52b04c..e644a44 100644
+--- a/examples/client/wayland_client.c
++++ b/examples/client/wayland_client.c
+@@ -375,7 +375,7 @@ int main(int argc, char** argv)
+ 
+     struct wl_display* display = wl_display_connect(NULL);
+     struct globals* globals;
+-    globals = calloc(sizeof *globals, 1);
++    globals = calloc(1, sizeof *globals);
+ 
+     struct wl_registry* registry = wl_display_get_registry(display);
+ 
+@@ -389,7 +389,7 @@ int main(int argc, char** argv)
+     void* pool_data = NULL;
+     struct wl_shm_pool* shm_pool = make_shm_pool(globals->shm, 400 * 400 * 4, &pool_data);
+ 
+-    struct draw_context* ctx = calloc(sizeof *ctx, 1);
++    struct draw_context* ctx = calloc(1, sizeof *ctx);
+ 
+     for (int i = 0; i < 4; ++i)
+     {
+-- 
+2.47.0
+

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -28,6 +28,22 @@ in
         url = "https://github.com/canonical/mir/commit/0704026bd06372ea8286a46d8c939286dd8a8c68.patch";
         hash = "sha256-k+51piPQandbHdm+ioqpBrb+C7Aqi2kugchAehZ1aiU=";
       })
+
+      # Fix ignored return value of std::lock_guard
+      # Remove when version > 2.15.0
+      # Was changed as part of the big platform API change, no individual upstream commit with this fix
+      ./1001-mir-2_15-Fix-ignored-return-value-of-std-lock_guard.patch
+
+      # Fix missing includes for methods from algorithm
+      # Remove when version > 2.16.4
+      # https://github.com/canonical/mir/pull/3191 backported to 2.15
+      ./1002-mir-2_15-Add-missing-includes-for-algorithm.patch
+
+      # Fix order of calloc arguments
+      # Remove when version > 2.16.4
+      # Partially done in https://github.com/canonical/mir/pull/3192, though one of the calloc was fixed earlier
+      # when some code was moved into that file
+      ./1003-mir-2_15-calloc-args-in-right-order.patch
     ];
   };
 }


### PR DESCRIPTION
wlcs:

- Fetch upstream patch to partially fix GCC 14 compat
- Force `-O2` to fix issue with `std::function` in tests
  I do not pretend to even comprehend what's going on there, so I'll just attach the full error and state that enforcing `-O0` - `-O2` makes the issue go away, and forcing `-O3` makes it re-appear. Maybe a regression in GCC?

<details>
  <summary>Welcome to C++ hell</summary>

```
[ 39%] Building CXX object CMakeFiles/wlcs.asan.dir/tests/xdg_popup.cpp.o
In file included from /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/functional:59,
                 from /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-matchers.h:43,
                 from /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/internal/gtest-death-test-internal.h:47,
                 from /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-death-test.h:43,
                 from /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest.h:64,
                 from /build/source/include/in_process_server.h:26,
                 from /build/source/tests/xdg_popup.cpp:29:
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]',
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:405:42: error: '*(std::function<std::pair<int, int>(int, int)>*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>)).std::function<std::pair<int, int>(int, int)>::_M_invoker' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  405 |       : _Function_base(), _M_invoker(__x._M_invoker)
      |                                      ~~~~^~~~~~~~~~
In file included from /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest.h:67:
/build/source/tests/xdg_popup.cpp: In function 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
In member function 'bool std::_Function_base::_M_empty() const',
    inlined from 'std::function<_Res(_ArgTypes ...)>::operator bool() const [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:574:25,
    inlined from 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:407:6,
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:247:37: error: '*(const std::_Function_base*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>)).std::_Function_base::_M_manager' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  247 |     bool _M_empty() const { return !_M_manager; }
      |                                     ^~~~~~~~~~
/build/source/tests/xdg_popup.cpp: In function 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]',
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:409:13: error: '*(const std::_Any_data*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>))' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  409 |             _M_functor = __x._M_functor;
      |             ^~~~~~~~~~
/build/source/tests/xdg_popup.cpp: In function 'std::string gtest_DefaultXdgPopupPositionerTest_EvalGenerateName_(const testing::TestParamInfo<{anonymous}::PositionerTestParams>&)':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]',
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:405:42: error: '*(std::function<std::pair<int, int>(int, int)>*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>)).std::function<std::pair<int, int>(int, int)>::_M_invoker' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  405 |       : _Function_base(), _M_invoker(__x._M_invoker)
      |                                      ~~~~^~~~~~~~~~
/build/source/tests/xdg_popup.cpp: In function 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
In member function 'bool std::_Function_base::_M_empty() const',
    inlined from 'std::function<_Res(_ArgTypes ...)>::operator bool() const [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:574:25,
    inlined from 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:407:6,
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:247:37: error: '*(const std::_Function_base*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>)).std::_Function_base::_M_manager' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  247 |     bool _M_empty() const { return !_M_manager; }
      |                                     ^~~~~~~~~~
/build/source/tests/xdg_popup.cpp: In function 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = std::pair<int, int>; _ArgTypes = {int, int}]',
    inlined from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = function<pair<int, int>(int, int)>; _Args = {function<pair<int, int>(int, int)>}]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:119:7,
    inlined from 'constexpr void std::_Optional_payload_base<_Tp>::_M_construct(_Args&& ...) [with _Args = {std::function<std::pair<int, int>(int, int)>}; _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:274:19,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:151:22,
    inlined from 'constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(bool, std::_Optional_payload_base<_Tp>&&) [with _Tp = std::function<std::pair<int, int>(int, int)>]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:147:7,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, true, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:395:42,
    inlined from 'constexpr std::_Optional_payload<std::function<std::pair<int, int>(int, int)>, false, false, false>::_Optional_payload(bool, std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >&&) [inherited from std::_Optional_payload_base<std::function<std::pair<int, int>(int, int)> >]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:429:57,
    inlined from 'constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::_Optional_base<_Tp, <anonymous>, <anonymous> >&&) [with _Tp = std::function<std::pair<int, int>(int, int)>; bool <anonymous> = false; bool <anonymous> = false]' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:542:9,
    inlined from 'constexpr std::optional<std::function<std::pair<int, int>(int, int)> >::optional(std::optional<std::function<std::pair<int, int>(int, int)> >&&)' at /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/optional:703:11,
    inlined from 'constexpr {anonymous}::PositionerTestParams::PositionerTestParams({anonymous}::PositionerTestParams&&)' at /build/source/tests/xdg_popup.cpp:132:8,
    inlined from 'testing::internal::ValueArray<T ...> testing::Values(T ...) [with T = {{anonymous}::PositionerTestParams}]' at /nix/store/jjk5d24nfk0z87cg78cv5mzy2yj5z2fa-gtest-1.15.2-dev/include/gtest/gtest-param-test.h:336:20,
    inlined from 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()' at /build/source/tests/xdg_popup.cpp:733:1:
/nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:409:13: error: '*(const std::_Any_data*)((char*)&<unnamed> + offsetof(<unnamed>::PositionerTestParams, <unnamed>::PositionerTestParams::parent_position_func.std::optional<std::function<std::pair<int, int>(int, int)> >::<unnamed>.std::_Optional_base<std::function<std::pair<int, int>(int, int)>, false, false>::<unnamed>))' may be used uninitialized [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Werror=maybe-uninitialized8;;]
  409 |             _M_functor = __x._M_functor;
      |             ^~~~~~~~~~
/build/source/tests/xdg_popup.cpp: In function 'testing::internal::ParamGenerator<{anonymous}::PositionerTestParams> gtest_DefaultXdgPopupPositionerTest_EvalGenerator_()':
/build/source/tests/xdg_popup.cpp:737:136: note: '<anonymous>' declared here
  737 |         PositionerTestParams{"default values", (window_width - popup_width) / 2, (window_height - popup_height) / 2, PositionerParams()}
      |                                                                                                                                        ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/wlcs.asan.dir/build.make:868: CMakeFiles/wlcs.asan.dir/tests/xdg_popup.cpp.o] Error 1
```

</details>

mir_2_15:

- Backport multiple upstream changes to fix GCC 14 compat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
