### PR TITLE
workflows: lock Ubuntu and macOS runners and update Ubuntu runner

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   tests:
     name: basic-eval-checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   tests:
     name: basic-eval-checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   check:
     name: cherry-pick-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   check:
     name: cherry-pick-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'NixOS'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-maintainers-sorted.yaml
+++ b/.github/workflows/check-maintainers-sorted.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   nixos:
     name: maintainer-list-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-maintainers-sorted.yaml
+++ b/.github/workflows/check-maintainers-sorted.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   nixos:
     name: maintainer-list-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -18,7 +18,7 @@ jobs:
 
   nixos:
     name: nixfmt-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -18,7 +18,7 @@ jobs:
 
   nixos:
     name: nixfmt-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   nixos:
     name: exp-nixf-tidy-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   nixos:
     name: exp-nixf-tidy-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   x86_64-linux:
     name: shell-check-x86_64-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -23,7 +23,7 @@ jobs:
 
   aarch64-darwin:
     name: shell-check-aarch64-darwin
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   x86_64-linux:
     name: shell-check-x86_64-linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -41,7 +41,7 @@ jobs:
   # Check that code owners is valid
   check:
     name: Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     steps:
@@ -88,7 +88,7 @@ jobs:
   # Request reviews from code owners
   request:
     name: Request
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -41,7 +41,7 @@ jobs:
   # Check that code owners is valid
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     steps:
@@ -88,7 +88,7 @@ jobs:
   # Request reviews from code owners
   request:
     name: Request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -16,7 +16,7 @@ jobs:
 
   tests:
     name: editorconfig-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -16,7 +16,7 @@ jobs:
 
   tests:
     name: editorconfig-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
   nixpkgs-lib-tests:
     name: nixpkgs-lib-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     steps:

--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
   nixpkgs-lib-tests:
     name: nixpkgs-lib-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     steps:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -21,7 +21,7 @@ jobs:
 
   attrs:
     name: Attributes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     # Skip this and dependent steps if the PR can't be merged
     if: needs.get-merge-commit.outputs.mergedSha
@@ -60,7 +60,7 @@ jobs:
 
   eval-aliases:
     name: Eval nixpkgs with aliases enabled
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ attrs, get-merge-commit ]
     steps:
       - name: Check out the PR at the test merge commit
@@ -78,7 +78,7 @@ jobs:
 
   outpaths:
     name: Outpaths
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ attrs, get-merge-commit ]
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
 
   process:
     name: Process
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ outpaths, attrs, get-merge-commit ]
     outputs:
       baseRunId: ${{ steps.baseRunId.outputs.baseRunId }}
@@ -218,7 +218,7 @@ jobs:
   # Separate job to have a very tightly scoped PR write token
   tag:
     name: Tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ attrs, process ]
     if: needs.process.outputs.baseRunId
     permissions:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -21,7 +21,7 @@ jobs:
 
   attrs:
     name: Attributes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     # Skip this and dependent steps if the PR can't be merged
     if: needs.get-merge-commit.outputs.mergedSha
@@ -60,7 +60,7 @@ jobs:
 
   eval-aliases:
     name: Eval nixpkgs with aliases enabled
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ attrs, get-merge-commit ]
     steps:
       - name: Check out the PR at the test merge commit
@@ -78,7 +78,7 @@ jobs:
 
   outpaths:
     name: Outpaths
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ attrs, get-merge-commit ]
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
 
   process:
     name: Process
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ outpaths, attrs, get-merge-commit ]
     outputs:
       baseRunId: ${{ steps.baseRunId.outputs.baseRunId }}
@@ -218,7 +218,7 @@ jobs:
   # Separate job to have a very tightly scoped PR write token
   tag:
     name: Tag
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ attrs, process ]
     if: needs.process.outputs.baseRunId
     permissions:

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   resolve-merge-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       mergedSha: ${{ steps.merged.outputs.mergedSha }}
     steps:

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   resolve-merge-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       mergedSha: ${{ steps.merged.outputs.mergedSha }}
     steps:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   labels:
     name: label-pr
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   labels:
     name: label-pr
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   nixos:
     name: nixos-manual-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   nixos:
     name: nixos-manual-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   nixpkgs:
     name: nixpkgs-manual-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   nixpkgs:
     name: nixpkgs-manual-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -16,7 +16,7 @@ jobs:
 
   tests:
     name: nix-files-parseable-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -16,7 +16,7 @@ jobs:
 
   tests:
     name: nix-files-parseable-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -25,7 +25,7 @@ jobs:
   check:
     name: nixpkgs-vet
     # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
     needs: get-merge-commit

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -25,7 +25,7 @@ jobs:
   check:
     name: nixpkgs-vet
     # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
     needs: get-merge-commit

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   fail:
     name: "This PR is is targeting a channel branch"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - run: |
         cat <<EOF

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   fail:
     name: "This PR is is targeting a channel branch"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - run: |
         cat <<EOF

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false

--- a/.github/workflows/periodic-merge-haskell-updates.yml
+++ b/.github/workflows/periodic-merge-haskell-updates.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: git merge-base master staging → haskell-updates
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/periodic-merge-haskell-updates.yml
+++ b/.github/workflows/periodic-merge-haskell-updates.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write  # for devmasx/merge-branch to merge branches
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.repository_owner == 'NixOS'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: git merge-base master staging → haskell-updates
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/ci/README.md
+++ b/ci/README.md
@@ -73,7 +73,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-merge-commit
     steps:
       - uses: actions/checkout@<VERSION>

--- a/ci/README.md
+++ b/ci/README.md
@@ -73,7 +73,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-merge-commit
     steps:
       - uses: actions/checkout@<VERSION>


### PR DESCRIPTION
Lock the Ubuntu and macOS runners to avoid accidental updates [1] and increase reproduciblity. Then, update the Ubuntu runner to what `ubuntu-latest` will soon point to [1], which hopefully causes no problems on our end.

[1]: https://github.com/actions/runner-images/issues/10636

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
