### PR TITLE
highscore: init at 0-unstable-2026-01-01

### DIFF
--- a/pkgs/by-name/hi/highscore-blastem/package.nix
+++ b/pkgs/by-name/hi/highscore-blastem/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-blastem";
+  version = "0-unstable-2025-06-28";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "blastem-highscore";
+    rev = "d19e9a8ddd0accf017f44dcc81bdd2661f63f25f";
+    hash = "sha256-KetitwqL4S0T4GayeTdwR5hG/LVUF+mJ8oGIN6XPLfU=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/highscore";
+
+  postPatch = ''
+    patchShebangs gen-db.sh
+
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty').stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of BlastEm to Highscore";
+    homepage = "https://github.com/highscore-emu/blastem-highscore";
+    license = lib.licenses.gpl3Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+    badPlatforms = lib.platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/hi/highscore-bsnes/package.nix
+++ b/pkgs/by-name/hi/highscore-bsnes/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-bsnes";
+  version = "0-unstable-2025-12-23";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "bsnes";
+    rev = "df88234e314f97a2ca124df1982e4bd39f6fcea0";
+    hash = "sha256-QI9mRvcsPkVBhUZlhchgGVPROj7HAqgtHHnbHVzIIBI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/bsnes";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  makeFlags = [
+    "target=highscore"
+    "binary=library"
+    "build=performance"
+    "local=false"
+    "platform=linux"
+  ];
+
+  installFlags = [
+    "libdir=${placeholder "out"}/lib"
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater {
+    url = finalAttrs.src.gitRepoUrl;
+  };
+
+  meta = {
+    description = "Port of bsnes to Highscore";
+    homepage = "https://github.com/highscore-emu/bsnes";
+    license = with lib.licenses; [
+      gpl2Plus
+      mit
+    ];
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-desmume/package.nix
+++ b/pkgs/by-name/hi/highscore-desmume/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  libGL,
+  libX11,
+  SDL2,
+  libpcap,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-desmume";
+  version = "0-unstable-2025-09-21";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "desmume";
+    rev = "7d80d2a70850a5595ac8160e6dee5dea8b2fe293";
+    hash = "sha256-wpW8Y68qzuu6J51snw2slbD6cnceFzONG4kutBOeB8I=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/desmume/src/frontend/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty').stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+    libGL
+    libX11
+    SDL2
+    libpcap
+  ];
+
+  # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of DeSmuME to Highscore";
+    homepage = "https://github.com/highscore-emu/desmume";
+    license = lib.licenses.gpl2Plus;
+    inherit (libhighscore.meta) platforms maintainers;
+  };
+})

--- a/pkgs/by-name/hi/highscore-gearsystem/package.nix
+++ b/pkgs/by-name/hi/highscore-gearsystem/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-gearsystem";
+  version = "0-unstable-2026-01-02";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "gearsystem";
+    rev = "7a2cd21c54f1487ec255b71eaf629d1e48d4bbf1";
+    hash = "sha256-y4ZSw2yXBNg49X4aB1TE79ydu3EVqvtb73eB2QBKLEk=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', '--match', ''', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/platforms/highscore";
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of Gearsystem to Highscore";
+    homepage = "https://github.com/highscore-emu/Gearsystem";
+    license = lib.licenses.gpl3Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-mednafen/package.nix
+++ b/pkgs/by-name/hi/highscore-mednafen/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  zstd,
+  libchdr,
+  libvorbis,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-mednafen";
+  version = "0-unstable-2025-12-28";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "mednafen-highscore";
+    rev = "58404782e3f69186c7be821a880cf1442b240f2f";
+    hash = "sha256-FXSfBAPpi+Ch9vuPQf6nqLMKxvrbXG+6F5HHaU9fs2s=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+    zstd
+    libchdr
+    libvorbis
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of Mednafen to Highscore";
+    homepage = "https://github.com/highscore-emu/mednafen-highscore";
+    license = lib.licenses.gpl2Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-mgba/package.nix
+++ b/pkgs/by-name/hi/highscore-mgba/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "highscore-mgba";
+  version = "0-unstable-2026-01-02";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "mgba";
+    rev = "a6d684ff03b91d219b861b85791f4069df698562";
+    hash = "sha256-Ur7BG+AJ6KQ+XX2qKoj13w556VNnHtxULXd1d+gHUig=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_DEBUGGERS" false)
+    (lib.cmakeBool "USE_EDITLINE" false)
+    (lib.cmakeBool "ENABLE_GDB_STUB" false)
+    (lib.cmakeBool "USE_ZLIB" false)
+    (lib.cmakeBool "USE_MINIZIP" false)
+    (lib.cmakeBool "USE_PNG" false)
+    (lib.cmakeBool "USE_LIBZIP" false)
+    (lib.cmakeBool "USE_SQLITE3" false)
+    (lib.cmakeBool "USE_ELF" false)
+    (lib.cmakeBool "USE_LUA" false)
+    (lib.cmakeBool "USE_JSON_C" false)
+    (lib.cmakeBool "USE_LZMA" false)
+    (lib.cmakeBool "USE_DISCORD_RPC" false)
+    (lib.cmakeBool "ENABLE_SCRIPTING" false)
+    (lib.cmakeBool "BUILD_QT" false)
+    (lib.cmakeBool "BUILD_SDL" false)
+    (lib.cmakeBool "BUILD_HIGHSCORE" true)
+    (lib.cmakeBool "SKIP_LIBRARY" true)
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of mGBA to Highscore";
+    homepage = "https://github.com/highscore-emu/mednafen-highscore";
+    license = lib.licenses.mpl20;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+}

--- a/pkgs/by-name/hi/highscore-mupen64plus/package.nix
+++ b/pkgs/by-name/hi/highscore-mupen64plus/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  mupen64plus,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-mupen64plus";
+  version = "0-unstable-2025-12-28";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "mupen64plus-highscore";
+    rev = "94ab5644e5363cf359b334ac057f3f36d24910be";
+    hash = "sha256-Q+6iL7DGr62C2fVEP0EWCgm7S7AYAW1C2X1GPKbI7aY=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+    mupen64plus
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of Mupen64Plus to Highscore";
+    homepage = "https://github.com/highscore-emu/mupen64plus-highscore";
+    license = lib.licenses.gpl2Plus;
+    inherit (libhighscore.meta) maintainers;
+    inherit (mupen64plus.meta) platforms broken;
+  };
+})

--- a/pkgs/by-name/hi/highscore-nestopia/package.nix
+++ b/pkgs/by-name/hi/highscore-nestopia/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-nestopia";
+  version = "0-unstable-2025-12-30";
+
+  src = fetchFromGitLab {
+    owner = "highscore-emu";
+    repo = "nestopia";
+    rev = "529e69b6e577f42a246c8fa44ef7f3095647adaf";
+    hash = "sha256-2aBEtut6AShP1Nz0BqNTFD3/gN2cj5PY8JL8WbLE7XE=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', '--match', ''', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of Nestopia to Highscore";
+    homepage = "https://gitlab.com/highscore-emu/nestopia";
+    license = lib.licenses.gpl2Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-prosystem/package.nix
+++ b/pkgs/by-name/hi/highscore-prosystem/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-prosystem";
+  version = "0-unstable-2025-12-27";
+
+  src = fetchFromGitLab {
+    owner = "highscore-emu";
+    repo = "prosystem";
+    rev = "44d86957d9377fdc1650c8cdaafbf7e2e2671827";
+    hash = "sha256-vxgh819XwI6rjoI7WwUEPx0PVpb58+MIOhCINQKom0Q=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', '--match', ''', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of ProSystem to Highscore";
+    homepage = "https://gitlab.com/highscore-emu/prosystem";
+    license = lib.licenses.gpl2Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-sameboy/package.nix
+++ b/pkgs/by-name/hi/highscore-sameboy/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  rgbds,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-sameboy";
+  version = "0-unstable-2025-12-31";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "SameBoy";
+    rev = "80e1d0b5aef4098539979a4670882d590ac9a1ca";
+    hash = "sha256-Fp9GODDu0170NoCHCfX5+vs8hQccS/P1N4jM+L784+o=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', '--match', ''', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rgbds
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of SameBoy to Highscore";
+    homepage = "https://github.com/highscore-emu/SameBoy";
+    license = lib.licenses.mit;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-stella/package.nix
+++ b/pkgs/by-name/hi/highscore-stella/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libhighscore,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-stella";
+  version = "0-unstable-2026-01-02";
+
+  src = fetchFromGitHub {
+    owner = "highscore-emu";
+    repo = "stella";
+    rev = "a8d92c100e83ae2249c5b30afcaa4b4ed31fcc46";
+    hash = "sha256-QfKtAIMCqniF15vCuWKz/pwb0FuE6xDp6/rfeUWpMgQ=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src/os/highscore";
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('git', 'describe', '--always', '--dirty', check: false).stdout().strip()" \
+        "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libhighscore
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Port of Stella to Highscore";
+    homepage = "https://github.com/highscore-emu/stella";
+    license = lib.licenses.gpl2Only;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore-unwrapped/cores-dir-from-envvar.patch
+++ b/pkgs/by-name/hi/highscore-unwrapped/cores-dir-from-envvar.patch
@@ -1,0 +1,25 @@
+diff --git a/shared/config.vapi b/shared/config.vapi
+index 1b0d8d7..e25bfbc 100644
+--- a/shared/config.vapi
++++ b/shared/config.vapi
+@@ -9,7 +9,6 @@ namespace Config {
+     public const string VERSION_SUFFIX;
+     public const string VCS_TAG;
+     public const string PROFILE;
+-    public const string CORES_DIR;
+     public const string DATA_DIR;
+     public const string RUNNER_PATH;
+ }
+diff --git a/src/core-register.vala b/src/core-register.vala
+index 892aca7..2485cc7 100644
+--- a/src/core-register.vala
++++ b/src/core-register.vala
+@@ -15,7 +15,7 @@ public class Highscore.CoreRegister : Object {
+         suggested_cores = new HashTable<string, SuggestedCore?> (str_hash, str_equal);
+ 
+         try {
+-            scan_directory (File.new_for_path (Config.CORES_DIR));
++            scan_directory (File.new_for_path (Environment.get_variable ("HIGHSCORE_CORES_DIR")));
+         } catch (Error e) {
+             critical ("Failed to scan cores: %s", e.message);
+         }

--- a/pkgs/by-name/hi/highscore-unwrapped/package.nix
+++ b/pkgs/by-name/hi/highscore-unwrapped/package.nix
@@ -1,0 +1,117 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  blueprint-compiler,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  glib,
+  gtk4,
+  desktop-file-utils,
+  itstool,
+  python3,
+  json-glib,
+  libgee,
+  libadwaita,
+  libarchive,
+  libglycin,
+  libhighscore,
+  libmanette,
+  sqlite,
+  libGL,
+  libepoxy,
+  libpulseaudio,
+  SDL2,
+  librsvg,
+  libmirage,
+  feedbackd,
+  unstableGitUpdater,
+}:
+
+let
+  libmanette-1-alpha = libmanette.overrideAttrs (prev: {
+    version = "0.2.13-unstable-2025-10-10";
+    src = fetchFromGitLab {
+      domain = "gitlab.gnome.org";
+      owner = "GNOME";
+      repo = "libmanette";
+      rev = "9b1b45e2aa3221938cd23e5f87a79b69e1996f64";
+      hash = "sha256-4Vinc3sBU2PJmOZUOrod6AJbRq6W2nNLcC//FVHGuhg=";
+    };
+
+    buildInputs = prev.buildInputs ++ [ libadwaita ];
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highscore-unwrapped";
+  version = "0-unstable-2026-01-01";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "highscore";
+    rev = "c9f537e06414a32632e9f9d7a73d9028b788f275";
+    hash = "sha256-6sBfjVFIFg0w3apzJBYMYEIjTavnOAE0YK3ayzoyDks=";
+  };
+
+  patches = [
+    # Highscore finds cores under $out/lib/highscore/cores/
+    # Allow the wrapper to override it with $HIGHSCORE_CORES_DIR
+    ./cores-dir-from-envvar.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build --replace-fail \
+      "run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()" \
+      "'${finalAttrs.src.rev}'"
+  '';
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    meson
+    ninja
+    pkg-config
+    vala
+    glib # For glib-compile-resources
+    gtk4 # For gtk4-update-icon-cache
+    desktop-file-utils
+    itstool
+    # Used in build time, detected by meson
+    (python3.withPackages (ps: [ ps.pygobject3 ]))
+    # To prevent double wrapping, not wrapping it here
+    # wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    libgee
+    gtk4
+    json-glib
+    libadwaita
+    libarchive
+    libglycin
+    libhighscore
+    libmanette-1-alpha
+    sqlite
+    libGL
+    libepoxy
+    libpulseaudio
+    SDL2
+    librsvg
+    libmirage
+    feedbackd
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Rewrite of Highscore, formerly gnome-games";
+    homepage = "https://gitlab.gnome.org/World/highscore/";
+    license = lib.licenses.gpl3Plus;
+    inherit (libhighscore.meta) maintainers platforms;
+  };
+})

--- a/pkgs/by-name/hi/highscore/package.nix
+++ b/pkgs/by-name/hi/highscore/package.nix
@@ -1,0 +1,73 @@
+{
+  symlinkJoin,
+  wrapGAppsHook4,
+  gtk4,
+  feedbackd,
+  librsvg,
+  glycin-loaders,
+  highscore-unwrapped,
+  highscore-blastem,
+  highscore-bsnes,
+  highscore-desmume,
+  highscore-gearsystem,
+  highscore-mednafen,
+  highscore-mgba,
+  highscore-mupen64plus,
+  highscore-nestopia,
+  highscore-prosystem,
+  highscore-sameboy,
+  highscore-stella,
+
+  # Allow users to override
+  cores ? builtins.filter (p: p.meta.available) [
+    highscore-blastem
+    highscore-bsnes
+    highscore-desmume
+    highscore-gearsystem
+    highscore-mednafen
+    highscore-mgba
+    highscore-mupen64plus
+    highscore-nestopia
+    highscore-prosystem
+    highscore-sameboy
+    highscore-stella
+  ],
+}:
+
+symlinkJoin {
+  pname = "highscore";
+  inherit (highscore-unwrapped) version meta;
+
+  paths = [ highscore-unwrapped ] ++ cores;
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    # For gsettings-schemas
+    highscore-unwrapped
+    gtk4
+    feedbackd
+    # For GDK_PIXBUF_MODULE_FILE
+    librsvg
+  ];
+
+  dontWrapGApps = true;
+
+  # symlinkJoin doesn't run other build phases
+  postBuild = ''
+    rm $out/share/dbus-1/services/app.drey.Highscore{,.SearchProvider}.service
+    cp {${highscore-unwrapped},$out}/share/dbus-1/services/app.drey.Highscore.service
+    cp {${highscore-unwrapped},$out}/share/dbus-1/services/app.drey.Highscore.SearchProvider.service
+    substituteInPlace $out/share/dbus-1/services/app.drey.Highscore{,.SearchProvider}.service \
+      --replace-fail "${highscore-unwrapped}" "$out"
+
+    gappsWrapperArgsHook
+
+    makeWrapper ${highscore-unwrapped}/bin/highscore $out/bin/highscore \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share" \
+      --set HIGHSCORE_CORES_DIR $out/lib/highscore/cores
+  '';
+}

--- a/pkgs/by-name/li/libchdr/package.nix
+++ b/pkgs/by-name/li/libchdr/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  zlib,
+  zstd,
+}:
+
+stdenv.mkDerivation {
+  pname = "libchdr";
+  version = "0-unstable-2025-12-27";
+
+  src = fetchFromGitHub {
+    owner = "rtissera";
+    repo = "libchdr";
+    rev = "07a7dad23378b001f4ab174ef51bd6553f883edd";
+    hash = "sha256-FCZ442mDF/pO5sNHNcPtWxSOB8o3I0YwwNXzu1B2vVQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    zlib
+    zstd
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "INSTALL_STATIC_LIBS" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "WITH_SYSTEM_ZLIB" true)
+    (lib.cmakeBool "WITH_SYSTEM_ZSTD" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+  ];
+
+  meta = {
+    description = "Standalone library for reading MAME's CHDv1-v5 formats";
+    homepage = "https://github.com/rtissera/libchdr";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/li/libhighscore/package.nix
+++ b/pkgs/by-name/li/libhighscore/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  vala,
+  gobject-introspection,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "libhighscore";
+  version = "0-unstable-2025-12-06";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "alicem";
+    repo = "libhighscore";
+    rev = "6920d96b440ccfc070fc87c39c51beab8ac053bd";
+    hash = "sha256-JXfPLPHA3HwXRG6sT/5TSMbtU+BqBh/+ZVrzJxW0xLg=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    glib # For glib-mkenums
+    gobject-introspection # For g-ir-scanner
+    vala # For vapigen
+  ];
+
+  # In highscore-1.pc
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Interface for porting emulators to Highscore";
+    homepage = "https://gitlab.gnome.org/alicem/libhighscore";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [
+      chuangzhu
+      aleksana
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Highscore, previously GNOME Games, is the GNOME frontend for many retro game emulator cores with very nice touchscreen control support.

![Running Highscore on Mobile NixOS](https://github.com/user-attachments/assets/325563ab-53fd-408e-92b9-ab95e09687de)

Highscore looks for cores under `$out/lib/highscore/cores/`. To make it extensible within Nix, a wrapper is introduced and the source is patched to add a `$HIGHSCORE_CORES_DIR` environment variable.

Tested `mgba`, `nestopia`, `desmume`.

It depends on unstable builds of `libadwaita` and `libmanette`. I don't know if it is the best time for packaging it in Nixpkgs, but it already works really well.

Upstreamed from [here](https://github.com/chuangzhu/nixpkgs-gnome-apps)

Closes #68863

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
