### PR TITLE
dmraid: patch dmevent_tool.c to compile on modern gcc versions (#367926)

### DIFF
--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
   };
 
   patches =
-    [ ./hardening-format.patch ]
+    [
+      ./hardening-format.patch
+      ./fix-dmevent_tool.patch
+    ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [
       (fetchpatch {
         url = "https://raw.githubusercontent.com/void-linux/void-packages/fceed4b8e96b3c1da07babf6f67b6ed1588a28b2/srcpkgs/dmraid/patches/006-musl-libc.patch";

--- a/pkgs/os-specific/linux/dmraid/fix-dmevent_tool.patch
+++ b/pkgs/os-specific/linux/dmraid/fix-dmevent_tool.patch
@@ -1,0 +1,20 @@
+--- a/1.0.0.rc16/tools/dmevent_tool.c.old	2024-12-26 18:39:04.294039876 -0700
++++ a/1.0.0.rc16/tools/dmevent_tool.c	2024-12-26 18:45:59.416784807 -0700
+@@ -123,7 +123,7 @@
+ }
+ 
+ /* Increment option counters. */
+-static _process_opt(int opt, const char *cmd)
++static int _process_opt(int opt, const char *cmd)
+ {
+ 	struct opt_def_struct {
+ 		const char opt;		/* Option character. */
+@@ -148,7 +148,7 @@
+ 
+ 			optc[o->type]++;
+ 			optc[OPT_SUM]++;
+-			return;
++			return 0;
+ 		}
+ 	}
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix dmevent_tool.c to compile on modern gcc versions. Resolves #367926.

close: https://github.com/NixOS/nixpkgs/pull/368747
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
